### PR TITLE
debian/patches: remove the explicit use of FORTIFY_SOURCE

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,8 +1,14 @@
 linuxcnc (1:2.10.0~pre0) UNRELEASED; urgency=medium
 
+  [ Andy Pugh ]
   * Master branch open for new features.
 
- -- Andy Pugh <andy@bodgesoc.org>  Mon, 09 Oct 2023 10:39:03 +0100
+  [ Pushkar Kulkarni ]
+  * debian/patches: Remove the use of FORTIFY_SOURCE and
+    depend on defaults passed by dpkg-buildflags on
+    Ubuntu and Debian (LP: #2104012)
+
+ -- Pushkar Kulkarni <pushkar.kulkarni@canonical.com>  Mon, 24 Mar 2025 20:50:08 +0530
 
 linuxcnc (1:2.9.4-1) unstable; urgency=medium
 

--- a/debian/patches/remove-FORTIFY_SOURCE-redefinition.patch
+++ b/debian/patches/remove-FORTIFY_SOURCE-redefinition.patch
@@ -1,0 +1,20 @@
+Subject: Remove redefinition of _FORTIFY_SOURCE
+  Starting Ubuntu 24.04, dpkg-buildflags passes _FORTIFY_SOURCE=3 by default.
+  On Debian, dpkg-buildflags passes _FORTIFY_SOURCE=2. Use of _FORTIFY_SOURCE=2
+  in the Makefile causes redefinition errors on Ubuntu. This patch enforces
+  depending on dpkg-buildflags for the _FORTIFY_SOURCE value.
+Author: Pushkar Kulkarni <pushkar.kulkarni@canonical.com>
+Bug-Ubuntu: https://bugs.launchpad.net/ubuntu/+source/linuxcnc/+bug/2104012
+
+
+--- a/src/Makefile
++++ b/src/Makefile
+@@ -252,7 +252,7 @@
+ # Compilation options.	Perhaps some of these should come from Makefile.inc? (CXXFLAGS now does)
+ INTEGER_OVERFLOW_FLAGS := -fwrapv
+ OPT := -O2 $(INTEGER_OVERFLOW_FLAGS)
+-DEBUG := $(DEBUG) -g -Wall -D_FORTIFY_SOURCE=2
++DEBUG := $(DEBUG) -g -Wall
+ CFLAGS := $(INCLUDE) $(OPT) $(DEBUG) -DULAPI -std=gnu11 -Werror=implicit-function-declaration $(CFLAGS) $(CPPFLAGS) $(EXTRA_DEBUG)
+ CXXFLAGS := $(INCLUDE) $(OPT) $(DEBUG) -DULAPI -Werror=overloaded-virtual $(CXXFLAGS) $(CPPFLAGS) $(EXTRA_DEBUG)
+ # In Debian 11, any inclusion of <boost/python.hpp> leads to several

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -1,0 +1,1 @@
+remove-FORTIFY_SOURCE-redefinition.patch


### PR DESCRIPTION
Starting Ubuntu 24.04, dpkg-buildflags passes _FORTIFY_SOURCE=3 by default.
On Debian, dpkg-buildflags passes _FORTIFY_SOURCE=2. The explicit use of _FORTIFY_SOURCE=2
in the Makefile causes redefinition errors on Ubuntu, failing the build. This patch enforces
depending on `dpkg-buildflags` for the _FORTIFY_SOURCE value.