### PR TITLE
Add stdio.h header for readline versions that need it

### DIFF
--- a/tests/halcompile/command_line_flags/flags.c
+++ b/tests/halcompile/command_line_flags/flags.c
@@ -10,6 +10,7 @@
 #error This is intended as a userspace component only.
 #endif
 
+#include <stdio.h>
 #include <readline.h>
 
 int main(int argc, char **argv)


### PR DESCRIPTION
Backport of #3217.