### PR TITLE
debian: lintian indicates hardening-no-relro: panelui, module_helper

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -44,14 +44,17 @@ linuxcnc (1:2.9.4) UNRELEASED; urgency=medium
   * Update m-code.adoc - typo exection -> execution
   * Merge pull request #3247 from Sigma1912/patch-1
   * gmoccapy.adoc: correct INI section name [MACROS]
-  * Disable "override limits" at the end of the jog. This fixes the issue that the override was not cleared in teleop (homed) mode Issue #2482
+  * Disable "override limits" at the end of the jog.
+    This fixes the issue that the override was not cleared
+    in teleop (homed) mode Issue #2482
   * Doc: User Defined Command, add note on exit codes != 0
   * gmoccapy: update release notes
   * docs: fix list in building-linuxcnc.adoc
   * Typos in carousel.comp
   * Merge pull request #3227 from BsAtHome/backport_2.9_3200-3202
   * Merge pull request #3226 from BsAtHome/backport_2.9_fix-hm2_spi
-  * Backport fix hm2_spi driver. This was discovered in master and fixed in PR #3225.
+  * Backport fix hm2_spi driver.
+    This was discovered in master and fixed in PR #3225.
   * Backport fix superfluous NULL check to 2.9 branch (issue #3202).
   * Backport fix invalid printf format to 2.9 branch (issue #3200).
   * Merge pull request #3212 from BsAtHome/hm2_spix-backport-2.9
@@ -73,7 +76,7 @@ linuxcnc (1:2.9.4) UNRELEASED; urgency=medium
   * Change to raw strings to fix Python SyntaxWarning
   * docs: improve "HAL Component Generator" doc page (halcompile)
   * Merge pull request #3158 from petterreinholdtsen/bug-debian-1080668-python3-setuptools
-  * Dropped use of depricated python3-setuptools / distutils.
+  * Dropped use of deprecated python3-setuptools / distutils.
   * Merge pull request #3159 from petterreinholdtsen/2.9-upstream-ax-python
   * Fetched latest ax_python.m4 and ax_python_devel.m4 from upstream.
   * Revert "Remove remaining use of deprecated distutils."
@@ -87,7 +90,8 @@ linuxcnc (1:2.9.4) UNRELEASED; urgency=medium
   * Merge pull request #3048 from hansu/gmoccapy-gcmc-config
   * qtvcp -action_buttons: fix momentary buttons status indicator
   * Merge pull request #3130 from hansu/gmoccapy-deprecation-warning-2
-  * gmoccapy: fix deprecation warning "Gtk.StyleContext.get_background_color is deprecated"
+  * gmoccapy: fix deprecation warning
+    "Gtk.StyleContext.get_background_color is deprecated"
   * Merge pull request #3115 from zz912/patch-30
   * Merge pull request #3125 from hansu/gmoccapy-deprecation-warning
   * gscreen: remove deprecated use of GtkLabel constructor
@@ -96,15 +100,16 @@ linuxcnc (1:2.9.4) UNRELEASED; urgency=medium
   * lathe_macros.ini - enable postgui.hal
   * Replace non-exist toolchange.py by stdglue.py
   * Merge pull request #3106 from LinuxCNC/andypugh/gscreen
-  * gscreen: Fix Spartan sim homing
-  * gscreen: Further tidying up to clear up runtime errors and startup verbosity
-  * gscreen: Fix broken configs - Silverdragon++ I found how to do settings when fixing gaxis
-  * gscreen: Fix broken configs - tester
-  * gscreen: Fix broken configs - gaxis
-  * gscreen: Fix broken configs - 9-axis
-  * gscreen: Fix broken configs - Spartan
-  * gscreen: Fix broken configs - Industrial
+  * gscreen:
+    - Fix Spartan sim homing
+    - Further tidying up to clear up runtime errors and startup verbosity
   * gscreen: Fix broken configs
+    - Silverdragon++ I found how to do settings when fixing gaxis
+    - tester
+    - gaxis
+    - 9-axis
+    - Spartan
+    - Industrial
   * docs: add note to gmoccapy keyboard shortcuts
   * fix: eliminated printf in shell script
   * Merge pull request #3090 from Sigma1912/2.9-fix-configs-apps-gladevcp
@@ -116,22 +121,27 @@ linuxcnc (1:2.9.4) UNRELEASED; urgency=medium
   * Update configs/apps/gladevcp/animated-backdrop/cairodraw.py
   * Merge pull request #3083 from hansu/gtk-sourceview-4-migration
   * configs/apps/gladevcp/animated-backdrop: partial fix
-  * configs/apps/gladevcp/by-widget/sourceview: fix 'up','down' button functionalitiy
-  * fix configs/apps/gladevcp: update to gtk3 ('sourceview' and 'animated backdrop' still not 100%))
+  * configs/apps/gladevcp/by-widget/sourceview:
+    fix 'up','down' button functionalitiy
+  * fix configs/apps/gladevcp: update to gtk3
+    ('sourceview' and 'animated backdrop' still not 100%))
   * Use now GtkSourceview 4
   * qtplasmac: fix file load after single cut
   * Merge pull request #3076 from Sigma1912/2.9-fix-sim-config-rack-toolchange
-  * Fix glade panel and remove depricated 'Features' entries in ini
+  * Fix glade panel and remove deprecated 'Features' entries in ini
   * qtvcp -tab_widget: fix float/int error with new libraries
   * Merge pull request #3054 from petterreinholdtsen/2.9-build-sid
   * Reinsert github CI test build on sid
   * Merge pull request #3026 from hansu/2966-gmoccapy-destroys-tooltable
   * Merge pull request #3049 from mark-v-d/2.9
-  * We need to turn cutter compensation off for the rapid to the startpoint as well.
+  * We need to turn cutter compensation off
+    for the rapid to the startpoint as well.
   * Merge pull request #3017 from petterreinholdtsen/2-9-smoe-debian_manpages
   * gmoccapy: add sim config for gcmc support
-  * tooledit: throw exeption when locale not set
-  * tooltable: create a backup file when error occurs on saving + add exception message
+  * tooledit: throw exception when locale not set
+  * tooltable:
+    - create a backup file when error occurs on saving
+    - add exception message
   * Adjusted handling of man pages to avoid duplicate lists.
   * Merge pull request #3043 from petterreinholdtsen/2.9-disable-unstable-build
   * Disabled github CI build on unstable/sid until it start working again.
@@ -147,8 +157,11 @@ linuxcnc (1:2.9.4) UNRELEASED; urgency=medium
   * docs: force monospace font in ASCII art (related to #3007)
   * docs: fix missing line break in toggle2nist man page
   * Merge pull request #3020 from mark-v-d/2.9
-  * Fixed bug #2939. But now new and improved. This fixes the case where the sub actually has a leadout, but it is too short.
-  * Fixed bug #2939. When fixing the case where there was no leadout move, I broke the case where the leadout was exceeding the starting point.
+  * Fixed bug #2939. But now new and improved.
+    This fixes the case where the sub actually has a leadout,
+    but it is too short.
+  * Fixed bug #2939. When fixing the case where there was no leadout move,
+    I broke the case where the leadout was exceeding the starting point.
   * Allow uniq_id to be used to select hal_input devices. (#3015)
 
  -- andypugh <andy@bodgesoc.org>  Sat, 25 Jan 2025 12:20:01 +0000
@@ -247,7 +260,7 @@ linuxcnc (1:2.9.3) UNRELEASED; urgency=medium
   * qtvcp -stylesheet editor: add the config's preferred search path
   * qtplasmac: add translation for tool type
   * qtplasmac: fix gcode filter spotting coordinates when overburn is active
-  * qtplasmac:  allow Z DRO to display torch height in manual cut
+  * qtplasmac: allow Z DRO to display torch height in manual cut
   * qtplasmac: run from line fixes
   * qtplasmac: fix state when cut recovery offsets are reset
   * plasmac: fix manual cut abort state
@@ -255,7 +268,8 @@ linuxcnc (1:2.9.3) UNRELEASED; urgency=medium
   * docs - qtplasmac:  fix locale creation
   * Merge pull request #2901 from jethornton/2.9
   * Update python-interface.adoc
-  * Note that the axes stat has been removed and show a way to get the same information from axis_mask
+  * Note that the axes stat has been removed and
+    show a way to get the same information from axis_mask
   * Removing While Loop, Correcting Typo
   * Execute 'aclocal' when generating configuration files
   * qtplasmac: fix missing g64 value in run from line
@@ -319,7 +333,8 @@ linuxcnc (1:2.9.3) UNRELEASED; urgency=medium
   * docs: Eliminated some terminal blanks in docs.
   * Typo found in documentation.
   * qtvcp -docs: add writeup on preferred way to add custom code to screens.
-  * gmoccapy: remember window size and position when switching back from fullscreen/maximized
+  * gmoccapy: remember window size and position
+    when switching back from fullscreen/maximized
   * gmoccapy: fix "window does not fit 1024x768 in fullscreen"
   * Update deprecated Pillow constant
   * docs: 2.9.2 to 2.9.y
@@ -387,14 +402,16 @@ linuxcnc (1:2.9.2) unstable; urgency=medium
   * Add dither option to PWMGen for improved analog resolution
   * axis: Fix run-from-line - bug #2771
   * debian/changelog: fix epoch & white space
-  * deleted craftsman gui, as it is not python 2 nor gtk3 based and not mantained for a long period
+  * deleted craftsman gui, as it is not python 2 nor gtk3 based
+    and not mantained for a long period
   * deleted gmoccapy plasma, as glade panels are still in gtk2
   * Docs: Many updates
   * fix hardcoded description in Spanish language Closes: #1057312
   * Fixes warnings for possible string truncation with strncpy()
   * Gladevcp: fix error on missing filter program
-  * gmoccapy: Fixed Inappropriate Logical Expression (#2769)
-  * gmoccapy: fixes error when trying to hide the turtle-jog button in gmoccapy
+  * gmoccapy:
+    - Fixed Inappropriate Logical Expression (#2769)
+    - Fixed error when trying to hide the turtle-jog button in gmoccapy
   * hal_glib -add get_linuxcnc_version function
   * Increase size of STACK_ENTRY_LEN
   * Merge pull request #2567 from petterreinholdtsen/2.9-gcode-g38.2
@@ -412,8 +429,9 @@ linuxcnc (1:2.9.2) unstable; urgency=medium
   * motion: fix brake/direction setting when S command is sent.
   * motion.c: Improve handling of misc_error pin names See #2780 #2773
   * pmx483-test: change package message to python3-serial
-  * pncconf - change spindle stepgen enable from spindle-enable to machine-is-on
-  * pncconf -fix HAL load command for 2 serialports
+  * pncconf
+    - change spindle stepgen enable from spindle-enable to machine-is-on
+    - fix HAL load command for 2 serialports
   * qtaxis -add version string to log
   * qtdragon -add a default 'factor' to avoid error message
   * qtdragon_hd -fix stylesheets for 5 axis, adjust qtdragon.ui
@@ -444,7 +462,8 @@ linuxcnc (1:2.9.2) unstable; urgency=medium
   * revert changes for strncat()
   * RTAI: Fix build against RTAI+GNU11
   * snprintf uses %d on a double (issue 2784)
-  * stdglue.py: Fix error on loading stdglue remaps using an R word. (The previous code errored on attempted comparison between dict and float)
+  * stdglue.py: Fix error on loading stdglue remaps using an R word.
+    (The previous code errored on attempted comparison between dict and float)
   * tests: status.state should be checked against command execution status
   * Update build-dependency for OpenGL
   * Update combi_dro.py
@@ -681,7 +700,8 @@ linuxcnc (1:2.9.0) unstable; urgency=medium
   * mesa_pktgyro_test.comp Allow use of uarts > 0
   * mesa-7i65: fix a bug with stale data in fifo
   * message: Update HAL component docs to match behavior
-  * Motion Type: Set the motion-type of rigid tap to 2 to match other spindle-sync cycles
+  * Motion Type: Set the motion-type of rigid tap to 2
+    to match other spindle-sync cycles
   * ohmic.comp - fix bugs
   * pncconf - Many updates
   * qt_istat.py: Fix typos
@@ -721,7 +741,7 @@ linuxcnc (1:2.9.0~pre1) UNRELEASED; urgency=medium
   * qtvcp -cam_align panel: add ability to set rotation increment
   * qtvcp -camview_widget: add the rotation increment display
   * qtvcp -cam_align panel: add window size setting option
-  * docs: qtplasmac fix image, add deprication notice
+  * docs: qtplasmac fix image, add deprecation notice
   * docs: add div2 to .gitignore
   * Merge pull request #2119 from Roguish000/component-div2
 
@@ -861,8 +881,7 @@ linuxcnc (1:2.8.3) buster; urgency=low
   * Update for new version of Rpi400
   * mb2hal: added pins to manpage
   * Merge pull request #1641 from JTrantow/2.8
-  * Change EDITOR = geany. Restore more generous dirhold and dirsetup
-      timing.
+  * Change EDITOR = geany. Restore more generous dirhold and dirsetup timing.
   * Updated the gantry example 
   * linuxcncrsh: check for errors when creating listening socket
   * gscreen -fix error related to keyboard jogging and limit switch
@@ -1637,9 +1656,10 @@ linuxcnc (1:2.7.5) unstable; urgency=medium
 
   * shuttlexpress: clean up the manpage & asciidocs
 
-  * GladeVCP: SpeedControl - changing limits do reset the increment
-  * GladeVCP: SpeedControl - set default increment after setting a new adjustment
-  * GladeVCP: SpeedControl - added widget icon
+  * GladeVCP: SpeedControl
+    - changing limits do reset the increment
+    - set default increment after setting a new adjustment
+    - added widget icon
   * GladeVCP: tooledit.glade - corrected typo
   * GladeVCP: hal_sourceview - fix permissions of created files
   * GladevCP: gremlin - bugfix mouse button modes 4 and 6
@@ -1648,7 +1668,8 @@ linuxcnc (1:2.7.5) unstable; urgency=medium
   * GladeVCP: Fix mdi error with tiny values
   * pyngcgui: find gcmc if not specified in ini
   * pyngcgui: remove mention of incorrect --height argument
-  * hal_glib: add callLevel to EMC_TASK_STAT class, to fix file-loaded bug
+  * hal_glib: add callLevel to EMC_TASK_STAT class,
+    to fix file-loaded bug
 
   * stepconf: fix default pitch for A axis
   * stepconf: dynamically show how step scale is calculated
@@ -1734,8 +1755,8 @@ linuxcnc (1:2.7.4) unstable; urgency=medium
   * docs: github is more official now
   * docs: fix a broken links
   * docs: fix a couple of places to note nine axes or planes supported
-  * docs: add info on how to stop the Axis GUI "do you really want to
-        quit" dialog
+  * docs: add info on how to stop the Axis GUI
+    "do you really want to quit" dialog
   * docs: add info about examples of logging from G-code
   * docs: make example code easier to cut and paste
   * docs: fix descriptions for G43.1 and G43.2
@@ -1766,8 +1787,8 @@ linuxcnc (1:2.7.4) unstable; urgency=medium
   * add gantry.comp from Charles Steinkuehler
   * xhc-hb04: fix negative jogs on non-x86 architectures
   * hostmot2: improved sserial error handling (don't crash)
-  * hy-vfd: set spindle_at_speed correctly when spindle is running
-        reverse
+  * hy-vfd: set spindle_at_speed correctly
+    when spindle is running reverse
   * serport: fix pin-1-in-not
   * sim_parport: fix pin names of inverted input
 
@@ -1776,19 +1797,20 @@ linuxcnc (1:2.7.4) unstable; urgency=medium
   * pncconf: fix setting or PID maxerror on servo configs
   * sample configs: make sim/canterp.ini runnable
   * sample configs: connect the orient mode pin to allow rotation
-        direction to be controlled in the VMC Vismach model
+    direction to be controlled in the VMC Vismach model
 
-  * emcmodule: Fix incorrect memory access by PyArg_ParseTuple and add better checks for string arguments
+  * emcmodule: Fix incorrect memory access by PyArg_ParseTuple and
+    add better checks for string arguments
   * interp: fix two error message typos that would lead a user astray
   * support RTAI 5
   * better error reporting in rtapi/sim
 
-  * realtime script: wait for the last rtapi_app to die when stopping
-        realtime
+  * realtime script: wait for the last rtapi_app to die
+    when stopping realtime
   * tests: verify that the exported realtime math functions exist
   * build: remove unsupported docs/src/Makefile
-  * build: build-depend on docbook-xsl, instead of using the network at
-        build-time
+  * build: build-depend on docbook-xsl,
+    instead of using the network at build-time
   * packaging: include udev rule file for ShuttleXpress USB jog pendant
   * packaging: gmoccapy depends on gstreamer0.10-plugins-base
   * packaging: use "set -e" to fail on error in the postinst script

--- a/debian/configure
+++ b/debian/configure
@@ -28,7 +28,7 @@ EOF
 
 cd "${0%/*}"
 
-if [ "$1" == "-h" -o "$1" == "-help" -o "$1" == "--help" ]; then
+if [ "$1" == "-h" ] || [ "$1" == "-help" ] || [ "$1" == "--help" ]; then
     usage
     exit 0
 fi
@@ -99,7 +99,7 @@ DEBHELPER="debhelper (>= 12)"
 COMPAT="12"
 
 case $DISTRIB_NAME in
-    Ubuntu-21.*|Debian-11|Debian-11.*|Debian-12|Debian-12.*|Debian-testing|Debian-unstable)
+    Ubuntu-21.*|Debian-11|Debian-11.*|Debian-12|Debian-12.*|Debian-13|Debian-13.*|Debian-testing|Debian-unstable)
         LIBREADLINE_DEV=libeditreadline-dev
         COMPAT=""
         DEBHELPER="debhelper-compat (= 13)"
@@ -195,4 +195,4 @@ fi
 
 
 rm -f ../build-stamp
-echo "successfully configured for '$DISTRIB_NAME'.."
+echo "Successfully configured for '$DISTRIB_NAME'."

--- a/debian/linuxcnc-doc-de.lintian-overrides
+++ b/debian/linuxcnc-doc-de.lintian-overrides
@@ -1,4 +1,6 @@
 # Just a couple of buttons to invoke a manual - xdg-open is a recommended dependency via xdg-utils
-linuxcnc-doc-de: desktop-command-not-in-package usr/share/applications/linuxcnc-documentation-de.desktop xdg-open
-linuxcnc-doc-de: desktop-command-not-in-package usr/share/applications/linuxcnc-gettingstarted-de.desktop xdg-open
-linuxcnc-doc-de: desktop-command-not-in-package usr/share/applications/linuxcnc-integratorinfo-de.desktop xdg-open
+linuxcnc-doc-de: desktop-command-not-in-package xdg-open [usr/share/applications/linuxcnc-integratorinfo_de.desktop]
+linuxcnc-doc-de: desktop-command-not-in-package xdg-open [usr/share/applications/linuxcnc-documentation_de.desktop]
+linuxcnc-doc-de: desktop-command-not-in-package x-www-browser [usr/share/applications/linuxcnc-gcoderef_de.desktop]
+linuxcnc-doc-de: desktop-command-not-in-package xdg-open [usr/share/applications/linuxcnc-gettingstarted_de.desktop]
+

--- a/debian/linuxcnc.lintian-overrides.in
+++ b/debian/linuxcnc.lintian-overrides.in
@@ -11,21 +11,8 @@ linuxcnc-uspace: elevated-privileges 4755 root/root [usr/bin/rtapi_app]
 # that is intentional - for now
 linuxcnc-uspace: package-name-doesnt-match-sonames liblinuxcnchal0 liblinuxcncini0 libnml0 libposemath0 libpyplugin0 librs274-0 libtooldata0
 
-# The man pages / documentation is likely to see an overhaul in a not too far future, prefer no to distract ourselves with these
-linuxcnc-uspace: groff-message 19: can't open '../man/images/toggle.ps': No such file or directory [usr/share/man/man9/toggle.9.gz:1]
-linuxcnc-uspace: groff-message 28: can't open '../man/images/toggle2nist.ps': No such file or directory [usr/share/man/man9/toggle2nist.9.gz:1]
-
 # These are dlopened by rtapi_app, which is already linked against libc.
-linuxcnc-uspace: library-not-linked-against-libc [usr/lib/linuxcnc/modules/bldc.so]
-linuxcnc-uspace: library-not-linked-against-libc [usr/lib/linuxcnc/modules/lineardeltakins.so]
-linuxcnc-uspace: library-not-linked-against-libc [usr/lib/linuxcnc/modules/maxkins.so]
-linuxcnc-uspace: library-not-linked-against-libc [usr/lib/linuxcnc/modules/pentakins.so]
-linuxcnc-uspace: library-not-linked-against-libc [usr/lib/linuxcnc/modules/plasmac.so]
-linuxcnc-uspace: library-not-linked-against-libc [usr/lib/linuxcnc/modules/rosekins.so]
-linuxcnc-uspace: library-not-linked-against-libc [usr/lib/linuxcnc/modules/rotarydeltakins.so]
-linuxcnc-uspace: library-not-linked-against-libc [usr/lib/linuxcnc/modules/rotatekins.so]
-linuxcnc-uspace: library-not-linked-against-libc [usr/lib/linuxcnc/modules/scorbot-kins.so]
-linuxcnc-uspace: library-not-linked-against-libc [usr/lib/linuxcnc/modules/siggen.so]
-linuxcnc-uspace: library-not-linked-against-libc [usr/lib/linuxcnc/modules/tpmod.so]
-linuxcnc-uspace: library-not-linked-against-libc [usr/lib/linuxcnc/modules/tripodkins.so]
+linuxcnc-uspace: library-not-linked-against-libc [usr/lib/linuxcnc/modules/*.so]
 
+# Not of immediate concern - https://lintian.debian.org/tags/shared-library-lacks-prerequisites.html
+linuxcnc-uspace: shared-library-lacks-prerequisites [usr/lib/linuxcnc/modules/*.so]

--- a/debian/rules.in
+++ b/debian/rules.in
@@ -129,10 +129,8 @@ override_dh_compress:
 
 override_dh_fixperms:
 	dh_fixperms -X/linuxcnc_module_helper -X/rtapi_app
-	# In case that only the indep packages are built
-	if [ -r  "$(DESTDIR)/usr/lib/tcltk/linuxcnc/linuxcnc.tcl" ]; then \
-		chmod -x $(DESTDIR)/usr/lib/tcltk/linuxcnc/linuxcnc.tcl; \
-	fi
+	# FIXME: Who sets those -x flags? This better be fixed at the root of the problem - to be found.
+	find debian -name linuxcnc.tcl -o -name cbutton.tcl -o -name mdi_text.py -o -name util.py | xargs -r chmod -x
 	# override_dh_python3: # not executed, so we attach it to fixperms
 	DEB_HOST_ARCH=`dpkg-architecture -qDEB_HOST_ARCH` dh_python3
 

--- a/src/hal/components/Submakefile
+++ b/src/hal/components/Submakefile
@@ -79,7 +79,7 @@ PYFLAGS := $(PYTHON_EXTRA_LDFLAGS) $(BOOST_PYTHON_LIB) $(PYTHON_LIBS) $(PYTHON_E
 
 ../bin/panelui: $(call TOOBJS, $(PYSAMPLERSRCS)) ../lib/liblinuxcnchal.so.0
 	$(ECHO) Linking $(notdir $@)
-	$(Q)$(CC) -o $@ $^ $(PYFLAGS)
+	$(Q)$(CC) -Wl,-z,relro -o $@ $^ $(PYFLAGS)
 TARGETS += ../bin/panelui
 
 hal/components/conv_float_s32.comp: hal/components/conv.comp.in hal/components/mkconv.sh hal/components/Submakefile

--- a/src/module_helper/Submakefile
+++ b/src/module_helper/Submakefile
@@ -4,14 +4,14 @@ MODULE_HELPERSRCS := \
 USERSRCS += $(MODULE_HELPERSRCS)
 
 ifneq ($(rip_moduledir),)
-    $(call TOOBJSDEPS, $(MODULE_HELPERSRCS)) : EXTRAFLAGS = -Wall -Werror
+    $(call TOOBJSDEPS, $(MODULE_HELPERSRCS)) : EXTRAFLAGS = -Wall -Werror -Wformat -Wformat-security
 else
-    $(call TOOBJSDEPS, $(MODULE_HELPERSRCS)) : EXTRAFLAGS = -Wall -Werror
+    $(call TOOBJSDEPS, $(MODULE_HELPERSRCS)) : EXTRAFLAGS = -Wall -Werror -Wformat -Wformat-security
 endif
 
 ../bin/linuxcnc_module_helper: $(call TOOBJS, $(MODULE_HELPERSRCS))
 	$(ECHO) Linking $(notdir $@)
-	@$(CC) -o $@ $^
+	$(CC) -Wl,-z,relro -o $@ $^
 
 TARGETS += ../bin/linuxcnc_module_helper
 endif


### PR DESCRIPTION
I wish there was a comment for panelui if the LDFLAGS were intentionally omitted.

We have no policy about the use of "@" (don't show the command) in Makefiles. I removed the one for the compilation of linuxcnc_module_helper since arguments to the compiler ar eimportant to know.  Was tempted to introduce it for all the $(ECHO) instructions, though, since we have little incentive to read the same lines twice.