### PR TITLE
Fix link version script

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1248,8 +1248,9 @@ modules: $(patsubst %.o,../rtlib/%.so,$(obj-m))
 ../rtlib/%.so:
 	$(ECHO) Linking $@
 	$(Q)ld -d -r -o objects/$*.tmp $^
-	$(Q)objcopy -j .rtapi_export -O binary objects/$*.tmp objects/$*.sym
-	$(Q)(echo '{ global : '; tr -s '\0' < objects/$*.sym | xargs -r0 printf '%s;\n' | grep .; echo 'local : * ; };') > objects/$*.ver
+	$(Q)objdump -w -j .rtapi_export -t objects/$*.tmp \
+	| awk 'BEGIN{print "{ global :"} /rtapi_exported_/{printf("%s;\n", substr($$6,16))} END{print "local : * ; };"}' \
+	> objects/$*.ver
 	$(Q)$(CC) -shared -Bsymbolic -Wl,--version-script,objects/$*.ver -o $@ $^ -lm $(LDFLAGS)
 	$(Q)chmod -x $@
 

--- a/src/Makefile.modinc.in
+++ b/src/Makefile.modinc.in
@@ -120,8 +120,9 @@ $(foreach mod,$(patsubst %.o,%,$(obj-m)),\
 %.so:
 	$(ECHO) Linking $@
 	$(Q)ld -d -r -o $*.tmp $^
-	$(Q)objcopy -j .rtapi_export -O binary $*.tmp $*.sym
-	$(Q)(echo '{ global : '; tr -s '\0' < $*.sym | xargs -r0 printf '%s;\n' | grep .; echo 'local : * ; };') > $*.ver
+	$(Q)objdump -w -j .rtapi_export -t $*.tmp \
+	| awk 'BEGIN{print "{ global :"} /rtapi_exported_/{printf("%s;\n", substr($$6,16))} END{print "local : * ; };"}' \
+	> $*.ver
 	$(Q)$(CC) -shared -Bsymbolic $(LDFLAGS) -Wl,--version-script,$*.ver -o $@ $^ -lm $(EXTRA_LDFLAGS)
 	$(Q)chmod -x $@
 endif

--- a/src/m4/ax_cxx_compile_stdcxx.m4
+++ b/src/m4/ax_cxx_compile_stdcxx.m4
@@ -52,7 +52,7 @@ AC_DEFUN([AX_CXX_COMPILE_STDCXX], [dnl
   m4_if([$1], [11], [ax_cxx_compile_alternatives="11 0x"],
         [$1], [14], [ax_cxx_compile_alternatives="14 1y"],
         [$1], [17], [ax_cxx_compile_alternatives="17 1z"],
-        [$1], [20], [ax_cxx_compile_alternatives="20"],
+        [$1], [20], [ax_cxx_compile_alternatives="20 2a"],
         [m4_fatal([invalid first argument `$1' to AX_CXX_COMPILE_STDCXX])])dnl
   m4_if([$2], [], [],
         [$2], [ext], [],


### PR DESCRIPTION
Fix linking RT modules by not using binary fiddling but objdump and awk as described in #3413.

Also, allow master to compile on Buster (debian 11) using clang-16, which should have enough c++20 compatibility.