### PR TITLE
Backport: Fix link version script

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1244,8 +1244,9 @@ modules: $(patsubst %.o,../rtlib/%.so,$(obj-m))
 ../rtlib/%.so:
 	$(ECHO) Linking $@
 	$(Q)ld -d -r -o objects/$*.tmp $^
-	$(Q)objcopy -j .rtapi_export -O binary objects/$*.tmp objects/$*.sym
-	$(Q)(echo '{ global : '; tr -s '\0' < objects/$*.sym | xargs -r0 printf '%s;\n' | grep .; echo 'local : * ; };') > objects/$*.ver
+	$(Q)objdump -w -j .rtapi_export -t objects/$*.tmp \
+	| awk 'BEGIN{print "{ global :"} /rtapi_exported_/{printf("%s;\n", substr($$6,16))} END{print "local : * ; };"}' \
+	> objects/$*.ver
 	$(Q)$(CC) -shared -Bsymbolic -Wl,--version-script,objects/$*.ver -o $@ $^ -lm $(LDFLAGS)
 	$(Q)chmod -x $@
 

--- a/src/Makefile.modinc.in
+++ b/src/Makefile.modinc.in
@@ -120,8 +120,9 @@ $(foreach mod,$(patsubst %.o,%,$(obj-m)),\
 %.so:
 	$(ECHO) Linking $@
 	$(Q)ld -d -r -o $*.tmp $^
-	$(Q)objcopy -j .rtapi_export -O binary $*.tmp $*.sym
-	$(Q)(echo '{ global : '; tr -s '\0' < $*.sym | xargs -r0 printf '%s;\n' | grep .; echo 'local : * ; };') > $*.ver
+	$(Q)objdump -w -j .rtapi_export -t $*.tmp \
+	| awk 'BEGIN{print "{ global :"} /rtapi_exported_/{printf("%s;\n", substr($$6,16))} END{print "local : * ; };"}' \
+	> $*.ver
 	$(Q)$(CC) -shared -Bsymbolic $(LDFLAGS) -Wl,--version-script,$*.ver -o $@ $^ -lm
 	$(Q)chmod -x $@
 endif


### PR DESCRIPTION
This is a backport of #3420.

Fix linking RT modules by not using binary fiddling but objdump and awk as described in #3413.