### PR TITLE
Fix modcompile issues

### DIFF
--- a/docs/src/man/man1/modcompile.1.adoc
+++ b/docs/src/man/man1/modcompile.1.adoc
@@ -4,17 +4,39 @@
 
 modcompile - Utility for compiling Modbus drivers
 
+== SYNOPSIS
+
+*modcompile -h*
+
+*modcompile* [*-k*] [*-n*] [*-v*] all
+
+*modcompile* [*-k*] [*-n*] [*-v*] module.mod ...
+
 == DESCRIPTION
 
-*modcompile* is used to compile modbus drivers that use the Mesa card UARTs.
+The *modcompile* utility is used to compile modbus drivers that use the PktUART
+interface of Mesa cards.
 
 See the main LinuxCNC documentation for more details.
 
 https://linuxcnc.org/docs/stable/html/drivers/mesa_modbus.html
 
+== OPTIONS
+
+*-h*, *--help*::
+  Brief help message.
+*-k*, *--keep*::
+  Keep the temporary files. The program will print a line where these are
+  located. You will be responsible for deleting them.
+*-n*, *--noinstall*::
+  Do not run the install step for the compiled module. This option is probably
+  only useful if you also use the *--keep* option.
+*-v*, *--verbose*::
+  Do a verbose build, showing all steps detailed while being performed.
+
 == SEE ALSO
 
-linuxcnc(1)*
+linuxcnc(1)
 
 Much more information about LinuxCNC and HAL is available in the
 LinuxCNC and HAL User Manuals, found at /usr/share/doc/LinuxCNC/.

--- a/src/hal/drivers/mesa-hostmot2/modbus/analogue.mod
+++ b/src/hal/drivers/mesa-hostmot2/modbus/analogue.mod
@@ -23,3 +23,5 @@ static const hm2_modbus_chan_descriptor_t channels[] = {
    internal workings. 1 is default (errors only)                    */
 
 #define DEBUG 1
+
+// vim: syn=c

--- a/src/hal/drivers/mesa-hostmot2/modbus/mesa_modbus.c.tmpl
+++ b/src/hal/drivers/mesa-hostmot2/modbus/mesa_modbus.c.tmpl
@@ -48,7 +48,7 @@ static const char *error_codes[]={
     "Server Device Busy",
     "Negative Acknowledge",
     "Memory Parity Error",
-    "Unknown exception code 9"
+    "Unknown exception code 9",
     "Gateway Path Unavailable",
     "Gateway Failed to Respond",
     "Comm Timeout"
@@ -890,4 +890,4 @@ static uint16_t RTU_CRC(rtapi_u8* buf, int len){
   return crc;  
 }
 
-// vim: syn=c
+// vim: syn=c ts=4

--- a/src/hal/drivers/mesa-hostmot2/modbus/mesa_modbus.mod.sample
+++ b/src/hal/drivers/mesa-hostmot2/modbus/mesa_modbus.mod.sample
@@ -29,3 +29,5 @@ static const hm2_modbus_chan_descriptor_t channels[] = {
 // Create 7 scaled FP HAL pins to control holfing registers at 0x400-0x406
     {HAL_FLOAT, 16,  0x0300, 1,     "more_floats"},
 };
+
+// vim: syn=c

--- a/src/hal/drivers/mesa-hostmot2/modbus/relayboard.mod
+++ b/src/hal/drivers/mesa-hostmot2/modbus/relayboard.mod
@@ -27,3 +27,4 @@ static const hm2_modbus_chan_descriptor_t channels[] = {
    Use 3 to see a lot of information about the modbus
    internal workings. 1 is default (errors only)                    */
 
+// vim: syn=c


### PR DESCRIPTION
The modcompile program is updated to take command-line arguments (see also #3380) and now properly removes temporary files, unless instructed to keep them.
The template is updated to fix a missing comma in the exception list.