### PR TITLE
Add missing tooldata header to install includes

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -391,6 +391,7 @@ SRCHEADERS := \
     emc/rs274ngc/modal_state.hh \
     emc/rs274ngc/rs274ngc.hh \
     emc/rs274ngc/saicanon.hh \
+    emc/tooldata/tooldata.hh \
     hal/hal.h \
     hal/hal_parport.h \
     hal/drivers/mesa-hostmot2/hostmot2-serial.h \

--- a/src/emc/tooldata/Submakefile
+++ b/src/emc/tooldata/Submakefile
@@ -30,6 +30,9 @@ $(call TOOBJSDEPS, $(LIBTOOLDATA_SRCS)) : EXTRAFLAGS=-fPIC
 	@rm -f $@
 	@$(CXX) $(CXXFLAGS) $(LDFLAGS) -Wl,-soname,$(notdir $@) -shared -o $@ $^ $(LIBDL)
 
+$(patsubst ./emc/tooldata/%,../include/%,$(wildcard ./emc/tooldata/*.hh)): ../include/%.hh: ./emc/tooldata/%.hh
+	cp $^ $@
+
 ifdef TOOL_NML_FLAG
 else
 TOOL_MMAP_READ_SRCS = emc/tooldata/tool_mmap_read.cc


### PR DESCRIPTION
The build process generates the library `libtooldata.so`, but the header is not included in the install. This is an issue for external programs that want to link against libtooldata, as they will have to manually download the correct header.