### PR TITLE
Add bitmerge as inverse of bitslice

### DIFF
--- a/docs/man/.gitignore
+++ b/docs/man/.gitignore
@@ -261,6 +261,7 @@ man9/axis.9
 man9/axistest.9
 man9/bin2gray.9
 man9/biquad.9
+man9/bitmerge.9
 man9/bitslice.9
 man9/bitwise.9
 man9/bldc.9

--- a/docs/src/hal/components.adoc
+++ b/docs/src/hal/components.adoc
@@ -283,6 +283,7 @@ the input is a position, this means that 'position', 'velocity', and 'accelerati
 [{tab_options}]
 |===
 | link:../man/man9/bin2gray.9.html[bin2gray] |Converts a number to the gray-code representation ||
+| link:../man/man9/bitmerge.9.html[bitmerge] |Converts individual input bits into an unsigned-32 ||
 | link:../man/man9/bitslice.9.html[bitslice] |Converts an unsigned-32 input into individual bits ||
 | link:../man/man9/conv_bit_float.9.html[conv_bit_float] |Converts from bit to float         ||
 | link:../man/man9/conv_bit_s32.9.html[conv_bit_s32]     |Converts from bit to s32           ||

--- a/src/hal/components/bitmerge.comp
+++ b/src/hal/components/bitmerge.comp
@@ -1,0 +1,20 @@
+component bitmerge "Converts individual bits into an unsigned-32";
+description """This component creates a compound unsigned-32 from individual
+bit-inputs for each bit of an unsigned-32 output. The number of bits can be
+limited by the "personality" modparam.
+The inverse process can be performed by the bitslice HAL component.""";
+pin out u32 out "The output value";
+pin in  bit in-##[32:personality];
+author "Andy Pugh";
+license "GPL2+";
+function _ nofp;
+option personality yes;
+option period no;
+;;
+rtapi_u32 v = 0;
+rtapi_u32 m = 1;
+for (int i = 0; i < personality; i++, m <<= 1) {
+	if (in(i))
+		v |= m;
+}
+out = v;

--- a/src/hal/components/bitslice.comp
+++ b/src/hal/components/bitslice.comp
@@ -2,7 +2,7 @@ component bitslice "Converts an unsigned-32 input into individual bits";
 description """This component creates individual bit-outputs for each bit of an
 unsigned-32 input. The number of bits can be limited by the "personality"
 modparam.
-The inverse process can be performed by the weighted_sum HAL component.""";
+The inverse process can be performed by the bitmerge HAL component.""";
 pin in u32 in "The input value";
 pin out bit out-##[32:personality];
 author "Andy Pugh";
@@ -11,7 +11,8 @@ function _ nofp;
 option personality yes;
 option period no;
 ;;
-int i;
-for (i = 0; i < personality ; i++){
-out(i) = (in >> i)&1;
+rtapi_u32 m = 1;
+rtapi_u32 v = in;
+for (int i = 0; i < personality; i++, m <<= 1) {
+	out(i) = (v & m) ? 1 : 0;
 }


### PR DESCRIPTION
The inverse function of bit slicing is bit merging. Add the component bitmerge to do so.
Also, prevent bitslice to read the source pin multiple times because volatiles are not cached and re-loaded on every dereference.