### PR TITLE
Remove duplicate members in libnml

### DIFF
--- a/src/libnml/buffer/shmem.cc
+++ b/src/libnml/buffer/shmem.cc
@@ -56,7 +56,6 @@ static inline bool not_zero(double x)
 /* Constructor for hard coded tests. */
 SHMEM::SHMEM(const char * /*n*/, long s, int /*nt*/, key_t k, int m)
   : CMS(s),
-    fast_mode(0),
     key(k),
     bsem_key(-1),
     second_read(0),
@@ -79,7 +78,6 @@ SHMEM::SHMEM(const char * /*n*/, long s, int /*nt*/, key_t k, int m)
 /* Constructor for use with cms_config. */
 SHMEM::SHMEM(const char *bufline, const char *procline, int set_to_server, int set_to_master)
   : CMS(bufline, procline, set_to_server),
-    fast_mode(0),
     bsem_key(-1),
     second_read(0),
     shm(NULL),

--- a/src/libnml/buffer/shmem.hh
+++ b/src/libnml/buffer/shmem.hh
@@ -46,7 +46,6 @@ class SHMEM:public CMS {
   private:
 
     /* data buffer stuff */
-    int fast_mode;
     int open();			/* get shared mem and sem */
     int close();		/* detach from shared mem and sem */
     key_t key;			/* key for shared mem and sem */

--- a/src/libnml/cms/cms_dup.hh
+++ b/src/libnml/cms/cms_dup.hh
@@ -56,7 +56,6 @@ class CMS_DISPLAY_ASCII_UPDATER:public CMS_UPDATER {
     char *end_current_string;
     long max_length_current_string;
     long length_current_string;
-    int encoding;
     int warning_count;
     int warning_count_max;
     int updating_string;


### PR DESCRIPTION
There were two instances of duplicate member variables in libnml that should be using the base-class' member. The solution was addressed in #3365 and the conclusion was that they should be removed from the sub-class. This PR does so.

This PR covers the final cppcheck warnings and errors. Yay :-)