### PR TITLE
Fix misleading machine state information after program abort

### DIFF
--- a/docs/src/config/ini-config.adoc
+++ b/docs/src/config/ini-config.adoc
@@ -568,7 +568,7 @@ FEATURES & 0x20 -> OWORD_WARNONLY
 * `REMAP=M400 modalgroup=10 argspec=Pq ngc=myprocedure`
   See <<cha:remap,Remap Extending G-code>> chapter for details.
 * `ON_ABORT_COMMAND=O <on_abort> call`
-  See <<cha:remap,Remap Extending G-code>> chapter for details.
+  Specifies a subroutine to be called in the event of a program abort. If not specified 'M2' is executed by default. See <<cha:remap,Remap Extending G-code>> chapter for details.
 
 [[sub:ini:sec:emcmot]]
 === [EMCMOT] Section(((INI File,Sections,[EMCMOT] Section)))

--- a/src/emc/rs274ngc/rs274ngc_pre.cc
+++ b/src/emc/rs274ngc/rs274ngc_pre.cc
@@ -2636,14 +2636,15 @@ int Interp::on_abort(int reason, const char *message)
     _setup.probe_flag = false;
     _setup.input_flag = false;
 
+    int status;
     if (_setup.on_abort_command == NULL) {
-	return -1;
+    status = execute("m2");
     }
-
+    else {
     char cmd[LINELEN];
-
     snprintf(cmd,sizeof(cmd), "%s [%d]",_setup.on_abort_command, reason);
-    int status = execute(cmd);
+    status = execute(cmd);
+    }
 
     ERP(status);
     return status;


### PR DESCRIPTION
This fixes issues #2745 and #2908 and adds clarification to the documentation

The current situation of not resetting the controller after a program abort leaves parameter values and the status channel out of sync. This causes the DRO to display wrong information about axis position and offset values after a program abort. 
The new default behavior (if no [RS274NGC] ON_ABORT_COMMAND entry is found in the ini file) is to issue 'M2' on a program abort which correctly resets and synchronizes the parameter values and the status channel. 