### PR TITLE
Various cleanup of hostmot2

### DIFF
--- a/src/hal/drivers/mesa-hostmot2/hostmot2.c
+++ b/src/hal/drivers/mesa-hostmot2/hostmot2.c
@@ -160,6 +160,7 @@ static void hm2_write(void *void_hm2, long period) {
     hm2_oneshot_write(hm2);   // update oneshot registers if needed
     hm2_periodm_write(hm2);   // update periodm registers if needed
     hm2_rcpwmgen_write(hm2);  // update rcpwmgen registers if needed
+    hm2_pktuart_write(hm2);   // update pktuart registers if needed
     hm2_inmux_write(hm2);     // update inmux control register if needed
     hm2_inm_write(hm2);       // update inm control register if needed
     hm2_xy2mod_write(hm2);    // update xy2mod motion registers if needed
@@ -225,7 +226,7 @@ const char *hm2_hz_to_mhz(rtapi_u32 freq_hz) {
 
 // FIXME: It would be nice if this was more generic
 EXPORT_SYMBOL_GPL(hm2_get_bspi);
-int hm2_get_bspi(hostmot2_t** hm2, char *name){
+int hm2_get_bspi(hostmot2_t** hm2, const char *name){
     struct rtapi_list_head *ptr;
     int i;
     rtapi_list_for_each(ptr, &hm2_list) {
@@ -240,7 +241,7 @@ int hm2_get_bspi(hostmot2_t** hm2, char *name){
 }
 
 EXPORT_SYMBOL_GPL(hm2_get_uart);
-int hm2_get_uart(hostmot2_t** hm2, char *name){
+int hm2_get_uart(hostmot2_t** hm2, const char *name){
     struct rtapi_list_head *ptr;
     int i;
     rtapi_list_for_each(ptr, &hm2_list) {
@@ -254,7 +255,7 @@ int hm2_get_uart(hostmot2_t** hm2, char *name){
     return -1;
 }
 EXPORT_SYMBOL_GPL(hm2_get_pktuart);
-int hm2_get_pktuart(hostmot2_t** hm2, char *name){
+int hm2_get_pktuart(hostmot2_t** hm2, const char *name){
     struct rtapi_list_head *ptr;
     int i;
     rtapi_list_for_each(ptr, &hm2_list) {
@@ -269,7 +270,7 @@ int hm2_get_pktuart(hostmot2_t** hm2, char *name){
 }
 EXPORT_SYMBOL_GPL(hm2_get_sserial);
 // returns a pointer to a remote struct
-hm2_sserial_remote_t *hm2_get_sserial(hostmot2_t** hm2, char *name){
+hm2_sserial_remote_t *hm2_get_sserial(hostmot2_t** hm2, const char *name){
    // returns inst * 64 + remote index
     struct rtapi_list_head *ptr;
     int i, j;
@@ -1160,6 +1161,7 @@ static void hm2_cleanup(hostmot2_t *hm2) {
     hm2_oneshot_cleanup(hm2);
     hm2_periodm_cleanup(hm2);
     hm2_rcpwmgen_cleanup(hm2);
+    hm2_pktuart_cleanup(hm2);
 
     // free all the tram entries
     hm2_tram_cleanup(hm2);
@@ -1187,6 +1189,7 @@ void hm2_print_modules(hostmot2_t *hm2) {
     hm2_inm_print_module(hm2);
     hm2_xy2mod_print_module(hm2);
     hm2_rcpwmgen_print_module(hm2);
+    hm2_pktuart_print_module(hm2);
 }
 
 

--- a/src/hal/drivers/mesa-hostmot2/hostmot2.h
+++ b/src/hal/drivers/mesa-hostmot2/hostmot2.h
@@ -1739,10 +1739,10 @@ const char *hm2_hz_to_mhz(rtapi_u32 freq_hz);
 void hm2_print_modules(hostmot2_t *hm2);
 
 // functions to get handles to components by name
-hm2_sserial_remote_t *hm2_get_sserial(hostmot2_t **hm2, char *name);
-int hm2_get_bspi(hostmot2_t **hm2, char *name);
-int hm2_get_uart(hostmot2_t **hm2, char *name);
-int hm2_get_pktuart(hostmot2_t **hm2, char *name);
+hm2_sserial_remote_t *hm2_get_sserial(hostmot2_t **hm2, const char *name);
+int hm2_get_bspi(hostmot2_t **hm2, const char *name);
+int hm2_get_uart(hostmot2_t **hm2, const char *name);
+int hm2_get_pktuart(hostmot2_t **hm2, const char *name);
 
 
 //

--- a/src/hal/drivers/mesa-hostmot2/pins.c
+++ b/src/hal/drivers/mesa-hostmot2/pins.c
@@ -662,7 +662,7 @@ const char* hm2_get_pin_secondary_hal_name(const hm2_pin_t *pin) {
         case HM2_GTAG_UART_TX:
             switch (sec_pin) {
                 case 0x1: return "tx";
-                case 0x2: return "tx-drive-enable";
+                case 0x2: return "tx-drv-en";
             }
             break;
 
@@ -674,7 +674,7 @@ const char* hm2_get_pin_secondary_hal_name(const hm2_pin_t *pin) {
         case HM2_GTAG_PKTUART_TX:
             switch (sec_pin) {
                 case 0x1: return "tx";
-                case 0x2: return "tx-drive-enable";
+                case 0x2: return "tx-drv-en";
             }
             break;
 


### PR DESCRIPTION
This PR is a preparation to more changes and is split for easy backports. Addressed in this PR:
- Use const char pointers
- Add missing pktuart calls
- Prevent hal name overruns