### PR TITLE
Fix various cppcheck indicated errors and warnings

### DIFF
--- a/src/emc/motion/homing.c
+++ b/src/emc/motion/homing.c
@@ -37,8 +37,8 @@ void homeMotFunctions(void(*pSetRotaryUnlock)(int,int)
                      ,int (*pGetRotaryIsUnlocked)(int)
                      )
 {
-    SetRotaryUnlock     = *pSetRotaryUnlock;
-    GetRotaryIsUnlocked = *pGetRotaryIsUnlocked;
+    SetRotaryUnlock     = pSetRotaryUnlock;
+    GetRotaryIsUnlocked = pGetRotaryIsUnlocked;
 }
 
 //========================================================

--- a/src/emc/motion/stashf_wrap.h
+++ b/src/emc/motion/stashf_wrap.h
@@ -91,7 +91,10 @@ const char *fmt, *efmt;
     if(*fmt) {
         result = PRINT("%s", fmt);
         if(result < 0) return SET_ERRNO(result);
-        EXTRA
+        // The below expansion of 'EXTRA' makes no sense. The function is about
+        // to exit and changing anything here does not change the outcome in
+        // any way. Therefore, make it a comment.
+        // EXTRA
     }
 
     return SET_ERRNO(result);

--- a/src/emc/pythonplugin/python_plugin.hh
+++ b/src/emc/pythonplugin/python_plugin.hh
@@ -70,8 +70,8 @@ public:
     int plugin_status() { return status; };
     bool usable() { return (status >= PLUGIN_OK); }
     int initialize();
-    std::string last_exception() { return exception_msg; };
-    std::string last_errmsg() { return error_msg; };
+    const std::string& last_exception() { return exception_msg; };
+    const std::string& last_errmsg() { return error_msg; };
     boost::python::object main_namespace;
 
 private:

--- a/src/emc/rs274ngc/interp_python.cc
+++ b/src/emc/rs274ngc/interp_python.cc
@@ -293,6 +293,8 @@ pycontext::~pycontext() { delete impl; }
 pycontext::pycontext(const pycontext &other)
     : impl(new pycontext_impl(*other.impl)) {}
 pycontext &pycontext::operator=(const pycontext &other) {
+    if(&other == this)  // Assign to self
+        return *this;
     delete impl;
     impl = new pycontext_impl(*other.impl);
     return *this;

--- a/src/emc/rs274ngc/rs274ngc_pre.cc
+++ b/src/emc/rs274ngc/rs274ngc_pre.cc
@@ -1953,6 +1953,13 @@ int Interp::save_parameters(const char *filename,      //!< name of file to writ
   infile = fopen(filename, "r");
   if(!infile)
     infile = fopen("/dev/null", "r");
+  if(!infile) {
+    // If we can't open the 'filename', we may not be able to open "/dev/null"
+    // either. If so, print an error, close 'outfile' and continue.
+    perror("Interp::save_parameters(): fopen(/dev/null)");
+    fclose(outfile);
+    return INTERP_OK;
+  }
 
   k = 0;
   index = 0;

--- a/src/emc/sai/saicanon.cc
+++ b/src/emc/sai/saicanon.cc
@@ -315,8 +315,8 @@ void STOP_SPEED_FEED_SYNCH()
 void NURBS_G5_FEED(int /*lineno*/, const std::vector<NURBS_CONTROL_POINT>& nurbs_control_points, unsigned int /*nurbs_order*/, CANON_PLANE /*plane*/) {
   ECHO_WITH_ARGS("%lu, ...", (unsigned long)nurbs_control_points.size());
 
-  _sai._program_position_x = nurbs_control_points[nurbs_control_points.size()].NURBS_X;
-  _sai._program_position_y = nurbs_control_points[nurbs_control_points.size()].NURBS_Y;
+  _sai._program_position_x = nurbs_control_points[nurbs_control_points.size()-1].NURBS_X;
+  _sai._program_position_y = nurbs_control_points[nurbs_control_points.size()-1].NURBS_Y;
 }
 
 /* Machining Functions G_6_2 */
@@ -325,8 +325,8 @@ void NURBS_G6_FEED(int /*lineno*/, const std::vector<NURBS_G6_CONTROL_POINT>& nu
   print_nc_line_number();
   fprintf(_outfile, "saicanon NURBS_G6_FEED_(%lu, ...)\n", (unsigned long)nurbs_control_points.size());
 
-  _sai._program_position_x = nurbs_control_points[nurbs_control_points.size()].NURBS_X;
-  _sai._program_position_y = nurbs_control_points[nurbs_control_points.size()].NURBS_Y;
+  _sai._program_position_x = nurbs_control_points[nurbs_control_points.size()-1].NURBS_X;
+  _sai._program_position_y = nurbs_control_points[nurbs_control_points.size()-1].NURBS_Y;
 }
 
 void ARC_FEED(int /*line_number*/,

--- a/src/emc/task/taskclass.hh
+++ b/src/emc/task/taskclass.hh
@@ -54,6 +54,10 @@ public:
     Task(EMC_IO_STAT &emcioStatus_in);
     virtual ~Task();
 
+    // Don't copy or assign
+    Task(const Task&) = delete;
+    Task& operator=(const Task&) = delete;
+
     virtual int emcIoInit();
     virtual int emcIoAbort(EMC_ABORT reason);
     virtual int emcAuxEstopOn();

--- a/src/emc/tp/tp.c
+++ b/src/emc/tp/tp.c
@@ -82,12 +82,12 @@ void tpMotFunctions(void(  *pDioWrite)(int,char)
                    ,double(*paxis_get_acc_limit)(int)
                    )
 {
-    _DioWrite            = *pDioWrite;
-    _AioWrite            = *pAioWrite;
-    _SetRotaryUnlock     = *pSetRotaryUnlock;
-    _GetRotaryIsUnlocked = *pGetRotaryIsUnlocked;
-    _axis_get_vel_limit  = *paxis_get_vel_limit;
-    _axis_get_acc_limit  = *paxis_get_acc_limit;
+    _DioWrite            = pDioWrite;
+    _AioWrite            = pAioWrite;
+    _SetRotaryUnlock     = pSetRotaryUnlock;
+    _GetRotaryIsUnlocked = pGetRotaryIsUnlocked;
+    _axis_get_vel_limit  = paxis_get_vel_limit;
+    _axis_get_acc_limit  = paxis_get_acc_limit;
 }
 
 void tpMotData(emcmot_status_t *pstatus

--- a/src/emc/usr_intf/emcrsh.cc
+++ b/src/emc/usr_intf/emcrsh.cc
@@ -1839,7 +1839,7 @@ static cmdResponseType getBrake(connectionRecType *context)
         if (n != spindle && spindle != -1)
             continue;
 
-        if (emcStatus->motion.spindle[spindle].brake == 1)
+        if (emcStatus->motion.spindle[n].brake == 1)
             OUT(pBrakeStr, "ON");
         else
             OUT(pBrakeStr, "OFF");

--- a/src/emc/usr_intf/emcsched.cc
+++ b/src/emc/usr_intf/emcsched.cc
@@ -74,9 +74,9 @@ class SchedEntry {
     void setOffsets(float x, float y, float z);
     int getZone() const;
     void setZone(int z);
-    string getFileName() const;
+    const string& getFileName() const;
     void setFileName(const string& s);
-    string getProgramName() const;
+    const string& getProgramName() const;
     void setProgramName(const string& s);
     float getFeedOverride() const;
     void setFeedOverride(float f);
@@ -146,7 +146,7 @@ void SchedEntry::setZone(int z) {
   zone = z;
   }
 
-string SchedEntry::getFileName() const {
+const string& SchedEntry::getFileName() const {
   return fileName;
   }
 
@@ -154,7 +154,7 @@ void SchedEntry::setFileName(const string& s) {
   fileName = s;
   }
 
-string SchedEntry::getProgramName() const {
+const string& SchedEntry::getProgramName() const {
   return programName;
   }
 
@@ -369,7 +369,7 @@ int getProgramById(int id, qRecType *qRec) {
   for (i=q.begin(); i!=q.end(); ++i) {
     if (i->getTagId() == id) break;
     }
-  if (i->getTagId() != id) return -1;
+  if (i == q.end() || i->getTagId() != id) return -1;
   qRec->priority = i->getPriority();
   qRec->tagId = i->getTagId();
   i->getOffsets(qRec->xpos, qRec->ypos, qRec->zpos);
@@ -384,14 +384,11 @@ int getProgramById(int id, qRecType *qRec) {
 
 int getProgramByIndex(int idx, qRecType *qRec) {
   list<SchedEntry>::iterator i;
-  int index;
 
-  if ((unsigned int) idx >= q.size()) return -1;
-  index = 0;
-  for (i=q.begin(); i!=q.end(); ++i) {
-    if (index == idx) break;
-    index++;
-    }
+  for(i = q.begin(); idx > 0; ++i) {
+    if(i == q.end()) return -1;  // return if idx was larger than number of entries
+    --idx;
+  }
   qRec->priority = i->getPriority();
   qRec->tagId = i->getTagId();
   i->getOffsets(qRec->xpos, qRec->ypos, qRec->zpos);

--- a/src/emc/usr_intf/emcsh.cc
+++ b/src/emc/usr_intf/emcsh.cc
@@ -3212,8 +3212,8 @@ static int emc_pendant(ClientData /*clientdata*/,
 		inBytes[4] = fgetc(inFile);	// Status byte
 		inBytes[2] = fgetc(inFile);	// Horizontal movement
 		inBytes[3] = fgetc(inFile);	// Vertical Movement
+	        fclose(inFile);
 	    }
-	    fclose(inFile);
 
 	    if (!strcmp(port, "/dev/psaux")) {	// For PS/2
 		inBytes[0] = (inBytes[4] & 0x01);	// Left button

--- a/src/hal/user_comps/gs2_vfd.c
+++ b/src/hal/user_comps/gs2_vfd.c
@@ -554,6 +554,8 @@ int main(int argc, char **argv)
                     goto out_noclose;
                 }
                 device = strdup(optarg);
+                if(!device)
+                    device  = "/dev/strdup/error_out_of_memory";
                 break;
             case 'g':
                 debug = 1;

--- a/src/hal/user_comps/xhc-whb04b-6/pendant.cc
+++ b/src/hal/user_comps/xhc-whb04b-6/pendant.cc
@@ -568,6 +568,8 @@ FeedRotaryButton& FeedRotaryButton::operator=(const FeedRotaryButton& other)
 {
     RotaryButton::operator=(other);
     mStepMode = other.mStepMode;
+    mStepSize = other.mStepSize;
+    mEventListener = other.mEventListener;
     return *this;
 }
 // ----------------------------------------------------------------------
@@ -669,6 +671,7 @@ std::ostream& operator<<(std::ostream& os, const AxisRotaryButton& data)
 AxisRotaryButton& AxisRotaryButton::operator=(const AxisRotaryButton& other)
 {
     RotaryButton::operator=(other);
+    mEventListener = other.mEventListener;
     return *this;
 }
 // ----------------------------------------------------------------------
@@ -832,6 +835,8 @@ ButtonsState& ButtonsState::operator=(const ButtonsState& other)
     mCurrentMetaButton = other.mCurrentMetaButton;
     mAxisButton        = other.mAxisButton;
     mFeedButton        = other.mFeedButton;
+    mPreviousState     = other.mPreviousState;
+    mEventListener     = other.mEventListener;
     return *this;
 }
 // ----------------------------------------------------------------------

--- a/src/hal/utils/halcmd_completion.c
+++ b/src/hal/utils/halcmd_completion.c
@@ -541,6 +541,8 @@ static char *loadrt_generator(const char *text, int state) {
         if(startswith(ent->d_name, "rtapi.")) continue;
         if(strncmp(text, ent->d_name, len) != 0) continue;
         result = strdup(ent->d_name);
+        if(!result)
+            return NULL;
         result[strlen(result) - strlen(MODULE_EXT)] = 0;
         return result;
     }

--- a/src/hal/utils/halrmt.c
+++ b/src/hal/utils/halrmt.c
@@ -3395,6 +3395,10 @@ void *readClient(void *arg)
   
 //  res = 1;
   context = (connectionRecType *) malloc(sizeof(connectionRecType));
+  if(NULL == context) {
+    perror("readClient():malloc");
+    abort();  // There is no "clean" way. Ensure we make some noise.
+  }
   context->cliSock = client_sockfd;
   context->linked = 0;
   context->echo = 1;

--- a/src/libnml/buffer/locmem.cc
+++ b/src/libnml/buffer/locmem.cc
@@ -60,7 +60,7 @@ LOCMEM::LOCMEM(const char *bufline, const char *procline, int set_to_server,
 	}
 	my_node = new BUFFERS_LIST_NODE;
 	lm_addr = my_node->addr = malloc(size);
-	if (my_node == NULL || lm_addr == NULL) {
+	if (lm_addr == NULL) {
 	    rcs_print_error("Can't malloc needed space.\n");
 	    status = CMS_CREATE_ERROR;
 	    return;

--- a/src/libnml/cms/cms.cc
+++ b/src/libnml/cms/cms.cc
@@ -32,6 +32,7 @@ extern "C" {
 #ifdef __cplusplus
 }
 #endif
+#include <string>
 #include <rtapi_string.h>
 #include "cms_cfg.hh"
 #include "cms.hh"		/* class CMS */
@@ -232,8 +233,10 @@ CMS::CMS(const char *bufline_in, const char *procline_in, int set_to_server)
 	return;
     }
 
-    char *bufline = strdup(bufline_in);
-    char *procline = strdup(procline_in);
+    std::string buflineString(bufline_in);   // Local copies without strdup()
+    std::string proclineString(procline_in);
+    char *bufline = buflineString.data();
+    char *procline = proclineString.data();
 
     convert2upper(buflineupper, bufline, LINELEN);
     convert2upper(proclineupper, procline, LINELEN);
@@ -279,8 +282,6 @@ CMS::CMS(const char *bufline_in, const char *procline_in, int set_to_server)
 	rcs_print_error("CMS: Error in buffer line from config file.\n");
 	rcs_print_error("%s\n", bufline);
 	status = CMS_CONFIG_ERROR;
-	free(bufline);
-	free(procline);
 	return;
     }
 
@@ -318,8 +319,6 @@ CMS::CMS(const char *bufline_in, const char *procline_in, int set_to_server)
 	rcs_print_error("CMS: Error in buffer line from config file.\n");
 	rcs_print_error("%s\n", bufline);
 	status = CMS_CONFIG_ERROR;
-	free(bufline);
-	free(procline);
 	return;
     }
 
@@ -336,8 +335,6 @@ CMS::CMS(const char *bufline_in, const char *procline_in, int set_to_server)
     } else {
 	rcs_print_error("CMS: invalid buffer type (%s)\n", buffer_type_name);
 	status = CMS_CONFIG_ERROR;
-	free(bufline);
-	free(procline);
 	return;
     }
 
@@ -346,8 +343,6 @@ CMS::CMS(const char *bufline_in, const char *procline_in, int set_to_server)
 	rcs_print_error("CMS: Error in buffer line from config file.\n");
 	rcs_print_error("%s\n", bufline);
 	status = CMS_CONFIG_ERROR;
-	free(bufline);
-	free(procline);
 	return;
     }
     for (i = 8; i < num_words && i < 32; i++) {
@@ -447,8 +442,6 @@ CMS::CMS(const char *bufline_in, const char *procline_in, int set_to_server)
 		("CMS: Error parsing process line from config file.\n");
 	    rcs_print_error("%s\n", procline);
 	    status = CMS_CONFIG_ERROR;
-	    free(bufline);
-	    free(procline);
 	    return;
 	}
     } else {
@@ -457,8 +450,6 @@ CMS::CMS(const char *bufline_in, const char *procline_in, int set_to_server)
 		("CMS: Error parsing process line from config file.\n");
 	    rcs_print_error("%s\n", procline);
 	    status = CMS_CONFIG_ERROR;
-	    free(bufline);
-	    free(procline);
 	    return;
 	}
     }
@@ -499,8 +490,6 @@ CMS::CMS(const char *bufline_in, const char *procline_in, int set_to_server)
 		("CMS: connection number(%lu) must be less than total connections (%lu).\n",
 		connection_number, total_connections);
 	    status = CMS_CONFIG_ERROR;
-	    free(bufline);
-	    free(procline);
 	    return;
 	}
     }
@@ -509,8 +498,6 @@ CMS::CMS(const char *bufline_in, const char *procline_in, int set_to_server)
 	rcs_print_error("CMS: Error in proc line from config file.\n");
 	rcs_print_error("%s\n", procline);
 	status = CMS_CONFIG_ERROR;
-	free(bufline);
-	free(procline);
 	return;
     }
 
@@ -607,8 +594,6 @@ CMS::CMS(const char *bufline_in, const char *procline_in, int set_to_server)
     if (enable_diagnostics) {
 	setup_diag_proc_info();
     }
-    free(bufline);
-    free(procline);
 }
 
 /* Function for allocating memory and initializing XDR streams, which */
@@ -652,20 +637,19 @@ void CMS::open(void)
     /* Save some memory and time if this is a PHANTOMMEM object. */
     if (!is_phantom) {
 	/* Allocate memory for the local copy of global buffer. */
-	data = malloc(size);
-	memset(data, 0, size);
-	subdiv_data = data;
-	if (force_raw) {
-	    encoded_data = data;
-	}
-	rcs_print_debug(PRINT_CMS_CONSTRUCTORS, "%p = data = calloc(%lu,1);\n",
-	    data, size);
+	data = calloc(size, 1);
 	/* Check to see if allocating memory was successful. */
 	if (data == NULL) {
 	    rcs_print_error("CMS: Can't allocate memory for local buffer.\n");
 	    status = CMS_CREATE_ERROR;
 	    return;
 	}
+	subdiv_data = data;
+	if (force_raw) {
+	    encoded_data = data;
+	}
+	rcs_print_debug(PRINT_CMS_CONSTRUCTORS, "%p = data = calloc(%lu,1);\n",
+	    data, size);
     }
     if (isserver || neutral || ((ProcessType == CMS_REMOTE_TYPE) && !force_raw)) {
 	switch (neutral_encoding_method) {

--- a/src/libnml/cms/cms_cfg.cc
+++ b/src/libnml/cms/cms_cfg.cc
@@ -122,9 +122,7 @@ int load_nml_config_file(const char *file)
     if (fp == NULL) {
 	rcs_print_error("cms_config: can't open '%s'. Error = %d -- %s\n",
 	    file, errno, strerror(errno));
-	if (NULL != info) {
-	    delete info;
-	}
+	delete info;
 	loading_config_file = 0;
 	return -1;
     }

--- a/src/libnml/cms/cms_srv.hh
+++ b/src/libnml/cms/cms_srv.hh
@@ -154,7 +154,10 @@ class CMS_SERVER {
     void run(int setup_CC_signal_handler = 1);
     int spawn();
     void kill_server();
-      CMS_SERVER();
+    CMS_SERVER();
+    // Don't copy or assign
+    CMS_SERVER(const CMS_SERVER&) = delete;
+    CMS_SERVER& operator=(const CMS_SERVER&) = delete;
     void add_local_port(CMS_SERVER_LOCAL_PORT *);
     void delete_all_local_ports();
     virtual void delete_from_list();

--- a/src/libnml/cms/cms_xup.cc
+++ b/src/libnml/cms/cms_xup.cc
@@ -19,6 +19,7 @@ extern "C" {
 #include <stdlib.h>		/* malloc(), free() */
 }
 
+#include <vector>
 #include "cms.hh"		/* class CMS */
 #include "cms_xup.hh"		/* class CMS_XDR_UPDATER */
 #include "rcs_print.hh"		/* rcs_print_error() */
@@ -656,23 +657,20 @@ CMS_STATUS CMS_XDR_UPDATER::update(long double *x, unsigned int len)
 	return (CMS_UPDATE_ERROR);
     }
 
-    unsigned int i;
-    double *y;
-    y = (double *) malloc(sizeof(double) * len);
-    for (i = 0; i < len; i++) {
-	y[i] = (double) x[i];
+    std::vector<double> y(len);
+    for(unsigned i = 0; i < len; i++) {
+        y[i] = (double) x[i];
     }
 
-    if (xdr_vector(current_stream, (char *) y, len, sizeof(double),
+    if (xdr_vector(current_stream, (char *)y.data(), len, sizeof(double),
 	    (xdrproc_t) xdr_double) != TRUE) {
 	rcs_print_error
 	    ("CMS_XDR_UPDATER: xdr_vector(... xdr_double) failed.\n");
 	return (status = CMS_UPDATE_ERROR);
     }
 
-    for (i = 0; i < len; i++) {
+    for(unsigned i = 0; i < len; i++) {
 	x[i] = (long double) y[i];
     }
-    free(y);
     return (status);
 }

--- a/src/libnml/cms/cmsdiag.cc
+++ b/src/libnml/cms/cmsdiag.cc
@@ -25,6 +25,7 @@
 #include "physmem.hh"           // PHYSMEM_HANDLE
 
 CMS_DIAGNOSTICS_INFO::CMS_DIAGNOSTICS_INFO()
+  : CMS_DIAG_HEADER()
 {
     last_writer_dpi = NULL;
     last_reader_dpi = NULL;

--- a/src/libnml/cms/tcp_srv.cc
+++ b/src/libnml/cms/tcp_srv.cc
@@ -1508,9 +1508,6 @@ void CMS_SERVER_REMOTE_TCP_PORT::add_subscription_client(int buffer_number,
     if (NULL == subscription_buffers) {
 	subscription_buffers = new LinkedList();
     }
-    if (NULL == subscription_buffers) {
-	rcs_print_error("Can`t create subscription_buffers list.\n");
-    }
 
     TCP_BUFFER_SUBSCRIPTION_INFO *buf_info =
 	(TCP_BUFFER_SUBSCRIPTION_INFO *) subscription_buffers->get_head();

--- a/src/libnml/cms/tcp_srv.hh
+++ b/src/libnml/cms/tcp_srv.hh
@@ -47,6 +47,9 @@ class CLIENT_TCP_PORT;
 class CMS_SERVER_REMOTE_TCP_PORT:public CMS_SERVER_REMOTE_PORT {
   public:
     CMS_SERVER_REMOTE_TCP_PORT(CMS_SERVER * _cms_server);
+    // Don't copy or assign
+    CMS_SERVER_REMOTE_TCP_PORT(const CMS_SERVER_REMOTE_TCP_PORT&) = delete;
+    CMS_SERVER_REMOTE_TCP_PORT& operator=(const CMS_SERVER_REMOTE_TCP_PORT&) = delete;
     virtual ~ CMS_SERVER_REMOTE_TCP_PORT();
     int accept_local_port_cms(CMS *);
     void run();

--- a/src/libnml/linklist/linklist.cc
+++ b/src/libnml/linklist/linklist.cc
@@ -234,6 +234,10 @@ int LinkedList::store_at_head(void *_data, size_t _size, int _copy)
 
     if (_copy) {
 	last_data_stored = malloc(_size);
+        if(!last_data_stored) {
+            perror("LinkedList::store_at_head()");
+            return -1;
+        }
 	memcpy(last_data_stored, _data, _size);
 	last_size_stored = _size;
 	new_head = new LinkedListNode(last_data_stored, _size);
@@ -316,6 +320,10 @@ int LinkedList::store_at_tail(void *_data, size_t _size, int _copy)
 
     if (_copy) {
 	last_data_stored = malloc(_size);
+        if(!last_data_stored) {
+            perror("LinkedList::store_at_tail()");
+            return -1;
+        }
 	memcpy(last_data_stored, _data, _size);
 	last_size_stored = _size;
 	new_tail = new LinkedListNode(last_data_stored, _size);
@@ -419,6 +427,10 @@ int LinkedList::store_after_current_node(void *_data, size_t _size,
 
     if (_copy) {
 	last_data_stored = malloc(_size);
+        if(!last_data_stored) {
+            perror("LinkedList::store_after_current_node()");
+            return -1;
+        }
 	memcpy(last_data_stored, _data, _size);
 	last_size_stored = _size;
 	new_node = new LinkedListNode(last_data_stored, _size);
@@ -539,6 +551,10 @@ int LinkedList::store_before_current_node(void *_data, size_t _size,
 
     if (_copy) {
 	last_data_stored = malloc(_size);
+        if(!last_data_stored) {
+            perror("LinkedList::store_before_current_node()");
+            return -1;
+        }
 	memcpy(last_data_stored, _data, _size);
 	last_size_stored = _size;
 	new_node = new LinkedListNode(last_data_stored, _size);

--- a/src/libnml/nml/nml.cc
+++ b/src/libnml/nml/nml.cc
@@ -187,7 +187,6 @@ NML::NML(NML_FORMAT_PTR f_ptr, const char *buf, const char *proc, const char *fi
     else {
 	rtapi_strlcpy(cfgfilename, file, 160);
     }
-    snprintf(cfgfilename, 160, "%s", file);
 
     if (rcs_errors_printed >= max_rcs_errors_to_print
 	&& max_rcs_errors_to_print > 0 && nml_reset_errors_printed) {
@@ -414,21 +413,19 @@ NML::NML(const char *buf, const char *proc, const char *file, const int set_to_s
     cms_status = (int *) &(cms->status);
     cms_inbuffer_header_size = &(cms->header.in_buffer_size);
 
-    if (NULL != cms) {
-	char *forced_type_eq = strstr(cms->buflineupper, "FORCE_TYPE=");
-	if (forced_type_eq != NULL) {
-	    long temp = 0;
-	    temp = strtol(forced_type_eq + 11, NULL, 0);
-	    if (temp > 0) {
-		forced_type = temp;
-		fast_mode = 0;
-	    }
-	}
-	char *brpi_eq = strstr(cms->buflineupper, "BRPI=");
-	if (brpi_eq != NULL) {
-	    blocking_read_poll_interval = strtod(brpi_eq + 5, NULL);
-	}
+    char *forced_type_eq = strstr(cms->buflineupper, "FORCE_TYPE=");
+    if (forced_type_eq != NULL) {
+        long temp = 0;
+        temp = strtol(forced_type_eq + 11, NULL, 0);
+        if (temp > 0) {
+	    forced_type = temp;
+        fast_mode = 0;
+        }
     }
+    char *brpi_eq = strstr(cms->buflineupper, "BRPI=");
+    if (brpi_eq != NULL) {
+        blocking_read_poll_interval = strtod(brpi_eq + 5, NULL);
+}
 
 }
 
@@ -522,23 +519,20 @@ NML::NML(const char * buffer_line, const char * proc_line)
     }
     cms_status = (int *) &(cms->status);
     cms_inbuffer_header_size = &(cms->header.in_buffer_size);
-    if (NULL != cms) {
-	char *forced_type_eq = strstr(cms->buflineupper, "FORCE_TYPE=");
-	if (forced_type_eq != NULL) {
-	    long temp = 0;
-	    temp = strtol(forced_type_eq + 11, NULL, 0);
-	    if (temp > 0) {
-		forced_type = temp;
-		fast_mode = 0;
-	    }
-	}
-	char *brpi_eq = strstr(cms->buflineupper, "BRPI=");
-	if (brpi_eq != NULL) {
-	    blocking_read_poll_interval = strtod(brpi_eq + 5, NULL);
-	}
-	register_with_server();
+    char *forced_type_eq = strstr(cms->buflineupper, "FORCE_TYPE=");
+    if (forced_type_eq != NULL) {
+        long temp = 0;
+        temp = strtol(forced_type_eq + 11, NULL, 0);
+        if (temp > 0) {
+            forced_type = temp;
+            fast_mode = 0;
+        }
     }
-
+    char *brpi_eq = strstr(cms->buflineupper, "BRPI=");
+    if (brpi_eq != NULL) {
+        blocking_read_poll_interval = strtod(brpi_eq + 5, NULL);
+    }
+    register_with_server();
 }
 
 /***************************************************************
@@ -637,7 +631,7 @@ NML::NML(NML * nml_ptr, const int set_to_server, const int set_to_master)
     }
     if (!ignore_format_chain) {
 	format_chain = new LinkedList;
-	if ((NULL != nml_ptr->format_chain) && (NULL != format_chain)) {
+	if (NULL != nml_ptr && NULL != nml_ptr->format_chain) {
 	    LinkedList *from, *to;
 	    NML_FORMAT_PTR format_func_ptr;
 	    from = nml_ptr->format_chain;

--- a/src/libnml/nml/nml_srv.cc
+++ b/src/libnml/nml/nml_srv.cc
@@ -58,20 +58,19 @@ NML_SERVER::NML_SERVER(NML * _nml, int _set_to_master):CMS_SERVER()
 		    if (NULL != new_nml) {
 			new_local_port = new NML_SERVER_LOCAL_PORT(new_nml);
 			add_local_port(new_local_port);
+		        new_local_port->local_channel_reused = 1;
 		    }
-		    new_local_port->local_channel_reused = 1;
 		} else {
 		    new_nml = new NML(_nml, 1, -1);
 		    if (NULL != new_nml) {
 			new_local_port = new NML_SERVER_LOCAL_PORT(new_nml);
 			add_local_port(new_local_port);
+		        new_local_port->local_channel_reused = 0;
 		    }
-		    new_local_port->local_channel_reused = 0;
 		}
 	    } else {
 		rcs_print_error
 		    ("NML_SERVER:(ERROR) ProcessType was REMOTE.\n");
-		_nml = NULL;
 	    }
 	} else {
 	    rcs_print_error("NML_SERVER:(ERROR) cms was NULL.\n");

--- a/src/libnml/nml/nml_srv.hh
+++ b/src/libnml/nml/nml_srv.hh
@@ -68,6 +68,9 @@ class NML_SUPER_SERVER {
   public:
     LinkedList * servers;
     NML_SUPER_SERVER();
+    // Don't copy or assign
+    NML_SUPER_SERVER(const NML_SUPER_SERVER&) = delete;
+    NML_SUPER_SERVER& operator=(const NML_SUPER_SERVER&) = delete;
     ~NML_SUPER_SERVER();
     void add_to_list(NML *);
     void add_to_list(NML_SERVER *);

--- a/src/libnml/os_intf/_sem.c
+++ b/src/libnml/os_intf/_sem.c
@@ -128,6 +128,10 @@ rcs_sem_t *rcs_sem_open(key_t name, int oflag, /* int mode */ ...)
        so we need to allocate space that users will free later with
        rcs_sem_close */
     retval = (rcs_sem_t *) malloc(sizeof(rcs_sem_t));
+    if(!retval) {
+        rcs_print_error("rcs_sem_open: %s\n", strerror(errno));
+        return NULL;
+    }
     *retval = semid;
     return retval;
 }

--- a/src/libnml/os_intf/inetnull.cc
+++ b/src/libnml/os_intf/inetnull.cc
@@ -39,9 +39,7 @@ INET_FILE *inet_file_open(const char *url, char *type)
 	return NULL;
     }
     inet_file = new INET_FILE;
-    if (NULL != inet_file) {
-	inet_file->fp = fp;
-    }
+    inet_file->fp = fp;
     return inet_file;
 }
 


### PR DESCRIPTION
Cppcheck has indicated another set of errors and warnings. Many are actual or potential bugs:
* not checking malloc, strdup or fopen return value
* checking return value after use of value
* missing initialization
* addressing array out of bounds
* potential negative array index
* dereferencing pointers to functions
* use after free
* classes without copy-constructor and assignment operator overload with dynamic content
* returning std::string instead of const std::string&
* superfluous NULL checks

All these instances have been fixed in this PR.