### PR TITLE
Update CI base for 2.9 branch to Ubuntu 24.04.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ on:
 jobs:
 
   rip-and-test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
     - name: Dump GitHub context
       env:
@@ -29,8 +29,6 @@ jobs:
         set -x
         sudo apt-get install -y eatmydata
         eatmydata ./scripts/travis-install-build-deps.sh
-        eatmydata curl -L -O https://snapshot.debian.org/archive/debian/20220716T154603Z/pool/main/p/po4a/po4a_0.67-2_all.deb
-        sudo eatmydata apt install ./po4a_0.67-2_all.deb
         cd src
         eatmydata ./autogen.sh
         eatmydata ./configure --with-realtime=uspace --disable-check-runtime-deps
@@ -39,7 +37,7 @@ jobs:
         eatmydata ../scripts/rip-environment runtests -p
 
   rip-and-test-clang:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
     - name: Dump GitHub context
       env:
@@ -56,8 +54,6 @@ jobs:
         sudo apt-get install -y eatmydata
         eatmydata ./scripts/travis-install-build-deps.sh
         sudo eatmydata apt-get install -y clang
-        eatmydata curl -L -O https://snapshot.debian.org/archive/debian/20220716T154603Z/pool/main/p/po4a/po4a_0.67-2_all.deb
-        sudo eatmydata apt install ./po4a_0.67-2_all.deb
         cd src
         eatmydata ./autogen.sh
         CC=clang CXX=clang++ eatmydata ./configure --with-realtime=uspace --disable-check-runtime-deps
@@ -66,7 +62,7 @@ jobs:
         eatmydata ../scripts/rip-environment runtests -p
 
   htmldocs:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
     - name: Dump GitHub context
       env:
@@ -81,8 +77,6 @@ jobs:
       run: |
         ./scripts/travis-install-build-deps.sh
         sudo apt-get install -y eatmydata
-        curl -L -O https://snapshot.debian.org/archive/debian/20220716T154603Z/pool/main/p/po4a/po4a_0.67-2_all.deb
-        sudo apt install ./po4a_0.67-2_all.deb
         cd src
         eatmydata ./autogen.sh
         eatmydata ./configure --with-realtime=uspace --disable-check-runtime-deps --enable-build-documentation=html

--- a/scripts/travis-install-build-deps.sh
+++ b/scripts/travis-install-build-deps.sh
@@ -1,6 +1,4 @@
 #!/bin/sh -ex
-sudo sh -c 'echo deb-src http://us.archive.ubuntu.com/ubuntu/ xenial main universe >> /etc/apt/sources.list'
-grep . /etc/apt/sources.list /etc/apt/sources.list.d/* || true
 sudo apt-get update -qq
 sudo apt-get install -y devscripts equivs build-essential --no-install-recommends
 sudo apt-get remove -f libreadline6-dev || true


### PR DESCRIPTION
This PR fixes #3408.

The po4a upgrade in Ubuntu 20.04 became a downgrade in 24.04. The minimum version, according to #2715, was 0.67 and the new Ubuntu 24.04 is at 0.69. Therefore, no special things required and the downgrade has been removed.