### PR TITLE
debian: usrmerge - Debian bugs #1073692,#1101346

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,28 @@
+linuxcnc (1:2.9.4-2) unstable; urgency=medium
+
+  * Team upload.
+
+  * Adding build dependency on pyqt5.qtweb{engine,kit} to avoid build
+    failures on, as kindly addressed by Adrian <Bunk>. (Closes: #1100882)
+  * Re-applied Petter's change to address usrmerge, kindly pointed out
+    by Michael <Biebl>. (Closes: #1101346, #1073692)
+  * Bumped policy to 4.7.2.
+  * Now truly added Andy to Uploaders.
+
+ -- Steffen Moeller <moeller@debian.org>  Mon, 14 Apr 2025 00:10:01 +0200
+
+linuxcnc (1:2.9.4-1) unstable; urgency=medium
+
+  * Team upload.
+
+  * New upstream version. (Closes: #1080668)
+  * Added Andy to Uploaders.
+  * Beautification as instructed by lintian
+    - Added debian/format (quilt).
+    - Removed overrides for files no longer in archive.
+
+ -- Steffen Moeller <moeller@debian.org>  Sat, 15 Mar 2025 21:05:57 +0100
+
 linuxcnc (1:2.9.4) UNRELEASED; urgency=medium
 
   * Merge pull request #3283 from Sigma1912/patch-2

--- a/debian/control.top.in
+++ b/debian/control.top.in
@@ -2,7 +2,10 @@ Source: linuxcnc
 Section: misc
 Priority: optional
 Maintainer: LinuxCNC Developers <emc-developers@lists.sourceforge.net>
-Uploaders: Jeff Epler <jepler@gmail.com>, Sebastian Kuzminsky <seb@highlab.com>
+Uploaders:
+    Jeff Epler <jepler@gmail.com>,
+    Sebastian Kuzminsky <seb@highlab.com>,
+    Andy Pugh <andy@bodgesoc.org>
 Build-Depends:
     @DEBHELPER@,
     @PYTHON_PACKAGING_DEPENDS@,

--- a/debian/control.top.in
+++ b/debian/control.top.in
@@ -41,6 +41,7 @@ Build-Depends:
     python3,
     python3-dev,
     python3-tk,
+    python3-pyqt5.qtwebengine | python3-pyqt5.qtwebkit,
     python3-xlib,
     tcl@TCLTK_VERSION@-dev,
     tclx,
@@ -49,7 +50,7 @@ Build-Depends:
     yapps2
 Build-Depends-Indep:
     @DOC_DEPENDS@,
-Standards-Version: 4.6.1
+Standards-Version: 4.7.2
 Homepage: https://linuxcnc.org/
 Vcs-Browser: https://github.com/LinuxCNC/linuxcnc
 Vcs-Git: https://github.com/LinuxCNC/linuxcnc.git

--- a/debian/linuxcnc.install.in
+++ b/debian/linuxcnc.install.in
@@ -152,7 +152,7 @@ src/emc/usr_intf/axis/README usr/share/doc/@MAIN_PACKAGE_NAME@/axis
 debian/linuxcnc-uspace.metainfo.xml usr/share/metainfo
 
 debian/extras/etc /
-debian/extras/lib /
+debian/extras/lib /usr
 
 debian/extras/usr/share/icons usr/share
 


### PR DESCRIPTION
This PR complements a thread on our mailing list about the efforts of Debian and other distros to merge /lib with /usr/lib and the recent bug report 1101346: My upload to Debian reintroduced a bug that Petter had already closed for 2.9.3, see https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1073692 and https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1101346 .

No idea if I had seen that if I had followed the linuxcnc-gbp approach for uploads to Debian.

Apparently the https://wiki.debian.org/UsrMerge is already a thing since Buster, so LinuxCNC can just broadly adopt it? Or should that be an option to configure? 
