### PR TITLE
HAL pin "conventional_directions" for configuration of rotational axis direction

### DIFF
--- a/configs/sim/axis/vismach/5axis/table-rotary-tilting/xyzac-trt.ini
+++ b/configs/sim/axis/vismach/5axis/table-rotary-tilting/xyzac-trt.ini
@@ -69,6 +69,7 @@ HALCMD = sets :z-offset     10
 HALCMD = setp xyzac-trt-kins.x-rot-point 0
 HALCMD = setp xyzac-trt-kins.y-rot-point 0
 HALCMD = setp xyzac-trt-kins.z-rot-point 0
+HALCMD = setp xyzac-trt-kins.conventional-directions 0
 
 [HALUI]
 # NOTE: kinstype==0 is identity kins because sparm=identityfirst

--- a/configs/sim/axis/vismach/5axis/table-rotary-tilting/xyzac-trt.txt
+++ b/configs/sim/axis/vismach/5axis/table-rotary-tilting/xyzac-trt.txt
@@ -28,3 +28,10 @@ Hal Input pins:
 X, Y and Z rot-point pins represent the
 offsets of the center of rotation of the C axis
 relative to the machine absolute zero
+
+Hal Input pins:
+  xyzac-trt-kins.conventional-directions
+
+Pin conventional-directions is false by default. If true,
+axis directions follow the conventions as defined
+at https://linuxcnc.org/docs/html/gcode/machining-center.html#_rotational_axes

--- a/configs/sim/axis/vismach/5axis/table-rotary-tilting/xyzbc-trt.ini
+++ b/configs/sim/axis/vismach/5axis/table-rotary-tilting/xyzbc-trt.ini
@@ -69,6 +69,7 @@ HALCMD = sets :z-offset     -15
 HALCMD = setp xyzbc-trt-kins.x-rot-point 0
 HALCMD = setp xyzbc-trt-kins.y-rot-point 0
 HALCMD = setp xyzbc-trt-kins.z-rot-point 0
+HALCMD = setp xyzbc-trt-kins.conventional-directions 0
 
 [HALUI]
 # NOTE: kinstype==0 is identity kins because sparm=identityfirst

--- a/configs/sim/axis/vismach/5axis/table-rotary-tilting/xyzbc-trt.txt
+++ b/configs/sim/axis/vismach/5axis/table-rotary-tilting/xyzbc-trt.txt
@@ -21,10 +21,17 @@ of rotation of the B axis relative to the center
 of rotation of the C axis.
 
 Hal Input pins:
-  xyzac-trt-kins.x-rot-point
-  xyzac-trt-kins.y-rot-point
-  xyzac-trt-kins.z-rot-point
+  xyzbc-trt-kins.x-rot-point
+  xyzbc-trt-kins.y-rot-point
+  xyzbc-trt-kins.z-rot-point
 
 X, Y and Z rot-point pins represent the
 offsets of the center of rotation of the C axis
 relative to the machine absolute zero
+
+Hal Input pins:
+  xyzbc-trt-kins.conventional-directions
+
+Pin conventional-directions is false by default. If true,
+axis directions follow the conventions as defined
+at https://linuxcnc.org/docs/html/gcode/machining-center.html#_rotational_axes

--- a/src/emc/kinematics/maxkins.c
+++ b/src/emc/kinematics/maxkins.c
@@ -32,6 +32,7 @@
 
 struct haldata {
     hal_float_t *pivot_length;
+    hal_bit_t *conventional_directions; //default is false
 } *haldata;
 
 int kinematicsForward(const double *joints,
@@ -41,23 +42,26 @@ int kinematicsForward(const double *joints,
 {
     (void)fflags;
     (void)iflags;
+
+    const real_t con = *(haldata->conventional_directions) ? 1.0 : -1.0;
+
     // B correction
-    double zb = (*(haldata->pivot_length) + joints[8]) * cos(d2r(joints[4]));
-    double xb = (*(haldata->pivot_length) + joints[8]) * sin(d2r(joints[4]));
+    const double zb = (*(haldata->pivot_length) + joints[8]) * cos(d2r(joints[4]));
+    const double xb = (*(haldata->pivot_length) + joints[8]) * sin(d2r(joints[4]));
         
     // C correction
-    double xyr = hypot(joints[0], joints[1]);
-    double xytheta = atan2(joints[1], joints[0]) + d2r(joints[5]);
+    const double xyr = hypot(joints[0], joints[1]);
+    const double xytheta = atan2(joints[1], joints[0]) + d2r(joints[5]);
 
     // U correction
-    double zv = joints[6] * sin(d2r(joints[4]));
-    double xv = joints[6] * cos(d2r(joints[4]));
+    const double zv = joints[6] * sin(d2r(joints[4]));
+    const double xv = joints[6] * cos(d2r(joints[4]));
 
     // V correction is always in joint 1 only
 
-    pos->tran.x = xyr * cos(xytheta) + xb - xv;
+    pos->tran.x = xyr * cos(xytheta) - (con * xb) - xv;
     pos->tran.y = xyr * sin(xytheta) - joints[7];
-    pos->tran.z = joints[2] - zb + zv + *(haldata->pivot_length);
+    pos->tran.z = joints[2] - zb - (con * zv) + *(haldata->pivot_length);
 
     pos->a = joints[3];
     pos->b = joints[4];
@@ -76,23 +80,26 @@ int kinematicsInverse(const EmcPose * pos,
 {
     (void)iflags;
     (void)fflags;
+
+    const real_t con = *(haldata->conventional_directions) ? 1.0 : -1.0;
+
     // B correction
-    double zb = (*(haldata->pivot_length) + pos->w) * cos(d2r(pos->b));
-    double xb = (*(haldata->pivot_length) + pos->w) * sin(d2r(pos->b));
+    const double zb = (*(haldata->pivot_length) + pos->w) * cos(d2r(pos->b));
+    const double xb = (*(haldata->pivot_length) + pos->w) * sin(d2r(pos->b));
         
     // C correction
-    double xyr = hypot(pos->tran.x, pos->tran.y);
-    double xytheta = atan2(pos->tran.y, pos->tran.x) - d2r(pos->c);
+    const double xyr = hypot(pos->tran.x, pos->tran.y);
+    const double xytheta = atan2(pos->tran.y, pos->tran.x) - d2r(pos->c);
 
     // U correction
-    double zv = pos->u * sin(d2r(pos->b));
-    double xv = pos->u * cos(d2r(pos->b));
+    const double zv = pos->u * sin(d2r(pos->b));
+    const double xv = pos->u * cos(d2r(pos->b));
 
     // V correction is always in joint 1 only
 
-    joints[0] = xyr * cos(xytheta) - xb + xv;
+    joints[0] = xyr * cos(xytheta) + (con * xb) + xv;
     joints[1] = xyr * sin(xytheta) + pos->v;
-    joints[2] = pos->tran.z + zb + zv - *(haldata->pivot_length);
+    joints[2] = pos->tran.z + zb - (con * zv) - *(haldata->pivot_length);
 
     joints[3] = pos->a;
     joints[4] = pos->b;
@@ -127,10 +134,13 @@ int rtapi_app_main(void) {
     haldata = hal_malloc(sizeof(struct haldata));
 
     result = hal_pin_float_new("maxkins.pivot-length", HAL_IO, &(haldata->pivot_length), comp_id);
+
+    result += hal_pin_bit_new("maxkins.conventional-directions", HAL_IN, &(haldata->conventional_directions), comp_id);
+
     if(result < 0) goto error;
 
     *(haldata->pivot_length) = 0.666;
-
+    *(haldata->conventional_directions) = 0; // default is unconventional
     hal_ready(comp_id);
     return 0;
 


### PR DESCRIPTION
Following discussion in PR https://github.com/LinuxCNC/linuxcnc/pull/2443:

Introduce HAL pin "conventional_directions" for configuration of rotational axis direction with selected kinematics.
For maxkins, xyzac-trt and xyzbc-trt kinematics, the value of this pin is set to 0 (false) by default so that behaviour of these kinematics is not changed by default for backwards compatibility.
The pin can be set to 1 (true) if the user wants conventional axis direction as defined in the NIST RS274NGC interpreter, version 3 and at https://linuxcnc.org/docs/html/gcode/machining-center.html#_rotational_axes.

I have no idea how to do the same for "5axiskins", so issue https://github.com/LinuxCNC/linuxcnc/issues/2435 should stay open.
This should probably be unit-tested and/or tested using a simulator, but I am not familiar enough with LinuxCNC.