### PR TITLE
Fix unused parameter warnings when compiling on ARM

### DIFF
--- a/src/rtapi/rtapi_parport.h
+++ b/src/rtapi/rtapi_parport.h
@@ -43,55 +43,75 @@ typedef struct rtapi_parport_t
 RTAPI_BEGIN_DECLS
 
 static inline int rtapi_parport_data_read(rtapi_parport_t *t) {
+    (void)t;
     return rtapi_inb(RTAPI_PARPORT_DATA_PORT(t));
 }
 
 static inline int rtapi_parport_control_read(rtapi_parport_t *t) {
+    (void)t;
     return rtapi_inb(RTAPI_PARPORT_CONTROL_PORT(t));
 }
 
 static inline int rtapi_parport_status_read(rtapi_parport_t *t) {
+    (void)t;
     return rtapi_inb(RTAPI_PARPORT_STATUS_PORT(t));
 }
 
 static inline unsigned char rtapi_parport_epp_data_readb(rtapi_parport_t *t) {
+    (void)t;
     return rtapi_inb(RTAPI_PARPORT_EPP_DATA_PORT(t));
 }
 
 static inline unsigned long rtapi_parport_epp_data_readl(rtapi_parport_t *t) {
+    (void)t;
     return rtapi_inl(RTAPI_PARPORT_EPP_DATA_PORT(t));
 }
 
 static inline unsigned long rtapi_parport_ecr_read(rtapi_parport_t *t) {
+    (void)t;
     return rtapi_inb(RTAPI_PARPORT_ECR_PORT(t));
 }
 
 
 static inline void rtapi_parport_data_write(rtapi_parport_t *t, unsigned char v) {
+    (void)t;
+    (void)v;
     rtapi_outb(v, RTAPI_PARPORT_DATA_PORT(t));
 }
 
 static inline void rtapi_parport_control_write(rtapi_parport_t *t, unsigned char v) {
+    (void)t;
+    (void)v;
     rtapi_outb(v, RTAPI_PARPORT_CONTROL_PORT(t));
 }
 
 static inline void rtapi_parport_status_write(rtapi_parport_t *t, unsigned char v) {
+    (void)t;
+    (void)v;
     rtapi_outb(v, RTAPI_PARPORT_STATUS_PORT(t));
 }
 
 static inline void rtapi_parport_epp_addr_write(rtapi_parport_t *t, unsigned char v) {
+    (void)t;
+    (void)v;
     rtapi_outb(v, RTAPI_PARPORT_EPP_ADDR_PORT(t));
 }
 
 static inline void rtapi_parport_epp_data_writeb(rtapi_parport_t *t, unsigned char v) {
+    (void)t;
+    (void)v;
     rtapi_outb(v, RTAPI_PARPORT_EPP_DATA_PORT(t));
 }
 
 static inline void rtapi_parport_epp_data_writel(rtapi_parport_t *t, unsigned long v) {
+    (void)t;
+    (void)v;
     rtapi_outl(v, RTAPI_PARPORT_EPP_DATA_PORT(t));
 }
 
 static inline void rtapi_parport_ecr_write(rtapi_parport_t *t, unsigned char v) {
+    (void)t;
+    (void)v;
     rtapi_outb(v, RTAPI_PARPORT_EPP_ADDR_PORT(t));
 }
 

--- a/src/rtapi/uspace_rtapi_app.cc
+++ b/src/rtapi/uspace_rtapi_app.cc
@@ -1180,6 +1180,7 @@ unsigned char Posix::do_inb(unsigned int port)
 #ifdef HAVE_SYS_IO_H
     return inb(port);
 #else
+    (void)port;
     return 0;
 #endif
 }
@@ -1188,6 +1189,9 @@ void Posix::do_outb(unsigned char val, unsigned int port)
 {
 #ifdef HAVE_SYS_IO_H
     return outb(val, port);
+#else
+    (void)val;
+    (void)port;
 #endif
 }
 


### PR DESCRIPTION
ARM CPUs (like used on RPi) have no IO port instructions like x86 systems. The rtapi wrappers hide the details and remove some code when the IO instructions are unavailable. However, that generates "unused parameter" warnings on ARM. This PR fixes those warnings.