### PR TITLE
Fix warnings on RPi/ARM

### DIFF
--- a/src/hal/classicladder/protocol_modbus_master.c
+++ b/src/hal/classicladder/protocol_modbus_master.c
@@ -256,9 +256,9 @@ int PrepPureModbusAskForCurrentReq( unsigned char * AskFrame )
 
 /* Response given here start directly with function code 
   (no IP header or Slave number) */
-char TreatPureModbusResponse( unsigned char * RespFrame, int SizeFrame )
+int TreatPureModbusResponse( unsigned char * RespFrame, int SizeFrame )
 {
-	char cError = -1;
+	int cError = -1;
 
 	if ( RespFrame[ 0 ]&MODBUS_FC_EXCEPTION_BIT )
 	{

--- a/src/hal/drivers/hal_gpio.c
+++ b/src/hal/drivers/hal_gpio.c
@@ -165,7 +165,7 @@ int build_chips_collection(char *name, hal_gpio_bulk_t **ptr, int *count){
     struct gpiod_line *temp_line;
     
     temp_line = gpiod_line_find(name);
-    if (temp_line <= 0) {
+    if (!temp_line) {
 	    rtapi_print_msg(RTAPI_MSG_ERR, "The GPIO line %s can not be found\n", name);
 	    return -EINVAL;
     }
@@ -312,6 +312,7 @@ int rtapi_app_main(void){
 
 static void hal_gpio_read(void *arg, long period)
 {
+    (void)period;
     hal_gpio_t *gpio = arg;
     int i, c;
     for (c = 0; c < gpio->num_in_chips; c++){
@@ -325,6 +326,7 @@ static void hal_gpio_read(void *arg, long period)
 
 static void hal_gpio_write(void *arg, long period)
 {
+    (void)period;
     hal_gpio_t *gpio = arg;
     int i, c;
     for (c = 0; c < gpio->num_out_chips; c++){

--- a/src/rtapi/rtapi.h
+++ b/src/rtapi/rtapi.h
@@ -809,6 +809,13 @@ RTAPI_BEGIN_DECLS
 *                        I/O RELATED FUNCTIONS                         *
 ************************************************************************/
 
+#if 0
+/*
+ * These prototypes interfere with non-x86 systems that do not have IO-mapped
+ * IO instructions.
+ * Also, the prototype is wrong because the port parameter is declared
+ * "unsigned short" in sys/io.h.
+ */
 /**
  * @brief Write @c byte to a hardware I/O @c port.
  * @param byte Byte to write.
@@ -828,6 +835,7 @@ RTAPI_BEGIN_DECLS
  * @note Many platforms provide an inline inb() that is faster.
  */
     extern unsigned char rtapi_inb(unsigned int port);
+#endif
 
 #if defined(__KERNEL__)
 #include <linux/version.h>

--- a/src/rtapi/rtapi_io.h
+++ b/src/rtapi/rtapi_io.h
@@ -34,13 +34,15 @@
 #define rtapi_outl outl
 #define rtapi_ioperm ioperm
 #else
-#define rtapi_inb(x) (0)
-#define rtapi_inw(x) (0)
-#define rtapi_inl(x) (0)
-#define rtapi_outb(x,y) ((void)0)
-#define rtapi_outw(x,y) ((void)0)
-#define rtapi_outl(x,y) ((void)0)
-#define rtapi_ioperm(x,y,z) ((void)0)
+// The prototypes follow the x86 sys/io.h prototypes
+__attribute__((always_inline)) static inline unsigned char  rtapi_inb(unsigned short port) { (void)port; return 0; }
+__attribute__((always_inline)) static inline unsigned short rtapi_inw(unsigned short port) { (void)port; return 0; }
+__attribute__((always_inline)) static inline unsigned int   rtapi_inl(unsigned short port) { (void)port; return 0; }
+__attribute__((always_inline)) static inline void rtapi_outb(unsigned char  val, unsigned short port) { (void)port; (void)val; }
+__attribute__((always_inline)) static inline void rtapi_outw(unsigned short val, unsigned short port) { (void)port; (void)val; }
+__attribute__((always_inline)) static inline void rtapi_outl(unsigned int   val, unsigned short port) { (void)port; (void)val; }
+__attribute__((always_inline)) static inline int rtapi_ioperm(unsigned long from, unsigned long num, int turn_on)
+{ (void)from; (void)num; (void)turn_on; return 0; }
 #endif
 
 #endif


### PR DESCRIPTION
This PR fixes another set of warnings that is exclusive to the ARM compile, mostly due to unavailable IO-mapped IO instructions. However, it also deals with an invalid pointer/integer comparison and a type range warning.

This PR replaces #3401.