### PR TITLE
Backport: fix make terminal clutter

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -27,7 +27,7 @@ install: install-software install-docs
 install-software: install-kernel-dep install-kernel-indep install-menu
 
 ifeq ($(origin KERNELRELEASE), undefined)
-MAKEFLAGS += --warn-undefined-variables
+#MAKEFLAGS += --warn-undefined-variables
 endif
 
 EXTRAFLAGS :=


### PR DESCRIPTION
This is a partly backport of #3260 removing the irrelevant "undefined variable" warning when running make.