### PR TITLE
fix: rs274 nullptr will collapse the milltask when hal para is wrong

### DIFF
--- a/src/emc/rs274ngc/gcodemodule.cc
+++ b/src/emc/rs274ngc/gcodemodule.cc
@@ -193,28 +193,8 @@ static InterpBase *pinterp;
 
 #define callmethod(o, m, f, ...) PyObject_CallMethod((o), (char*)(m), (char*)(f), ## __VA_ARGS__)
 
-static void maybe_new_line();
 static void maybe_new_line(int sequence_number);
-
-static void maybe_new_line() {
-    if(!pinterp) return;
-    if(interp_error) return;
-    int sequence_number = pinterp->sequence_number();
-    if(sequence_number == last_sequence_number)
-        return;
-    LineCode *new_line_code =
-        (LineCode*)(PyObject_New(LineCode, &LineCodeType));
-    pinterp->active_settings(new_line_code->settings);
-    pinterp->active_g_codes(new_line_code->gcodes);
-    pinterp->active_m_codes(new_line_code->mcodes);
-    new_line_code->gcodes[0] = sequence_number;
-    last_sequence_number = sequence_number;
-    PyObject *result = 
-        callmethod(callback, "next_line", "O", new_line_code);
-    Py_DECREF(new_line_code);
-    if(result == NULL) interp_error ++;
-    Py_XDECREF(result);
-}
+static void maybe_new_line();
 
 static void maybe_new_line(int sequence_number) {
     if(!pinterp) return;
@@ -233,6 +213,11 @@ static void maybe_new_line(int sequence_number) {
     Py_DECREF(new_line_code);
     if(result == NULL) interp_error ++;
     Py_XDECREF(result);
+}
+
+static void maybe_new_line() {
+    if(!pinterp) return;
+    maybe_new_line(pinterp->sequence_number());
 }
 
 //das ist für die Vorschau

--- a/src/emc/rs274ngc/gcodemodule.cc
+++ b/src/emc/rs274ngc/gcodemodule.cc
@@ -193,10 +193,11 @@ static InterpBase *pinterp;
 
 #define callmethod(o, m, f, ...) PyObject_CallMethod((o), (char*)(m), (char*)(f), ## __VA_ARGS__)
 
-static void maybe_new_line(int sequence_number=pinterp->sequence_number());
+static void maybe_new_line(int sequence_number=0);
 static void maybe_new_line(int sequence_number) {
     if(!pinterp) return;
     if(interp_error) return;
+    sequence_number=pinterp->sequence_number();
     if(sequence_number == last_sequence_number)
         return;
     LineCode *new_line_code =

--- a/src/emc/rs274ngc/gcodemodule.cc
+++ b/src/emc/rs274ngc/gcodemodule.cc
@@ -193,11 +193,32 @@ static InterpBase *pinterp;
 
 #define callmethod(o, m, f, ...) PyObject_CallMethod((o), (char*)(m), (char*)(f), ## __VA_ARGS__)
 
-static void maybe_new_line(int sequence_number=0);
+static void maybe_new_line();
+static void maybe_new_line(int sequence_number);
+
+static void maybe_new_line() {
+    if(!pinterp) return;
+    if(interp_error) return;
+    int sequence_number = pinterp->sequence_number();
+    if(sequence_number == last_sequence_number)
+        return;
+    LineCode *new_line_code =
+        (LineCode*)(PyObject_New(LineCode, &LineCodeType));
+    pinterp->active_settings(new_line_code->settings);
+    pinterp->active_g_codes(new_line_code->gcodes);
+    pinterp->active_m_codes(new_line_code->mcodes);
+    new_line_code->gcodes[0] = sequence_number;
+    last_sequence_number = sequence_number;
+    PyObject *result = 
+        callmethod(callback, "next_line", "O", new_line_code);
+    Py_DECREF(new_line_code);
+    if(result == NULL) interp_error ++;
+    Py_XDECREF(result);
+}
+
 static void maybe_new_line(int sequence_number) {
     if(!pinterp) return;
     if(interp_error) return;
-    sequence_number=pinterp->sequence_number();
     if(sequence_number == last_sequence_number)
         return;
     LineCode *new_line_code =


### PR DESCRIPTION
rs274 nullptr will collapse the milltask when hal para is wrong. 