### PR TITLE
Configure test and warning fix for python 3.13 

### DIFF
--- a/src/emc/rs274ngc/gcodemodule.cc
+++ b/src/emc/rs274ngc/gcodemodule.cc
@@ -174,6 +174,9 @@ static PyTypeObject LineCodeType = {
     0,                      /*tp_vectorcall*/
 #if PY_VERSION_HEX >= 0x030c00f0	// 3.12
     0,                      /*tp_watched*/
+#if PY_VERSION_HEX >= 0x030d00f0	// 3.13
+    0,                      /*tp_versions_used*/
+#endif
 #endif
 #endif
 };

--- a/src/emc/usr_intf/axis/extensions/emcmodule.cc
+++ b/src/emc/usr_intf/axis/extensions/emcmodule.cc
@@ -212,6 +212,9 @@ static PyTypeObject Ini_Type = {
     0,                      /*tp_vectorcall*/
 #if PY_VERSION_HEX >= 0x030c00f0	// 3.12
     0,                      /*tp_watched*/
+#if PY_VERSION_HEX >= 0x030d00f0	// 3.13
+    0,                      /*tp_versions_used*/
+#endif
 #endif
 #endif
 };
@@ -891,6 +894,9 @@ static PyTypeObject Stat_Type = {
     0,                      /*tp_vectorcall*/
 #if PY_VERSION_HEX >= 0x030c00f0	// 3.12
     0,                      /*tp_watched*/
+#if PY_VERSION_HEX >= 0x030d00f0	// 3.13
+    0,                      /*tp_versions_used*/
+#endif
 #endif
 #endif
 };
@@ -1685,6 +1691,9 @@ static PyTypeObject Command_Type = {
     0,                      /*tp_vectorcall*/
 #if PY_VERSION_HEX >= 0x030c00f0	// 3.12
     0,                      /*tp_watched*/
+#if PY_VERSION_HEX >= 0x030d00f0	// 3.13
+    0,                      /*tp_versions_used*/
+#endif
 #endif
 #endif
 };
@@ -1807,6 +1816,9 @@ static PyTypeObject Error_Type = {
     0,                      /*tp_vectorcall*/
 #if PY_VERSION_HEX >= 0x030c00f0	// 3.12
     0,                      /*tp_watched*/
+#if PY_VERSION_HEX >= 0x030d00f0	// 3.13
+    0,                      /*tp_versions_used*/
+#endif
 #endif
 #endif
 };
@@ -2538,6 +2550,9 @@ static PyTypeObject PositionLoggerType = {
     0,                      /*tp_vectorcall*/
 #if PY_VERSION_HEX >= 0x030c00f0	// 3.12
     0,                      /*tp_watched*/
+#if PY_VERSION_HEX >= 0x030d00f0	// 3.13
+    0,                      /*tp_versions_used*/
+#endif
 #endif
 #endif
 };

--- a/src/hal/halmodule.cc
+++ b/src/hal/halmodule.cc
@@ -704,6 +704,9 @@ PyTypeObject halobject_type = {
     0,                         /*tp_vectorcall*/
 #if PY_VERSION_HEX >= 0x030c00f0	// 3.12
     0,                         /*tp_watched*/
+#if PY_VERSION_HEX >= 0x030d00f0	// 3.13
+    0,                         /*tp_versions_used*/
+#endif
 #endif
 #endif
 };
@@ -866,6 +869,9 @@ PyTypeObject halpin_type = {
     0,                         /*tp_vectorcall*/
 #if PY_VERSION_HEX >= 0x030c00f0	// 3.12
     0,                         /*tp_watched*/
+#if PY_VERSION_HEX >= 0x030d00f0	// 3.13
+    0,                         /*tp_versions_used*/
+#endif
 #endif
 #endif
 };
@@ -1671,6 +1677,9 @@ PyTypeObject shm_type = {
     0,                         /*tp_vectorcall*/
 #if PY_VERSION_HEX >= 0x030c00f0	// 3.12
     0,                         /*tp_watched*/
+#if PY_VERSION_HEX >= 0x030d00f0	// 3.13
+    0,                         /*tp_versions_used*/
+#endif
 #endif
 #endif
 };
@@ -1918,6 +1927,9 @@ PyTypeObject stream_type = {
     0,                         /*tp_vectorcall*/
 #if PY_VERSION_HEX >= 0x030c00f0	// 3.12
     0,                         /*tp_watched*/
+#if PY_VERSION_HEX >= 0x030d00f0	// 3.13
+    0,                         /*tp_versions_used*/
+#endif
 #endif
 #endif
 };

--- a/src/m4/ax_python.m4
+++ b/src/m4/ax_python.m4
@@ -55,7 +55,7 @@
 AC_DEFUN([AX_PYTHON],
 [AC_MSG_CHECKING(for python build information)
 AC_MSG_RESULT([])
-for python in python3.12 python3.11 python3.10 python3.9 python3.8 python3.7 python3.6 python3.5 python3.4 python3.3 python3.2 python3.1 python3.0 python2.7 python2.6 python2.5 python2.4 python2.3 python2.2 python2.1 python; do
+for python in python3.13 python3.12 python3.11 python3.10 python3.9 python3.8 python3.7 python3.6 python3.5 python3.4 python3.3 python3.2 python3.1 python3.0 python2.7 python2.6 python2.5 python2.4 python2.3 python2.2 python2.1 python; do
 AC_CHECK_PROGS(PYTHON_BIN, [$python])
 ax_python_bin=$PYTHON_BIN
 if test x$ax_python_bin != x; then


### PR DESCRIPTION
The current python version 3.13 will fail configure. Additionally, when the version is recognized, several missing initializer warnings are issued because the PyTypeObject structure was appended.
This PR fixes these problems.