### PR TITLE
Fix building man-pages

### DIFF
--- a/docs/src/man/man9/hm2_rpspi.9.adoc
+++ b/docs/src/man/man9/hm2_rpspi.9.adoc
@@ -1,13 +1,11 @@
 = hm2_rpspi(9)
 
-== NOTE
-
-This driver has been superseded for most purposes by the hm2_spix driver.
-
 == NAME
 
-hm2_rpspi - LinuxCNC HAL driver for the Mesa Electronics SPI Anything IO
-boards, with HostMot2 firmware.
+hm2_rpspi - This driver has been superseded by the hm2_spix driver. LinuxCNC
+HAL driver for the Mesa Electronics SPI Anything IO boards, with HostMot2
+firmware.
+
 
 == SYNOPSIS
 
@@ -149,9 +147,14 @@ echo -n performance > /sys/devices/system/cpu/cpufreq/policy0/scaling_governor
 
 Be sure to have a proper heatsink mounted on the SoC or it will get too warm and crashes.
 
+== NOTE
+
+This driver has been superseded for most purposes by the hm2_spix driver.
+
 == SEE ALSO
 
 hostmot2(9)
+hm2_spix(9)
 
 == LICENSE
 

--- a/docs/src/man/man9/hm2_spi.9.adoc
+++ b/docs/src/man/man9/hm2_spi.9.adoc
@@ -1,13 +1,9 @@
 = hm2_spi(9)
 
-== NOTE
-
-This driver has been superseded for most purposes by the hm2_spix driver.
-
 == NAME
 
-hm2_spi - LinuxCNC HAL driver for the Mesa Electronics SPI Anything IO
-boards, with HostMot2 firmware.
+hm2_spi - This driver has been superseded by the hm2_spix driver. LinuxCNC HAL
+driver for the Mesa Electronics SPI Anything IO boards, with HostMot2 firmware.
 
 == SYNOPSIS
 
@@ -56,9 +52,14 @@ https://github.com/jepler/odroid-linux/tree/odroid-3.8.13-rt[on github].
 The maximum SPI clock of the 7i90 is documented as 50MHz. Other elements
 of the data path between HAL and the 7i90 may impose other limitations.
 
+== NOTE
+
+This driver has been superseded for most purposes by the hm2_spix driver.
+
 == SEE ALSO
 
 hostmot2(9)
+hm2_spix(9)
 
 == LICENSE
 


### PR DESCRIPTION
A recent addition of a note to the old RPi spi drivers made the build fail. The layout of adoc/man-page is very strict. The note is now moved to the bottom and the the message is repeated at the start of the document in the 'name' line.