### PR TITLE
Fix string truncation warnings

### DIFF
--- a/src/hal/drivers/mesa-hostmot2/abs_encoder.c
+++ b/src/hal/drivers/mesa-hostmot2/abs_encoder.c
@@ -236,6 +236,7 @@ int hm2_absenc_parse_format(hm2_sserial_remote_t *chan,  hm2_absenc_format_t *de
     char* AA64 = "%5pbatt_fail%1b%2ppos_invalid%1b%9plow%16l%2pencoder%16h%2pcomm%10u%7pcrc%5u";
     char* format = def->string;
     char name[HM2_SSERIAL_MAX_STRING_LENGTH+1] = "";
+    char *nameptr = name;
     
     if (chan->myinst == HM2_GTAG_FABS && strncmp(format, "AA64",4) == 0){
         format = AA64;
@@ -329,7 +330,6 @@ int hm2_absenc_parse_format(hm2_sserial_remote_t *chan,  hm2_absenc_format_t *de
                                   " paired with one of the other data types\n");
                     return -EINVAL;
                 }
-                
             }
             else
             {
@@ -337,13 +337,16 @@ int hm2_absenc_parse_format(hm2_sserial_remote_t *chan,  hm2_absenc_format_t *de
                 return -EINVAL;
             }
             //Start a new name
-            rtapi_strxcpy(name, "");
+            nameptr = name;
+            *nameptr = 0;
             //move to the next string
             format++;
         }
         else
         {
-            strncat(name, format++, 1);
+            // Not a % format, append name
+            *nameptr++ = *format++;
+            *nameptr = 0;
         }
     }
     return 0;

--- a/src/hal/drivers/mesa-hostmot2/hm2_eth.c
+++ b/src/hal/drivers/mesa-hostmot2/hm2_eth.c
@@ -49,7 +49,7 @@
 
 struct kvlist {
     struct rtapi_list_head list;
-    char key[16];
+    char key[16+1];
     int value;
 };
 
@@ -63,7 +63,7 @@ static int *kvlist_lookup(struct rtapi_list_head *head, const char *name) {
         if(strncmp(name, ent->key, sizeof(ent->key)) == 0) return &ent->value;
     }
     struct kvlist *ent = rtapi_kzalloc(sizeof(struct kvlist), RTAPI_GPF_KERNEL);
-    strncpy(ent->key, name, sizeof(ent->key));
+    strncpy(ent->key, name, sizeof(ent->key)-1);
     rtapi_list_add(&ent->list, head);
     return &ent->value;
 }
@@ -1054,8 +1054,8 @@ static int hm2_eth_probe(hm2_eth_t *board) {
     lbp16_cmd_addr read_packet;
 
     int ret, send, recv;
-    char board_name[16] = {0, };
-    char llio_name[16] = {0, };
+    char board_name[16] = {};
+    char llio_name[16] = {};
 
     LBP16_INIT_PACKET4(read_packet, CMD_READ_BOARD_INFO_ADDR16_INCR(16/2), 0);
     send = eth_socket_send(board->sockfd, (void*) &read_packet, sizeof(read_packet), 0);
@@ -1075,8 +1075,7 @@ static int hm2_eth_probe(hm2_eth_t *board) {
     board->llio.split_read = true;
 
     if (strncmp(board_name, "7I80DB-16", 9) == 0) {
-        strncpy(llio_name, board_name, 4);
-        llio_name[1] = tolower(llio_name[1]);
+        memcpy(llio_name, board_name, 4);
 
         board->llio.num_ioport_connectors = 4;
         board->llio.pins_per_connector = 17;
@@ -1087,8 +1086,7 @@ static int hm2_eth_probe(hm2_eth_t *board) {
         board->llio.fpga_part_number = "XC6SLX16";
         board->llio.num_leds = 4;
     } else if (strncmp(board_name, "7I80DB-25", 9) == 0) {
-        strncpy(llio_name, board_name, 4);
-        llio_name[1] = tolower(llio_name[1]);
+        memcpy(llio_name, board_name, 4);
 
         board->llio.num_ioport_connectors = 4;
         board->llio.pins_per_connector = 17;
@@ -1099,8 +1097,7 @@ static int hm2_eth_probe(hm2_eth_t *board) {
         board->llio.fpga_part_number = "XC6SLX25";
         board->llio.num_leds = 4;
     } else if (strncmp(board_name, "7I80HD-16", 9) == 0) {
-        strncpy(llio_name, board_name, 4);
-        llio_name[1] = tolower(llio_name[1]);
+        memcpy(llio_name, board_name, 4);
 
         board->llio.num_ioport_connectors = 3;
         board->llio.pins_per_connector = 24;
@@ -1110,8 +1107,7 @@ static int hm2_eth_probe(hm2_eth_t *board) {
         board->llio.fpga_part_number = "XC6SLX16";
         board->llio.num_leds = 4;
     } else if (strncmp(board_name, "7I80HD-25", 9) == 0) {
-        strncpy(llio_name, board_name, 4);
-        llio_name[1] = tolower(llio_name[1]);
+        memcpy(llio_name, board_name, 4);
 
         board->llio.num_ioport_connectors = 3;
         board->llio.pins_per_connector = 24;
@@ -1121,8 +1117,7 @@ static int hm2_eth_probe(hm2_eth_t *board) {
         board->llio.fpga_part_number = "XC6SLX25";
         board->llio.num_leds = 4;
     } else if (strncmp(board_name, "7I80HDT", 7) == 0) {
-        strncpy(llio_name, board_name, 4);
-        llio_name[1] = tolower(llio_name[1]);
+        memcpy(llio_name, board_name, 4);
 
         board->llio.num_ioport_connectors = 3;
         board->llio.pins_per_connector = 24;
@@ -1132,9 +1127,7 @@ static int hm2_eth_probe(hm2_eth_t *board) {
         board->llio.fpga_part_number = "T20F256";
         board->llio.num_leds = 4;
     } else if (strncmp(board_name, "7I76E-16", 8) == 0) {
-        strncpy(llio_name, board_name, 5);
-        llio_name[1] = tolower(llio_name[1]);
-        llio_name[4] = tolower(llio_name[4]);
+        memcpy(llio_name, board_name, 5);
 
         board->llio.num_ioport_connectors = 3;
         board->llio.pins_per_connector = 17;
@@ -1144,9 +1137,7 @@ static int hm2_eth_probe(hm2_eth_t *board) {
         board->llio.fpga_part_number = "XC6SLX16";
         board->llio.num_leds = 4;
     } else if (strncmp(board_name, "7I76EU", 8) == 0) {
-        strncpy(llio_name, board_name, 5);
-        llio_name[1] = tolower(llio_name[1]);
-        llio_name[4] = tolower(llio_name[4]);
+        memcpy(llio_name, board_name, 5);
 
         board->llio.num_ioport_connectors = 3;
         board->llio.pins_per_connector = 17;
@@ -1156,8 +1147,7 @@ static int hm2_eth_probe(hm2_eth_t *board) {
         board->llio.fpga_part_number = "T20F256";
         board->llio.num_leds = 4;
     } else if (strncmp(board_name, "7I92", 4) == 0) {
-        strncpy(llio_name, board_name, 4);
-        llio_name[1] = tolower(llio_name[1]);
+        memcpy(llio_name, board_name, 4);
 
         board->llio.num_ioport_connectors = 2;
         board->llio.pins_per_connector = 17;
@@ -1166,8 +1156,7 @@ static int hm2_eth_probe(hm2_eth_t *board) {
         board->llio.fpga_part_number = "XC6SLX9";
         board->llio.num_leds = 4;
     } else if (strncmp(board_name, "7I92T", 5) == 0) {
-        strncpy(llio_name, board_name, 4);
-        llio_name[1] = tolower(llio_name[1]);
+        memcpy(llio_name, board_name, 4);
 
         board->llio.num_ioport_connectors = 2;
         board->llio.pins_per_connector = 17;
@@ -1177,8 +1166,7 @@ static int hm2_eth_probe(hm2_eth_t *board) {
         board->llio.num_leds = 4;
 
     } else if (strncmp(board_name, "7I93", 4) == 0) {
-        strncpy(llio_name, board_name, 4);
-        llio_name[1] = tolower(llio_name[1]);
+        memcpy(llio_name, board_name, 4);
         board->llio.num_ioport_connectors = 2;
         board->llio.pins_per_connector = 24;
         board->llio.ioport_connector_name[0] = "P2";
@@ -1187,8 +1175,7 @@ static int hm2_eth_probe(hm2_eth_t *board) {
         board->llio.num_leds = 4;
 
     } else if (strncmp(board_name, "7I94", 8) == 0) {
-        strncpy(llio_name, board_name, 8);
-        llio_name[1] = tolower(llio_name[1]);
+        memcpy(llio_name, board_name, 4);
         board->llio.num_ioport_connectors = 2;
         board->llio.pins_per_connector = 21;
         board->llio.io_connector_pin_names = hm2_7i94_pin_names;
@@ -1208,8 +1195,7 @@ static int hm2_eth_probe(hm2_eth_t *board) {
         board->llio.fpga_part_number = "6slx9tqg144";
         board->llio.num_leds = 4;
     } else if (strncmp(board_name, "7I94T", 8) == 0) {
-        strncpy(llio_name, board_name, 4);
-        llio_name[1] = tolower(llio_name[1]);
+        memcpy(llio_name, board_name, 4);
         board->llio.num_ioport_connectors = 2;
         board->llio.pins_per_connector = 21;
         board->llio.io_connector_pin_names = hm2_7i94_pin_names;
@@ -1230,8 +1216,7 @@ static int hm2_eth_probe(hm2_eth_t *board) {
         board->llio.num_leds = 4;
 
     } else if (strncmp(board_name, "7I95", 8) == 0) {
-        strncpy(llio_name, board_name, 4);
-        llio_name[1] = tolower(llio_name[1]);
+        memcpy(llio_name, board_name, 4);
         board->llio.num_ioport_connectors = 2;
         board->llio.pins_per_connector = 29;
         board->llio.io_connector_pin_names = hm2_7i95_pin_names;
@@ -1261,8 +1246,7 @@ static int hm2_eth_probe(hm2_eth_t *board) {
         board->llio.num_leds = 4;
 
     } else if (strncmp(board_name, "7I95T", 8) == 0) {
-        strncpy(llio_name, board_name, 4); 
-        llio_name[1] = tolower(llio_name[1]);
+        memcpy(llio_name, board_name, 4);
         board->llio.num_ioport_connectors = 2;
         board->llio.pins_per_connector = 29;
         board->llio.io_connector_pin_names = hm2_7i95_pin_names;
@@ -1292,8 +1276,7 @@ static int hm2_eth_probe(hm2_eth_t *board) {
         board->llio.num_leds = 4;
 
     } else if (strncmp(board_name, "7I96", 8) == 0) {
-        strncpy(llio_name, board_name, 8);
-        llio_name[1] = tolower(llio_name[1]);
+        memcpy(llio_name, board_name, 4);
         board->llio.num_ioport_connectors = 3;
         board->llio.pins_per_connector = 17;
         board->llio.io_connector_pin_names = hm2_7i96_pin_names;
@@ -1314,10 +1297,8 @@ static int hm2_eth_probe(hm2_eth_t *board) {
         board->llio.num_leds = 4;
 
     } else if (strncmp(board_name, "7I96S", 8) == 0) {
-        strncpy(llio_name, board_name, 8);
-        llio_name[1] = tolower(llio_name[1]);
-        llio_name[4] = tolower(llio_name[4]);
-       board->llio.num_ioport_connectors = 3;
+        memcpy(llio_name, board_name, 5);
+        board->llio.num_ioport_connectors = 3;
         board->llio.pins_per_connector = 17;
         board->llio.io_connector_pin_names = hm2_7i96_pin_names;
 
@@ -1337,8 +1318,7 @@ static int hm2_eth_probe(hm2_eth_t *board) {
         board->llio.num_leds = 4;
 
     } else if (strncmp(board_name, "7I97", 8) == 0) {
-        strncpy(llio_name, board_name, 8);
-        llio_name[1] = tolower(llio_name[1]);
+        memcpy(llio_name, board_name, 4);
         board->llio.num_ioport_connectors = 3;
         board->llio.pins_per_connector = 17;
         board->llio.io_connector_pin_names = hm2_7i97_pin_names;
@@ -1365,8 +1345,7 @@ static int hm2_eth_probe(hm2_eth_t *board) {
         board->llio.num_leds = 4;
 
     } else if (strncmp(board_name, "7I97T", 8) == 0) {
-        strncpy(llio_name, board_name, 4);
-        llio_name[1] = tolower(llio_name[1]);
+        memcpy(llio_name, board_name, 4);
         board->llio.num_ioport_connectors = 3;
         board->llio.pins_per_connector = 17;
         board->llio.io_connector_pin_names = hm2_7i97_pin_names;
@@ -1394,8 +1373,7 @@ static int hm2_eth_probe(hm2_eth_t *board) {
 
 
     } else if (strncmp(board_name, "7I98", 4) == 0) {
-        strncpy(llio_name, board_name, 4);
-        llio_name[1] = tolower(llio_name[1]);
+        memcpy(llio_name, board_name, 4);
         board->llio.num_ioport_connectors = 3;
         board->llio.pins_per_connector = 17;
         board->llio.ioport_connector_name[0] = "P1";
@@ -1406,8 +1384,7 @@ static int hm2_eth_probe(hm2_eth_t *board) {
 
 
     } else if (strncmp(board_name, "MC04", 4) == 0) {
-        strncpy(llio_name, board_name, 4);
-        llio_name[1] = tolower(llio_name[1]);
+        memcpy(llio_name, board_name, 4);
         board->llio.num_ioport_connectors = 2;
         board->llio.pins_per_connector = 30;
         board->llio.ioport_connector_name[0] = "P1";
@@ -1420,8 +1397,7 @@ static int hm2_eth_probe(hm2_eth_t *board) {
 
 
      } else if (strncmp(board_name, "8CSS", 4) == 0) {
-        strncpy(llio_name, board_name, 4);
-        llio_name[1] = tolower(llio_name[1]);
+        memcpy(llio_name, board_name, 4);
         board->llio.num_ioport_connectors = 2;
         board->llio.pins_per_connector = 30;
         board->llio.ioport_connector_name[0] = "P1";
@@ -1434,8 +1410,7 @@ static int hm2_eth_probe(hm2_eth_t *board) {
 
     } else {
         LL_PRINT("Unrecognized ethernet board found: %.16s -- port names will be wrong\n", board_name);
-        strncpy(llio_name, board_name, 4);
-        llio_name[1] = tolower(llio_name[1]);
+        memcpy(llio_name, board_name, 4);
 
         // this is a layering violation.  it would be nice if special values
         // (such as 0 or -1) could be passed here and the layer which can
@@ -1455,6 +1430,11 @@ static int hm2_eth_probe(hm2_eth_t *board) {
             board->llio.ioport_connector_name[i] = "??";
         board->llio.fpga_part_number = "??";
         board->llio.num_leds = 0;
+    }
+
+    // Make llio_name lower case
+    for(char *cptr = llio_name; *cptr; cptr++) {
+        *cptr = tolower(*cptr);
     }
 
     LL_PRINT("discovered %.*s\n", 16, board_name);

--- a/src/hal/drivers/mesa-hostmot2/hostmot2.c
+++ b/src/hal/drivers/mesa-hostmot2/hostmot2.c
@@ -369,7 +369,9 @@ int hm2_fabs_parse(hostmot2_t *hm2, char *token, int gtag){
     }
     def->gtag = gtag;
     def->index = i;
-    strncpy(def->string, ++token, MAX_ABSENC_LEN);
+    // MAX_ABS_LENGTH-1 because this string, in a fixed size buffer, must be
+    // NUL-terminated. It is used as such in abs_encoder.c.
+    strncpy(def->string, ++token, MAX_ABSENC_LEN-1);
     rtapi_list_add(&def->list, &hm2->config.absenc_formats);
     return 0;
 }

--- a/src/hal/drivers/mesa-hostmot2/ioport.c
+++ b/src/hal/drivers/mesa-hostmot2/ioport.c
@@ -204,8 +204,12 @@ static int do_alias(const char *orig_base, const char *alias_base,
         const char *suffix, int (*funct)(const char *, const char *)) {
     char orig_name[HAL_NAME_LEN];
     char alias_name[HAL_NAME_LEN];
-    snprintf(orig_name, sizeof(orig_name), "%s%s", orig_base, suffix);
-    snprintf(alias_name, sizeof(alias_name), "%s%s", alias_base, suffix);
+    // Take ncpy/ncat tour. Using snprintf() causes warning about possible
+    // trunctation, which in practice never happens.
+    strncpy(orig_name, orig_base, sizeof(orig_name)-1);
+    strncat(orig_name, suffix, sizeof(orig_name)-1);
+    strncpy(alias_name, alias_base, sizeof(alias_name)-1);
+    strncat(alias_name, suffix, sizeof(alias_name)-1);
     return funct(orig_name, alias_name);
 }
 


### PR DESCRIPTION
Several string truncation warnings appear when optimization is switched from -Os to -O2 (see #3343).
This PR fixes the warnings before the optimization switch is done.