### PR TITLE
Fix most remaining warnings on ARM

### DIFF
--- a/src/hal/classicladder/protocol_modbus_master.c
+++ b/src/hal/classicladder/protocol_modbus_master.c
@@ -256,9 +256,9 @@ int PrepPureModbusAskForCurrentReq( unsigned char * AskFrame )
 
 /* Response given here start directly with function code 
   (no IP header or Slave number) */
-char TreatPureModbusResponse( unsigned char * RespFrame, int SizeFrame )
+int TreatPureModbusResponse( unsigned char * RespFrame, int SizeFrame )
 {
-	char cError = -1;
+	int cError = -1;
 
 	if ( RespFrame[ 0 ]&MODBUS_FC_EXCEPTION_BIT )
 	{

--- a/src/hal/drivers/hal_gpio.c
+++ b/src/hal/drivers/hal_gpio.c
@@ -165,7 +165,7 @@ int build_chips_collection(char *name, hal_gpio_bulk_t **ptr, int *count){
     struct gpiod_line *temp_line;
     
     temp_line = gpiod_line_find(name);
-    if (temp_line <= 0) {
+    if (!temp_line) {
 	    rtapi_print_msg(RTAPI_MSG_ERR, "The GPIO line %s can not be found\n", name);
 	    return -EINVAL;
     }
@@ -312,6 +312,7 @@ int rtapi_app_main(void){
 
 static void hal_gpio_read(void *arg, long period)
 {
+    (void)period;
     hal_gpio_t *gpio = arg;
     int i, c;
     for (c = 0; c < gpio->num_in_chips; c++){
@@ -325,6 +326,7 @@ static void hal_gpio_read(void *arg, long period)
 
 static void hal_gpio_write(void *arg, long period)
 {
+    (void)period;
     hal_gpio_t *gpio = arg;
     int i, c;
     for (c = 0; c < gpio->num_out_chips; c++){

--- a/src/hal/drivers/hal_ppmc.c
+++ b/src/hal/drivers/hal_ppmc.c
@@ -2375,6 +2375,7 @@ static void BusReset(unsigned int port_addr)
 /* tests for an EPP bus timeout, and clears it if so */
 static int ClrTimeout(unsigned int port_addr)
 {
+    (void)port_addr;
     unsigned char r;
 
     r = rtapi_inb(STATUSPORT(port_addr));
@@ -2396,6 +2397,7 @@ static int ClrTimeout(unsigned int port_addr)
 /* sets the EPP address and then reads one byte from that address */
 static unsigned short SelRead(unsigned char epp_addr, unsigned int port_addr)
 {
+    (void)epp_addr;
     unsigned char b;
     
     ClrTimeout(port_addr);
@@ -2417,6 +2419,7 @@ static unsigned short SelRead(unsigned char epp_addr, unsigned int port_addr)
    when hardware has auto-increment address cntr */
 static unsigned short ReadMore(unsigned int port_addr)
 {
+    (void)port_addr;
     unsigned char b;
     b = rtapi_inb(DATAPORT(port_addr));
     return b;
@@ -2426,6 +2429,8 @@ static unsigned short ReadMore(unsigned int port_addr)
 /* sets the EPP address and then writes one byte to that address */
 static void SelWrt(unsigned char byte, unsigned char epp_addr, unsigned int port_addr)
 {
+    (void)byte;
+    (void)epp_addr;
     ClrTimeout(port_addr);
     /* set port direction to output */
     rtapi_outb(0x04,CONTROLPORT(port_addr));
@@ -2440,6 +2445,8 @@ static void SelWrt(unsigned char byte, unsigned char epp_addr, unsigned int port
    when hardware has auto-increment address cntr */
 static void WrtMore(unsigned char byte, unsigned int port_addr)
 {
+    (void)byte;
+    (void)port_addr;
     rtapi_outb(byte,DATAPORT(port_addr));
     return;
 }

--- a/src/hal/drivers/mesa-hostmot2/hm2_7i43.c
+++ b/src/hal/drivers/mesa-hostmot2/hm2_7i43.c
@@ -75,22 +75,26 @@ static int num_boards;
 // 
 
 static inline void hm2_7i43_epp_addr8(rtapi_u8 addr, hm2_7i43_t *board) {
+    (void)board;
     rtapi_outb(addr, board->port.base + HM2_7I43_EPP_ADDRESS_OFFSET);
     LL_PRINT_IF(debug_epp, "selected address 0x%02X\n", addr);
 }
 
 static inline void hm2_7i43_epp_addr16(rtapi_u16 addr, hm2_7i43_t *board) {
+    (void)board;
     rtapi_outb((addr & 0x00FF), board->port.base + HM2_7I43_EPP_ADDRESS_OFFSET);
     rtapi_outb((addr >> 8),     board->port.base + HM2_7I43_EPP_ADDRESS_OFFSET);
     LL_PRINT_IF(debug_epp, "selected address 0x%04X\n", addr);
 }
 
 static inline void hm2_7i43_epp_write(int w, hm2_7i43_t *board) {
+    (void)board;
     rtapi_outb(w, board->port.base + HM2_7I43_EPP_DATA_OFFSET);
     LL_PRINT_IF(debug_epp, "wrote data 0x%02X\n", w);
 }
 
 static inline int hm2_7i43_epp_read(hm2_7i43_t *board) {
+    (void)board;
     int val;
     val = rtapi_inb(board->port.base + HM2_7I43_EPP_DATA_OFFSET);
     LL_PRINT_IF(debug_epp, "read data 0x%02X\n", val);
@@ -128,6 +132,7 @@ static inline void hm2_7i43_epp_write32(uint32_t w, hm2_7i43_t *board) {
 }
 
 static inline uint8_t hm2_7i43_epp_read_status(hm2_7i43_t *board) {
+    (void)board;
     uint8_t val;
     val = rtapi_inb(board->port.base + HM2_7I43_EPP_STATUS_OFFSET);
     LL_PRINT_IF(debug_epp, "read status 0x%02X\n", val);
@@ -135,11 +140,13 @@ static inline uint8_t hm2_7i43_epp_read_status(hm2_7i43_t *board) {
 }
 
 static inline void hm2_7i43_epp_write_status(uint8_t status_byte, hm2_7i43_t *board) {
+    (void)board;
     rtapi_outb(status_byte, board->port.base + HM2_7I43_EPP_STATUS_OFFSET);
     LL_PRINT_IF(debug_epp, "wrote status 0x%02X\n", status_byte);
 }
 
 static inline void hm2_7i43_epp_write_control(uint8_t control_byte, hm2_7i43_t *board) {
+    (void)board;
     rtapi_outb(control_byte, board->port.base + HM2_7I43_EPP_CONTROL_OFFSET);
     LL_PRINT_IF(debug_epp, "wrote control 0x%02X\n", control_byte);
 }

--- a/src/hal/drivers/mesa-hostmot2/hm2_7i90.c
+++ b/src/hal/drivers/mesa-hostmot2/hm2_7i90.c
@@ -71,22 +71,26 @@ static int num_boards;
 //
 
 static inline void hm2_7i90_epp_addr8(rtapi_u8 addr, hm2_7i90_t *board) {
+    (void)board;
     rtapi_outb(addr, board->port.base + HM2_7I90_EPP_ADDRESS_OFFSET);
     LL_PRINT_IF(debug_epp, "selected address 0x%02X\n", addr);
 }
 
 static inline void hm2_7i90_epp_addr16(rtapi_u16 addr, hm2_7i90_t *board) {
+    (void)board;
     rtapi_outb((addr & 0x00FF), board->port.base + HM2_7I90_EPP_ADDRESS_OFFSET);
     rtapi_outb((addr >> 8),     board->port.base + HM2_7I90_EPP_ADDRESS_OFFSET);
     LL_PRINT_IF(debug_epp, "selected address 0x%04X\n", addr);
 }
 
 static inline void hm2_7i90_epp_write(int w, hm2_7i90_t *board) {
+    (void)board;
     rtapi_outb(w, board->port.base + HM2_7I90_EPP_DATA_OFFSET);
     LL_PRINT_IF(debug_epp, "wrote data 0x%02X\n", w);
 }
 
 static inline int hm2_7i90_epp_read(hm2_7i90_t *board) {
+    (void)board;
     int val;
     val = rtapi_inb(board->port.base + HM2_7I90_EPP_DATA_OFFSET);
     LL_PRINT_IF(debug_epp, "read data 0x%02X\n", val);
@@ -124,6 +128,7 @@ static inline void hm2_7i90_epp_write32(uint32_t w, hm2_7i90_t *board) {
 }
 
 static inline uint8_t hm2_7i90_epp_read_status(hm2_7i90_t *board) {
+    (void)board;
     uint8_t val;
     val = rtapi_inb(board->port.base + HM2_7I90_EPP_STATUS_OFFSET);
     LL_PRINT_IF(debug_epp, "read status 0x%02X\n", val);
@@ -131,11 +136,13 @@ static inline uint8_t hm2_7i90_epp_read_status(hm2_7i90_t *board) {
 }
 
 static inline void hm2_7i90_epp_write_status(uint8_t status_byte, hm2_7i90_t *board) {
+    (void)board;
     rtapi_outb(status_byte, board->port.base + HM2_7I90_EPP_STATUS_OFFSET);
     LL_PRINT_IF(debug_epp, "wrote status 0x%02X\n", status_byte);
 }
 
 static inline void hm2_7i90_epp_write_control(uint8_t control_byte, hm2_7i90_t *board) {
+    (void)board;
     rtapi_outb(control_byte, board->port.base + HM2_7I90_EPP_CONTROL_OFFSET);
     LL_PRINT_IF(debug_epp, "wrote control 0x%02X\n", control_byte);
 }

--- a/src/hal/drivers/mesa-hostmot2/hm2_pci.c
+++ b/src/hal/drivers/mesa-hostmot2/hm2_pci.c
@@ -244,6 +244,7 @@ static int hm2_pci_write(hm2_lowlevel_io_t *this, rtapi_u32 addr, const void *bu
 
 static int hm2_plx9030_program_fpga(hm2_lowlevel_io_t *this, const bitfile_t *bitfile) {
     hm2_pci_t *board = this->private;
+    (void)board;   // otherwise ARM compile gives warning
     rtapi_u32 status, control;
 
     // set /WRITE low for data transfer, and turn on LED
@@ -287,6 +288,7 @@ fail:
 
 static int hm2_plx9030_reset(hm2_lowlevel_io_t *this) {
     hm2_pci_t *board = this->private;
+    (void)board;   // otherwise ARM compile gives warning
     rtapi_u32 status;
     rtapi_u32 control;
 
@@ -348,6 +350,7 @@ static void hm2_plx9030_fixup_LASxBRD_READY(hm2_pci_t *board) {
     for (i = 0; i < 4; i ++) {
         rtapi_u32 val;
         int addr = board->ctrl_base_addr + offsets[i];
+        (void)addr;   // otherwise ARM compile gives warning
 
         val = rtapi_inl(addr);
         if (!(val & LASxBRD_READY)) {
@@ -363,6 +366,7 @@ static void hm2_plx9030_fixup_LASxBRD_READY(hm2_pci_t *board) {
 
 static int hm2_plx9054_program_fpga(hm2_lowlevel_io_t *this, const bitfile_t *bitfile) {
     hm2_pci_t *board = this->private;
+    (void)board;   // otherwise ARM compile gives warning
     unsigned i;
     rtapi_u32 status;
 
@@ -389,6 +393,9 @@ static int hm2_plx9054_reset(hm2_lowlevel_io_t *this) {
     hm2_pci_t *board = this->private;
     int i;
     rtapi_u32 status, control;
+
+    (void)board;   // otherwise ARM compile gives warning
+    (void)control;
 
     // set GPIO bits to GPIO function
     status = rtapi_inl(board->ctrl_base_addr + CTRL_STAT_OFFSET_5I22);


### PR DESCRIPTION
This PR fixes another set of warnings that is exclusive to the ARM compile, mostly due to unavailable IO-mapped IO instructions. However, it also deals with an invalid pointer/integer comparison and a type range warning.