### PR TITLE
Don't use date in doc header

### DIFF
--- a/docs/src/Master_Developer.adoc
+++ b/docs/src/Master_Developer.adoc
@@ -1,10 +1,9 @@
 :lang: en
 :lversion: {sys: cat ../VERSION}
-:date: {sys: LANG=C date --date="@$(dpkg-parsechangelog --file ../debian/changelog -S timestamp)" '+%d %b %Y'}
 :ascii-ids:
 :masterdir: {indir}
 :revdate: 2021-10-28
-= Developer Manual V{lversion}, {date}
+= Developer Manual V{lversion}
 
 == Introduction
 

--- a/docs/src/Master_Documentation.adoc
+++ b/docs/src/Master_Documentation.adoc
@@ -1,11 +1,10 @@
 :lang: en
 :lversion: {sys: cat ../VERSION}
-:date: {sys: LANG=C date --date="@$(dpkg-parsechangelog --file ../debian/changelog -S timestamp)" '+%d %b %Y'}
 :ascii-ids:
 :masterdir: {indir}
 :revdate: 2021-10-28 
-LinuxCNC V{lversion}, {date}
-============================
+= LinuxCNC V{lversion}
+
 
 :leveloffset: 0
 = Getting Started & Configuration

--- a/docs/src/Master_Getting_Started.adoc
+++ b/docs/src/Master_Getting_Started.adoc
@@ -1,10 +1,9 @@
 :lang: en
 :lversion: {sys: cat ../VERSION}
-:date: {sys: LANG=C date --date="@$(dpkg-parsechangelog --file ../debian/changelog -S timestamp)" '+%d %b %Y'}
 :ascii-ids:
 :masterdir: {indir}
 :revdate: 2021-10-28
-= Getting Started V{lversion}, {date}
+= Getting Started V{lversion}
 
 The LinuxCNC Team
 

--- a/docs/src/Master_Integrator.adoc
+++ b/docs/src/Master_Integrator.adoc
@@ -1,10 +1,9 @@
 :lang: en
 :lversion: {sys: cat ../VERSION}
-:date: {sys: LANG=C date --date="@$(dpkg-parsechangelog --file ../debian/changelog -S timestamp)" '+%d %b %Y'}
 :ascii-ids:
 :masterdir: {indir}
 :revdate: 2021-10-28
-= Integrator Information V{lversion}, {date}
+= Integrator Information V{lversion}
 
 :leveloffset: 1
 


### PR DESCRIPTION
This fixes #3462.

This also fixes a very long list of asciidoc error messages in the build caused by a markdown underline at the top-level.