### PR TITLE
Avoiding po4a mishaps with lines starting with a "*" (smoe:documentation_20250309)

### DIFF
--- a/docs/src/install/latency-test.adoc
+++ b/docs/src/install/latency-test.adoc
@@ -102,7 +102,7 @@ get good results, but your maximum step rate might be a little
 disappointing, especially if you use microstepping or have very
 fine pitch leadscrews. If the numbers are 100 µs or more,
 i.e. >= 100,000 nanoseconds (ns), then the PC is not a good candidate for software
-stepping. Numbers over 1 millisecond (1,000,000 ns) mean
+stepping. Numbers over 1 millisecond (1,000,000 ns) mean
 the PC is not a good candidate for LinuxCNC, regardless of whether you
 use software stepping or not.
 
@@ -169,12 +169,12 @@ Options:
   --nox            (no gui, display elapsed,min,max,sdev for each thread)
 ----
 
-Note:
-When determining the latency, LinuxCNC and HAL should not be running, stop with halrun -U.
+[NOTE]
+When determining the latency, LinuxCNC and HAL should not be running, stop with `halrun -U`.
 Large number of bins and/or small binsizes will slow updates.
-For single thread, specify --nobase (and options for servo thread).
+For single thread, specify `--nobase` (and options for servo thread).
 Measured latencies outside of the +/- bin range are reported with special end bars.
-Use --show to show count for the off-chart [pos|neg] bin
+Use `--show` to show count for the off-chart [pos|neg] bin.
 
 .`latency-histogram` Window
 image::../config/images/latency-histogram.png["latency-histogram Window"]

--- a/docs/src/man/man1/halmeter.1.adoc
+++ b/docs/src/man/man1/halmeter.1.adoc
@@ -10,9 +10,10 @@ halmeter - observe HAL pins, signals, and parameters
 
 == DESCRIPTION
 
-*halmeter* is used to observe HAL (Hardware Abstraction Layer) pins,
+The tool *halmeter* is used to observe HAL (Hardware Abstraction Layer) pins,
 signals, or parameters. It serves the same purpose as a multimeter does
-when working on physical systems.
+when working on physical systems. It is an application in its own right and
+connects independently from other GUIs to HAL.
 
 == OPTIONS
 
@@ -59,9 +60,8 @@ dialog without changing the displayed item.
   "Select" button to choose an item. Runs in the background leaving the
   shell free for other commands.
 *halmeter pin* _parport.0.pin-03-out_ *&*::
-  Open a meter window, initially displaying HAL pin
-  _parport.0.pin-03-out_. The "Select" button can be used to display
-  other items. Runs in background.
+  Open a meter window, initially displaying HAL pin _parport.0.pin-03-out_.
+  The "Select" button can be used to display other items. Runs in background.
 *halmeter -s pin* _parport.0.pin-03-out_ *&*::
   Open a small meter window, displaying HAL pin _parport.0.pin-03-out_.
   The displayed item cannot be changed. Runs in background.

--- a/docs/src/man/man1/halmeter.1.adoc
+++ b/docs/src/man/man1/halmeter.1.adoc
@@ -12,7 +12,7 @@ halmeter - observe HAL pins, signals, and parameters
 
 The tool *halmeter* is used to observe HAL (Hardware Abstraction Layer) pins,
 signals, or parameters. It serves the same purpose as a multimeter does
-when working on physical systems. It is an application in its own right and
+when working on physical systems. It is an self-contained application and
 connects independently from other GUIs to HAL.
 
 == OPTIONS

--- a/docs/src/man/man1/halrmt.1.adoc
+++ b/docs/src/man/man1/halrmt.1.adoc
@@ -22,7 +22,7 @@ socket, without port specification it uses default port 5006.
 == DESCRIPTION
 
 The application *halrmt* supports six commands that are meant to be sent
-to an instance of HAl that is running on another machine. Of these, the commands _set_ and _get_ contain HAL specific sub-commands that are based
+to an instance of HAL that is running on another machine. Of these, the commands _set_ and _get_ contain HAL specific sub-commands that are based
 on the commands supported by _halcmd_.
 
 Commands and most parameters are not case sensitive.

--- a/docs/src/man/man1/halrmt.1.adoc
+++ b/docs/src/man/man1/halrmt.1.adoc
@@ -21,12 +21,15 @@ socket, without port specification it uses default port 5006.
 
 == DESCRIPTION
 
-*halrmt* supports six commands of which the commands _set_ and _get_
-contain HAL specific sub-commands based on the commands supported by
-_halcmd_. Commands and most parameters are not case sensitive. The
-exceptions are passwords, file paths and text strings. The supported
-commands are as follows: *HELLO* Hello <password> <client> <version>
+The application *halrmt* supports six commands that are meant to be sent
+to an instance of HAl that is running on another machine. Of these, the commands _set_ and _get_ contain HAL specific sub-commands that are based
+on the commands supported by _halcmd_.
 
+Commands and most parameters are not case sensitive.
+The exceptions are passwords, file paths and text strings.
+The supported commands are as follows:
+
+Hello <password> <client> <version>::
 If a valid password was entered the server will respond with HELLO ACK
 _Server Name>_ _<Server Version>_ where server name and server version are
 looked up from the implementation. If an invalid password or any other

--- a/docs/src/man/man1/halshow.1.adoc
+++ b/docs/src/man/man1/halshow.1.adoc
@@ -21,16 +21,14 @@ Example: "%.5f" displays a float with 5 digits right of the decimal point
 
 == DESCRIPTION
 
-*halshow* creates a GUI interface to view and interact with a running HAL session.
-It is documented in the PDF and HTML docs much more completely than is possible in a manpage:
-https://linuxcnc.org/docs/html/hal/halshow.html[]
+The program *halshow* creates a GUI interface to view and interact with a running HAL session.
 
 == SEE ALSO
 
 linuxcnc(1)
 
-Much more information about LinuxCNC and HAL is available in the
-LinuxCNC and HAL User Manuals, found at /usr/share/doc/LinuxCNC/.
+Halshow is documented in the PDF and HTML documentation much more completely than is possible in a manpage:
+https://linuxcnc.org/docs/html/hal/halshow.html[]
 
 == HISTORY
 

--- a/docs/src/man/man1/halstreamer.1.adoc
+++ b/docs/src/man/man1/halstreamer.1.adoc
@@ -12,10 +12,9 @@ halstreamer - stream file data into HAL in real-time
 
 == DESCRIPTION
 
-*streamer*(9) and *halstreamer* are used together to stream data from a file into the HAL in real-time.
-*streamer* is a real-time HAL component that exports HAL pins and creates a FIFO in shared memory.
-*hal_streamer* is a non-realtime program that copies data from stdin into the FIFO, so that *streamer* can write it to the HAL pins.
-
+The HAL component *streamer*(9) and the program *halstreamer* are used together to stream data from a file into the HAL in real-time.
+In real-time, *streamer* exports HAL pins and creates a FIFO (first in, first out queue) in shared memory.
+The non-realtime program *halstreamer* copies data from stdin into the FIFO, so that *streamer* can write it to the HAL pins.
 
 == OPTIONS
 
@@ -26,7 +25,6 @@ halstreamer - stream file data into HAL in real-time
 
 _FILENAME_::
   Instructs *halsampler* to read from _FILENAME_ instead of from stdin.
-
 
 == USAGE
 

--- a/docs/src/man/man1/haltcl.1.adoc
+++ b/docs/src/man/man1/haltcl.1.adoc
@@ -11,8 +11,7 @@ haltcl - manipulate the LinuxCNC HAL from the command line using a Tcl interpret
 == DESCRIPTION
 
 Tcl is a scripting language from the 90s that is very easy to extend.  *Haltcl*
-extends the regular Tcl interpreter with a set of commands to interact with HAL, i.e.
-it allows to manipulate the HAL (Hardware Abstraction Layer) from
+extends the regular Tcl interpreter with a set of commands to interact with HAL, i.e. it allows to manipulate the HAL (Hardware Abstraction Layer) from
 the command line using a Tcl interpreter. *haltcl* can optionally read
 commands from a file (filename), allowing complex HAL configurations to
 be set up with a single command.
@@ -49,8 +48,7 @@ SECTION_B(ITEM_1) = 10
 
 == COMMANDS
 
-The executable  *haltcl* includes the commands of a Tcl interpreter augmented with
-commands for the hal language as described for *halcmd*(1).
+The executable  *haltcl* includes the commands of a Tcl interpreter augmented with commands for the hal language as described for *halcmd*(1).
 The augmented commands can be listed with the command:
 
 ----

--- a/docs/src/man/man1/haltcl.1.adoc
+++ b/docs/src/man/man1/haltcl.1.adoc
@@ -10,8 +10,9 @@ haltcl - manipulate the LinuxCNC HAL from the command line using a Tcl interpret
 
 == DESCRIPTION
 
-Tcl is a scripting language from the 90s that is very easy to extend.  *Haltcl*
-extends the regular Tcl interpreter with a set of commands to interact with HAL, i.e. it allows to manipulate the HAL (Hardware Abstraction Layer) from
+Tcl is a scripting language from the 90s that is very easy to extend. *Haltcl*
+extends the regular Tcl interpreter with a set of commands to interact with HAL,
+i.e. it allows to manipulate the HAL (Hardware Abstraction Layer) from
 the command line using a Tcl interpreter. *haltcl* can optionally read
 commands from a file (filename), allowing complex HAL configurations to
 be set up with a single command.
@@ -48,7 +49,7 @@ SECTION_B(ITEM_1) = 10
 
 == COMMANDS
 
-The executable  *haltcl* includes the commands of a Tcl interpreter augmented with commands for the hal language as described for *halcmd*(1).
+The executable *haltcl* includes the commands of a Tcl interpreter augmented with commands for the hal language as described for *halcmd*(1).
 The augmented commands can be listed with the command:
 
 ----

--- a/docs/src/man/man1/halui.1.adoc
+++ b/docs/src/man/man1/halui.1.adoc
@@ -10,7 +10,7 @@ halui - observe HAL pins and command LinuxCNC through NML
 
 == DESCRIPTION
 
-*halui* is used to build a User Interface using hardware knobs and switches.
+The program *halui* is used to build a User Interface using hardware knobs and switches.
 It exports a big number of pins, and acts accordingly when these change.
 
 == OPTIONS
@@ -26,7 +26,7 @@ When run, *halui* will export a large number of pins. A user can connect
 those to his physical knobs & switches & leds, and when a change is
 noticed halui triggers an appropriate event.
 
-*halui* expects the signals to be debounced, so if needed (bad knob
+Caveat, *halui* expects the signals to be debounced, so if needed (bad knob
 contact) connect the physical button to a HAL debounce filter first.
 
 == PINS

--- a/docs/src/man/man1/hbmgui.1.adoc
+++ b/docs/src/man/man1/hbmgui.1.adoc
@@ -6,7 +6,7 @@ hbmgui - Vismach Virtual Machine GUI
 
 == DESCRIPTION
 
-*hbmgui* is one of the sample *Vismach* GUIs for LinuxCNC, simulating a Horizontal Boring Machine.
+The *hbmgui* is one of the sample *Vismach* GUIs for LinuxCNC, simulating a Horizontal Boring Machine.
 
 See the main LinuxCNC documentation for more details.
 

--- a/docs/src/man/man1/hexagui.1.adoc
+++ b/docs/src/man/man1/hexagui.1.adoc
@@ -6,7 +6,7 @@ hexagui - Vismach Virtual Machine GUI
 
 == DESCRIPTION
 
-*hexagui* is one of the sample *Vismach* GUIs for LinuxCNC, simulating a Horizontal Boring Machine.
+The *hexagui* is one of the sample *Vismach* GUIs for LinuxCNC, simulating a Horizontal Boring Machine.
 
 See the main LinuxCNC documentation for more details.
 

--- a/docs/src/man/man1/milltask.1.adoc
+++ b/docs/src/man/man1/milltask.1.adoc
@@ -6,8 +6,9 @@ milltask - Non-realtime task controller for LinuxCNC
 
 == DESCRIPTION
 
-*milltask* is an internal process of LinuxCNC. It is generally not
-invoked directly but by an INI file setting: *[TASK]TASK=milltask*.
+The internal process *milltask* of LinuxCNC is generally not
+invoked directly but by an INI file setting:
+`[TASK]TASK=milltask``.
 The *milltask* process creates the `ini.\*` HAL pins listed below and owned by the *inihal* component.
 These pins may be modified while LinuxCNC is running to alter values
 that are typically specified statically in an INI file.
@@ -15,8 +16,7 @@ that are typically specified statically in an INI file.
 The *inihal* pins are sampled in every task cycle, however, commands
 affected by their values typically use the value present at the time
 when the command is processed. Such commands include all codes handled
-by the interpreter (*G-code* programs and *MDI* commands) and NML
-*jogging* commands issued by a GUI (including *halui*). *Wheel jogging*
+by the interpreter (*G-code* programs and *MDI* commands) and NML *jogging* commands issued by a GUI (including *halui*). *Wheel jogging*
 is implemented in the realtime motion module so *inihal* pin changes
 (e.g., `ini.*.max_velocity`, `ini.*.max_acceleration`) may be honored as
 soon as altered values are propagated to the motion module.
@@ -84,11 +84,9 @@ soon as altered values are propagated to the motion module.
 == NOTES
 
 The *inihal* pins cannot be linked or set in a HAL file that is
-specified by an INI file **[HAL]HALFILE** item because they are not
+specified by an INI file `[HAL]HALFILE` item because they are not
 created until *milltask* is started. The *inihal* pin values can be
-altered by independent halcmd programs specified by **[APPLICATION]APP**
-items or by GUIs that support a **[HAL]POSTGUI_HALFILE**.
+altered by independent halcmd programs specified by `[APPLICATION]APP`
+items or by GUIs that support a `[HAL]POSTGUI_HALFILE`.
 
-The INI file is not automatically updated with values altered by
-*inihal* pin settings but can be updated using the calibration program
-(emccalib.tcl) when using a **[HAL]POSTGUI_HALFILE**.
+The INI file is not automatically updated with values altered by *inihal* pin settings but can be updated using the calibration program (emccalib.tcl) when using a `[HAL]POSTGUI_HALFILE`.

--- a/docs/src/man/man1/panelui.1.adoc
+++ b/docs/src/man/man1/panelui.1.adoc
@@ -10,7 +10,7 @@ panelui - interface buttons to LinuxCNC or HAL
 
 == DESCRIPTION
 
-*panelui* is a non-realtime component to interface buttons to LinuxCNC or HAL.
+The non-realtime component *panelui* interfaces buttons to LinuxCNC or HAL.
 It decodes MESA 7I73 style key-scan codes and calls the appropriate routine.
 It gets input from a realtime component - sampler.
 Sampler gets it's input from either the MESA 7i73 or sim_matrix_kb component.

--- a/docs/src/man/man1/xhc-hb04.1.adoc
+++ b/docs/src/man/man1/xhc-hb04.1.adoc
@@ -52,7 +52,7 @@ file.
 
 Usage:
 
-$ xhc-hb04 [options]
+`xhc-hb04` [_options_]
 
 == Options
 
@@ -110,7 +110,7 @@ Example: `loadusr -W xhc-hb04-H -I` _path_to_cfg_file_ `-s 2`
 
 == Input Pins (Control)
 
-_xhc-hb04.stepsize-up (bit in)::
+xhc-hb04.stepsize-up (bit in)::
   A 1 pulse on this pin changes the stepsize to the next higher stepsize
   in the stepsize sequence specified in the xhc-hb04 (loadusr) command.
 xhc-hb04.stepsize-down (bit in)::
@@ -238,10 +238,7 @@ ROW 5
 
 == Synthesized button pins
 
-Additional buttons are synthesized for buttons named *zero*,
-*goto-zero*, and *half*. These synthesized buttons are active when the
-button is pressed AND the selector-switch is set to the corresponding
-axis [xyza].
+Additional buttons are synthesized for buttons named *zero*, *goto-zero*, and *half*. These synthesized buttons are active when the button is pressed AND the selector-switch is set to the corresponding axis [xyza].
 
 ....
    (bit out) xhc-hb04.button-zero-[xyza]
@@ -291,7 +288,7 @@ See the README and .txt files in the above directory for usage.
 The sim configs use the AXIS GUI but the scripts are available
 with any HAL configuration or GUI. The same scripts can be used to adapt
 the xhc-hb04 to existing configurations provided that the halui, motion,
-and axis.N pins needed are not otherwise claimed. Instructions are
+and axis._N_ pins needed are not otherwise claimed. Instructions are
 included in README file in the directory named above.
 
 Use halcmd to display the pins and signals used by the xhc-hb04.tcl script:

--- a/docs/src/man/man3/hal_add_funct_to_thread.3.adoc
+++ b/docs/src/man/man3/hal_add_funct_to_thread.3.adoc
@@ -31,10 +31,10 @@ position::
 
 == DESCRIPTION
 
-*hal_add_funct_to_thread* adds a function exported by a realtime HAL component to a realtime thread.
+The function *hal_add_funct_to_thread* adds another function that is exported by a realtime HAL component to a realtime thread.
 This determines how often and in what order functions are executed.
 
-*hal_del_funct_from_thread* removes a function from a thread.
+The function *hal_del_funct_from_thread* removes a function from a thread.
 
 == RETURN VALUE
 

--- a/docs/src/man/man3/hal_exit.3hal.adoc
+++ b/docs/src/man/man3/hal_exit.3hal.adoc
@@ -15,8 +15,8 @@ comp_id::
 
 == DESCRIPTION
 
-*hal_exit* shuts down and cleans up HAL and RTAPI. It must be called
-prior to exit by any module that called *hal_init*.
+The function *hal_exit* shuts down and cleans up HAL and RTAPI.
+It must be called prior to exit by any module that called *hal_init*.
 
 == REALTIME CONSIDERATIONS
 

--- a/docs/src/man/man9/sampler.9.adoc
+++ b/docs/src/man/man9/sampler.9.adoc
@@ -10,7 +10,7 @@ sampler - sample data from HAL in real time
 
 == DESCRIPTION
 
-The HAL components *sampler* and **halsampler**(1) are used together
+The HAL component *sampler* and the program **halsampler**(1) are used together
 to sample HAL data in real time and store it in a file.
 Of these, *sampler* performs in realtime, exporting HAL pins and creates a FIFO (first-in, first out queue) in shared memory.
 It then samples data from the HAL and sends these to the FIFO.

--- a/docs/src/man/man9/sampler.9.adoc
+++ b/docs/src/man/man9/sampler.9.adoc
@@ -10,13 +10,12 @@ sampler - sample data from HAL in real time
 
 == DESCRIPTION
 
-*sampler* and **halsampler**(1) are used together to sample HAL data in
-real time and store it in a file. *sampler* is a realtime HAL component
-that exports HAL pins and creates a FIFO in shared memory. It then
-begins sampling data from the HAL and storing it to the FIFO.
-*halsampler* is a non-realtime program that copies data from the FIFO to
-stdout, where it can be redirected to a file or piped to some other
-program.
+The HAL components *sampler* and **halsampler**(1) are used together
+to sample HAL data in real time and store it in a file.
+Of these, *sampler* performs in realtime, exporting HAL pins and creates a FIFO (first-in, first out queue) in shared memory.
+It then samples data from the HAL and sends these to the FIFO.
+The application *halsampler* copies data from the FIFO to stdout,
+where it can be redirected to a file or piped to some other program.
 
 == OPTIONS
 


### PR DESCRIPTION
*man pages* frequently have a bold start of the line while introducing a tool/function. These are then miss-interpreted by po4a which affects line breaks, which in turn breaks translations. A similar effect was observed for the "Note:". 

By changing the wording, the text IMHO becomes easier to read and avoid that technical issue with po4a.

I went through a few paragraphs that were indicated as problematic to me by weblate.