### PR TITLE
Backport: Fix invalid escape sequence warnings

### DIFF
--- a/src/hal/components/bldc.comp
+++ b/src/hal/components/bldc.comp
@@ -131,7 +131,7 @@ Note that a number of incorrect commutations will have non-zero net torque which
 
 If your motor lacks documentation it might be worth trying every pattern.
 
-.ie '\*[.T]'html' \\{\\
+.ie '\\*[.T]'html' \\{\\
 .HTML \\
 <STYLE> \\
 #pattern TD { text-align: center; padding-left: .5ex; padding-right: .5ex } \\
@@ -313,7 +313,7 @@ This can be over-ridden by the \\fBT\\fR tag. Sinusoidal commutation is signific
 To use an encoder for commutation a reference 0-degrees point must be found.
 The component uses the convention that motor zero is the point that an unloaded
 motor aligns to with a positive voltage on the A (or U) terminal and the B & C
-(or V and W) terminals connected together and to \-ve voltage. There will be
+(or V and W) terminals connected together and to -ve voltage. There will be
 two such positions on a 4-pole motor, 3 on a 6-pole and so on. They are all
 functionally equivalent as far as driving the motor is concerned.
 If the motor has Hall sensors then the motor can be started in trapezoidal

--- a/src/hal/components/histobins.comp
+++ b/src/hal/components/histobins.comp
@@ -5,7 +5,7 @@ Usage:
   Read availablebins pin for the number of bins available.
   Set the minvalue, binsize, and nbins pins.
     Ensure nbins <= availablebins
-    For nbins = N, the bins are numbered: 0 ... N\-1 
+    For nbins = N, the bins are numbered: 0 ... N-1
   Iterate:
     Set index pin to a bin number: 0 <= index < nbins.
     Read check pin and verify that check pin == index pin.
@@ -15,7 +15,7 @@ Usage:
          (nextra   is count for all bins   < minvalue)
 
  If index is out of range (index < 0 or index > maxbinnumber)
- then binvalue == \-1.
+ then binvalue == -1.
  The input-error pin is set when input rules are violated
  and updates cease.
  The reset pin may be used to restart.

--- a/src/hal/components/joyhandle.comp
+++ b/src/hal/components/joyhandle.comp
@@ -30,13 +30,13 @@ The component \\fBjoyhandle\\fR uses the following formula for a non linear joyp
 
 The parameters a and b are adjusted in such a way, that the function starts at (deadband,offset) and ends at (1,scale+offset).
 
-Negative values will be treated point symmetrically to origin. Values \-deadband < x < +deadband will be set to zero.
+Negative values will be treated point symmetrically to origin. Values -deadband < x < +deadband will be set to zero.
 
-Values x > 1 and x < \-1 will be skipped to \\(+-(scale+offset). Invert transforms the function to a progressive movement.
+Values x > 1 and x < -1 will be skipped to \\(+-(scale+offset). Invert transforms the function to a progressive movement.
 
 With power one can adjust the nonlinearity (default = 2). Default for deadband is 0.
 
-Valid values are: power >= 1.0 (reasonable values are 1.x .. 4\(hy5, take higher power\(hyvalues for higher deadbands (>0.5), if you want to start with a nearly horizontal slope), 0 <= deadband < 0.99 (reasonable 0.1).
+Valid values are: power >= 1.0 (reasonable values are 1.x .. 4\\(hy5, take higher power\\(hyvalues for higher deadbands (>0.5), if you want to start with a nearly horizontal slope), 0 <= deadband < 0.99 (reasonable 0.1).
 
 An additional offset component can be set in special cases (default = 0).
 

--- a/src/hal/components/latencybins.comp
+++ b/src/hal/components/latencybins.comp
@@ -3,11 +3,11 @@ component latencybins
 
 Usage:
   Read availablebins pin for the number of bins available.
-  Set the maxbinnumber pin for the number of \(+- bins.
+  Set the maxbinnumber pin for the number of \\(+- bins.
     Ensure maxbinnumber <= availablebins
     For maxbinnumber = N, the bins are numbered:
-       \-N ... 0 ... + N bins
-    (the \-0 bin is not populated)
+       -N ... 0 ... + N bins
+    (the -0 bin is not populated)
     (total effective bins = 2*maxbinnumber +1)
   Set nsbinsize pin for the binsize (ns)
   Iterate:
@@ -15,14 +15,14 @@ Usage:
     Read check pin and verify that check pin == index pin.
     Read output pins:
          pbinvalue is count for bin = +index
-         nbinvalue is count for bin = \-index
+         nbinvalue is count for bin = -index
          pextra    is count for all bins > maxbinnumber
          nextra    is count for all bins < maxbinnumber
          latency-min is max negative latency
          latency-max is max positive latency
 
    If index is out of range ( index < 0 or index > maxbinnumber)
-   then pbinvalue = nbinvalue = \-1.
+   then pbinvalue = nbinvalue = -1.
    The reset pin may be used to restart.
    The latency pin outputs the instantaneous latency.
 

--- a/src/hal/components/lut5.comp
+++ b/src/hal/components/lut5.comp
@@ -40,7 +40,7 @@ TRUE whenever exactly one of the inputs is true, so the correct value for
 connected to signals, because if any other bit is \\fBTRUE\\fR then the output
 will be \\fBFALSE\\fR.
 .PP
-.ie '\*[.T]'html' \\{\\
+.ie '\\*[.T]'html' \\{\\
 .HTML \\
 <STYLE> \\
 #weight TD { text-align: center; padding-left: .5ex; padding-right: .5ex } \\

--- a/src/hal/components/sim_parport.comp
+++ b/src/hal/components/sim_parport.comp
@@ -5,11 +5,11 @@ description
 Sim_parport is used to replace the pins of a real parport without changing
 any of the pins names in the rest of the config.
 .br
-It has pass-through pins (ending in \-fake) that allows connecting to other components.
+It has pass-through pins (ending in -fake) that allows connecting to other components.
 
-eg pin\-02\-in     will follow     pin\-02\-in\-fake 's logic.
+eg pin-02-in     will follow     pin-02-in-fake 's logic.
 .br
-pin_01_out\-fake     will follow    pin_01_out (possibly modified by pin_01_out\-invert)
+pin_01_out-fake     will follow    pin_01_out (possibly modified by pin_01_out-invert)
 
 It creates all possible pins of both 'in' and 'out' options of the hal_parport component.
 .br

--- a/src/hal/components/toggle2nist.comp
+++ b/src/hal/components/toggle2nist.comp
@@ -6,9 +6,9 @@ Toggle2nist can be used with a momentary push button
 to control a device that has separate on and off inputs
 and an is-on output. 
 
-\[bu] On a rising edge on pin \\fIin\\fR when \\fIis-on\\fR is low: It sets \\fIon\\fR until \\fIis-on\\fR becomes high.
+\\[bu] On a rising edge on pin \\fIin\\fR when \\fIis-on\\fR is low: It sets \\fIon\\fR until \\fIis-on\\fR becomes high.
 
-\[bu] On a rising edge on pin \\fIin\\fR when \\fIis-on\\fR is high: It sets \\fIoff\\fR until \\fIis-on\\fR becomes low.
+\\[bu] On a rising edge on pin \\fIin\\fR when \\fIis-on\\fR is high: It sets \\fIoff\\fR until \\fIis-on\\fR becomes low.
 
 
        ┐     ┌─────xxxxxxxxxxxx┐           ┌─────xxxxxxxxxxxx┐

--- a/src/hal/utils/halcompile.g
+++ b/src/hal/utils/halcompile.g
@@ -28,7 +28,7 @@ parser Hal:
     token NAME: "[a-zA-Z_][a-zA-Z0-9_]*"
     token STARREDNAME: "[*]*[a-zA-Z_][a-zA-Z0-9_]*"
     token HALNAME: "[#a-zA-Z_][-#a-zA-Z0-9_.]*"
-    token FPNUMBER: "-?([0-9]*\.[0-9]+|[0-9]+\.?)([Ee][+-]?[0-9]+)?f?"
+    token FPNUMBER: "-?([0-9]*\\.[0-9]+|[0-9]+\\.?)([Ee][+-]?[0-9]+)?f?"
     token NUMBER: "0x[0-9a-fA-F]+|[+-]?[0-9]+"
     token STRING: "\"(\\.|[^\\\"])*\""
     token HEADER: "<.*?>"
@@ -63,9 +63,9 @@ parser Hal:
     rule Personality: {{ pp = [] }} (PersonalityPart {{ pp.append(PersonalityPart) }} )* {{ return " ".join(pp) }}
     rule PersonalityPart: NUMBER {{ return NUMBER }}
             | POP {{ return POP }}
-    rule OptSimpleArray: "\[" NUMBER "\]" {{ return int(NUMBER) }}
+    rule OptSimpleArray: "\\[" NUMBER "\\]" {{ return int(NUMBER) }}
             | {{ return 0 }}
-    rule OptArray: "\[" NUMBER OptArrayPersonality "\]" {{ return OptArrayPersonality and (int(NUMBER), OptArrayPersonality) or int(NUMBER) }}
+    rule OptArray: "\\[" NUMBER OptArrayPersonality "\\]" {{ return OptArrayPersonality and (int(NUMBER), OptArrayPersonality) or int(NUMBER) }}
             | {{ return 0 }}
     rule OptArrayPersonality: ":" Personality {{ return Personality }}
             | {{ return None }} 


### PR DESCRIPTION
This is a backport of #3233.

It fixes the SyntaxError messages by fixing escape-sequences.