### PR TITLE
2.9: typos, punctuation in comments

### DIFF
--- a/docs/src/drivers/mesa_modbus.adoc
+++ b/docs/src/drivers/mesa_modbus.adoc
@@ -327,8 +327,7 @@ Tx+ to Rx+ and Tx- to Rx-.
 
 Note that there are differing naming standards for Modbus pins.
 Typically Rx+ and TX+ will connect to the B- pin on the modbus device
-and Rx- and Tx- will connect to the A+ pin. (ie, +/- will appear
-reversed.
+and Rx- and Tx- will connect to the A+ pin, i.e., +/- will appear reversed.
 
 
 === Ad-hoc Modbus device access ===

--- a/docs/src/hal/halui-examples.adoc
+++ b/docs/src/hal/halui-examples.adoc
@@ -23,7 +23,7 @@ HALUI = halui
 
 To connect a remote program start button to LinuxCNC you use the
 `halui.program.run` pin and the `halui.mode.auto` pin.
-You have to insure that it is OK to run first by using the
+You have to ensure that it is OK to run first by using the
 `halui.mode.is-auto` pin. You do this with an `and2`
 component. The following figure shows how this is done.
 When the Remote Run Button is pressed it is connected to

--- a/src/hal/drivers/mesa-hostmot2/hm2_pci.c
+++ b/src/hal/drivers/mesa-hostmot2/hm2_pci.c
@@ -394,7 +394,7 @@ static int hm2_plx9054_reset(hm2_lowlevel_io_t *this) {
     control = status | DONE_ENABLE_5I22 | _PROG_ENABLE_5I22;
     rtapi_outl(control, board->ctrl_base_addr + CTRL_STAT_OFFSET_5I22);
 
-    // Turn off /PROGRAM bit and insure that DONE isn't asserted
+    // Turn off /PROGRAM bit and ensure that DONE is not asserted
     rtapi_outl(control & ~_PROGRAM_MASK_5I22, board->ctrl_base_addr + CTRL_STAT_OFFSET_5I22);
 
     status = rtapi_inl(board->ctrl_base_addr + CTRL_STAT_OFFSET_5I22);
@@ -411,7 +411,7 @@ static int hm2_plx9054_reset(hm2_lowlevel_io_t *this) {
 
     // Delay for at least 100 uS. to allow the FPGA to finish its reset
     // sequencing.  3300 reads is at least 100 us, could be as long as a
-    // few ms
+    // few ms.
     for (i = 0; i < 3300; i++) {
         status = rtapi_inl(board->ctrl_base_addr + CTRL_STAT_OFFSET);
     }


### PR DESCRIPTION
I had run into the "insure" vs "ensure" problem again while translating. I had thought that I had already eliminated all those issues. It was fine, though, just a problem of .po file synchronisation it seems, the problem only appears only in a comment.