### PR TITLE
Halscope: set button padding to allow smaller window width

### DIFF
--- a/src/hal/utils/scope_vert.c
+++ b/src/hal/utils/scope_vert.c
@@ -1179,12 +1179,13 @@ static void style_with_css(GtkWidget *widget, int color_index)
     GtkStyleContext *context;
     GtkCssProvider *provider;
 
-    char buf[270];
+    char buf[310];
     snprintf(buf, sizeof(buf), "* {margin: 1px; border-style:solid; border-width: 2px;}\n"
                                "#selected {border-color: black; font-weight: bold;}\n"
                                "*:checked, *:active {background: rgb(%d,%d,%d);}\n"
                                "*:hover {background: rgba(%d,%d,%d,0.3);}\n"
-                               "*:hover#selected {background: rgba(%d,%d,%d,0.6);}\n",
+                               "*:hover#selected {background: rgba(%d,%d,%d,0.6);}\n"
+                               "button {padding-left: 0; padding-right: 0;}",
                                normal_colors[color_index][0],normal_colors[color_index][1],
                                normal_colors[color_index][2],
                                normal_colors[color_index][0],normal_colors[color_index][1],


### PR DESCRIPTION
Sets the left and right padding of buttons to 0 to lower the window width to fit smaller screens.

Before:
![halscope-1030](https://github.com/user-attachments/assets/9345fcd5-262a-433c-908f-37f3a4dd63b5)

After:
![halscope-860px](https://github.com/user-attachments/assets/48ef59de-3a99-4f1e-91d5-18b85a9b3301)

Not sure if this should better go into master instead, but it's a very small change.