### PR TITLE
Add semicolon to make cppcheck happy

### DIFF
--- a/src/hal/components/lcd.c
+++ b/src/hal/components/lcd.c
@@ -75,7 +75,7 @@ static int parse_fmt(char *in, int *ptr, char *out, void *val, char dp);
 char *digits = "0123456789ABCDEF";
 
 char *fmt_strings[MAX_CHAN];
-RTAPI_MP_ARRAY_STRING(fmt_strings, MAX_CHAN, "screen formatting scancodes")
+RTAPI_MP_ARRAY_STRING(fmt_strings, MAX_CHAN, "screen formatting scancodes");
 
 #ifndef do_div
 # define do_div(n,base) ({					 \

--- a/src/hal/components/matrix_kb.c
+++ b/src/hal/components/matrix_kb.c
@@ -64,9 +64,9 @@ static int comp_id;
 static kb_t *kb;
 
 char *config[MAX_CHAN];
-RTAPI_MP_ARRAY_STRING(config, MAX_CHAN, "screen formatting scancodes")
+RTAPI_MP_ARRAY_STRING(config, MAX_CHAN, "screen formatting scancodes");
 char *names[MAX_CHAN];
-RTAPI_MP_ARRAY_STRING(names, MAX_CHAN, "component names")
+RTAPI_MP_ARRAY_STRING(names, MAX_CHAN, "component names");
 
 void keyup(kb_inst_t *inst){
     unsigned r, c;

--- a/src/hal/drivers/hal_gpio.c
+++ b/src/hal/drivers/hal_gpio.c
@@ -54,23 +54,23 @@ static unsigned long ns2tsc_factor;
 #define MAX_CHAN 128
 
 char *inputs[MAX_CHAN];
-RTAPI_MP_ARRAY_STRING(inputs, MAX_CHAN, "list of pins to use for input")
+RTAPI_MP_ARRAY_STRING(inputs, MAX_CHAN, "list of pins to use for input");
 char *outputs[MAX_CHAN];
-RTAPI_MP_ARRAY_STRING(outputs, MAX_CHAN, "list of pins to use for output")
+RTAPI_MP_ARRAY_STRING(outputs, MAX_CHAN, "list of pins to use for output");
 char *invert[MAX_CHAN];
-RTAPI_MP_ARRAY_STRING(invert, MAX_CHAN, "set as inverted")
+RTAPI_MP_ARRAY_STRING(invert, MAX_CHAN, "set as inverted");
 char *reset[MAX_CHAN];
-RTAPI_MP_ARRAY_STRING(reset, MAX_CHAN, "add to reset list")
+RTAPI_MP_ARRAY_STRING(reset, MAX_CHAN, "add to reset list");
 char *opendrain[MAX_CHAN];
-RTAPI_MP_ARRAY_STRING(opendrain, MAX_CHAN, "set OPEN_DRAIN flag")
+RTAPI_MP_ARRAY_STRING(opendrain, MAX_CHAN, "set OPEN_DRAIN flag");
 char *opensource[MAX_CHAN];
-RTAPI_MP_ARRAY_STRING(opensource, MAX_CHAN, "set OPEN_SOURCE flag")
+RTAPI_MP_ARRAY_STRING(opensource, MAX_CHAN, "set OPEN_SOURCE flag");
 char *biasdisable[MAX_CHAN];
-RTAPI_MP_ARRAY_STRING(biasdisable, MAX_CHAN, "set BIAS_DISABLE flag")
+RTAPI_MP_ARRAY_STRING(biasdisable, MAX_CHAN, "set BIAS_DISABLE flag");
 char *pulldown[MAX_CHAN];
-RTAPI_MP_ARRAY_STRING(pulldown, MAX_CHAN, "set BIAS_PULL_DOWN flag")
+RTAPI_MP_ARRAY_STRING(pulldown, MAX_CHAN, "set BIAS_PULL_DOWN flag");
 char *pullup[MAX_CHAN];
-RTAPI_MP_ARRAY_STRING(pullup, MAX_CHAN, "set BIAS_PULL_UP flag")
+RTAPI_MP_ARRAY_STRING(pullup, MAX_CHAN, "set BIAS_PULL_UP flag");
 
 /***********************************************************************
 *                STRUCTURES AND GLOBAL VARIABLES                       *

--- a/src/hal/drivers/mesa-hostmot2/hm2_eth.c
+++ b/src/hal/drivers/mesa-hostmot2/hm2_eth.c
@@ -90,7 +90,7 @@ static char *board_ip[MAX_ETH_BOARDS];
 RTAPI_MP_ARRAY_STRING(board_ip, MAX_ETH_BOARDS, "ip address of ethernet board(s)");
 
 static char *config[MAX_ETH_BOARDS];
-RTAPI_MP_ARRAY_STRING(config, MAX_ETH_BOARDS, "config string for the AnyIO boards (see hostmot2(9) manpage)")
+RTAPI_MP_ARRAY_STRING(config, MAX_ETH_BOARDS, "config string for the AnyIO boards (see hostmot2(9) manpage)");
 
 int debug = 0;
 RTAPI_MP_INT(debug, "Developer/debug use only!  Enable debug logging.");

--- a/src/hal/drivers/mesa-hostmot2/hm2_rpspi.c
+++ b/src/hal/drivers/mesa-hostmot2/hm2_rpspi.c
@@ -118,7 +118,7 @@ static int comp_id;				// Upstream assigned component ID
  * Configuration parameters
  */
 static char *config[RPSPI_MAX_BOARDS];
-RTAPI_MP_ARRAY_STRING(config, RPSPI_MAX_BOARDS, "config string for the AnyIO boards (see hostmot2(9) manpage)")
+RTAPI_MP_ARRAY_STRING(config, RPSPI_MAX_BOARDS, "config string for the AnyIO boards (see hostmot2(9) manpage)");
 
 /*
  * RPI3 NOTE:
@@ -160,8 +160,8 @@ RTAPI_MP_ARRAY_STRING(config, RPSPI_MAX_BOARDS, "config string for the AnyIO boa
  */
 static int spiclk_rate = 31250;
 static int spiclk_rate_rd = -1;
-RTAPI_MP_INT(spiclk_rate, "SPI clock rate in kHz (default 31250 kHz, slowest 3 kHz)")
-RTAPI_MP_INT(spiclk_rate_rd, "SPI clock rate for reading in kHz (default same as spiclk_rate)")
+RTAPI_MP_INT(spiclk_rate, "SPI clock rate in kHz (default 31250 kHz, slowest 3 kHz)");
+RTAPI_MP_INT(spiclk_rate_rd, "SPI clock rate for reading in kHz (default same as spiclk_rate)");
 
 /*
  * Override the "safe" base frequency of the SPI peripheral. The clock speed
@@ -171,7 +171,7 @@ RTAPI_MP_INT(spiclk_rate_rd, "SPI clock rate for reading in kHz (default same as
  */
 #define F_PERI	400000000UL
 static int spiclk_base = F_PERI;
-RTAPI_MP_INT(spiclk_base, "SPI clock base rate in Hz (default 400000000 Hz)")
+RTAPI_MP_INT(spiclk_base, "SPI clock base rate in Hz (default 400000000 Hz)");
 
 /*
  * Enable/disable pullup/pulldown on the SPI pins
@@ -182,9 +182,9 @@ RTAPI_MP_INT(spiclk_base, "SPI clock base rate in Hz (default 400000000 Hz)")
 static int spi_pull_miso = SPI_PULL_DOWN;
 static int spi_pull_mosi = SPI_PULL_DOWN;
 static int spi_pull_sclk = SPI_PULL_DOWN;
-RTAPI_MP_INT(spi_pull_miso, "Enable/disable pull-{up,down} on SPI MISO (default pulldown, 0=off, 1=pulldown, 2=pullup)")
-RTAPI_MP_INT(spi_pull_mosi, "Enable/disable pull-{up,down} on SPI MOSI (default pulldown, 0=off, 1=pulldown, 2=pullup)")
-RTAPI_MP_INT(spi_pull_sclk, "Enable/disable pull-{up,down} on SPI SCLK (default pulldown, 0=off, 1=pulldown, 2=pullup)")
+RTAPI_MP_INT(spi_pull_miso, "Enable/disable pull-{up,down} on SPI MISO (default pulldown, 0=off, 1=pulldown, 2=pullup)");
+RTAPI_MP_INT(spi_pull_mosi, "Enable/disable pull-{up,down} on SPI MOSI (default pulldown, 0=off, 1=pulldown, 2=pullup)");
+RTAPI_MP_INT(spi_pull_sclk, "Enable/disable pull-{up,down} on SPI SCLK (default pulldown, 0=off, 1=pulldown, 2=pullup)");
 
 /*
  * Select which SPI channel(s) to probe. There are two SPI interfaces exposed
@@ -213,7 +213,7 @@ RTAPI_MP_INT(spi_pull_sclk, "Enable/disable pull-{up,down} on SPI SCLK (default 
 #define SPI1_PROBE_CE2	(1 << 4)
 #define SPI1_PROBE_MASK	(SPI1_PROBE_CE0 | SPI1_PROBE_CE1 | SPI1_PROBE_CE2)
 static int spi_probe = SPI0_PROBE_CE0;
-RTAPI_MP_INT(spi_probe, "Bit-field to select which SPI/CE combinations to probe (default 1 (SPI0/CE0))")
+RTAPI_MP_INT(spi_probe, "Bit-field to select which SPI/CE combinations to probe (default 1 (SPI0/CE0))");
 
 /*
  * Set the message level for debugging purpose. This has the (side-)effect that
@@ -222,7 +222,7 @@ RTAPI_MP_INT(spi_probe, "Bit-field to select which SPI/CE combinations to probe 
  * The upstream message level is not touched if spi_debug == -1.
  */
 static int spi_debug = -1;
-RTAPI_MP_INT(spi_debug, "Set message level for debugging purpose [0...5] where 0=none and 5=all (default: -1; upstream defined)")
+RTAPI_MP_INT(spi_debug, "Set message level for debugging purpose [0...5] where 0=none and 5=all (default: -1; upstream defined)");
 
 /*********************************************************************/
 #if defined(RPSPI_DEBUG_PIN)

--- a/src/hal/drivers/mesa-hostmot2/hm2_spi.c
+++ b/src/hal/drivers/mesa-hostmot2/hm2_spi.c
@@ -57,7 +57,7 @@ static char *spidev_path[MAX_BOARDS] = { "/dev/spidev1.0" };
 RTAPI_MP_ARRAY_STRING(spidev_path, MAX_BOARDS, "path to spi device");
 
 static char *config[MAX_BOARDS];
-RTAPI_MP_ARRAY_STRING(config, MAX_BOARDS, "config string for the AnyIO boards (see hostmot2(9) manpage)")
+RTAPI_MP_ARRAY_STRING(config, MAX_BOARDS, "config string for the AnyIO boards (see hostmot2(9) manpage)");
 
 typedef struct {
     hm2_lowlevel_io_t llio;

--- a/src/hal/drivers/mesa-hostmot2/hm2_spix.c
+++ b/src/hal/drivers/mesa-hostmot2/hm2_spix.c
@@ -105,27 +105,27 @@ static const uint32_t iocookie[3] = {
  * Configuration parameters forwarded to hostmot2 hm2_register() call
  */
 static char *config[SPIX_MAX_BOARDS];
-RTAPI_MP_ARRAY_STRING(config, SPIX_MAX_BOARDS, "config string for the AnyIO boards (see hostmot2(9) manpage)")
+RTAPI_MP_ARRAY_STRING(config, SPIX_MAX_BOARDS, "config string for the AnyIO boards (see hostmot2(9) manpage)");
 
 /*
  * SPI clock rates for read and write.
  */
 static int spiclk_rate[SPIX_MAX_BOARDS] = { 25000 };
 static int spiclk_rate_rd[SPIX_MAX_BOARDS];
-RTAPI_MP_ARRAY_INT(spiclk_rate, SPIX_MAX_BOARDS, "SPI clock rates in kHz (default 25000 kHz)")
-RTAPI_MP_ARRAY_INT(spiclk_rate_rd, SPIX_MAX_BOARDS, "SPI clock rates for reading in kHz (default same as spiclk_rate)")
+RTAPI_MP_ARRAY_INT(spiclk_rate, SPIX_MAX_BOARDS, "SPI clock rates in kHz (default 25000 kHz)");
+RTAPI_MP_ARRAY_INT(spiclk_rate_rd, SPIX_MAX_BOARDS, "SPI clock rates for reading in kHz (default same as spiclk_rate)");
 
 /*
  * Forcefully specify the hardware driver
  */
 static const char *force_driver = NULL;
-RTAPI_MP_STRING(force_driver, "Force one specific hardware driver (default empty, auto detecting hardware))")
+RTAPI_MP_STRING(force_driver, "Force one specific hardware driver (default empty, auto detecting hardware))");
 
 /*
  * Which SPI port(s) to probe
  */
 static int spi_probe = SPIX_PROBE_SPI0_CE0;
-RTAPI_MP_INT(spi_probe, "Bit-field to select which SPI/CE combinations to probe (default 1 (SPI0/CE0))")
+RTAPI_MP_INT(spi_probe, "Bit-field to select which SPI/CE combinations to probe (default 1 (SPI0/CE0))");
 
 /*
  * Normally, all requests are queued if requested by upstream and sent in one
@@ -133,7 +133,7 @@ RTAPI_MP_INT(spi_probe, "Bit-field to select which SPI/CE combinations to probe 
  * each transfer visible and more easily debugable.
  */
 static int spi_noqueue = 0;
-RTAPI_MP_INT(spi_noqueue, "Disable queued SPI requests, use for debugging only (default 0 (off))")
+RTAPI_MP_INT(spi_noqueue, "Disable queued SPI requests, use for debugging only (default 0 (off))");
 
 /*
  * Set the message level for debugging purpose. This has the (side-)effect that
@@ -142,13 +142,13 @@ RTAPI_MP_INT(spi_noqueue, "Disable queued SPI requests, use for debugging only (
  * The upstream message level is not touched if spi_debug == -1.
  */
 static int spi_debug = -1;
-RTAPI_MP_INT(spi_debug, "Set message level for debugging purpose [0...5] where 0=none and 5=all (default: -1; upstream defined)")
+RTAPI_MP_INT(spi_debug, "Set message level for debugging purpose [0...5] where 0=none and 5=all (default: -1; upstream defined)");
 
 /*
  * Spidev driver device node path overrides
  */
 static char *spidev_path[SPIX_MAX_BOARDS];
-RTAPI_MP_ARRAY_STRING(spidev_path, SPIX_MAX_BOARDS, "The device node path override(s) for the spidev driver (default /dev/spidev{0.[01],1.[012]})")
+RTAPI_MP_ARRAY_STRING(spidev_path, SPIX_MAX_BOARDS, "The device node path override(s) for the spidev driver (default /dev/spidev{0.[01],1.[012]})");
 
 /*
  * We have these for compatibility with the hm2_rpspi driver. You can simply
@@ -158,9 +158,9 @@ RTAPI_MP_ARRAY_STRING(spidev_path, SPIX_MAX_BOARDS, "The device node path overri
 static int spi_pull_miso = -1;
 static int spi_pull_mosi = -1;
 static int spi_pull_sclk = -1;
-RTAPI_MP_INT(spi_pull_miso, "Obsolete parameter")
-RTAPI_MP_INT(spi_pull_mosi, "Obsolete parameter")
-RTAPI_MP_INT(spi_pull_sclk, "Obsolete parameter")
+RTAPI_MP_INT(spi_pull_miso, "Obsolete parameter");
+RTAPI_MP_INT(spi_pull_mosi, "Obsolete parameter");
+RTAPI_MP_INT(spi_pull_sclk, "Obsolete parameter");
 
 /*********************************************************************/
 /*

--- a/src/hal/utils/scope_rt.c
+++ b/src/hal/utils/scope_rt.c
@@ -46,7 +46,7 @@ MODULE_LICENSE("GPL");
 
 long num_samples = 16000;
 long shm_size;
-RTAPI_MP_LONG(num_samples, "Number of samples in the shared memory block")
+RTAPI_MP_LONG(num_samples, "Number of samples in the shared memory block");
 
 /***********************************************************************
 *                         GLOBAL VARIABLES                             *


### PR DESCRIPTION
The option macros RTAPI_MP_*() for RT components/modules need a semicolon to terminate the statement to make cppcheck happy.

These macros, without semicolon, will generate an "unknown macro" error. It only happens when ULAPI is defined because that is true, these are not defined in that case. In practice, having ULAPI defined in RT components is not possible, but cppcheck does not know that.

Luckily it doesn't matter, code-wise, whether or not a semicolon is there. So this PR just makes cppcheck happy and prevents the unknown macro errors by adding the semicolon.