### PR TITLE
Account for differences between cppcheck versions

### DIFF
--- a/scripts/cppcheck.sh
+++ b/scripts/cppcheck.sh
@@ -34,30 +34,41 @@ cd "$(dirname "$0")/../src" || { echo "Could not change directory to '$(dirname 
 
 # Only process individual files if passed on the command line.
 if [ $# -gt 0 ]; then
+    retval=0
     for f in "$@"; do
         if [ -r "$f" ]; then
             case "$f" in
             *.hh|*.cc)
-                cppcheck -I"$(dirname "$f")" "${CPPCHKCX[@]}" "$f"
+                cppcheck -I"$(dirname "$f")" "${CPPCHKCX[@]}" "$f" || retval=1
                 ;;
             *.h|*.c)
-                cppcheck -I"$(dirname "$f")" "${CPPCHKCC[@]}" "$f"
+                cppcheck -I"$(dirname "$f")" "${CPPCHKCC[@]}" "$f" || retval=1
                 ;;
             esac
         else
             echo "Cannot read file '$f'"
+            retval=1
         fi
     done
-    exit 0
+    exit $retval
 fi
 
 docheck() {
-    mapfile -t files < <(find "$1" -maxdepth 1 \( -name "*.c" -o -name "*.h" \) )
-    [ "${#files[@]}" -gt 0 ] && cppcheck -I"$1" "${CPPCHKCC[@]}" "${files[@]}"
-
-    mapfile -t files < <(find "$1" -maxdepth 1 \( -name "*.cc" -o -name "*.hh" \) )
-    [ "${#files[@]}" -gt 0 ] && cppcheck -I"$1" "${CPPCHKCX[@]}" "${files[@]}"
+    local rv
+    rv=0
+    mapfile -t files < <(find "$1" -maxdepth 1 -name "*.c")
+    if [ "${#files[@]}" -gt 0 ]; then
+        cppcheck -I"$1" "${CPPCHKCC[@]}" "${files[@]}" || rv=1
+    fi
+    mapfile -t files < <(find "$1" -maxdepth 1 -name "*.cc")
+    if [ "${#files[@]}" -gt 0 ]; then
+        cppcheck -I"$1" "${CPPCHKCX[@]}" "${files[@]}" || rv=1
+    fi
+    return $rv
 }
+
+# Collected returns; will be zero if all succeed
+result=0
 
 # *** HAL files ***
 echo "I (1/4): checking HAL folders with both C and C++ code"
@@ -67,7 +78,7 @@ do
     case "$d" in hal/user_comps/mb2hal/examples*) continue;; esac
 
     echo "I (1/4): checking $d"
-    docheck "$d"
+    docheck "$d" || result=1
 done < <(find hal/ -type d -not -name "*__pycache__" -print0)
 
 # *** EMC files ***
@@ -78,7 +89,7 @@ do
     case "$d" in emc/usr_intf/axis/extensions*) continue;; esac
 
     echo "I (2/4): checking $d"
-    docheck "$d"
+    docheck "$d" || result=1
 done < <(find emc/ -type d -not -name "*__pycache__" -print0)
 
 # *** NML files ***
@@ -86,7 +97,7 @@ echo "I (3/4): checking LIBNML folders with both C and C++ code"
 while IFS= read -r -d '' d
 do
     echo "I (3/4): checking $d"
-    docheck "$d"
+    docheck "$d" || result=1
 done < <(find libnml/ -type d -not -name "*__pycache__" -print0)
 
 # *** RTAPI files ***
@@ -94,7 +105,7 @@ echo "I (4/4): checking RTAPI folders with both C and C++ code"
 while IFS= read -r -d '' d
 do
     echo "I (4/4): checking $d"
-    docheck "$d"
+    docheck "$d" || result=1
 done < <(find rtapi/ -type d -not -name "*__pycache__" -print0)
 
-exit 0
+exit $result

--- a/src/emc/kinematics/genserfuncs.c
+++ b/src/emc/kinematics/genserfuncs.c
@@ -247,7 +247,7 @@ int genser_kin_jac_inv(void *kins,
     GO_MATRIX_DECLARE(Jfwd, Jfwd_stg, 6, GENSER_MAX_JOINTS);
     GO_MATRIX_DECLARE(Jinv, Jinv_stg, GENSER_MAX_JOINTS, 6);
     go_pose T_L_0;
-    go_link linkout[GENSER_MAX_JOINTS];
+    go_link linkout[GENSER_MAX_JOINTS] = {};
     go_real vw[6];
     int link;
     int retval;
@@ -287,7 +287,7 @@ int genser_kin_jac_fwd(void *kins,
     genser_struct *genser = (genser_struct *) kins;
     GO_MATRIX_DECLARE(Jfwd, Jfwd_stg, 6, GENSER_MAX_JOINTS);
     go_pose T_L_0;
-    go_link linkout[GENSER_MAX_JOINTS];
+    go_link linkout[GENSER_MAX_JOINTS] = {};
     go_real vw[6];
     int link;
     int retval;
@@ -395,7 +395,7 @@ int genserKinematicsForward(const double *joint,
 int genser_kin_fwd(void *kins, const go_real * joints, go_pose * pos)
 {
     genser_struct *genser = kins;
-    go_link linkout[GENSER_MAX_JOINTS];
+    go_link linkout[GENSER_MAX_JOINTS] = {};
 
     int link;
     int retval;

--- a/src/emc/kinematics/tripodkins.c
+++ b/src/emc/kinematics/tripodkins.c
@@ -263,7 +263,7 @@ int main(int argc, char *argv[])
     if (NULL == fgets(buffer, BUFFERLEN, stdin)) {
       break;
     }
-    if (1 != sscanf(buffer, "%s", cmd)) {
+    if (1 != sscanf(buffer, "%255s", cmd)) {
       continue;
     }
 
@@ -279,7 +279,7 @@ int main(int argc, char *argv[])
       continue;
     }
     if (! strcmp(cmd, "ff")) {
-      if (1 != sscanf(buffer, "%*s %d", &fflags)) {
+      if (1 != sscanf(buffer, "%*s %lu", &fflags)) {
 	printf("need forward flag\n");
       }
       continue;
@@ -308,7 +308,7 @@ int main(int argc, char *argv[])
     }
     else {			/* forward kins */
       if (flags) {
-	if (4 != sscanf(buffer, "%lf %lf %lf %d", 
+	if (4 != sscanf(buffer, "%lf %lf %lf %lu",
 			&joints[0],
 			&joints[1],
 			&joints[2],

--- a/src/emc/motion/stashf_wrap.h
+++ b/src/emc/motion/stashf_wrap.h
@@ -25,6 +25,7 @@ const char *fmt, *efmt;
     result = dbuf_get_string(o, &fmt);
     if(result < 0) return result;
 
+    // cppcheck-suppress selfAssignment
     if(*fmt) fmt = gettext(fmt);
 
     while((efmt = strchr(fmt, '%'))) {
@@ -79,6 +80,7 @@ const char *fmt, *efmt;
                     const char *s;
                     result = dbuf_get_string(o, &s);
                     if(result < 0) return SET_ERRNO(result);
+                    // cppcheck-suppress selfAssignment
                     if(*s) s = gettext(s);
                     result = PRINT(block, s);
                 }

--- a/src/emc/task/emccanon.cc
+++ b/src/emc/task/emccanon.cc
@@ -112,8 +112,6 @@ void UPDATE_TAG(const StateTag& tag) {
 
 /* macros for converting program units to internal (mm/deg) units */
 #define FROM_PROG_LEN(prog) ((prog) * (canon.lengthUnits == CANON_UNITS_INCHES ? 25.4 : canon.lengthUnits == CANON_UNITS_CM ? 10.0 : 1.0))
-// Compiler will optimize: a=FROM_PROG_ANG(a) ==> a=a.
-// cppcheck-suppress-macro selfAssignment
 #define FROM_PROG_ANG(prog) (prog)
 
 /* Certain axes are periodic.  Hardcode this for now */
@@ -275,8 +273,13 @@ static void from_prog(double &x, double &y, double &z, double &a, double &b, dou
     x = FROM_PROG_LEN(x);
     y = FROM_PROG_LEN(y);
     z = FROM_PROG_LEN(z);
+    // Compiler will optimize: a=FROM_PROG_ANG(a) ==> a=a.
+    // 2.10 cannot handle suppress-macro
+    // cppcheck-suppress selfAssignment
     a = FROM_PROG_ANG(a);
+    // cppcheck-suppress selfAssignment
     b = FROM_PROG_ANG(b);
+    // cppcheck-suppress selfAssignment
     c = FROM_PROG_ANG(c);
     u = FROM_PROG_LEN(u);
     v = FROM_PROG_LEN(v);
@@ -2329,8 +2332,13 @@ void ARC_FEED(int line_number,
 		rotate_and_offset_pos(fe, se, ae, unused, unused, unused, unused, unused, unused);
 		rotate_and_offset_pos(fa, sa, unused, unused, unused, unused, unused, unused, unused);
         if (chord_deviation(lx, ly, fe, se, fa, sa, rotation, mx, my) < canon.naivecamTolerance) {
+			// Compiler will optimize: a=FROM_PROG_ANG(a) ==> a=a.
+			// 2.10 cannot handle suppress-macro
+			// cppcheck-suppress selfAssignment
 			a = FROM_PROG_ANG(a);
+			// cppcheck-suppress selfAssignment
 			b = FROM_PROG_ANG(b);
+			// cppcheck-suppress selfAssignment
 			c = FROM_PROG_ANG(c);
 			u = FROM_PROG_LEN(u);
 			v = FROM_PROG_LEN(v);

--- a/src/emc/task/emccanon.cc
+++ b/src/emc/task/emccanon.cc
@@ -112,6 +112,8 @@ void UPDATE_TAG(const StateTag& tag) {
 
 /* macros for converting program units to internal (mm/deg) units */
 #define FROM_PROG_LEN(prog) ((prog) * (canon.lengthUnits == CANON_UNITS_INCHES ? 25.4 : canon.lengthUnits == CANON_UNITS_CM ? 10.0 : 1.0))
+// Compiler will optimize: a=FROM_PROG_ANG(a) ==> a=a.
+// cppcheck-suppress-macro selfAssignment
 #define FROM_PROG_ANG(prog) (prog)
 
 /* Certain axes are periodic.  Hardcode this for now */

--- a/src/emc/tp/tp.c
+++ b/src/emc/tp/tp.c
@@ -1644,7 +1644,7 @@ STATIC blend_type_t tpCheckBlendArcType(
 
     //If exact stop, we don't compute the arc
     if (prev_tc->term_cond != TC_TERM_COND_PARABOLIC) {
-        tp_debug_print("Wrong term cond = %u\n", prev_tc->term_cond);
+        tp_debug_print("Wrong term cond = %d\n", prev_tc->term_cond);
         return BLEND_NONE;
     }
 
@@ -1659,7 +1659,7 @@ STATIC blend_type_t tpCheckBlendArcType(
         return BLEND_NONE;
     }
 
-    tp_debug_print("Motion types: prev_tc = %u, tc = %u\n",
+    tp_debug_print("Motion types: prev_tc = %d, tc = %d\n",
             prev_tc->motion_type,tc->motion_type);
     //If not linear blends, we can't easily compute an arc
     if ((prev_tc->motion_type == TC_LINEAR) && (tc->motion_type == TC_LINEAR)) {

--- a/src/hal/drivers/mesa-hostmot2/hm2_spix.c
+++ b/src/hal/drivers/mesa-hostmot2/hm2_spix.c
@@ -615,7 +615,7 @@ static int spix_setup(void)
 
 	if(!hwdriver) {
 		if(force_driver) {
-			LL_ERR("Unsupported platform: '%s' for forced driver '%s'\n", buf, hwdriver->name);
+			LL_ERR("Unsupported platform: '%s' for forced driver '%s'\n", buf, force_driver);
 		} else {
 			LL_ERR("Unsupported platform: '%s'\n", buf);
 		}

--- a/src/hal/drivers/mesa-hostmot2/spix_rpi3.c
+++ b/src/hal/drivers/mesa-hostmot2/spix_rpi3.c
@@ -209,8 +209,11 @@ static int spi0_transfer(const spix_port_t *sp, uint32_t *wptr, size_t txlen, in
 	rpi3_port_t *rp = (rpi3_port_t *)sp;
 	uint8_t *w8ptr = (uint8_t *)wptr;
 	uint8_t *r8ptr = (uint8_t *)wptr;	// read into write buffer
+	// Happens with cppcheck 2.13, not with 2.17
+	// cppcheck-suppress-begin duplicateAssignExpression
 	size_t tx8len = txlen * sizeof(uint32_t);	// Bytes to send
 	size_t rx8len = txlen * sizeof(uint32_t);	// Bytes to read
+	// cppcheck-suppress-end duplicateAssignExpression
 	size_t u;
 	uint32_t cs;
 
@@ -306,8 +309,11 @@ static int spi1_transfer(const spix_port_t *sp, uint32_t *wptr, size_t txlen, in
 	rpi3_port_t *rp = (rpi3_port_t *)sp;
 	uint16_t *w16ptr = (uint16_t *)wptr;
 	uint16_t *r16ptr = (uint16_t *)wptr;
+	// Happens with cppcheck 2.13, not with 2.17
+	// cppcheck-suppress-begin duplicateAssignExpression
 	size_t tx16len = txlen * 2;	// There are twice as many 16-bit words as there are 32-bit words
 	size_t rx16len = txlen * 2;
+	// cppcheck-suppress-end duplicateAssignExpression
 	size_t u;
 	unsigned pending = 0;
 

--- a/src/hal/drivers/mesa-hostmot2/spix_rpi3.c
+++ b/src/hal/drivers/mesa-hostmot2/spix_rpi3.c
@@ -209,11 +209,12 @@ static int spi0_transfer(const spix_port_t *sp, uint32_t *wptr, size_t txlen, in
 	rpi3_port_t *rp = (rpi3_port_t *)sp;
 	uint8_t *w8ptr = (uint8_t *)wptr;
 	uint8_t *r8ptr = (uint8_t *)wptr;	// read into write buffer
-	// Happens with cppcheck 2.13, not with 2.17
-	// cppcheck-suppress-begin duplicateAssignExpression
+	// Happens with cppcheck 2.13, not with 2.17. Debian 12 (2.10)
+	// cannot handle suppress-begin/suppress-end ranges
+	// cppcheck-suppress duplicateAssignExpression
 	size_t tx8len = txlen * sizeof(uint32_t);	// Bytes to send
+	// cppcheck-suppress duplicateAssignExpression
 	size_t rx8len = txlen * sizeof(uint32_t);	// Bytes to read
-	// cppcheck-suppress-end duplicateAssignExpression
 	size_t u;
 	uint32_t cs;
 
@@ -309,11 +310,12 @@ static int spi1_transfer(const spix_port_t *sp, uint32_t *wptr, size_t txlen, in
 	rpi3_port_t *rp = (rpi3_port_t *)sp;
 	uint16_t *w16ptr = (uint16_t *)wptr;
 	uint16_t *r16ptr = (uint16_t *)wptr;
-	// Happens with cppcheck 2.13, not with 2.17
-	// cppcheck-suppress-begin duplicateAssignExpression
+	// Happens with cppcheck 2.13, not with 2.17. Debian 12 (2.10)
+	// cannot handle suppress-begin/suppress-end ranges
+	// cppcheck-suppress duplicateAssignExpression
 	size_t tx16len = txlen * 2;	// There are twice as many 16-bit words as there are 32-bit words
+	// cppcheck-suppress duplicateAssignExpression
 	size_t rx16len = txlen * 2;
-	// cppcheck-suppress-end duplicateAssignExpression
 	size_t u;
 	unsigned pending = 0;
 

--- a/src/hal/drivers/mesa-hostmot2/sserial.c
+++ b/src/hal/drivers/mesa-hostmot2/sserial.c
@@ -2274,17 +2274,15 @@ void hm2_sserial_cleanup(hostmot2_t *hm2){
                          &buff,
                          sizeof(rtapi_u32));
         if (hm2->sserial.instance[i].remotes != NULL){
-            if (hm2->sserial.instance[i].remotes){
-                for (r = 0 ; r < hm2->sserial.instance[i].num_remotes; r++){
-                    if (hm2->sserial.instance[i].remotes[r].num_confs > 0){
-                        rtapi_kfree(hm2->sserial.instance[i].remotes[r].confs);
-                    };
-                    if (hm2->sserial.instance[i].remotes[r].num_modes > 0){
-                        rtapi_kfree(hm2->sserial.instance[i].remotes[r].modes);
-                    }
+            for (r = 0 ; r < hm2->sserial.instance[i].num_remotes; r++){
+                if (hm2->sserial.instance[i].remotes[r].num_confs > 0){
+                    rtapi_kfree(hm2->sserial.instance[i].remotes[r].confs);
+                };
+                if (hm2->sserial.instance[i].remotes[r].num_modes > 0){
+                    rtapi_kfree(hm2->sserial.instance[i].remotes[r].modes);
                 }
-                rtapi_kfree(hm2->sserial.instance[i].remotes);
             }
+            rtapi_kfree(hm2->sserial.instance[i].remotes);
         }
 
     }

--- a/src/hal/hal_priv.h
+++ b/src/hal/hal_priv.h
@@ -133,6 +133,8 @@
 RTAPI_BEGIN_DECLS
 extern char *hal_shmem_base;
 extern struct hal_data_t *hal_data;
+// The false error seems to be a cppcheck 2.13 problem
+// cppcheck-suppress unknownMacro
 RTAPI_END_DECLS
 
 #ifdef __cplusplus

--- a/src/hal/utils/scope_files.c
+++ b/src/hal/utils/scope_files.c
@@ -246,7 +246,7 @@ void write_log_file(char *filename)
     scope_vert_t *vert;
     hal_type_t type[16];
 
-    char *label[16];
+    char *label[16] = {};
     char *old_locale, *saved_locale;
     int sample_len, chan_active, chan_num, sample_period_ns, samples, n;
     FILE *fp;

--- a/src/libnml/cms/cms.hh
+++ b/src/libnml/cms/cms.hh
@@ -460,6 +460,7 @@ class CMS {
     CMS_DIAG_PROC_INFO *dpi;
     virtual CMS_DIAG_PROC_INFO *get_diag_proc_info();
     virtual void set_diag_proc_info(CMS_DIAG_PROC_INFO *);
+    // cppcheck-suppress virtualCallInConstructor
     virtual void setup_diag_proc_info();
     virtual void calculate_and_store_diag_info(PHYSMEM_HANDLE * _handle,
 	void *);

--- a/src/libnml/cms/cms_up.hh
+++ b/src/libnml/cms/cms_up.hh
@@ -67,6 +67,7 @@ class CMS_UPDATER {
 						   header.size */
     virtual int set_mode(CMS_UPDATER_MODE);
     virtual CMS_UPDATER_MODE get_mode();
+    // cppcheck-suppress virtualCallInConstructor
     virtual void set_encoded_data(void *, long _encoded_data_size);
 
   protected:

--- a/src/libnml/cms/cmsdiag.hh
+++ b/src/libnml/cms/cmsdiag.hh
@@ -72,6 +72,7 @@ class CMS_DIAG_PROC_INFO:public CMS_DIAG_STATIC_PROC_INFO {
 
 class CMS_DIAG_HEADER {
   public:
+    CMS_DIAG_HEADER() : last_writer(0), last_reader(0) {}
     virtual ~CMS_DIAG_HEADER() {}
     long last_writer;
     long last_reader;

--- a/src/libnml/nml/nml.cc
+++ b/src/libnml/nml/nml.cc
@@ -170,6 +170,9 @@ void NML::operator delete(void *nml_space)
 *  later if the constructor returned before creating the objects
 *  the pointers are intended to point at.
 ******************************************************************/
+// Cppcheck 2.10 cannot see that a function called from the constructor
+// does the initialization.
+// cppcheck-suppress uninitMemberVar
 NML::NML(NML_FORMAT_PTR f_ptr, const char *buf, const char *proc, const char *file,
     const int set_to_server, const int set_to_master)
 {


### PR DESCRIPTION
Different versions of cppcheck result in some differences in warnings and errors. Specifically, Debian 12 is at 2.10 and Ubuntu 24.4 is at 2.13 (used in CI), while current version is 2.17. Interestingly, older cppcheck versions found some problems not seen by newer versions.

This PR fixes the messages. Some are actual problems, like printf/scanf formats or arguments. Also missing initialization could occur in some corner-cases. Other messages are more like informational noise or design choices that cannot easily be changed (like virtual call in constructor).

There were initially messages left in Debian 12 because cppcheck 2.10 lacks some suppress and depth features, but these problems are handled for now by reformulating some suppression and ignoring some.

Additionally, the scripts/cppcheck.sh script now ignores header files because some .h files are not necessarily C headers. Headers are checked anyway because cppcheck does includes. The script's return/exit value is non-zero if any cppcheck fails.