### PR TITLE
Fix copy elision warning

### DIFF
--- a/src/emc/task/emccanon.cc
+++ b/src/emc/task/emccanon.cc
@@ -2726,7 +2726,7 @@ auto SPINDLE_SPEED_(int s, int dir, double speed)
      //   canon.css_numerator = 0; FIXME: Do we need this?
     }
 
-    return std::move(emc_spindle_msg);
+    return emc_spindle_msg;
 }
 
 void START_SPINDLE_CLOCKWISE(int s, int wait_for_atspeed)


### PR DESCRIPTION
Debian 12 on ARM (RPi5) with gcc 12.2.0 gives an extra warning about copy elision because std::move is used. The std::move is removed as this is a case where it all works automagically fine.