### PR TITLE
Fix HAL_TYPE_MAX to be the largest numerical value

### DIFF
--- a/src/hal/hal.h
+++ b/src/hal/hal.h
@@ -279,9 +279,9 @@ typedef enum {
     HAL_FLOAT = 2,
     HAL_S32 = 3,
     HAL_U32 = 4,
+    HAL_PORT = 5,
     HAL_S64 = 6,
     HAL_U64 = 7,
-    HAL_PORT = 5,
     HAL_TYPE_MAX,
 } hal_type_t;
 

--- a/src/hal/halmodule.cc
+++ b/src/hal/halmodule.cc
@@ -376,8 +376,8 @@ static PyObject *pyhal_read_common(halitem *item) {
             case HAL_S64: return to_python(*(item->u->pin.s64));
             case HAL_FLOAT: return to_python(*(item->u->pin.f));
             case HAL_PORT: // HAL_PORT is currently not supported
-            case HAL_TYPE_UNSPECIFIED: /* fallthrough */ ;
-            case HAL_TYPE_UNINITIALIZED: /* fallthrough */ ;
+            default:
+                break;
         }
     } else {
         switch(item->type) {
@@ -388,8 +388,8 @@ static PyObject *pyhal_read_common(halitem *item) {
             case HAL_S64: return to_python(item->u->param.s64);
             case HAL_FLOAT: return to_python(item->u->param.f);
             case HAL_PORT: // HAL_PORT is currently not supported
-            case HAL_TYPE_UNSPECIFIED: /* fallthrough */ ;
-            case HAL_TYPE_UNINITIALIZED: /* fallthrough */ ;
+            default:
+                break;
         }
     }
     PyErr_Format(pyhal_error_type, "Invalid item type %d", item->type);
@@ -1218,8 +1218,8 @@ PyObject *get_value(PyObject * /*self*/, PyObject *args) {
             case HAL_S64: return Py_BuildValue("l",  (long long)*(hal_s64_t *)d_ptr);
             case HAL_FLOAT: return Py_BuildValue("f",  (double)*(hal_float_t *)d_ptr);
             case HAL_PORT: // HAL_PORT is currently not supported
-            case HAL_TYPE_UNSPECIFIED: /* fallthrough */ ;
-            case HAL_TYPE_UNINITIALIZED: /* fallthrough */ ;
+            default:
+                break;
         }
     }
     /* not found, search pin list for name */
@@ -1244,8 +1244,8 @@ PyObject *get_value(PyObject * /*self*/, PyObject *args) {
             case HAL_S64: return Py_BuildValue("l",  (long long)*(hal_s64_t *)d_ptr);
             case HAL_FLOAT: return Py_BuildValue("f",  (double)*(hal_float_t *)d_ptr);
             case HAL_PORT: // HAL_PORT is currently not supported
-            case HAL_TYPE_UNSPECIFIED: /* fallthrough */ ;
-            case HAL_TYPE_UNINITIALIZED: /* fallthrough */ ;
+            default:
+                break;
         }
     }
     sig = halpr_find_sig_by_name(name);
@@ -1263,8 +1263,8 @@ PyObject *get_value(PyObject * /*self*/, PyObject *args) {
             case HAL_S64: return Py_BuildValue("l",  (long long)*(hal_s64_t *)d_ptr);
             case HAL_FLOAT: return Py_BuildValue("f",  (double)*(hal_float_t *)d_ptr);
             case HAL_PORT: // HAL_PORT is currently not supported
-            case HAL_TYPE_UNSPECIFIED: /* fallthrough */ ;
-            case HAL_TYPE_UNINITIALIZED: /* fallthrough */ ;
+            default:
+                break;
         }
     }
     /* error if here */


### PR DESCRIPTION
The numerical constant of the largest legal value in the hal type enum <code>HAL_TYPE_MAX</code> was, although properly placed last, not the correct value because the other enumerations were not in order while using fixed value assignments. Unassigned enums always take the "last value plus one" approach and that resulted in the wrong enum value for <code>HAL_TYPE_MAX</code>.

The above fix exposed enum switch-cases that were not handled properly. These are fixed to use a default clause now.