### PR TITLE
Backport: fix debug -O0

### DIFF
--- a/src/rtapi/Submakefile
+++ b/src/rtapi/Submakefile
@@ -14,7 +14,7 @@ RTAPI_APP_SRCS := \
 	rtapi/rtapi_pci.cc
 USERSRCS += $(RTAPI_APP_SRCS)
 
-$(call TOOBJSDEPS, rtapi/rtapi_pci.cc): EXTRAFLAGS += $(LIBUDEV_CFLAGS) -O0
+$(call TOOBJSDEPS, rtapi/rtapi_pci.cc): EXTRAFLAGS += $(LIBUDEV_CFLAGS)
 $(call TOOBJSDEPS, $(RTAPI_APP_SRCS)): EXTRAFLAGS += -DSIM \
 	-UULAPI -DRTAPI -pthread
 ../bin/rtapi_app: $(call TOOBJS, $(RTAPI_APP_SRCS))


### PR DESCRIPTION
This is a backport of #3257.

Using -O0 to gives a FORTYFY_SOURCE warning and is not necessary.