### PR TITLE
QtVcp calculator and operator value line improvements

### DIFF
--- a/docs/src/gui/qtvcp-widgets.adoc
+++ b/docs/src/gui/qtvcp-widgets.adoc
@@ -2738,7 +2738,7 @@ It is based on PyQt's _QDialog_.
 .QtVCP `CalculatorDialog`: Calculator Dialog Widget
 image::images/qtvcp_calculator.png["QtVCP CalculatorDialog: Calculator Dialog Widget",scale="25%"]
 
-This is a dialog to *display a calculator for numeric entry*, such as origin offset.
+This is a dialog to *display a calculator for numeric entry*, such as origin offset, spindle RPM, etc.
 
 It returns the entry via `STATUS` messages using a Python `DICT`.
 
@@ -2748,12 +2748,15 @@ When using ``STATUS``'s `request-dialog` function, the default launch name is *`
 
 It is based on PyQt's _QDialog_.
 
-==== INI file options for CALCULATOR
+==== Preferences file options
 
-In the `DISPLAY` section of the INI file the following options may be set:
+In the `CALCULATOR` section of the preferences file the following options may be set:
 
-* `CALCULATOR_CONST_VALUES` - a comma-delimited list of common values you might enter, that will appear on a dedicated row of buttons at the bottom of the calculator.  e.g. setting to `0.100,-0.100` would provide two buttons for +0.100 and -0.100 which are commonly used when edge-finding on inch mills.  Up to six (6) values may be entered, beyond that the list will be truncated.  Values must be valid floating point or integer.
-* `CALCULATOR_ON_SHOW` - optionally set to `CLEAR_ALL` to issue a "Clear All" each time the calculator is shown.  This will clear any previously entered values from the last time the calculator was used and open with the display value set to `0`
+* `constValuesList` - A comma-delimited list of common values you might enter, that will appear on a dedicated row of buttons at the bottom of the calculator.  e.g. setting to `0.100, -0.100` would provide two buttons for +0.100 and -0.100 which are commonly used when edge-finding on inch mills.  Up to six (6) values may be entered, beyond that the list will be truncated.  Values must be valid floating point or integer.
+* `onShowBehavior` - A list of optional behaviors that will be triggered when the calculator dialog is shown.  Each option must be separated by a comma.
+  - `CLEAR_ALL` to issue a *Clear All* each time the calculator is shown.  This will clear any previously entered values from the last time the calculator was used and open with the display value set to `0`
+  - `FORCE_FOCUS` will force the focus to the calculator input field when the widget is shown.  This will allow a physical keyboard to provide input to the widget properly without additional clicks.  Also, it has the side-effect of selecting the current value, such that typing from a physical keyboard will replace the existing value unless the text selection is changed.
+* `acceptOnReturnKey` - If set to `True`, the calculator will accept the current value and close the dialog when the return key is pressed.  If set to `False`, the return key will be ignored and the *Apply* button must be clicked.
 
 [[sub:qtvcp:widgets:runfromlinedialog]]
 === `RunFromLine` - Run-From-Line Dialog Widget

--- a/lib/python/qtvcp/widgets/operator_value_line.py
+++ b/lib/python/qtvcp/widgets/operator_value_line.py
@@ -56,27 +56,6 @@ class OperatorValue(QLineEdit):
         STATUS.connect('all-homed', lambda w: self.setEnabled(STATUS.machine_is_on()))
         STATUS.connect('general',self.return_value)
 
-    def getSpeedText(self):
-        text = str(self.text()).strip()
-        return text
-
-
-    def keyPressEvent(self, event):
-        super(OperatorValue, self).keyPressEvent(event)
-        if event.key() == Qt.Key_Up:
-            self.increase()
-        if event.key() == Qt.Key_Down:
-            self.decrease()
-
-    def increase(self):
-        LOG.debug('increase')
-        STATUS.emit('spindle-increase')
-
-    def decrease(self):
-        LOG.debug('decrease')
-        STATUS.emit('spindle-decrease')
-
-
 class OperatorValueLine(OperatorValue):
     def __init__(self, parent=None):
         super(OperatorValueLine, self).__init__(parent)
@@ -85,6 +64,7 @@ class OperatorValueLine(OperatorValue):
         self.soft_keyboard = False
         self.dialog_keyboard = False
         self.issue_mdi_on_submit = False
+        self.issue_mdi_on_return = False
         self.mdi_command_format = "M3 S{value}"
         self.pending_value = False
         self._input_panel_full = SoftInputWidget(self, 'default')
@@ -92,18 +72,13 @@ class OperatorValueLine(OperatorValue):
 
         self.returnPressed.connect(self.handleReturnKey)
 
-
     def handleReturnKey(self):
         self.setFocus()
         self.setCursorPosition(len(self.text())+1)
-        if self.issue_mdi_on_submit:
+        if self.issue_mdi_on_return:
             self.pending_value = False
             self._style_polish('isPendingValue', self.pending_value)
             self.submit(self.mdi_command_format)
-        else:
-            self.pending_value = True
-            self._style_polish('isPendingValue', self.pending_value)
-
 
     def submit(self, mdi_format):
         value = str(self.text()).strip()
@@ -173,6 +148,15 @@ class OperatorValueLine(OperatorValue):
         self.issue_mdi_on_submit = False
 
     issue_mdi_on_submit_option = pyqtProperty(bool, get_issue_mdi_on_submit, set_issue_mdi_on_submit, reset_issue_mdi_on_submit)
+
+    def set_issue_mdi_on_return(self, data):
+            self.issue_mdi_on_return = data
+    def get_issue_mdi_on_return(self):
+        return self.issue_mdi_on_return
+    def reset_issue_mdi_on_return(self):
+        self.issue_mdi_on_return = False
+
+    issue_mdi_on_return_option = pyqtProperty(bool, get_issue_mdi_on_return, set_issue_mdi_on_return, reset_issue_mdi_on_return)
 
     def set_mdi_command_format(self, data):
         self.mdi_command_format = data


### PR DESCRIPTION
Per a request from @snowgoer540 :
https://github.com/LinuxCNC/linuxcnc/commit/f16d729d4778d4b37c703a707f856152166513f6#commitcomment-153113741

The new calculator options that I added in a previous PR have been moved from the INI file into the Preferences.

This PR also adds a couple new options like the ability to force focus and accept-on-return-key to the calculator.  This makes it work much better with a physical keypad.

Also a couple fixes to my OperatorValueLine widget along the same lines to improve behavior with a physical return key.

Changes documented in the .adoc
