### PR TITLE
Move halcompile generated docs to asciidoc instead of (t)roff

### DIFF
--- a/docs/html/asciidoc.css
+++ b/docs/html/asciidoc.css
@@ -1,0 +1,527 @@
+/* Shared CSS for AsciiDoc xhtml11 and html5 backends */
+
+/* Default font. */
+body {
+  font-family: Georgia,serif;
+}
+
+/* Title font. */
+h1, h2, h3, h4, h5, h6,
+div.title, caption.title,
+thead, p.table.header,
+#toctitle,
+#author, #revnumber, #revdate, #revremark,
+#footer {
+  font-family: Arial,Helvetica,sans-serif;
+}
+
+body {
+  margin: 1em 5% 1em 5%;
+}
+
+a {
+  color: blue;
+  text-decoration: underline;
+}
+a:visited {
+  color: fuchsia;
+}
+
+em {
+  font-style: italic;
+  color: navy;
+}
+
+strong {
+  font-weight: bold;
+  color: #083194;
+}
+
+h1, h2, h3, h4, h5, h6 {
+  color: #527bbd;
+  margin-top: 1.2em;
+  margin-bottom: 0.5em;
+  line-height: 1.3;
+}
+
+h1, h2, h3 {
+  border-bottom: 2px solid silver;
+}
+h2 {
+  padding-top: 0.5em;
+}
+h3 {
+  float: left;
+}
+h3 + * {
+  clear: left;
+}
+h5 {
+  font-size: 1.0em;
+}
+
+div.sectionbody {
+  margin-left: 0;
+}
+
+hr {
+  border: 1px solid silver;
+}
+
+p {
+  margin-top: 0.5em;
+  margin-bottom: 0.5em;
+}
+
+ul, ol, li > p {
+  margin-top: 0;
+}
+ul > li     { color: #aaa; }
+ul > li > * { color: black; }
+
+.monospaced, code, pre {
+  font-family: "Courier New", Courier, monospace;
+  font-size: inherit;
+  color: navy;
+  padding: 0;
+  margin: 0;
+}
+pre {
+  white-space: pre-wrap;
+}
+
+#author {
+  color: #527bbd;
+  font-weight: bold;
+  font-size: 1.1em;
+}
+#email {
+}
+#revnumber, #revdate, #revremark {
+}
+
+#footer {
+  font-size: small;
+  border-top: 2px solid silver;
+  padding-top: 0.5em;
+  margin-top: 4.0em;
+}
+#footer-text {
+  float: left;
+  padding-bottom: 0.5em;
+}
+#footer-badges {
+  float: right;
+  padding-bottom: 0.5em;
+}
+
+#preamble {
+  margin-top: 1.5em;
+  margin-bottom: 1.5em;
+}
+div.imageblock, div.exampleblock, div.verseblock,
+div.quoteblock, div.literalblock, div.listingblock, div.sidebarblock,
+div.admonitionblock {
+  margin-top: 1.0em;
+  margin-bottom: 1.5em;
+}
+div.admonitionblock {
+  margin-top: 2.0em;
+  margin-bottom: 2.0em;
+  margin-right: 10%;
+  color: #606060;
+}
+
+div.content { /* Block element content. */
+  padding: 0;
+}
+
+/* Block element titles. */
+div.title, caption.title {
+  color: #527bbd;
+  font-weight: bold;
+  text-align: left;
+  margin-top: 1.0em;
+  margin-bottom: 0.5em;
+}
+div.title + * {
+  margin-top: 0;
+}
+
+td div.title:first-child {
+  margin-top: 0.0em;
+}
+div.content div.title:first-child {
+  margin-top: 0.0em;
+}
+div.content + div.title {
+  margin-top: 0.0em;
+}
+
+div.sidebarblock > div.content {
+  background: #ffffee;
+  border: 1px solid #dddddd;
+  border-left: 4px solid #f0f0f0;
+  padding: 0.5em;
+}
+
+div.listingblock > div.content {
+  border: 1px solid #dddddd;
+  border-left: 5px solid #f0f0f0;
+  background: #f8f8f8;
+  padding: 0.5em;
+}
+
+div.quoteblock, div.verseblock {
+  padding-left: 1.0em;
+  margin-left: 1.0em;
+  margin-right: 10%;
+  border-left: 5px solid #f0f0f0;
+  color: #888;
+}
+
+div.quoteblock > div.attribution {
+  padding-top: 0.5em;
+  text-align: right;
+}
+
+div.verseblock > pre.content {
+  font-family: inherit;
+  font-size: inherit;
+}
+div.verseblock > div.attribution {
+  padding-top: 0.75em;
+  text-align: left;
+}
+/* DEPRECATED: Pre version 8.2.7 verse style literal block. */
+div.verseblock + div.attribution {
+  text-align: left;
+}
+
+div.admonitionblock .icon {
+  vertical-align: top;
+  font-size: 1.1em;
+  font-weight: bold;
+  text-decoration: underline;
+  color: #527bbd;
+  padding-right: 0.5em;
+}
+div.admonitionblock td.content {
+  padding-left: 0.5em;
+  border-left: 3px solid #dddddd;
+}
+
+div.exampleblock > div.content {
+  border-left: 3px solid #dddddd;
+  padding-left: 0.5em;
+}
+
+div.imageblock div.content { padding-left: 0; }
+span.image img { border-style: none; vertical-align: text-bottom; }
+a.image:visited { color: white; }
+
+dl {
+  margin-top: 0.8em;
+  margin-bottom: 0.8em;
+}
+dt {
+  margin-top: 0.5em;
+  margin-bottom: 0;
+  font-style: normal;
+  color: navy;
+}
+dd > *:first-child {
+  margin-top: 0.1em;
+}
+
+ul, ol {
+    list-style-position: outside;
+}
+ol.arabic {
+  list-style-type: decimal;
+}
+ol.loweralpha {
+  list-style-type: lower-alpha;
+}
+ol.upperalpha {
+  list-style-type: upper-alpha;
+}
+ol.lowerroman {
+  list-style-type: lower-roman;
+}
+ol.upperroman {
+  list-style-type: upper-roman;
+}
+
+div.compact ul, div.compact ol,
+div.compact p, div.compact p,
+div.compact div, div.compact div {
+  margin-top: 0.1em;
+  margin-bottom: 0.1em;
+}
+
+tfoot {
+  font-weight: bold;
+}
+td > div.verse {
+  white-space: pre;
+}
+
+div.hdlist {
+  margin-top: 0.8em;
+  margin-bottom: 0.8em;
+}
+div.hdlist tr {
+  padding-bottom: 15px;
+}
+dt.hdlist1.strong, td.hdlist1.strong {
+  font-weight: bold;
+}
+td.hdlist1 {
+  vertical-align: top;
+  font-style: normal;
+  padding-right: 0.8em;
+  color: navy;
+}
+td.hdlist2 {
+  vertical-align: top;
+}
+div.hdlist.compact tr {
+  margin: 0;
+  padding-bottom: 0;
+}
+
+.comment {
+  background: yellow;
+}
+
+.footnote, .footnoteref {
+  font-size: 0.8em;
+}
+
+span.footnote, span.footnoteref {
+  vertical-align: super;
+}
+
+#footnotes {
+  margin: 20px 0 20px 0;
+  padding: 7px 0 0 0;
+}
+
+#footnotes div.footnote {
+  margin: 0 0 5px 0;
+}
+
+#footnotes hr {
+  border: none;
+  border-top: 1px solid silver;
+  height: 1px;
+  text-align: left;
+  margin-left: 0;
+  width: 20%;
+  min-width: 100px;
+}
+
+div.colist td {
+  padding-right: 0.5em;
+  padding-bottom: 0.3em;
+  vertical-align: top;
+}
+div.colist td img {
+  margin-top: 0.3em;
+}
+
+@media print {
+  #footer-badges { display: none; }
+}
+
+#toc {
+  margin-bottom: 2.5em;
+}
+
+#toctitle {
+  color: #527bbd;
+  font-size: 1.1em;
+  font-weight: bold;
+  margin-top: 1.0em;
+  margin-bottom: 0.1em;
+}
+
+div.toclevel0, div.toclevel1, div.toclevel2, div.toclevel3, div.toclevel4 {
+  margin-top: 0;
+  margin-bottom: 0;
+}
+div.toclevel2 {
+  margin-left: 2em;
+  font-size: 0.9em;
+}
+div.toclevel3 {
+  margin-left: 4em;
+  font-size: 0.9em;
+}
+div.toclevel4 {
+  margin-left: 6em;
+  font-size: 0.9em;
+}
+
+span.aqua { color: aqua; }
+span.black { color: black; }
+span.blue { color: blue; }
+span.fuchsia { color: fuchsia; }
+span.gray { color: gray; }
+span.green { color: green; }
+span.lime { color: lime; }
+span.maroon { color: maroon; }
+span.navy { color: navy; }
+span.olive { color: olive; }
+span.purple { color: purple; }
+span.red { color: red; }
+span.silver { color: silver; }
+span.teal { color: teal; }
+span.white { color: white; }
+span.yellow { color: yellow; }
+
+span.aqua-background { background: aqua; }
+span.black-background { background: black; }
+span.blue-background { background: blue; }
+span.fuchsia-background { background: fuchsia; }
+span.gray-background { background: gray; }
+span.green-background { background: green; }
+span.lime-background { background: lime; }
+span.maroon-background { background: maroon; }
+span.navy-background { background: navy; }
+span.olive-background { background: olive; }
+span.purple-background { background: purple; }
+span.red-background { background: red; }
+span.silver-background { background: silver; }
+span.teal-background { background: teal; }
+span.white-background { background: white; }
+span.yellow-background { background: yellow; }
+
+span.big { font-size: 2em; }
+span.small { font-size: 0.6em; }
+
+span.underline { text-decoration: underline; }
+span.overline { text-decoration: overline; }
+span.line-through { text-decoration: line-through; }
+
+div.unbreakable { page-break-inside: avoid; }
+
+
+/*
+ * xhtml11 specific
+ *
+ * */
+
+div.tableblock {
+  margin-top: 1.0em;
+  margin-bottom: 1.5em;
+}
+div.tableblock > table {
+  border: 3px solid #527bbd;
+}
+thead, p.table.header {
+  font-weight: bold;
+  color: #527bbd;
+}
+p.table {
+  margin-top: 0;
+}
+/* Because the table frame attribute is overridden by CSS in most browsers. */
+div.tableblock > table[frame="void"] {
+  border-style: none;
+}
+div.tableblock > table[frame="hsides"] {
+  border-left-style: none;
+  border-right-style: none;
+}
+div.tableblock > table[frame="vsides"] {
+  border-top-style: none;
+  border-bottom-style: none;
+}
+
+
+/*
+ * html5 specific
+ *
+ * */
+
+table.tableblock {
+  margin-top: 1.0em;
+  margin-bottom: 1.5em;
+}
+thead, p.tableblock.header {
+  font-weight: bold;
+  color: #527bbd;
+}
+p.tableblock {
+  margin-top: 0;
+}
+table.tableblock {
+  border-width: 3px;
+  border-spacing: 0px;
+  border-style: solid;
+  border-color: #527bbd;
+  border-collapse: collapse;
+}
+th.tableblock, td.tableblock {
+  border-width: 1px;
+  padding: 4px;
+  border-style: solid;
+  border-color: #527bbd;
+}
+
+table.tableblock.frame-topbot {
+  border-left-style: hidden;
+  border-right-style: hidden;
+}
+table.tableblock.frame-sides {
+  border-top-style: hidden;
+  border-bottom-style: hidden;
+}
+table.tableblock.frame-none {
+  border-style: hidden;
+}
+
+th.tableblock.halign-left, td.tableblock.halign-left {
+  text-align: left;
+}
+th.tableblock.halign-center, td.tableblock.halign-center {
+  text-align: center;
+}
+th.tableblock.halign-right, td.tableblock.halign-right {
+  text-align: right;
+}
+
+th.tableblock.valign-top, td.tableblock.valign-top {
+  vertical-align: top;
+}
+th.tableblock.valign-middle, td.tableblock.valign-middle {
+  vertical-align: middle;
+}
+th.tableblock.valign-bottom, td.tableblock.valign-bottom {
+  vertical-align: bottom;
+}
+
+
+/*
+ * manpage specific
+ *
+ * */
+
+body.manpage h1 {
+  padding-top: 0.5em;
+  padding-bottom: 0.5em;
+  border-top: 2px solid silver;
+  border-bottom: 2px solid silver;
+}
+body.manpage h2 {
+  border-style: none;
+}
+body.manpage div.sectionbody {
+  margin-left: 3em;
+}
+
+@media print {
+  body.manpage div#toc { display: none; }
+}

--- a/docs/html/linuxcnc.css
+++ b/docs/html/linuxcnc.css
@@ -1,7 +1,8 @@
 :target { background: #DEF !important;  }
 tt {font-family: "Courier New", Courier, monospace; font-size: 0.95em;}
 pre { font-family: monospace !important; }
-h1, h2 { background: #c0c0f0; }
+h1, h2 { background: #c0c0f0; padding-left: 0.5em;}
+h2 { padding-top: 0.35em; padding-bottom:0.15em;}
 h1, h2, h3, h4, h5 { border-bottom: 2px solid #8080c0; color: black; }
 div.nav { float: right; background: #ffffff; }
 dt { font-weight: bold; }
@@ -47,3 +48,4 @@ figcaption.title {
 dt.hdlist1 {
 	font-weight: normal;
 }
+#footer { margin-top: 1em; border-top: 1px dashed silver;}

--- a/docs/po4a.cfg
+++ b/docs/po4a.cfg
@@ -1,6 +1,12 @@
 [options] --master-charset UTF-8 --localized-charset UTF-8
 
-[po4a_langs] ar bg ckb cs da de es fr hu it ka nb pl pt_BR pt ro ru sai sk sv tr uk vi zh_CN
+# Original list
+#[po4a_langs] ar bg ckb cs da de es fr hu it ka nb pl pt_BR pt ro ru sai sk sv tr uk vi zh_CN
+# Actual in makefile(s)
+#[po4a_langs] ar de es fr nb ru sv tr zh_CN
+# Languages with any real translations
+[po4a_langs] de es fr nb ru zh_CN
+
 [po4a_paths] po/documentation.pot $lang:po/$lang.po
 
 [po4a_alias:AsciiDoc_def] AsciiDoc opt:"--keep 0 --option 'entry=lang' --option 'tablecells'"
@@ -406,7 +412,6 @@
 [type: man_def] man/man9/flipflop.9 $lang:man/$lang/man9/flipflop.9
 [type: man_def] man/man9/gantry.9 $lang:man/$lang/man9/gantry.9
 [type: man_def] man/man9/gearchange.9 $lang:man/$lang/man9/gearchange.9
-[type: man_def] man/man9/genserkins.9 $lang:man/$lang/man9/genserkins.9
 [type: man_def] man/man9/gray2bin.9 $lang:man/$lang/man9/gray2bin.9
 [type: man_def] man/man9/histobins.9 $lang:man/$lang/man9/histobins.9
 [type: man_def] man/man9/hypot.9 $lang:man/$lang/man9/hypot.9

--- a/docs/src/Submakefile
+++ b/docs/src/Submakefile
@@ -15,11 +15,8 @@ GENERATED_MANPAGES += $(patsubst ../docs/src/man/%.adoc, ../docs/man/%, $(wildca
 
 MAN_SRCS = $(sort \
 	$(wildcard $(DOC_DIR)/man/man1/*.1) \
-	$(wildcard $(DOC_DIR)/man/man3/*.3*) \
+	$(wildcard $(DOC_DIR)/man/man3/*.3) \
 	$(wildcard $(DOC_DIR)/man/man9/*.9) \
-	$(wildcard $(DOC_DIR)/man/es/man1/*.1) \
-	$(wildcard $(DOC_DIR)/man/es/man3/*.3*) \
-	$(wildcard $(DOC_DIR)/man/es/man9/*.9) \
 	$(GENERATED_MANPAGES))
 
 $(DOC_SRCDIR)/man/man1/linuxcnc.1.adoc: $(DOC_SRCDIR)/man/man1/linuxcnc.1.adoc.in config.status
@@ -171,7 +168,7 @@ DOC_SRCS_EN := \
 	Master_Integrator.adoc \
 	Master_Developer.adoc
 
-LANGUAGES := $(shell grep '\[po4a_langs\]' $(DOC_DIR)/po4a.cfg| cut -d" " -f2-)
+LANGUAGES := $(shell sed -e's/#.*//' < $(DOC_DIR)/po4a.cfg | grep '^\[po4a_langs\]' | cut -d" " -f2-)
 LANGUAGES_MATCH := $(shell echo $(LANGUAGES) | tr " " "|")
 
 
@@ -190,13 +187,19 @@ ifneq (${TIME_CMD},)
     TIME_CMD := ${TIME_CMD} -v
 endif
 
+ifeq ($(BUILD_VERBOSE),1)
+  PO4A_VERBOSE = -v
+else
+  PO4A_VERBOSE =
+endif
+
 $(DOC_DIR)/po/documentation.pot: $(addprefix $(DOC_SRCDIR)/, $(DOC_SRCS_EN))
-	cd $(DOC_DIR); ${TIME_CMD} po4a -v --msgmerge-opt='-v' --no-translations po4a.cfg
+	cd $(DOC_DIR); ${TIME_CMD} po4a $(PO4A_VERBOSE) --msgmerge-opt='-v' --no-translations po4a.cfg
 pofiles: $(DOC_DIR)/po/documentation.pot
 
 ifeq ($(BUILD_DOCS_TRANSLATED),yes)
 translateddocs: manpages $(DOC_DIR)/po/documentation.pot
-	cd $(DOC_DIR); ${TIME_CMD} po4a -v --msgmerge-opt='-v' --no-update po4a.cfg
+	cd $(DOC_DIR); ${TIME_CMD} po4a $(PO4A_VERBOSE) --msgmerge-opt='-v' --no-update po4a.cfg
 else
 translateddocs:
 endif
@@ -538,11 +541,41 @@ $(DOC_DIR)/LinuxCNC_Developer_zh_CN.pdf: $(DOC_SRCDIR)/zh_CN/Master_Developer.pd
 $(DOC_DIR)/html/man/%.html: $(DOC_DIR)/man/%
 	@echo Formatting $(notdir $<) as HTML
 	@mkdir -p $(dir $@)
-#   Attention! This is a temporary fix until Groff 1.23 is released. Should be
-#   set back to "-m man" when 1.23 is available.
-#	This fixes the formatting of subsections and appearance in the toc.
-#   It uses the local an-old.tmac instead of the one which is shipped with Groff.
-	@(cd $(DOC_DIR)/man; groff -Thtml -m an-old-fixed -M . stylesheet.9 $(patsubst $(DOC_DIR)/man/%,%,$<)) > $@
+	$(Q)if grep -q '^\.so' $<; then \
+		ln -srf ../docs/html/man/$$(awk '{print $$2}' $<).html $@; \
+	else \
+		N="$$(basename "$<").adoc"; \
+		D="$$(dirname "$<")"; \
+		S="$$(basename "$$D")"; \
+		if [ -r "$(DOC_SRCDIR)/man/$$S/$$N" ]; then \
+			F="$(DOC_SRCDIR)/man/$$S/$$N"; \
+		elif [ -r "objects/man/$$S/$$N" ]; then \
+			F="objects/man/$$S/$$N"; \
+		else \
+			echo "Error: Cannot find manpage '$<' in adoc format"; \
+			exit 1; \
+		fi; \
+		asciidoc \
+			--doctype=manpage \
+			--backend=html \
+			-a mansource=LinuxCNC \
+			-a manmanual='LinuxCNC Documentation' \
+			-f $(DOC_SRCDIR)/xhtml11.conf \
+			-f $(DOC_SRCDIR)/xhtml11-head-foot.conf \
+			-f $(DOC_SRCDIR)/asciidoc-dont-replace-arrows.conf \
+			-f $(LOC_HL_DIR)/emc-langs-source-highlight.conf \
+			-a "source_highlight_dir=$(LOC_HL_DIR)/local" \
+			-a disable-javascript \
+			-a autowidth-option \
+			-a "footer-style=none" \
+			-a linkcss \
+			-a "scriptsdir=../.." \
+			-a "stylesdir=../.." \
+			-a stylesheet=linuxcnc.css \
+			-o $@ \
+			"$$F" \
+			; \
+	fi;
 
 SA := <p><a onclick=\"return toggle('man_
 SB := ')\"><img id=\"man_
@@ -581,13 +614,17 @@ objects/index.incl: $(GENERATED_MANPAGES) objects/var-MAN_HTML_TARGETS $(DOC_SRC
 	$(call ADD_HTML_MANPAGES, rtapi, API: RTAPI,    $(filter $(DOC_DIR)/html/man/man3/rtapi%.html, $(MAN_HTML_TARGETS))) \
 	$(call ADD_HTML_MANPAGES, hm2,   API: Hostmot2, $(filter $(DOC_DIR)/html/man/man3/hm2%.html, $(MAN_HTML_TARGETS))) \
 	$(call ADD_HTML_MANPAGES, 3,     API: General,  $(filter-out $(DOC_DIR)/html/man/man3/hal%.html, $(filter-out $(DOC_DIR)/html/man/man3/rtapi%.html, $(filter-out $(DOC_DIR)/html/man/man3/hm2%.html, $(filter $(DOC_DIR)/html/man/man3/%.html, $(MAN_HTML_TARGETS)))))) \
-	# now make sure all manpages made it into the html index \
+	# now make sure all manpages made it into the html index
 	FAIL=0; \
 	for F in $$(find $(DOC_DIR)/man/man* -type f); do \
 		B=$$(basename $$F); \
 		if ! grep -q $$B $@; then \
-			echo stray manpage not added to index: $$B; \
 			FAIL=1; \
+			if ! grep -q '^\.so' $$F; then \
+				echo stray manpage not added to index: $$F; \
+			else \
+				echo manpage alias not added to index: $$F; \
+			fi; \
 		fi; \
 	done; \
 	if [ $$FAIL -ne 0 ]; then exit 1; fi
@@ -606,7 +643,7 @@ $(DOC_DIR)/html/index.html: $(DOC_SRCDIR)/index.tmpl objects/index.incl $(DOC_SR
 $(DOC_SRCDIR)/%.pdf: $(DOC_SRCDIR)/%.adoc svgs_made_from_dots .adoc-images-stamp
 	$(ECHO) Building $@
 	@rm -f $@
-	$(A2X) -L -d book -vf pdf $< || (X=$$?; rm -f $@; exit $$X)
+	$(Q)$(A2X) -L -d book -vf pdf $< || (X=$$?; rm -f $@; exit $$X)
 	@test -f $@
 
 depends/%.d: $(DOC_SRCDIR)/%.adoc $(DOC_SRCDIR)/asciideps .include-stamp
@@ -617,9 +654,9 @@ depends/%.d: $(DOC_SRCDIR)/%.adoc $(DOC_SRCDIR)/asciideps .include-stamp
 
 objects/%.links-stamp: $(DOC_SRCDIR)/%.adoc $(DOC_SRCDIR)/links.xslt
 	@mkdir -p `dirname $@`
-	asciidoc -f $(DOC_SRCDIR)/attribute-colon.conf -a "scriptdir=$(DOC_SRCDIR)/" -d book -o- -b docbook $< | xsltproc $(DOC_SRCDIR)/links.xslt - > $@.tmp || (X=$$?; rm -f $@; exit $$X)
-	sh move-if-change $@.tmp $(patsubst %-stamp,%,$@)
-	touch $@
+	$(Q)asciidoc -f $(DOC_SRCDIR)/attribute-colon.conf -a "scriptdir=$(DOC_SRCDIR)/" -d book -o- -b docbook $< | xsltproc $(DOC_SRCDIR)/links.xslt - > $@.tmp || (X=$$?; rm -f $@; exit $$X)
+	$(Q)sh move-if-change $@.tmp $(patsubst %-stamp,%,$@)
+	$(Q)touch $@
 
 objects/%.links: objects/%.links-stamp
 	@:
@@ -734,7 +771,8 @@ $(DOC_SRCDIR)/%.html: STYLES_SCRIPTS=$(shell \
 )
 
 $(patsubst %.adoc,$(DOC_SRCDIR)/%.html,$(DOC_SRCS_EN_SMALL)): $(DOC_SRCDIR)/%.html: $(DOC_SRCDIR)/%.adoc objects/xref_en.links $(LOC_LANG_MAP)
-	asciidoc -f $(DOC_SRCDIR)/xhtml11.conf \
+	$(ECHO) "Building 'en' adoc to html: " $<
+	$(Q)asciidoc -f $(DOC_SRCDIR)/xhtml11.conf \
 		 -f $(DOC_SRCDIR)/asciidoc-dont-replace-arrows.conf \
 		 -f $(LOC_HL_DIR)/emc-langs-source-highlight.conf \
 		 -a "source_highlight_dir=$(LOC_HL_DIR)/local" \
@@ -747,7 +785,8 @@ $(patsubst %.adoc,$(DOC_SRCDIR)/%.html,$(DOC_SRCS_EN_SMALL)): $(DOC_SRCDIR)/%.ht
 		 -d book -a toc -a numbered -b xhtml11 $< || (X=$$?; rm -f $@; exit $$X)
 
 $(patsubst %.adoc,$(DOC_SRCDIR)/%.html,$(DOC_SRCS_AR_SMALL)): $(DOC_SRCDIR)/%.html: $(DOC_SRCDIR)/%.adoc objects/xref_ar.links $(LOC_LANG_MAP)
-	asciidoc -f $(DOC_SRCDIR)/xhtml11.conf \
+	$(ECHO) "Building 'ar' adoc to html: " $<
+	$(Q)asciidoc -f $(DOC_SRCDIR)/xhtml11.conf \
 		 -f $(DOC_SRCDIR)/asciidoc-dont-replace-arrows.conf \
 		 -f $(LOC_HL_DIR)/emc-langs-source-highlight.conf \
 		 -a "source_highlight_dir=$(LOC_HL_DIR)/local" \
@@ -760,7 +799,8 @@ $(patsubst %.adoc,$(DOC_SRCDIR)/%.html,$(DOC_SRCS_AR_SMALL)): $(DOC_SRCDIR)/%.ht
 		 -d book -a toc -a numbered -b xhtml11 $< || (X=$$?; rm -f $@; exit $$X)
 
 $(patsubst %.adoc,$(DOC_SRCDIR)/%.html,$(DOC_SRCS_DE_SMALL)): $(DOC_SRCDIR)/%.html: $(DOC_SRCDIR)/%.adoc objects/xref_de.links $(LOC_LANG_MAP)
-	asciidoc -f $(DOC_SRCDIR)/xhtml11.conf \
+	$(ECHO) "Building 'de' adoc to html: " $<
+	$(Q)asciidoc -f $(DOC_SRCDIR)/xhtml11.conf \
 		 -f $(DOC_SRCDIR)/asciidoc-dont-replace-arrows.conf \
 		 -f $(LOC_HL_DIR)/emc-langs-source-highlight.conf \
 		 -a "source_highlight_dir=$(LOC_HL_DIR)/local" \
@@ -773,7 +813,8 @@ $(patsubst %.adoc,$(DOC_SRCDIR)/%.html,$(DOC_SRCS_DE_SMALL)): $(DOC_SRCDIR)/%.ht
 		 -d book -a toc -a numbered -b xhtml11 $< || (X=$$?; rm -f $@; exit $$X)
 
 $(patsubst %.adoc,$(DOC_SRCDIR)/%.html,$(DOC_SRCS_ES_SMALL)): $(DOC_SRCDIR)/%.html: $(DOC_SRCDIR)/%.adoc objects/xref_es.links $(LOC_LANG_MAP)
-	asciidoc -f $(DOC_SRCDIR)/xhtml11.conf \
+	$(ECHO) "Building 'es' adoc to html: " $<
+	$(Q)asciidoc -f $(DOC_SRCDIR)/xhtml11.conf \
 		 -f $(DOC_SRCDIR)/asciidoc-dont-replace-arrows.conf \
 		 -f $(LOC_HL_DIR)/emc-langs-source-highlight.conf \
 		 -a "source_highlight_dir=$(LOC_HL_DIR)/local" \
@@ -786,7 +827,8 @@ $(patsubst %.adoc,$(DOC_SRCDIR)/%.html,$(DOC_SRCS_ES_SMALL)): $(DOC_SRCDIR)/%.ht
 		 -d book -a toc -a numbered -b xhtml11 $< || (X=$$?; rm -f $@; exit $$X)
 
 $(patsubst %.adoc,$(DOC_SRCDIR)/%.html,$(DOC_SRCS_FR_SMALL)): $(DOC_SRCDIR)/%.html: $(DOC_SRCDIR)/%.adoc objects/xref_fr.links $(LOC_LANG_MAP)
-	asciidoc -f $(DOC_SRCDIR)/xhtml11.conf \
+	$(ECHO) "Building 'fr' adoc to html: " $<
+	$(Q)asciidoc -f $(DOC_SRCDIR)/xhtml11.conf \
 		 -f $(DOC_SRCDIR)/asciidoc-dont-replace-arrows.conf \
 		 -f $(LOC_HL_DIR)/emc-langs-source-highlight.conf \
 		 -a "source_highlight_dir=$(LOC_HL_DIR)/local" \
@@ -799,7 +841,8 @@ $(patsubst %.adoc,$(DOC_SRCDIR)/%.html,$(DOC_SRCS_FR_SMALL)): $(DOC_SRCDIR)/%.ht
 		 -d book -a toc -a numbered -b xhtml11 $< || (X=$$?; rm -f $@; exit $$X)
 
 $(patsubst %.adoc,$(DOC_SRCDIR)/%.html,$(DOC_SRCS_NB_SMALL)): $(DOC_SRCDIR)/%.html: $(DOC_SRCDIR)/%.adoc objects/xref_nb.links $(LOC_LANG_MAP)
-	asciidoc -f $(DOC_SRCDIR)/xhtml11.conf \
+	$(ECHO) "Building 'nb' adoc to html: " $<
+	$(Q)asciidoc -f $(DOC_SRCDIR)/xhtml11.conf \
 		 -f $(DOC_SRCDIR)/asciidoc-dont-replace-arrows.conf \
 		 -f $(LOC_HL_DIR)/emc-langs-source-highlight.conf \
 		 -a "source_highlight_dir=$(LOC_HL_DIR)/local" \
@@ -812,7 +855,8 @@ $(patsubst %.adoc,$(DOC_SRCDIR)/%.html,$(DOC_SRCS_NB_SMALL)): $(DOC_SRCDIR)/%.ht
 		 -d book -a toc -a numbered -b xhtml11 $< || (X=$$?; rm -f $@; exit $$X)
 
 $(patsubst %.adoc,$(DOC_SRCDIR)/%.html,$(DOC_SRCS_RU_SMALL)): $(DOC_SRCDIR)/%.html: $(DOC_SRCDIR)/%.adoc objects/xref_ru.links $(LOC_LANG_MAP)
-	asciidoc -f $(DOC_SRCDIR)/xhtml11.conf \
+	$(ECHO) "Building 'ru' adoc to html: " $<
+	$(Q)asciidoc -f $(DOC_SRCDIR)/xhtml11.conf \
 		 -f $(DOC_SRCDIR)/asciidoc-dont-replace-arrows.conf \
 		 -f $(LOC_HL_DIR)/emc-langs-source-highlight.conf \
 		 -a "source_highlight_dir=$(LOC_HL_DIR)/local" \
@@ -825,7 +869,8 @@ $(patsubst %.adoc,$(DOC_SRCDIR)/%.html,$(DOC_SRCS_RU_SMALL)): $(DOC_SRCDIR)/%.ht
 		 -d book -a toc -a numbered -b xhtml11 $< || (X=$$?; rm -f $@; exit $$X)
 
 $(patsubst %.adoc,$(DOC_SRCDIR)/%.html,$(DOC_SRCS_SV_SMALL)): $(DOC_SRCDIR)/%.html: $(DOC_SRCDIR)/%.adoc objects/xref_sv.links $(LOC_LANG_MAP)
-	asciidoc -f $(DOC_SRCDIR)/xhtml11.conf \
+	$(ECHO) "Building 'sv' adoc to html: " $<
+	$(Q)asciidoc -f $(DOC_SRCDIR)/xhtml11.conf \
 		 -f $(DOC_SRCDIR)/asciidoc-dont-replace-arrows.conf \
 		 -f $(LOC_HL_DIR)/emc-langs-source-highlight.conf \
 		 -a "source_highlight_dir=$(LOC_HL_DIR)/local" \
@@ -838,7 +883,8 @@ $(patsubst %.adoc,$(DOC_SRCDIR)/%.html,$(DOC_SRCS_SV_SMALL)): $(DOC_SRCDIR)/%.ht
 		 -d book -a toc -a numbered -b xhtml11 $< || (X=$$?; rm -f $@; exit $$X)
 
 $(patsubst %.adoc,$(DOC_SRCDIR)/%.html,$(DOC_SRCS_TR_SMALL)): $(DOC_SRCDIR)/%.html: $(DOC_SRCDIR)/%.adoc objects/xref_tr.links $(LOC_LANG_MAP)
-	asciidoc -f $(DOC_SRCDIR)/xhtml11.conf \
+	$(ECHO) "Building 'tr' adoc to html: " $<
+	$(Q)asciidoc -f $(DOC_SRCDIR)/xhtml11.conf \
 		 -f $(DOC_SRCDIR)/asciidoc-dont-replace-arrows.conf \
 		 -f $(LOC_HL_DIR)/emc-langs-source-highlight.conf \
 		 -a "source_highlight_dir=$(LOC_HL_DIR)/local" \
@@ -851,7 +897,8 @@ $(patsubst %.adoc,$(DOC_SRCDIR)/%.html,$(DOC_SRCS_TR_SMALL)): $(DOC_SRCDIR)/%.ht
 		 -d book -a toc -a numbered -b xhtml11 $< || (X=$$?; rm -f $@; exit $$X)
 
 $(patsubst %.adoc,$(DOC_SRCDIR)/%.html,$(DOC_SRCS_ZH_CN_SMALL)): $(DOC_SRCDIR)/%.html: $(DOC_SRCDIR)/%.adoc objects/xref_zh_CN.links $(LOC_LANG_MAP)
-	asciidoc -f $(DOC_SRCDIR)/xhtml11.conf \
+	$(ECHO) "Building 'zh_CN' adoc to html: " $<
+	$(Q)asciidoc -f $(DOC_SRCDIR)/xhtml11.conf \
 		 -f $(DOC_SRCDIR)/asciidoc-dont-replace-arrows.conf \
 		 -a linkcss \
 		 $(STYLES_SCRIPTS) \

--- a/docs/src/Submakefile
+++ b/docs/src/Submakefile
@@ -901,6 +901,8 @@ $(patsubst %.adoc,$(DOC_SRCDIR)/%.html,$(DOC_SRCS_ZH_CN_SMALL)): $(DOC_SRCDIR)/%
 	$(Q)asciidoc -f $(DOC_SRCDIR)/xhtml11.conf \
 		 -f $(DOC_SRCDIR)/asciidoc-dont-replace-arrows.conf \
 		 -a linkcss \
+		 -f $(LOC_HL_DIR)/emc-langs-source-highlight.conf \
+		 -a "source_highlight_dir=$(LOC_HL_DIR)/local" \
 		 $(STYLES_SCRIPTS) \
 	         -a "scriptdir=$(DOC_SRCDIR)/" \
 	         -a "relindir=$(shell dirname $*)" \

--- a/docs/src/gen_complist.py
+++ b/docs/src/gen_complist.py
@@ -41,17 +41,17 @@ def generate_complist(complist_path):
     gen_filename = '../docs/src/hal/components_gen.adoc'
     file2 = open(gen_filename, 'w')
     if len(miss_in_list) > 0:
-        file2.write('=== Not categorized (auto generated from man pages)\n')
-        file2.write('[{tab_options}]\n|=======================\n')
+        file2.write('\n== Not categorized (auto generated from man pages)\n')
+        file2.write('[{tab_options}]\n|===\n')
         for i in sorted(miss_in_list):
             file2.write('| ' + i + ' |||\n')
-        file2.write('|=======================\n')
+        file2.write('|===\n')
     if len(miss_in_man) > 0:
-        file2.write('\n=== Without man page or broken link (auto generated from component list)\n')
-        file2.write('[{tab_options}]\n|=======================\n')
+        file2.write('\n== Without man page or broken link (auto generated from component list)\n')
+        file2.write('[{tab_options}]\n|===\n')
         for i in sorted(miss_in_man):
             file2.write('| ' + i + ' |||\n')
-        file2.write('|=======================\n')
+        file2.write('|===\n')
     file2.close()
 
     generate_links(gen_filename, False, True)

--- a/docs/src/man/man1/halcompile.1.adoc
+++ b/docs/src/man/man1/halcompile.1.adoc
@@ -7,10 +7,10 @@ halcompile - Build, compile and install LinuxCNC HAL components
 == SYNOPSIS
 
 ____
-*halcompile* [**--compile**|**--preprocess**|**--document**|**--view-doc**] compfile...
+*halcompile* [*--compile*|*--preprocess*|*--document*|*--adoc*|*--view-doc*] compfile...
 ____
 
-_sudo_ *halcompile* [**--install**|**--install-doc**] compfile...
+_sudo_ *halcompile* [*--install*|*--install-doc*] compfile...
 
 ____
 *halcompile* *--compile* *--userspace* cfile...
@@ -33,6 +33,51 @@ to set the maximum of personality items to 4: [sudo] *halcompile
 
 Do not use [sudo] for RIP installation.
 
+== OPTIONS
+
+*-a*, *--adoc*::
+Extract only asciidoc format documentation from the component.
+*-c*, *--compile*::
+Compile a component or C-source module.
+*-d*, *--document*::
+Extract man-page format documentation from the component (builds asciidoc and
+then converts to manpage). This option requires **asciidoctor**(1) or **a2x**(1)
+to be installed on your system.
+*-h*, *-?*, *--help*::
+Show a brief usage message and exit.
+*-i*, *--install*::
+Build and install a component.
+*-J*, *--view-doc*::
+Deprecated. Live view the manpage of the component (builds asciidoc, converts
+to manpage and runs **man**(1)). This option requires **asciidoctor**(1)
+or **a2x**(1) to be installed on your system.
+*-j*, *--install-doc*::
+Install the man-page documentation in _usr/share/man1_ or _usr/share/man9_,
+depending whether this is a userspace or realtime component.
+*-k* _file_, *--keep-adoc*=_file_::
+Keep the generated asciidoc file when generating manpage documentation. The
+file is saved to _file_. You cannot specify multiple input files when using
+this option and it has no effect when only asciidoc formatted documentation is
+requested using the *-a* or *--adoc* option.
+*-l*, *--require-license*::
+Obsolete. The component is always required to have a *licence* tag.
+*-o* _file_, *--outfile*=_file_::
+Write output to _file_. Can _only_ be used with *--preprocess*, *--adoc* and
+*--document* processing.
+*-P* _int_, *--personalities*=_int_ (default: 64)::
+Set the maximum number of personalities in the component.
+*-p*, *--preprocess*::
+Only generate a C-file from the component file.
+*-U*, *--unix*::
+Require the source to have unix-style NL-only line endings.
+*-u*, *--userspace*::
+Create a userspace C-source (non-realtime). Default is to build realtime
+components.
+*--extra-compile-args*=_args_::
+Extra arguments passed to the C-compiler.
+*--extra-link-args*=_args_::
+Extra arguments passed to the linker.
+
 == DESCRIPTION
 
 *halcompile* performs many different functions:
@@ -42,19 +87,19 @@ components (the *--compile* flag)
 * Compile *.comp* and *.c* files into HAL non-realtime components (the
 *--compile --userspace* flag)
 * Preprocess *.comp* files into *.c* files (the *--preprocess* flag)
-* Extract documentation from *.comp* files into *.9* manpage files (the
-*--document* flag)
+* Extract documentation from *.comp* files into asciidoc or manpage
+section *1* or *9* files (the *--adoc* and *--document* flags)
 * Display documentation from *.comp* files onscreen (the *--view-doc*
 flag)
 * Compile and install *.comp* and *.c* files into the proper directory
 for HAL realtime components (the *--install* flag), which may require
 _sudo_ to write to system directories.
 * Install *.c* and *.py* files into the proper directory for HAL
-non-realtime components (the *--install --userspace* flag), which may
+non-realtime components (the *--install* *--userspace* flag), which may
 require _sudo_ to write to system directories.
-* Extract documentation from *.comp* files into *.9* manpage files in
-the proper system directory (the *--install* flag), which may require
-_sudo_ to write to system directories.
+* Extract documentation from *.comp* files into *.1* or *.9* manpage
+files in the proper system directory (the *--install* flag), which may
+require _sudo_ to write to system directories.
 * Preprocess *.comp* files into *.c* files (the *--preprocess* flag)
 
 == SEE ALSO

--- a/docs/src/man/man9/encoder.9.adoc
+++ b/docs/src/man/man9/encoder.9.adoc
@@ -39,12 +39,12 @@ position sensors.
 
 == FUNCTIONS
 
-*encoder.update-counters* (no floating-point)::
+*encoder*.*update-counters* (no floating-point)::
   Does the actual counting, by sampling the encoder signals and decoding
   the quadrature waveforms. Must be called as frequently as possible,
   preferably twice as fast as the maximum desired count rate. Operates
   on all channels at once.
-*encoder.capture-position* (uses floating point)::
+*encoder*.*capture-position* (uses floating point)::
   Captures the raw counts from *update-counters* and performs scaling
   and other necessary conversion, handles counter rollover, etc. Can
   (and should) be called less frequently than *update-counters*.
@@ -52,94 +52,94 @@ position sensors.
 
 == NAMING
 
-The names for pins and parameters are prefixed as: *encoder.N.* for
+The names for pins and parameters are prefixed as: *encoder*.__N__. for
 N=0,1,...,num-1 when using *num_chan=num* *nameN.* for
 nameN=name1,name2,... when using *names=name1,name2,...*
 
-The *encoder.N.* format is shown in the following descriptions.
+The *encoder*.__N__. format is shown in the following descriptions.
 
 == PINS
 
-**encoder.**_N_**.counter-mode** bit i/o::
+**encoder**.__N__.**counter-mode** bit i/o::
   Enables counter mode. When true, the counter counts each rising edge
   of the phase-A input, ignoring the value on phase-B. This is useful
   for counting the output of a single channel (non-quadrature) sensor.
   When false (the default), it counts in quadrature mode.
-**encoder.**_N_**.counts** s32 out::
+**encoder**.__N__.**counts** s32 out::
   Position in encoder counts.
-**encoder.**_N_**.index-enable** bit i/o::
+**encoder**.__N__.**index-enable** bit i/o::
   When true, *counts* and *position* are reset to zero on the next
   rising edge of *Phase-Z*. At the same time, *index-enable* is reset to
   zero to indicate that the rising edge has occurred.
-**encoder.**_N_**.min-speed-estimate** float in (default: 1.0)::
+**encoder**.__N__.**min-speed-estimate** float in (default: 1.0)::
   Determine the minimum speed at which *velocity* will be estimated as
   nonzero and *postition-interpolated* will be interpolated. The units
   of *min-speed-estimate* are the same as the units of *velocity*.
   Setting this parameter too low will cause it to take a long time for
-  *velocity** to go to 0 after encoder pulses have stopped arriving.
-**encoder.**_N_**.phase-A** bit in::
+  *velocity* to go to 0 after encoder pulses have stopped arriving.
+**encoder**.__N__.**phase-A** bit in::
   Quadrature input for encoder channel _N_.
-**encoder.**_N_**.phase-B** bit in::
+**encoder**.__N__.**phase-B** bit in::
   Quadrature input.
-**encoder.**_N_**.phase-Z** bit in::
+**encoder**.__N__.**phase-Z** bit in::
   Index pulse input.
-**encoder.**_N_**.position** float out::
+**encoder**.__N__.**position** float out::
   Position in scaled units (see *position-scale*)
-**encoder.**_N_**.position-interpolated** float out::
+**encoder**.__N__.**position-interpolated** float out::
   Position in scaled units, interpolated between encoder counts. Only
   valid when velocity is approximately constant and above
   *min-speed-estimate*. Do not use for position control.
-**encoder.**_N_**.position-scale** float i/o::
+**encoder**.__N__.**position-scale** float i/o::
   Scale factor, in counts per length unit. For example, if
   *position-scale* is 500, then 1000 counts of the encoder will be
   reported as a position of 2.0 units.
-**encoder.**_N_**.missing-teeth** s32 in::
+**encoder**.__N__.**missing-teeth** s32 in::
   The number of teeth missing from the index gap. For example a 60 tooth
   gear with two teeth shortened to form an index so that there are 58
   pulses per revolution would use a position-scale of 60 and a
   missing-teeth of 2.
-**encoder.**_N_**.rawcounts** s32 out::
+**encoder**.__N__.**rawcounts** s32 out::
   The raw count, as determined by *update-counters*. This value is
-  updated more frequently than *counts** and *position*. It is also
+  updated more frequently than *counts* and *position*. It is also
   unaffected by *reset* or the index pulse.
-**encoder.**_N_**.reset** bit in::
+**encoder**.__N__.**reset** bit in::
   When true, *counts* and *position* are reset to zero immediately.
-**encoder.**_N_**.velocity** float out::
+**encoder**.__N__.**velocity** float out::
   Velocity in scaled units per second. *encoder* uses an algorithm that
   greatly reduces quantization noise as compared to simply
   differentiating the *position* output. When the magnitude of the true
   velocity is below min-speed-estimate, the velocity output is 0.
-**encoder.**_N_**.velocity-rpm** float out::
-  Velocity in scaled units per minute. Simply *encoder.**_N_**.velocity*
+**encoder**.__N__.**velocity-rpm** float out::
+  Velocity in scaled units per minute. Simply *encoder**.__N__.**velocity*
   scaled by a factor of 60 for convenience.
-**encoder.**_N_**.x4-mode** bit i/o::
+**encoder**.__N__.**x4-mode** bit i/o::
   Enables times-4 mode. When true (the default), the counter counts each
   edge of the quadrature waveform (four counts per full cycle). When
   false, it only counts once per full cycle. In *counter-mode*, this
   parameter is ignored.
-**encoder.**_N_**.latch-input** bit in::
+**encoder**.__N__.**latch-input** bit in::
    +
 
-**encoder.**_N_**.latch-falling** bit in (default: *TRUE*)::
+**encoder**.__N__.**latch-falling** bit in (default: *TRUE*)::
    +
 
-**encoder.**_N_**.latch-rising** bit in (default: *TRUE*)::
+**encoder**.__N__.**latch-rising** bit in (default: *TRUE*)::
    +
 
-**encoder.**_N_**.counts-latched** s32 out::
+**encoder**.__N__.**counts-latched** s32 out::
    +
 
-**encoder.**_N_**.position-latched** float out::
-  Update *counts-latched** and *position-latched* on the rising and/or
+**encoder**.__N__.**position-latched** float out::
+  Update *counts-latched* and *position-latched* on the rising and/or
   falling edges of *latch-input* as indicated by *latch-rising* and
   *latch-falling*.
-**encoder.**_N_**.counter-mode** bit rw::
+**encoder**.__N__.**counter-mode** bit rw::
   Enables counter mode. When true, the counter counts each rising edge
   of the phase-A input, ignoring the value on phase-B. This is useful
   for counting the output of a single channel (non-quadrature) sensor.
   When false (the default), it counts in quadrature mode.
-  *encoder.**_N_**.capture-position.tmax** s32 rw Maximum number of CPU
-  cycles it took to execute this function.
+**encoder**.__N__.**capture-position.tmax** s32 rw::
+  Maximum number of CPU cycles it took to execute this function.
 
 == PARAMETERS
 

--- a/docs/src/man/man9/hal_parport.9.adoc
+++ b/docs/src/man/man9/hal_parport.9.adoc
@@ -25,13 +25,13 @@ The hal_parport component supports up to **8** physical parallel ports.
   port(s) and whether the port(s) is/are used as an input or output
   port(s). Up to eight parallel ports are supported by the component.
 
-The **port_addr **parameter of the configuration string may be either
+The *port_addr* parameter of the configuration string may be either
 the physical base address of a parallel port or specified as the
 detected parallel port via Linux parport_pc driver. In which case, a
-**port_addr** of __0 __is the first parallel port detected on the
-system, __1__ is the next, and so on.
+*port_addr* of _0_ is the first parallel port detected on the
+system, _1_ is the next, and so on.
 
-The **type **parameter of the configuration string determines how the
+The *type* parameter of the configuration string determines how the
 I/O bits of the port are used. There are four possible options and if
 none is specified will default to out.
 
@@ -49,11 +49,11 @@ _x_:: The option allows ports with open collectorts on the control group pins to
 The pins created by the hal_parport component depends on how it is
 configured in the **cfg="" **string passed to it, see OPTIONS.
 
-**parport.**_p_**.pin-**_n_**-out** (bit):: Drives a physical output pin.
+**parport**.__p__.**pin-**__n__**-out** (bit):: Drives a physical output pin.
 
-**parport.**_p_**.pin-**_n_**-in** (bit):: Tracks a physical input pin.
+**parport**.__p__.**pin-**__n__**-in** (bit):: Tracks a physical input pin.
 
-**parport.**_p_**.pin-**_n_**-in-not** (bit):: Tracks a physical input pin, but inverted.
+**parport**.__p__.**pin-**__n__**-in-not** (bit):: Tracks a physical input pin, but inverted.
 
 For each pin created, **_p_** is the port number, and **_n_** is the
 physical pin number in the 25 pin D-shell connector.
@@ -82,26 +82,26 @@ in the cfg="" string.
 
 == PARAMETERS
 
-**parport.**_p_**.pin-<n>-out-invert** (bit)::
+**parport**.__p__.*pin-<n>-out-invert** (bit)::
   Inverts an output pin.
-**parport.**_p_**.pin-<n>-out-reset** (bit)::
+**parport**.__p__.**pin-<n>-out-reset** (bit)::
   (only for out pins) TRUE if this pin should be reset when the .reset
   function is executed.
-**parport.**_p_**.reset-time** (u32)::
+**parport**.__p__.**reset-time** (u32)::
   The time (in nanoseconds) between a pin is set by write and reset by
   the reset function if it is enabled.
 
 == FUNCTIONS
 
-*parport.**_p**.read(funct)::
+**parport**.__p__.**read** (funct)::
   Reads physical input pins of port <portnum> and updates HAL -in and -in-not pins.
 **parport.read-all** (funct)::
   Reads physical input pins of all ports and updates HAL -in and -in-not pins.
-**parport.**_p**.write** (funct)::
+**parport**.__p__.**write** (funct)::
   Reads HAL -out pins of port _p_ and updates that port's physical output pins.
 **parport.write-all** (funct)::
   Reads HAL -out pins of all ports and updates all physical output pins.
-**parport.**_p**.reset** (funct)::
+**parport**.__p__.**reset** (funct)::
   Waits until __reset-time__ has elapsed since the associated write,
   then resets pins to values indicated by __-out-reset__ and __-out-invert__ settings.
   Reset must be later in the same thread as write.

--- a/docs/src/man/man9/hal_parport.9.adoc
+++ b/docs/src/man/man9/hal_parport.9.adoc
@@ -82,7 +82,7 @@ in the cfg="" string.
 
 == PARAMETERS
 
-**parport**.__p__.*pin-<n>-out-invert** (bit)::
+**parport**.__p__.**pin-<n>-out-invert** (bit)::
   Inverts an output pin.
 **parport**.__p__.**pin-<n>-out-reset** (bit)::
   (only for out pins) TRUE if this pin should be reset when the .reset

--- a/docs/src/man/man9/hm2_spix.9.adoc
+++ b/docs/src/man/man9/hm2_spix.9.adoc
@@ -7,9 +7,8 @@ boards with SPI enabled HostMot2 firmware.
 
 == SYNOPSIS
 
-*loadrt hm2_spix*
+*loadrt hm2_spix* [arg [arg [...]]]
 
-____
 *config* [default: ""]::
   HostMot2 config strings, described in the *hostmot2*(9) manpage.
 *spiclk_rate* [default: 25000]::
@@ -53,7 +52,6 @@ ____
   Caveat Emptor: changing the message level is process-wide and all
   modules within the process will spit out messages at the requested
   level. This may cause quite some clutter in your terminal.
-____
 
 == DESCRIPTION
 

--- a/docs/src/man/man9/lcd.9.adoc
+++ b/docs/src/man/man9/lcd.9.adoc
@@ -52,100 +52,102 @@ https://en.wikipedia.org/wiki/Printf .
 The component can be configured to display an unlimited number of
 differently-formatted pages, which may be selected with a HAL pin.
 
-*Escaped codes*::
-  `\n` Inserts a clear-to-end, carriage return and line feed character.
+=== Escaped codes
+
+* `\n` Inserts a clear-to-end, carriage return and line feed character.
   This will still linefeed and clear even if an automatic wrap has
   occurred (lcd has no knowledge of the width of the lcd display).
   To print in the rightmost column it is necessary to allow the format to
   wrap and omit the `\n` code.
-+
-`\t` Inserts a tab (actually 4 spaces in the current version rather than a
-true tab).
-+
-`\NN` inserts the character defined by the hexadecimal code _NN_.
-As the ',' character is used in the format string to separate LCD instances it must
-be represented by `\2C` in the format string (the decimal separator is handled differently).
-+
-`\\` Inserts a literal `\`.
 
-*Numerical formats*::
-  *lcd* differs slightly from the standard printf conventions. One
-  significant difference is that width limits are strictly enforced to
-  prevent the LCD display wrapping and spoiling the layout. The field
-  width includes the sign character so that negative numbers will often
-  have a smaller valid range than positive. Numbers that do not fit in
-  the specified width are displayed as a line of asterisks (`**********`).
-+
+* `\t` Inserts a tab (actually 4 spaces in the current version rather than a
+  true tab).
+
+* `\NN` inserts the character defined by the hexadecimal code _NN_.
+  As the ',' character is used in the format string to separate LCD instances it must
+  be represented by `\2C` in the format string (the decimal separator is handled differently).
+
+* `\\` Inserts a literal `\`.
+
+=== Numerical formats
+
+*lcd* differs slightly from the standard printf conventions. One
+significant difference is that width limits are strictly enforced to
+prevent the LCD display wrapping and spoiling the layout. The field
+width includes the sign character so that negative numbers will often
+have a smaller valid range than positive. Numbers that do not fit in
+the specified width are displayed as a line of asterisks (`**********`).
+
 Each format begins with a "`%`" symbol. (For a literal `%` use "`%%`").
 Immediately after the % the following modifiers may be used:
-+ 
-" " (space) Pad the number to the specified width with spaces. This is
-the default and is not strictly necessary.
-+ 
-"0" Pad the number to the specified width with the numeral 0.
-+ 
-"+" Force display of a + symbol before positive numbers.
-This (like the - sign) will appear immediately to the left of the digits for a
-space-padded number and in the extreme left position for a 0-padded number.
-+ 
-"1234567890" A numerical entry (other than the leading 0 above) defines
-the total number of characters to display including the decimal
-separator and the sign. Whilst this number can be as many digits as
-required, the maximum field width is 20 characters. The inherent
-precision of the "double" data type means that more than 14 digits will
-tend to show errors in the least significant digits. The integer data
-types will never fill more than 10 decimal digits.
-+ 
+ 
+* " " (space) Pad the number to the specified width with spaces. This is
+  the default and is not strictly necessary.
+
+* "0" Pad the number to the specified width with the numeral 0.
+
+* "+" Force display of a + symbol before positive numbers.
+  This (like the - sign) will appear immediately to the left of the digits for a
+  space-padded number and in the extreme left position for a 0-padded number.
+
+* "1234567890" A numerical entry (other than the leading 0 above) defines
+  the total number of characters to display including the decimal
+  separator and the sign. Whilst this number can be as many digits as
+  required, the maximum field width is 20 characters. The inherent
+  precision of the "double" data type means that more than 14 digits will
+  tend to show errors in the least significant digits. The integer data
+  types will never fill more than 10 decimal digits.
+ 
 Following the width specifier should be the decimal specifier. This can
 only be a full-stop character (.) as the comma (,) is used as the
 instance separator. Currently lcd does not access the locale information
 to determine the correct separator but the *decimal-separator* HAL
 parameter can be used to choose any desired separator.
-+ 
+
 Following the decimal separator should be a number that determines how
 many places of decimals to display. This entry is ignored in the case of
 integer formats.
- 
+
 All the above modifiers are optional, but to specify a decimal precision
 the decimal point must precede the precision, e.g., as in "%.3f".
 The default decimal precision is 4.
 
 The numerical formats supported are:
 
-*%f %F* (for example, %+09.3f): These create a floating-point type HAL pin.
-The example would be displayed in a 9-character field, with 3 places of decimals,
-as a decimal separator, padded to the left with 0s and with a sign displayed
-for both positive and negative. Conversely a plain %f would be 6 digits of decimal,
-variable format width, with a sign only shown for negative numbers.
-Both %f and %F create exactly the same format.
+* *%f %F* (for example, %+09.3f): These create a floating-point type HAL pin.
+  The example would be displayed in a 9-character field, with 3 places of decimals,
+  as a decimal separator, padded to the left with 0s and with a sign displayed
+  for both positive and negative. Conversely a plain %f would be 6 digits of decimal,
+  variable format width, with a sign only shown for negative numbers.
+  Both %f and %F create exactly the same format.
 
-*%i %d* (For example %+ 4d): Creates a signed (s32) HAL pin. The example
-would display the value at a fixed 4 characters, space padded, width
-including the "+" giving a range of +999 to -999. %i and %d create
-identical output.
+* *%i %d* (For example %+ 4d): Creates a signed (s32) HAL pin. The example
+  would display the value at a fixed 4 characters, space padded, width
+  including the "+" giving a range of +999 to -999. %i and %d create
+  identical output.
 
-*%u* (for example %08u): Creates an unsigned (u32) HAL pin.
-The example would be a fixed 8 characters wide, padded with zeros.
+* *%u* (for example %08u): Creates an unsigned (u32) HAL pin.
+  The example would be a fixed 8 characters wide, padded with zeros.
 
-*%x, %X*: Creates an unsigned (u32) HAL pin and displays the value in Hexadecimal.
-Both %x and %X display capital letters for digits ABCDEF.
-A width may be specified, though the u32 HAL type is only 8 hex digits wide.
+* *%x, %X*: Creates an unsigned (u32) HAL pin and displays the value in Hexadecimal.
+  Both %x and %X display capital letters for digits ABCDEF.
+  A width may be specified, though the u32 HAL type is only 8 hex digits wide.
 
-*%o*: Creates an unsigned (u32) pin and displays the value in octal representation.
+* *%o*: Creates an unsigned (u32) pin and displays the value in octal representation.
 
-*%c*: Creates a u32 HAL pin and displays the character corresponding to
-the value of the pin. Values less than 32 (space) are suppressed.
-A width specifier may be used, for example %20c might be used to create a
-complete line of one character.
+* *%c*: Creates a u32 HAL pin and displays the character corresponding to
+  the value of the pin. Values less than 32 (space) are suppressed.
+  A width specifier may be used, for example %20c might be used to create a
+  complete line of one character.
 
-*%b*: This specifier has no equivalent in printf. It creates a bit
-(boolean) type HAL pin. The b should be followed by two characters and
-the display will show the first of these when the pin is true, and the
-second when false. Note that the characters follow, not precede the "b",
-unlike the case with other formats. The characters may be "escaped" Hex
-values. For example "%b\FF " will display a solid black block if true,
-and a space if false and "%b\7F\7E" would display right-arrow for false
-and left-arrow for true. An unexpected value of 'E' indicates a formatting error.
+* *%b*: This specifier has no equivalent in printf. It creates a bit
+  (boolean) type HAL pin. The b should be followed by two characters and
+  the display will show the first of these when the pin is true, and the
+  second when false. Note that the characters follow, not precede the "b",
+  unlike the case with other formats. The characters may be "escaped" Hex
+  values. For example "%b\FF " will display a solid black block if true,
+  and a space if false and "%b\7F\7E" would display right-arrow for false
+  and left-arrow for true. An unexpected value of 'E' indicates a formatting error.
 
 *Pages*: The page separator is the "|" (pipe) character (if the actual
 character is needed then \7C may be used). A "Page" in this context

--- a/docs/src/man/man9/mux_generic.9.adoc
+++ b/docs/src/man/man9/mux_generic.9.adoc
@@ -14,16 +14,16 @@ mux_generic - choose one from several input values
 
 == PINS
 
-**mux-gen.**_NN_**.suppress-no-input** bit in::
+**mux-gen**.__N__.**suppress-no-input** bit in::
   This suppresses changing the output if all select lines are false.
   This stops unwanted jumps in output between transitions of input but makes in00 unavailable.
-**mux-gen.**_NN_**.debounce-us* unsigned in::
+**mux-gen**.__N__.**debounce-us** unsigned in::
   sets debounce time in microseconds, e.g. 100000 = a tenth of a second.
   The selection inputs must be stable this long before the output
   changes. This helps to ignore 'noisy' switches.
-**mux-gen.**_NN_**.sel-bit-*_MM_ bit in (M=0..N)::
-**mux-gen.**_NN_**.sel-int* unsigned in::
-  Together, these determine which **in**_N_ value is copied to *output*.
+**mux-gen**.__N__.**sel-bit-**__MM__ bit in (M=0..N)::
+**mux-gen**.__N__.**sel-int** unsigned in::
+  Together, these determine which **in**__N__ value is copied to *output*.
   The bit pins are interpreted as binary bits, and the result is simply
   added on to the integer pin input. It is expected that either one or
   the other would normally be used. However, the possibility exists to
@@ -32,20 +32,20 @@ mux_generic - choose one from several input values
   component is an integer power of two. This component (unlike mux16)
   does not offer the option of decoding Gray-code, however the same
   effect can be achieved by arranging the order of the input values to suit.
-**mux-gen.**_NN_**.out-**[**bit**/**float**/**s32**/**u32**] variable-type out::
-  Follows the value of one of the *in*_N_ values according to the
+**mux-gen**.__N__.**out-**[**bit**/**float**/**s32**/**u32**] variable-type out::
+  Follows the value of one of the **in**__N__ values according to the
   selection bits and/or the selection number. Values will be
   converted/truncated according to standard C rules. This means, for
   example that a float input greater than 2147483647 will give an S32
   output of -2147483648.
-**mux-gen.**_NN_**.in-**[**bit**/**float**/**s32**/**u32**]**-**_MM_ variable-type in::
+**mux-gen**.__N__.**in-**[**bit**/**float**/**s32**/**u32**]**-**__MM__ variable-type in::
   The possible output values that are selected by the selection pins.
 
 == PARAMETERS
 
-**mux-gen.**_N_**.elapsed** float r::
+**mux-gen**.__N__.**elapsed** float r::
   Current value of the internal debounce timer for debugging.
-**mux-gen.**_N_**.selected** s32 r::
+**mux-gen**.__N__.**selected** s32 r::
   Current value of the internal selection variable after conversion for debugging.
   Possibly useful for setting up gray-code switches.
 

--- a/docs/src/man/man9/opto_ac5.9.adoc
+++ b/docs/src/man/man9/opto_ac5.9.adoc
@@ -19,8 +19,12 @@ HAL pin 1, header connector pin 45 and so on, until bit 24 would be HAL
 pin 23, header connector pin 1. "1" bits represent output points. So
 channel 0..11 as inputs and 12..23 as outputs would be represented by
 (in binary) 111111111111000000000000 which is 0xfff000 in hexadecimal.
-That is the number you would use, e.g.,
-`loadrt opto_ac5 portconfig0=0xfff000`.
+That is the number you would use, e.g.
+
+[source,hal]
+----
+loadrt opto_ac5 portconfig0=0xfff000
+----
 
 If no portconfig variable is specified the default configuration is 12
 inputs then 12 outputs.

--- a/docs/src/man/man9/setsserial.9.adoc
+++ b/docs/src/man/man9/setsserial.9.adoc
@@ -21,7 +21,10 @@ None
 
 == USAGE
 
-*loadrt setsserial cmd=*"set hm2_8i20.001f.nvmaxcurrent 750"
+[source,hal]
+----
+loadrt setsserial cmd="set hm2_8i20.001f.nvmaxcurrent 750"
+----
 
 Commands available are *set* and *flash*.
 
@@ -30,13 +33,14 @@ any realtime threads running.
 
 A typical command sequence would be:
 
-....
+[source,hal]
+----
 halrun
 loadrt hostmot2 use_serial_numbers=1 loadrt hm2_pci config="firmware=hm2/5i23/svss8_8.bit"
 show param
 loadrt setsserial cmd="set hm2_8i20.001f.nvmaxcurrent 750"
 exit
-....
+----
 
 This example uses the option to have the HAL pins and parameters labelled by the serial number of the remote.
 This is not necessary but can reduce the scope for confusion.
@@ -78,7 +82,10 @@ to monitor progress.
 
 In the first terminal enter
 
-`tail -f /var/log/kern.log`
+[source,sh]
+----
+tail -f /var/log/kern.log
+----
 
 This terminal will now display status information.
 
@@ -89,12 +96,15 @@ smart-serial remote drive and to switch smart-serial communication to a
 slower baudrate.
 
 A typical command sequence is then
-....
+
+[source,hal]
+----
 halrun
 loadrt hostmot2 sserial_baudrate=115200 loadrt hm2_pci config="firmware=hm2/5i23/svss8_8.bit"
 loadrt setsserial cmd="flash hm2_5i23.0.8i20.0.1 hm2/8i20/8i20T.BIN"
 exit
-....
+----
+
 It is not necessary (or useful) to specify a config string in a system using the 5i25 or 6i25 cards.
 
 Note that it is necessary to exit halrun and unload the realtime

--- a/docs/src/xhtml11-head-foot.conf
+++ b/docs/src/xhtml11-head-foot.conf
@@ -1,0 +1,156 @@
+#
+# xhtml11-head-foot.conf
+#
+# Redefinition of man-page header and footer html
+#
+# From: xhtml11.conf
+# Asciidoc configuration file.
+# xhtml11 backend, generates XHTML 1.1 conformant markup.
+#
+
+[header]
+<!DOCTYPE html>
+<html lang="{lang=en}">
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset={encoding}">
+<meta name="description" content="{description}">
+<meta name="keywords" content="{keywords}">
+<title>{title}</title>
+{title%}<title>{doctitle=}</title>
+ifdef::linkcss[]
+<link rel="stylesheet" href="{stylesdir=.}/{theme=asciidoc}.css" type="text/css">
+ifdef::quirks[]
+<link rel="stylesheet" href="{stylesdir=.}/xhtml11-quirks.css" type="text/css">
+endif::quirks[]
+ifeval::["{source-highlighter}"=="pygments"]
+<link rel="stylesheet" href="{stylesdir=.}/pygments.css" type="text/css">
+endif::[]
+
+# DEPRECATED: 'pygments' attribute.
+ifdef::pygments[<link rel="stylesheet" href="{stylesdir=.}/pygments.css" type="text/css">]
+
+ifdef::toc2[<link rel="stylesheet" href="{stylesdir=.}/toc2.css" type="text/css">]
+<link rel="stylesheet" href="{stylesdir=.}/{stylesheet}" type="text/css">
+endif::linkcss[]
+ifndef::linkcss[]
+<style type="text/css">
+include1::{theme%}{stylesdir=./stylesheets}/asciidoc.css[]
+include1::{themedir}/{theme}.css[]
+ifdef::quirks[]
+include1::{stylesdir=./stylesheets}/xhtml11-quirks.css[]
+endif::quirks[]
+ifeval::["{source-highlighter}"=="pygments"]
+include1::{stylesdir=./stylesheets}/pygments.css[]
+endif::[]
+
+# DEPRECATED: 'pygments' attribute.
+ifdef::pygments[]
+include1::{stylesdir=./stylesheets}/pygments.css[]
+endif::pygments[]
+
+ifdef::toc2[]
+include1::{stylesdir=./stylesheets}/toc2.css[]
+endif::toc2[]
+include1::{stylesheet}[]
+</style>
+endif::linkcss[]
+ifndef::disable-javascript[]
+ifdef::linkcss[]
+<script type="text/javascript" src="{scriptsdir=.}/asciidoc.js"></script>
+<script type="text/javascript" src="{scriptsdir=.}/{theme}.js"></script>
+<script type="text/javascript">
+asciidoc.install({toc,toc2?{toclevels}});
+</script>
+endif::linkcss[]
+ifndef::linkcss[]
+<script type="text/javascript">
+include1::{scriptsdir=./javascripts}/asciidoc.js[]
+include1::{themedir}/{theme}.js[warnings=False]
+asciidoc.install({toc,toc2?{toclevels}});
+</script>
+endif::linkcss[]
+endif::disable-javascript[]
+ifdef::asciimath[]
+ifdef::linkcss[]
+<script type="text/javascript" src="{scriptsdir=.}/ASCIIMathML.js"></script>
+endif::linkcss[]
+ifndef::linkcss[]
+<script type="text/javascript">
+include1::{scriptsdir=./javascripts}/ASCIIMathML.js[]
+</script>
+endif::linkcss[]
+endif::asciimath[]
+ifdef::latexmath[]
+ifdef::linkcss[]
+<script type="text/javascript" src="{scriptsdir=.}/LaTeXMathML.js"></script>
+endif::linkcss[]
+ifndef::linkcss[]
+<script type="text/javascript">
+include1::{scriptsdir=./javascripts}/LaTeXMathML.js[]
+</script>
+endif::linkcss[]
+endif::latexmath[]
+ifdef::mathjax[]
+<script type="text/x-mathjax-config">
+    MathJax.Hub.Config({
+      extensions: ["tex2jax.js"],
+      jax: ["input/TeX", "output/HTML-CSS"],
+      tex2jax: {
+        inlineMath: [ ['$','$'], ["\\(","\\)"] ],
+        displayMath: [ ['$$','$$'], ["\\[","\\]"] ],
+        processEscapes: true
+      },
+      "HTML-CSS": { availableFonts: ["TeX"] }
+    });
+  </script>
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS-MML_HTMLorMML"> </script>
+endif::mathjax[]
+{docinfo1,docinfo2#}{include:{docdir}/docinfo.html}
+{docinfo,docinfo2#}{include:{docdir}/{docname}-docinfo.html}
+template::[docinfo]
+</head>
+<body class="{doctype}"{max-width? style="max-width:{max-width}"}{css-signature? id="{css-signature}"}>
+# Article, book header.
+ifndef::doctype-manpage[]
+<div id="header">
+ifndef::notitle[<h1>{doctitle}</h1>]
+ifdef::doctitle[]
+<span id="author">{author}</span><br>
+<span id="email"><code>&lt;<a href="mailto:{email}">{email}</a>&gt;</code></span><br>
+<span id="revnumber">version {revnumber}{revdate?,}</span>
+<span id="revdate">{revdate}</span>
+<br><span id="revremark">{revremark}</span>
+endif::doctitle[]
+{toc,toc2#}{toc-placement$auto:}{template:toc}
+</div>
+endif::doctype-manpage[]
+# Man page header.
+ifdef::doctype-manpage[]
+<div id="header">
+<h1>
+{doctitle}
+</h1>
+{toc,toc2#}{toc-placement$auto:}{template:toc}
+<h2>{manname-title}</h2>
+<div class="sectionbody">
+<p>{manname} -
+   {manpurpose}
+</p>
+</div>
+</div>
+endif::doctype-manpage[]
+<div id="content">
+
+[footer]
+</div>
+{disable-javascript%<div id="footnotes"><hr></div>}
+<div id="footer">
+# Removing footer date and version if footer-style set to none
+ifeval::["{footer-style=default}"!="none"]
+<div id="footer-text">
+template::[footer-text]
+</div>
+endif::[]
+</div>
+</body>
+</html>

--- a/src/hal/components/Submakefile
+++ b/src/hal/components/Submakefile
@@ -56,14 +56,17 @@ obj-m += $(patsubst hal/drivers/%.comp, %.o, $(patsubst hal/components/%.comp, %
 
 $(COMP_MANPAGES): ../docs/man/man9/%.9: hal/components/%.comp ../bin/halcompile
 	$(ECHO) Making halcompile manpage $(notdir $@)
-	@mkdir -p $(dir $@)
-	$(Q)../bin/halcompile -U --document -o $@.new $< && preconv -r < $@.new > $@
-	$(Q)$(RM) $@.new
+	@mkdir -p $(dir $@) objects/man/man9
+	$(Q)../bin/halcompile -U --document --keep-adoc=$@.adoc -o $@ $<
+	$(Q)sed -i -e's/^\.als /.\\" .als /' $@
+	$(Q)mv -f $@.adoc objects/man/man9/
 
 $(COMP_DRIVER_MANPAGES): ../docs/man/man9/%.9: hal/drivers/%.comp ../bin/halcompile
 	$(ECHO) Making halcompile manpage $(notdir $@)
-	@mkdir -p $(dir $@)
-	$(Q)../bin/halcompile -U --document -o $@ $<
+	@mkdir -p $(dir $@) objects/man/man9
+	$(Q)../bin/halcompile -U --document --keep-adoc=$@.adoc -o $@ $<
+	$(Q)sed -i -e's/^\.als /.\\" .als /' -e's/^\.URL / /' $@
+	$(Q)mv -f $@.adoc objects/man/man9/
 
 objects/%.mak: %.comp hal/components/Submakefile
 	$(ECHO) "Creating $(notdir $@)"

--- a/src/hal/components/and2.comp
+++ b/src/hal/components/and2.comp
@@ -1,27 +1,34 @@
 component and2 "Two-input AND gate";
-pin in bit in0;
-pin in bit in1;
-pin out bit out """
-.P
-The \\fBout\\fR pin is computed from the value of the \\fBin0\\fR and
-\\fBin1\\fR pins according to the following rule:
-.RS
-.TP
-\\fBin0=TRUE in1=TRUE\\fB
-\\fBout=TRUE\\fR
-.TP
-Otherwise,
-\\fBout=FALSE\\fR
-.RE"""
+pin in bit in0 "First input";
+pin in bit in1 "Second input";
+pin out bit out "Output";
+
+description """
+The *out* pin is computed from the value of the *in0* and *in1* pins according
+to the following truth table:
+
+[options="header",cols="^1,^1,^1"]
+|===
+^h|in1
+^h|in0
+^h|out
+
+|0|0|0
+|0|1|0
+|1|0|0
+|1|1|1
+|===
+
+"""
 ;
 option period no;
 function _ nofp;
 see_also """
-\\fBlogic\\fR(9),
-\\fBlut5\\fR(9),
-\\fBnot\\fR(9),
-\\fBor2\\fR(9),
-\\fBxor2\\fR(9).
+*logic*(9),
+*lut5*(9),
+*not*(9),
+*or2*(9),
+*xor2*(9).
 """;
 license "GPL";
 author "Jeff Epler";

--- a/src/hal/components/anglejog.comp
+++ b/src/hal/components/anglejog.comp
@@ -1,37 +1,39 @@
 // based on src/emc/motion/simple_tp.c Author: jmkasunich
-component anglejog """Jog two axes (or joints) at an angle
+component anglejog """Jog two axes (or joints) at an angle""";
 
-This component accepts a dynamic counts-in input (typically from a
+description """
+The anglejog component accepts a dynamic counts-in input (typically from a
 manual pulse generator (MPG)) and static angle and scale factor
 settings.  It computes the counts and scale values required to jog two
 (M,N) axes (or joints) at an angle.  The corresponding output pins
-must be connected to the candidate axis.[MN].jog* (or joint.[MN].jog*)
+must be connected to the candidate *axis.[MN].jog* (or *joint.[MN].jog*)
 pins to create motion at the current angle.  HAL pins are provided to
 set the vector velocity and acceleration and to enable the
 computations.
 
-Notes:\n
-1. The max-vel, max-accel settings should be \\fBless than or
-equal\\fR to the smallest settings for both of the target axes.\n
+Notes:
+
+1. The max-vel, max-accel settings should be *less than or
+equal* to the smallest settings for both of the target axes.
 2. The scale-in pin is sampled only when the enable-in pin
-is false.  The value in use is output on the current-scale pin.\n
+is false.  The value in use is output on the current-scale pin.
 3. The angle-degrees-in pin is sampled only when the enable-in
 pin is false.  The value in use is output on the current-angle-degrees
-pin.\n
+pin.
 4. The value of the iscale-factor pin multiplies counts-in internally
 to support integer (s32) calculations for counting.  The current-scale-out
 is divided by the same amount.  The pin is sampled only when the
 enable-in pin is false.  The default value should work in most
-applications.\n
+applications.
 5. For identity kins machines that support both world jogging (axis letter)
 and joint jogging (joint number), connections are needed for both the
-axis pins: axis.[MN].jog-enable,jog-scale,jog-counts and the corresponding
-joint pins: joint.[mn].jog-enable,jog-scale,jog-counts where [mn] are
+axis pins: *axis.[MN].jog-enable*, *jog-scale*, *jog-counts* and the corresponding
+joint pins: *joint*.`[mn]`.*jog-enable*, *jog-scale*, *jog-counts* where `[mn]` are
 the joint numbers corresponding to the [MN] axis letters.
 6. The current-scale pin is for information, the required output scaling
 pin is current-scale-out as it depends on the iscale-factor setting.
 
-\\fBSimulation Config\\fR: configs/sim/axis/anglejog/anglejog.in
+Simulation Config: `configs/sim/axis/anglejog/anglejog.in`
 """;
 
 pin in  bit   enable_in "enables motion (disables alteration of angle and scale)";

--- a/src/hal/components/biquad.comp
+++ b/src/hal/components/biquad.comp
@@ -36,23 +36,23 @@
 component biquad "Biquad IIR filter";
 
 description """Biquad IIR filter. Implements the following transfer function:
-H(z) = (n0 + n1z-1 + n2z-2) / (1+ d1z-1 + d2z-2)""";
+H(z) = (n~0~ + n~1~z^-1^ + n~2~z^-2^) / (1 + d~1~z^-1^ + d~2~z^-2^)""";
 
 pin in float in "Filter input.";
 pin out float out "Filter output.";
-pin in bit enable = 0 "Filter enable. When false, the \\fBin\\fR pin \
-is passed to the \\fBout\\fR pin without any filtering.  \
-A \\fBtransition from false to true\\fR causes filter \
+pin in bit enable = 0 "Filter enable. When false, the *in* pin \
+is passed to the *out* pin without any filtering.  \
+A *transition from false to true* causes filter \
 coefficients to be calculated according to the current \
-\\fBtype\\fR and the describing pin and parameter settings";
+*type* and the describing pin and parameter settings";
 pin out bit valid = 0 "When false, indicates an error occurred when calculating \
-filter coefficients (require 2>\\fBQ\\fR>0.5 and \\fBf0\\fR>sampleRate/2)";
+filter coefficients (require 2>**Q**>0.5 and *f0*>sampleRate/2)";
 
 pin   in u32 type_ = 0 "Filter type determines the type of filter \
 coefficients calculated.  When 0, coefficients must be loaded directly \
-from the \\fBn0,n1,n2,d1\\fR params.  When 1, \
-a low pass filter is created specified by the \\fBf0,Q\\fR pins.  \
-When 2, a notch filter is created specified by the \\fBf0,Q\\fR pins.";
+from the *n0,n1,n2,d1* params.  When 1, \
+a low pass filter is created specified by the *f0,Q* pins.  \
+When 2, a notch filter is created specified by the *f0,Q* pins.";
 pin   in float f0 = 250.0 "The corner frequency of the filter.";
 pin   in float Q = 0.7071 "The Q of the filter.";
 

--- a/src/hal/components/bldc.comp
+++ b/src/hal/components/bldc.comp
@@ -1,6 +1,5 @@
 component bldc """BLDC and AC-servo control component 
-.B loadrt bldc cfg=qi6,aH\\fB""";
-// 1.3.2 (26/1/11 20:10)
+*loadrt* *bldc* *cfg*=_qi6,aH_""";
 
 pin in bit hall1 if personality & 0x01 "Hall sensor signal 1";
 pin in bit hall2 if personality & 0x01 "Hall sensor signal 2";
@@ -35,14 +34,13 @@ This is only used indicate to the bldc control component that an index has been 
 pin in bit init if (personality & 0x05) == 4
 """A rising edge on this pin starts the motor alignment sequence.
 This pin should be connected in such a way that the motors re-align any time that encoder monitoring has been interrupted.
-Typically this will only be at machine power-off.
+Typically this will only be at machine power-off. +
 The alignment process involves powering the motor phases in such a way as to put the motor in a known position.
-The encoder counts are then stored in the \\fBoffset\\fP parameter.
-The alignment process will tend to cause a following error if it is triggered while the axis is enabled, so should be set before the matching axis.N.enable pin.
-The complementary \\fBinit-done\\fP pin can be used to handle the required sequencing.
-
+The encoder counts are then stored in the *offset* parameter.
+The alignment process will tend to cause a following error if it is triggered while the axis is enabled, so should be set before the matching axis.N.enable pin. +
+The complementary *init-done* pin can be used to handle the required sequencing. +
 Both pins can be ignored if the encoder offset is known explicitly, such as is the case with an absolute encoder.
-In that case the \\fBoffset\\fP parameter can be set directly in the HAL file.""";
+In that case the *offset* parameter can be set directly in the HAL file.""";
 
 pin out bit init-done = 0 if (personality & 0x05) == 4
 "Indicates homing sequence complete.";
@@ -88,7 +86,7 @@ pin out float out
 "Current output, including the effect of the dir pin and the alignment sequence.";
 
 pin out bit out-dir
-"Direction output, high if /fBvalue/fR is negative XOR /fBrev/fR is true.";
+"Direction output, high if *value* is negative XOR *rev* is true.";
 
 pin out float out-abs
 "Absolute value of the input value";
@@ -112,147 +110,88 @@ It is used to back-calculate from commanded angle to actual phase angle.
 It is only relevant to drives which expect rotor-angle input rather than phase-angle demand. Should be 0 for most drives.""";
 
 param rw unsigned output-pattern=25 if personality & 0x400
-"""Commutation pattern to be output in Hall Signal translation mode. See the description of /fBpattern/fR for details.""";
+"""Commutation pattern to be output in Hall Signal translation mode. See the description of *pattern* for details.""";
 
 param rw unsigned pattern=25 if personality & 0x01
 """Commutation pattern to use, from 0 to 47. Default is type 25.
 Every plausible combination is included.
-The table shows the excitation pattern along the top, and the pattern code on the left hand side.
+The table below shows the excitation pattern along the top, and the pattern code on the left hand side.
 The table entries are the hall patterns in H1, H2, H3 order.
-Common patterns are:
-0 (30 degree commutation) and 26, its reverse.
-17 (120 degree).
-18 (alternate 60 degree).
-21 (300 degree, Bodine).
-22 (240 degree).
-25 (60 degree commutation).
-
-Note that a number of incorrect commutations will have non-zero net torque which might look as if they work, but don't really.
-
+Common patterns are: +
+ + 0 (30 degree commutation) and 26, its reverse. +
+ + 17 (120 degree) +
+ + 18 (alternate 60 degree) +
+ + 21 (300 degree, Bodine) +
+ + 22 (240 degree) +
+ + 25 (60 degree commutation) +
+Note that a number of incorrect commutations will have non-zero net torque which might look as if they work, but don't really. +
 If your motor lacks documentation it might be worth trying every pattern.
 
-.ie '\\*[.T]'html' \\{\\
-.HTML \\
-<STYLE> \\
-#pattern TD { text-align: center; padding-left: .5ex; padding-right: .5ex } \\
-#pattern TH { text-align: center; padding-left: .5ex; padding-right: .5ex } \\
-#pattern TD.W { text-align: right; } \\
-</STYLE> \\
-<TABLE ID="pattern" STYLE="border: 1px solid black; border-collapse: collapse"> \\
-<COL SPAN=7 STYLE="margin: .2ex"><COL SPAN=1 STYLE="border-left: 1px solid black"> \\
-<TR><TD>&nbsp;<TH COLSPAN=6 CLASS=W>Phases, Source - Sink \\
-<TR><TH CLASS=W>pat<TH CLASS=W>B-A<TH CLASS=W>C-A<TH CLASS=W>C-B<TH CLASS=W>A-B<TH CLASS=W>A-C<TH CLASS=W>B-C \\
-<TR><TH>0<TD>000<TD>001<TD>011<TD>111<TD>110<TD>100 \\
-<TR><TH>1<TD>001<TD>000<TD>010<TD>110<TD>111<TD>101 \\
-<TR><TH>2<TD>000<TD>010<TD>011<TD>111<TD>101<TD>100 \\
-<TR><TH>3<TD>001<TD>011<TD>010<TD>110<TD>100<TD>101 \\
-<TR><TH>4<TD>010<TD>011<TD>001<TD>101<TD>100<TD>110 \\
-<TR><TH>5<TD>011<TD>010<TD>000<TD>100<TD>101<TD>111 \\
-<TR><TH>6<TD>010<TD>000<TD>001<TD>101<TD>111<TD>110 \\
-<TR><TH>7<TD>011<TD>001<TD>000<TD>100<TD>110<TD>111 \\
-<TR><TH>8<TD>000<TD>001<TD>101<TD>111<TD>110<TD>010 \\
-<TR><TH>9<TD>001<TD>000<TD>100<TD>110<TD>111<TD>011 \\
-<TR><TH>10<TD>000<TD>010<TD>110<TD>111<TD>101<TD>001 \\
-<TR><TH>11<TD>001<TD>011<TD>111<TD>110<TD>100<TD>000 \\
-<TR><TH>12<TD>010<TD>011<TD>111<TD>101<TD>100<TD>000 \\
-<TR><TH>13<TD>011<TD>010<TD>110<TD>100<TD>101<TD>001 \\
-<TR><TH>14<TD>010<TD>000<TD>100<TD>101<TD>111<TD>011 \\
-<TR><TH>15<TD>011<TD>001<TD>101<TD>100<TD>110<TD>010 \\
-<TR><TH>16<TD>000<TD>100<TD>101<TD>111<TD>011<TD>010 \\
-<TR><TH>17<TD>001<TD>101<TD>100<TD>110<TD>010<TD>011 \\
-<TR><TH>18<TD>000<TD>100<TD>110<TD>111<TD>011<TD>001 \\
-<TR><TH>19<TD>001<TD>101<TD>111<TD>110<TD>010<TD>000 \\
-<TR><TH>20<TD>010<TD>110<TD>111<TD>101<TD>001<TD>000 \\
-<TR><TH>21<TD>011<TD>111<TD>110<TD>100<TD>000<TD>001 \\
-<TR><TH>22<TD>010<TD>110<TD>100<TD>101<TD>001<TD>011 \\
-<TR><TH>23<TD>011<TD>111<TD>101<TD>100<TD>000<TD>010 \\
-<TR><TH>24<TD>100<TD>101<TD>111<TD>011<TD>010<TD>000 \\
-<TR><TH>25<TD>101<TD>100<TD>110<TD>010<TD>011<TD>001 \\
-<TR><TH>26<TD>100<TD>110<TD>111<TD>011<TD>001<TD>000 \\
-<TR><TH>27<TD>101<TD>111<TD>110<TD>010<TD>000<TD>001 \\
-<TR><TH>28<TD>110<TD>111<TD>101<TD>001<TD>000<TD>010 \\
-<TR><TH>29<TD>111<TD>110<TD>100<TD>000<TD>001<TD>011 \\
-<TR><TH>30<TD>110<TD>100<TD>101<TD>001<TD>011<TD>010 \\
-<TR><TH>31<TD>111<TD>101<TD>100<TD>000<TD>010<TD>011 \\
-<TR><TH>32<TD>100<TD>101<TD>001<TD>011<TD>010<TD>110 \\
-<TR><TH>33<TD>101<TD>100<TD>000<TD>010<TD>011<TD>111 \\
-<TR><TH>34<TD>100<TD>110<TD>010<TD>011<TD>001<TD>101 \\
-<TR><TH>35<TD>101<TD>111<TD>011<TD>010<TD>000<TD>100 \\
-<TR><TH>36<TD>110<TD>111<TD>011<TD>001<TD>000<TD>100 \\
-<TR><TH>37<TD>111<TD>110<TD>010<TD>000<TD>001<TD>101 \\
-<TR><TH>38<TD>110<TD>100<TD>000<TD>001<TD>011<TD>111 \\
-<TR><TH>39<TD>111<TD>101<TD>001<TD>000<TD>010<TD>110 \\
-<TR><TH>40<TD>100<TD>000<TD>001<TD>011<TD>111<TD>110 \\
-<TR><TH>41<TD>101<TD>001<TD>000<TD>010<TD>110<TD>111 \\
-<TR><TH>42<TD>100<TD>000<TD>010<TD>011<TD>111<TD>101 \\
-<TR><TH>43<TD>101<TD>001<TD>011<TD>010<TD>110<TD>100 \\
-<TR><TH>44<TD>110<TD>010<TD>011<TD>001<TD>101<TD>100 \\
-<TR><TH>45<TD>111<TD>011<TD>010<TD>000<TD>100<TD>101 \\
-<TR><TH>46<TD>110<TD>010<TD>000<TD>001<TD>101<TD>111 \\
-<TR><TH>47<TD>111<TD>011<TD>001<TD>000<TD>100<TD>110 \\
-</TABLE>
-\\}
-.el \\{\\
+[cols="1,1,1,1,1,1,1"]
+|===
+h|
+2+^h|Phases
+2+^h|Source
+2+^h|Sink
 
-.TS
-box tab(;);
-cb s s s s s s
-cb|cb cb cb cb cb cb
-c | c  c  c  c c r.
-Phases, Source - Sink
-_
-pat;B-A;C-A;C-B;A-B;A-C;B-C
-_
-0;000;001;011;111;110;100
-1;001;000;010;110;111;101
-2;000;010;011;111;101;100
-3;001;011;010;110;100;101
-4;010;011;001;101;100;110
-5;011;010;000;100;101;111
-6;010;000;001;101;111;110
-7;011;001;000;100;110;111
-8;000;001;101;111;110;010
-9;001;000;100;110;111;011
-10;000;010;110;111;101;001
-11;001;011;111;110;100;000
-12;010;011;111;101;100;000
-13;011;010;110;100;101;001
-14;010;000;100;101;111;011
-15;011;001;101;100;110;010
-16;000;100;101;111;011;010
-17;001;101;100;110;010;011
-18;000;100;110;111;011;001
-19;001;101;111;110;010;000
-20;010;110;111;101;001;000
-21;011;111;110;100;000;001
-22;010;110;100;101;001;011
-23;011;111;101;100;000;010
-24;100;101;111;011;010;000
-25;101;100;110;010;011;001
-26;100;110;111;011;001;000
-27;101;111;110;010;000;001
-28;110;111;101;001;000;010
-29;111;110;100;000;001;011
-30;110;100;101;001;011;010
-31;111;101;100;000;010;011
-32;100;101;001;011;010;110
-33;101;100;000;010;011;111
-34;100;110;010;011;001;101
-35;101;111;011;010;000;100
-36;110;111;011;001;000;100
-37;111;110;010;000;001;101
-38;110;100;000;001;011;111
-39;111;101;001;000;010;110
-40;100;000;001;011;111;110
-41;101;001;000;010;110;111
-42;100;000;010;011;111;101
-43;101;001;011;010;110;100
-44;110;010;011;001;101;100
-45;111;011;010;000;100;101
-46;110;010;000;001;101;111
-47;111;011;001;000;100;110
-.TE
-\\}
+h|
+h|B-A
+h|C-A
+h|C-B
+h|A-B
+h|A-C
+h|B-C
+
+|0|000|001|011|111|110|100
+|1|001|000|010|110|111|101
+|2|000|010|011|111|101|100
+|3|001|011|010|110|100|101
+|4|010|011|001|101|100|110
+|5|011|010|000|100|101|111
+|6|010|000|001|101|111|110
+|7|011|001|000|100|110|111
+|8|000|001|101|111|110|010
+|9|001|000|100|110|111|011
+|10|000|010|110|111|101|001
+|11|001|011|111|110|100|000
+|12|010|011|111|101|100|000
+|13|011|010|110|100|101|001
+|14|010|000|100|101|111|011
+|15|011|001|101|100|110|010
+|16|000|100|101|111|011|010
+|17|001|101|100|110|010|011
+|18|000|100|110|111|011|001
+|19|001|101|111|110|010|000
+|20|010|110|111|101|001|000
+|21|011|111|110|100|000|001
+|22|010|110|100|101|001|011
+|23|011|111|101|100|000|010
+|24|100|101|111|011|010|000
+|25|101|100|110|010|011|001
+|26|100|110|111|011|001|000
+|27|101|111|110|010|000|001
+|28|110|111|101|001|000|010
+|29|111|110|100|000|001|011
+|30|110|100|101|001|011|010
+|31|111|101|100|000|010|011
+|32|100|101|001|011|010|110
+|33|101|100|000|010|011|111
+|34|100|110|010|011|001|101
+|35|101|111|011|010|000|100
+|36|110|111|011|001|000|100
+|37|111|110|010|000|001|101
+|38|110|100|000|001|011|111
+|39|111|101|001|000|010|110
+|40|100|000|001|011|111|110
+|41|101|001|000|010|110|111
+|42|100|000|010|011|111|101
+|43|101|001|011|010|110|100
+|44|110|010|011|001|101|100
+|45|111|011|010|000|100|101
+|46|110|010|000|001|101|111
+|47|111|011|001|000|100|110
+|===
+
 """;
 
 description """
@@ -260,56 +199,67 @@ This component is designed as an interface between the most common forms of thre
 However, there is no requirement that the motor and drive should necessarily be of inherently compatible types.
 
 Each instance of the component is defined by a group of letters describing the input and output types.
-A comma separates individual instances of the component. For example \\fBloadrt bldc cfg=qi6,aH\\fR.
+A comma separates individual instances of the component. For example *loadrt bldc cfg=qi6,aH*.
 
-.SH Tags
-Input type definitions are all lower-case.
+=== TAGS
+Input type definitions are all lower-case:
 
-\\fBn\\fR No motor feedback. This mode could be used to drive AC induction motors,
-but is also potentially useful for creating free-running motor simulators for drive testing.
+* *n*: No motor feedback. +
+This mode could be used to drive AC induction motors, but is also potentially
+useful for creating free-running motor simulators for drive testing.
 
-\\fBh\\fR Hall sensor input.
-Brushless DC motors (electronically commutated permanent magnet 3-phase motors) typically use a set of three Hall sensors to measure the angular position of the rotor.
-A lower-case \\fBh\\fR in the cfg string indicates that these should be used.
+* *h*: Hall sensor input.
+Brushless DC motors (electronically commutated permanent magnet 3-phase motors)
+typically use a set of three Hall sensors to measure the angular position of
+the rotor. +
+A lower-case *h* in the cfg string indicates that these should be used.
 
-\\fBa\\fR Absolute encoder input. (Also possibly used by some forms of Resolver conversion hardware).
-The presence of this tag over-rides all other inputs.
-Note that the component still requires to be be connected to the \\fBrawcounts\\fR encoder pin to prevent loss of commutation on index-reset.
+* *a*: Absolute encoder input (also possibly used by some forms of Resolver
+conversion hardware).
+The presence of this tag over-rides all other inputs. +
+Note that the component still requires to be be connected to the *rawcounts*
+encoder pin to prevent loss of commutation on index-reset.
 
-\\fBq\\fR Incremental (quadrature) encoder input.
-If this input is used then the rotor will need to be homed before the motor can be run.
+* *q*: Incremental (quadrature) encoder input.
+If this input is used then the rotor will need to be homed before the motor can
+be run.
 
-\\fBi\\fR Use the index of an incremental encoder as a home reference.
+* *i*: Use the index of an incremental encoder as a home reference.
 
-\\fBf\\fR Use a 4-bit Gray-scale pattern to determine rotor alignment.
-This scheme is only used on the Fanuc "Red Cap" motors.
-This mode could be used to control one of these motors using a non-Fanuc drive.
+* *f*: Use a 4-bit Gray-scale pattern to determine rotor alignment. +
+This scheme is only used on the Fanuc "Red Cap" motors. This mode could be
+used to control one of these motors using a non-Fanuc drive.
 
-Output type descriptions are all upper-case.
+Output type descriptions are all upper-case:
 
-\\fBDefaults\\fR The component will always calculate rotor angle, phase angle and the absolute value of the input \\fBvalue\\fR for interfacing with drives such as the Mesa 8I20.
-It will also default to three individual, bipolar phase output values if no other output type modifiers are used.
+Defaults: The component will always calculate rotor angle, phase angle and the
+absolute value of the input *value* for interfacing with drives such as the
+Mesa 8I20. It will also default to three individual, bipolar phase output
+values if no other output type modifiers are used.
 
-\\fBB\\fR Bit level outputs. Either 3 or 6 logic-level outputs indicating which high or low gate drivers on an external drive should be used.
+* *B*: Bit level outputs. Either 3 or 6 logic-level outputs indicating which
+high or low gate drivers on an external drive should be used.
 
-\\fB6\\fR Create 6 rather than the default 3 outputs.
-In the case of numeric value outputs these are separate positive and negative drive amplitudes.
-Both have positive magnitude.
+* *6*: Create 6 rather than the default 3 outputs. +
+In the case of numeric value outputs these are separate positive and negative
+drive amplitudes. Both have positive magnitude.
 
-\\fBH\\fR Emulated Hall sensor output.
-This mode can be used to control a drive which expects 3x Hall signals,
-or to convert between a motor with one hall pattern and a drive which expects a different one.
+* *H*: Emulated Hall sensor output.
+This mode can be used to control a drive which expects 3x Hall signals, or to
+convert between a motor with one hall pattern and a drive which expects a
+different one.
 
-\\fBF\\fR Emulated Fanuc Red Cap Gray-code encoder output.
-This mode might be used to drive a non-Fanuc motor using a Fanuc drive intended for the "Red-Cap" motors.
+* *F*: Emulated Fanuc Red Cap Gray-code encoder output.
+This mode might be used to drive a non-Fanuc motor using a Fanuc drive intended
+for the "Red-Cap" motors.
 
-\\fBT\\fR Force Trapezoidal mode.
+* *T*: Force Trapezoidal mode.
 
-.SH OPERATING MODES
+=== OPERATING MODES
 The component can control a drive in either Trapezoidal or Sinusoidal mode, but will always default to sinusoidal if the input and output modes allow it.
-This can be over-ridden by the \\fBT\\fR tag. Sinusoidal commutation is significantly smoother (trapezoidal commutation induces 13% torque ripple).
+This can be over-ridden by the *T* tag. Sinusoidal commutation is significantly smoother (trapezoidal commutation induces 13% torque ripple).
 
-.SH ROTOR HOMING.
+=== ROTOR HOMING.
 To use an encoder for commutation a reference 0-degrees point must be found.
 The component uses the convention that motor zero is the point that an unloaded
 motor aligns to with a positive voltage on the A (or U) terminal and the B & C
@@ -318,23 +268,24 @@ two such positions on a 4-pole motor, 3 on a 6-pole and so on. They are all
 functionally equivalent as far as driving the motor is concerned.
 If the motor has Hall sensors then the motor can be started in trapezoidal
 commutation mode, and will switch to sinusoidal commutation when an alignment is
-found. If the mode is \\fBqh\\fR then the first Hall state-transition will be
-used. If the mode is \\fBqhi\\fR then the encoder index will be used. This
+found. If the mode is *qh* then the first Hall state-transition will be
+used. If the mode is *qhi* then the encoder index will be used. This
 gives a more accurate homing position if the distance in encoder counts between
 motor zero and encoder index is known. To force homing to the Hall edges instead
-simply omit the \\fBi\\fR.
+simply omit the *i*.
 
 Motors without Hall sensors may be homed in synchronous/direct mode.
-The better of these options is to home to the encoder zero using the \\fBiq\\fR
-config parameter. When the \\fBinit\\fR pin goes high the motor will rotate (in
-a direction determined by the \\fBrev\\fR pin) until the encoder indicates an
+The better of these options is to home to the encoder zero using the *iq*
+config parameter. When the *init* pin goes high the motor will rotate (in
+a direction determined by the *rev* pin) until the encoder indicates an
 index-latch (the servo thread runs too slowly to rely on detecting an encoder
 index directly).
+
 If there is no encoder index or its location relative to motor zero can not be
-found, then an alternative is to use \\fImagnetic\\fR homing using the \\fBq\\fR
+found, then an alternative is to use _magnetic_ homing using the *q*
 config. In this mode the motor will go through an alignment sequence ending at
 motor zero when the init pin goes high It will then set the final position as
-motor zero. Unfortunately the motor is rather \\fIspringy\\fR in this mode and
+motor zero.  Unfortunately the motor is rather _springy_ in this mode and
 so alignment is likely to be fairly sensitive to load.
 """;
 

--- a/src/hal/components/carousel.comp
+++ b/src/hal/components/carousel.comp
@@ -1,27 +1,26 @@
 component carousel """Orient a toolchanger carousel using various encoding schemes
 
-.B loadrt carousel pockets=\\fIN\\fR[,\\fIN\\fR]
-.B encoding=\\fIssss\\fR[,\\fIsss\\fR]\\fB
-.B num_sense=\\fIN\\fR[,\\fIN\\fR]
-.B dir=\\fIN\\fR[,\\fIN]
+*loadrt* *carousel* *pockets*=_N_[,_N_] *encoding*=_ssss_[,_sss_] *num_sense*=_N_[,_N_] *dir*=_N_[,_N_]
 
-.RS 4
-.TP
-\\fBpockets\\fR The number of pockets in each toolchanger.
+*pockets* The number of pockets in each toolchanger::
 Use up to 8 numbers separated by commas to create multiple carousel components.
-.TP
-\\fBencoding\\fR The position encoding.
-gray, binary, bcd, index, edge, counts or single. Default = 'gray'
-.TP
-\\fBnum_sense\\fR The number of position sense pins.
+
+*encoding*::
+The position encoding.
+One of `gray`, `binary`, `bcd`, `index`, `edge`, `counts` or `single`. Default = `gray`.
+
+*num_sense*::
+The number of position sense pins.
 Default = 4.
-.TP
-\\fBdir\\fR Set to 1 for unidirectional or  2 for bidirectional operation.
+
+*dir*::
+Set to 1 for unidirectional or  2 for bidirectional operation.
 Default = bidirectional
-.TP
-\\fBparity\\fR Set to 1 for odd parity, 0 for even parity checking.
+
+*parity*::
+Set to 1 for odd parity, 0 for even parity checking.
 Default = 0 (even)
-.RE""";
+""";
 
 description """This component is intended to help operate various types of
 carousel-type toolchangers. 
@@ -32,7 +31,7 @@ It can alternatively work with an individual sensor for each tool position
 ('single' mode) or with a sensor at each tool position and a separate index
 ('index' mode). Systems using a stepper motor or quadrature encoder are
 also supported ('counts' mode).
-\\fBedge\\fR is a special case of index mode for tool
+*edge* is a special case of index mode for tool
 changers with pockets on both the rising and falling edges of the position sensor.
 (Seen on at least one Denford Orac.)
 
@@ -68,8 +67,8 @@ input needs to be set to set home. Additionally in 'counts' mode the usual index
 logic of the encoder counters is supported.
 
 With some carousel designs the carousel will not stop immediately. To allow for
-this set the \\fBalign-dc\\fR pin to a low velocity to be used for a final latching move, and
-set the \\fBdecel-time\\fR to a suitable value.
+this set the *align-dc* pin to a low velocity to be used for a final latching move, and
+set the *decel-time* to a suitable value.
 Once the decel-time has expired the carousel will, if it was moving forwards, reverse back on
 to the position marker, off of the marker and then back on to the FWD edge. If moving in reverse
 it will continue off the marker and then reverse slowly on to the FWD edge.
@@ -85,9 +84,9 @@ homing on first tool change is not needed then the enable pin can be toggled by
 an axis homing pin or a script and the homing process will continue even if that
 driving signal resets during the carousel homing move.
 
-To operate the component with an encoder or stepgen use mode "C". The \\fBscale\\fR
+To operate the component with an encoder or stepgen use mode "C". The *scale*
 pin should be the number of steps or encoder counts between pocket centres. The
-\\fBwidth\\fR pin can be used to stop the motor some distance before the centre of
+*width* pin can be used to stop the motor some distance before the centre of
 the pocket to allow the motor time to decelerate.
 In mode "C" it is possible to use either the speed/direction control used in other
 modes or to use direct position mode using the counts-target pin. The
@@ -96,7 +95,7 @@ hal component will be needed for encoder applications whereas stepgen
 configurations can use a stepgen in position control mode or in velocity
 control mode with a PID.
 
-For tool changers which lock the carousel against a stop the \\fBrev-pulse\\fR pin can
+For tool changers which lock the carousel against a stop the *rev-pulse* pin can
 be set to a non-zero value. The motor-rev pin will then be set for this many seconds
 at the completion of the tool search and at the same time the reverse duty/cycle
 velocity value will be sent to the motor-vel pin.

--- a/src/hal/components/clarke2.comp
+++ b/src/hal/components/clarke2.comp
@@ -1,15 +1,16 @@
 component clarke2 "Two input version of Clarke transform";
 description """The Clarke transform can be used to translate a vector
 quantity from a three phase system (three components 120 degrees
-apart) to a two phase Cartesian system.\n.P\n\\fBclarke2\\fR implements
+apart) to a two phase Cartesian system. +
+*clarke2* implements
 a special case of the Clarke transform, which only needs two of the
 three input phases.  In a three wire three phase system, the sum of the
 three phase currents or voltages must always be zero.  As a result only
 two of the three are needed to completely define the current or voltage.
-\\fBclarke2\\fR assumes that the sum is zero, so it only uses phases A and
+*clarke2* assumes that the sum is zero, so it only uses phases A and
 B of the input.  Since the H (homopolar) output will always be zero in
 this case, it is not generated.""";
-see_also """\\fBclarke3\\fR(9) for the general case, \\fBclarkeinv\\fR(9) for
+see_also """*clarke3*(9) for the general case, *clarkeinv*(9) for
 the inverse transform.""";
 pin in float a;
 pin in float b "first two phases of three phase input";

--- a/src/hal/components/clarke3.comp
+++ b/src/hal/components/clarke3.comp
@@ -2,11 +2,12 @@ component clarke3 "Clarke (3 phase to cartesian) transform";
 description """The Clarke transform can be used to translate a vector
 quantity from a three phase system (three components 120 degrees
 apart) to a two phase Cartesian system (plus a homopolar component
-if the three phases don't sum to zero).\n.P\n\\fBclarke3\\fR implements
+if the three phases don't sum to zero). +
+*clarke3* implements
 the general case of the transform, using all three phases.  If the
-three phases are known to sum to zero, see \\fBclarke2\\fR for a
+three phases are known to sum to zero, see *clarke2* for a
 simpler version.""";
-see_also """\\fBclarke2\\fR(9) for the 'a+b+c=0' case, \\fBclarkeinv\\fR(9) for
+see_also """*clarke2*(9) for the 'a+b+c=0' case, *clarkeinv*(9) for
 the inverse transform.""";
 pin in float a;
 pin in float b;

--- a/src/hal/components/clarkeinv.comp
+++ b/src/hal/components/clarkeinv.comp
@@ -2,7 +2,7 @@ component clarkeinv "Inverse Clarke transform";
 description """The inverse Clarke transform can be used rotate a 
 vector quantity and then translate it from Cartesian coordinate
 system to a three phase system (three components 120 degrees apart).""";
-see_also """\\fBclarke2\\fR(9) and \\fBclarke3\\fR(9) for the forward transform.""";
+see_also """*clarke2*(9) and *clarke3*(9) for the forward transform.""";
 pin in float x;
 pin in float y "cartesian components of input";
 pin in float h "homopolar component of input (usually zero)";

--- a/src/hal/components/comp.comp
+++ b/src/hal/components/comp.comp
@@ -1,16 +1,16 @@
 component comp "Two input comparator with hysteresis";
 pin in float in0 "Inverting input to the comparator";
 pin in float in1 "Non-inverting input to the comparator";
-pin out bit out "Normal output. True when \\fBin1\\fR > \\fBin0\\fR (see parameter \\fBhyst\\fR for details)";
-pin out bit equal "Match output.  True when difference between \\fBin1\\fR and \\fBin0\\fR is less than \\fBhyst\\fR/2";
+pin out bit out "Normal output. True when *in1* > *in0* (see parameter *hyst* for details)";
+pin out bit equal "Match output.  True when difference between *in1* and *in0* is less than *hyst*/2";
 
 param rw float hyst=0.0 """Hysteresis of the comparator (default 0.0)
 
-With zero hysteresis, the output is true when \\fBin1\\fR > \\fBin0\\fR.  With nonzero
+With zero hysteresis, the output is true when *in1* > *in0*.  With nonzero
 hysteresis, the output switches on and off at two different values,
-separated by distance \\fBhyst\\fR around the point where \\fBin1\\fR = \\fBin0\\fR.
+separated by distance *hyst* around the point where *in1* = *in0*.
 Keep in mind that floating point calculations are never absolute
-and it is wise to always set \\fBhyst\\fR if you intend to use equal """;
+and it is wise to always set *hyst* if you intend to use equal """;
 
 option period no;
 function _ fp "Update the comparator";

--- a/src/hal/components/corexy_by_hal.comp
+++ b/src/hal/components/corexy_by_hal.comp
@@ -15,36 +15,38 @@ pin out float beta_cmd "typ: command to beta ts motor";
 
 function _;
 description """
-Implement \\fBCoreXY\\fR forward and inverse transformations
-\\fBin HAL\\fR.  This component provides an alternative
-method for implementing \\fBCoreXY\\fR kinematics.
+Implement *CoreXY* forward and inverse transformations
+*in HAL*.  This component provides an alternative
+method for implementing *CoreXY* kinematics.
 
 In the INI file, use:
 
-\\fB[KINS]KINEMATICS=trivkins coordinates=xyz kinstype=both\\fR
+[source,ini]
+----
+[KINS]
+KINEMATICS=trivkins
+coordinates=xyz
+kinstype=both
+----
 
-This component accepts two joint (\\fBj0,j1\\fR) motor
-position commands for a trivkins coordinates=xyz configuration
-and computes equivalent \\fBCoreXY\\fR motor commands for
-two motors identified as \\fBalpha,beta\\fR.  Similarly,
-the component accepts feedback values for the
-\\fBalpha,beta\\fR motor controllers and converts to
-equivalent joint (\\fBj0,j1\\fR) motor position feedback values.
+This component accepts two joint (*j0*, *j1*) motor position commands for a
+trivkins coordinates=xyz configuration and computes equivalent *CoreXY* motor
+commands for two motors identified as *alpha*, *beta*.  Similarly, the
+component accepts feedback values for the *alpha,beta* motor controllers and
+converts to equivalent joint (*j0*, *j1*) motor position feedback values.
 
 Notes:
 
-1) Using \\fBtrivkins\\fR with this module allows home switches
-to trigger according to the \\fBCartesian x,y\\fR positions
+1. Using *trivkins* with this module allows home switches to trigger according
+to the *Cartesian x,y* positions
 
-2) Joint pin names are based on \\fBcoordinates=xyz\\fR and
-the corresponding joint number assignments used by
-\\fBtrivkins\\fR so \\fBj0==x, j1==y\\fR
-(man trivkins for more information)
+2. Joint pin names are based on *coordinates=xyz* and the corresponding joint
+number assignments used by *trivkins* so *j0==x*, *j1==y* (see *trivkins*(9)).
 
-3) \\fBCoreXY\\fR kinematics can also be implemented using
-the kinematics module named \\fBcorexykins\\fR with home
-switches triggered by the \\fB j0,j1 motor\\fR positions.
-(man kins for more information)
+3. *CoreXY* kinematics can also be implemented using the kinematics module
+named *corexykins* with home switches triggered by the *j0*,*j1* *motor*
+positions (see *kins*(9)).
+
 """;
 
 option period no;

--- a/src/hal/components/dbounce.comp
+++ b/src/hal/components/dbounce.comp
@@ -1,8 +1,9 @@
-component dbounce """alternative debounce component\n
-This component is similar to the \\fBdebounce\\fR component\n
-(man \\fBdebounce\\fR) but uses settable delay pins for each instance\n
-and supports \\fBcount\\fR= or \\fBnames\\fR= parameters\n
-(groups are not used)""";
+component dbounce """alternative debounce component""";
+description """
+This component is similar to the *debounce*(9) component but uses settable
+delay pins for each instance and supports *count*= or *names*= parameters
+(groups are not used)
+""";
 
 pin in  bit in;
 pin out bit out;

--- a/src/hal/components/deadzone.comp
+++ b/src/hal/components/deadzone.comp
@@ -1,11 +1,11 @@
 component deadzone "Return the center if within the threshold";
 param rw float center = 0.0 "The center of the dead zone";
-param rw float threshold = 1.0 "The dead zone is \\fBcenter\\fR \\(+- (\\fBthreshold\\fR/2)";
+param rw float threshold = 1.0 "The dead zone is *center* ±(*threshold*/2)";
 pin in float in;
 pin out float out;
 
 option period no;
-function _ "Update \\fBout\\fR based on \\fBin\\fR and the parameters.";
+function _ "Update *out* based on *in* and the parameters.";
 
 license "GPL";
 author "Jeff Epler";

--- a/src/hal/components/demux.comp
+++ b/src/hal/components/demux.comp
@@ -17,7 +17,7 @@ pin out bit out-## [32:personality] "The set of output bits";
 option default_personality 32;
 param rw bit bargraph = 0;
 
-see_also "\\fBselect8\\fR(9)";
+see_also "*select8*(9)";
 license "GPL 2+";
 author "Andy Pugh";
 

--- a/src/hal/components/div2.comp
+++ b/src/hal/components/div2.comp
@@ -23,7 +23,7 @@ component div2 "Quotient of two floating point inputs";
 pin in  float in0 "the Dividend";
 pin in  float in1 "the Divisor";
 pin out float out "the Quotient   out = in0 / in1";
-param rw float deadband "The \\fBout\\fR will be zero if \\fBin\\fR is between -\\fBdeadband\\fR and +\\fBdeadband\\fR" ;
+param rw float deadband "The *out* will be zero if *in* is between -*deadband* and +*deadband*" ;
 
 description """
 A very simple comp to divide a floating point number

--- a/src/hal/components/eoffset_per_angle.comp
+++ b/src/hal/components/eoffset_per_angle.comp
@@ -3,60 +3,60 @@ component eoffset_per_angle "Compute External Offset Per Angle";
 description
 """
 
-An offset is computed (from one of several functions) based on
-an input angle in degrees.  The angle could be a rotary
-coordinate value or a spindle angle.
+An offset is computed (from one of several functions) based on an input angle
+in degrees. The angle could be a rotary coordinate value or a spindle angle.
 
-The computed offset is represented as an s32 \\fBkcounts\\fR output
-pin that is a compatible input to external offset pins like
-\\fBaxis.L.eoffset-counts\\fR where \\fBL\\fR is the coordinate
-letter.  Scaling of the s32 \\fBkcounts\\fR is controlled by the
-input (\\fBk\\fR) -- its reciprocal value is presented on an output pin
-(\\fBkreciprocal\\fR) for connection to \\fBaxis.L.eoffset-scale\\fR.
-The default value for \\fBk\\fR should be suitable for most uses.
+The computed offset is represented as an s32 *kcounts* output pin that is a
+compatible input to external offset pins like *axis.L.eoffset-counts* where *L*
+is the coordinate letter. Scaling of the s32 *kcounts* is controlled by the
+input (*k*) -- its reciprocal value is presented on an output pin *kreciprocal*
+for connection to *axis.L.eoffset-scale*. The default value for *k* should be
+suitable for most uses.
 
-The built-in functions use pins \\fBfmult\\fR and \\fBrfraction\\fR
-to control the output frequency (or number of polygon sides)
-and amplitude respectively.  The  \\fBrfraction\\fR pin controls
-the offset amplitude as a fraction of the \\fBradius-ref\\fR pin.
+The built-in functions use pins *fmult* and *rfraction* to control the
+output frequency (or number of polygon sides) and amplitude respectively.
+The *rfraction* pin controls the offset amplitude as a fraction of
+the *radius-ref* pin.
 
-One of the four built-in functions is specified by the \\fBfnum\\fR pin:
-  \\fB0\\fR: f0 inside  polygon  (requires \\fBfmult\\fR == nsides >= 3)
-  \\fB1\\fR: f1 outside polygon  (requires \\fBfmult\\fR == nsides >= 3)
-  \\fB2\\fR: f2 sinusoid
-  \\fB3\\fR: f3 square wave
+One of the four built-in functions is specified by the *fnum* pin:
 
-Unsupported \\fBfnum\\fR values default to use function f0.
+* 0: f0 inside  polygon  (requires *fmult* == nsides ≥ 3)
+* 1: f1 outside polygon  (requires *fmult* == nsides ≥ 3)
+* 2: f2 sinusoid
+* 3: f3 square wave
+
+Unsupported *fnum* values default to use function f0.
 """;
 
 notes """
-\\fBradius-ref\\fR:
-The computed offsets are based on the \\fBradius-ref\\fR pin
-value.  This pin may be set to a constant radius value or
-controlled by a user interface or by g code program (using
-\\fBM68\\fR and a \\fBmotion.analog-out-NN pin for instance).
+radius-ref::
+The computed offsets are based on the *radius-ref* pin value. This pin may be
+set to a constant radius value or controlled by a user interface or by g code
+program (using *M68* and a *motion.analog-out-NN* pin for instance).
 
-\\fBStopping\\fR:
-When the \\fBenable-in\\fR pin is deasserted, the offset is
-returned to zero respecting the allocated acceleration
-and velocity limits.  The allocations for coordinate \\fBL\\fR
-are typically controlled by an ini file setting:
-\\fB[AXIS_L]OFFSET_AV_RATIO\\fR.
+Stopping::
+When the *enable-in* pin is deasserted, the offset is returned to zero
+respecting the allocated acceleration and velocity limits. The allocations for
+coordinate *L* are typically controlled by an ini file setting:
 
-If unsupported parameters are supplied to a function (for instance
-a polygon with fewer than three sides), the current offset
-will be returned to zero (respecting velocity and acceleration
-constraints).  After correcting the offending parameter, the
-\\fBenable-in\\fR pin must be toggled to resume offset
+[source,ini]
+----
+[AXIS_L]
+OFFSET_AV_RATIO=...
+----
+
+If unsupported parameters are supplied to a function (for instance a polygon
+with fewer than three sides), the current offset will be returned to zero
+(respecting velocity and acceleration constraints). After correcting the
+offending parameter, the *enable-in* pin must be toggled to resume offset
 computations.
 """;
 
 examples """
 An example simulation configuration is provided at:
-\\fBconfigs/sim/axis/external_offsets/opa.ini\\fR.  A
-simulated XZC machine uses the \\fBC\\fR coordinate angle to
-offset the transverse \\fBX\\fR coordinate according to
-the selected \\fBfnum\\fR function.
+`configs/sim/axis/external_offsets/opa.ini`. +
+A simulated XZC machine uses the *C* coordinate angle to offset the
+transverse *X* coordinate according to the selected *fnum* function.
 """;
 
 //" quote char for vim highlighting

--- a/src/hal/components/estop_latch.comp
+++ b/src/hal/components/estop_latch.comp
@@ -5,61 +5,32 @@ This component can be used as a part of a simple software ESTOP chain.
 
 It has two states: "OK" and "Faulted".
 
-The initial state is "Faulted".  When faulted, the
-.B out-ok
-output is false,
-the
-.B fault-out
-output is true, and the
-.B watchdog
+The initial state is "Faulted".  When faulted, the *out-ok*
+output is false, the *fault-out* output is true, and the *watchdog*
 output is unchanging.
 
-The state changes from "Faulted" to "OK" when
-.B all
-these conditions are true:
-.RS
-.IP \\(bu
-.B fault-in
-is false
-.IP \\(bu
-.B ok-in
-is true
-.IP \\(bu
-.B reset
-changes from false to true
-.RE
+The state changes from "Faulted" to "OK" when *all* these conditions are true:
 
-When "OK", the
-.B out-ok
-output is true, the
-.B fault-out
-output is false, and the
-.B watchdog
-output is toggling.
+* *fault-in* is false
+* *ok-in* is true
+* *reset* changes from false to true
 
-The state changes from "OK" to "Faulted" when
-.B any
-of the following are true:
-.RS
-.IP \\(bu
-.B fault-in
-is true
-.IP \\(bu
-.B ok-in
-is false
-.RE
+When "OK", the *out-ok* output is true, the *fault-out* output is false, and
+the *watchdog* output is toggling.
 
-To facilitate using only a single fault source,
-.B ok-in
-and
-.B fault-en
+The state changes from "OK" to "Faulted" when *any* of the following are true:
+
+* *fault-in* is true
+* *ok-in* is false
+
+To facilitate using only a single fault source, *ok-in* and *fault-en*
 are both set to the non-fault-causing value when no signal is connected.
 For estop-latch to ever be able to signal a fault, at least one of these
 inputs must be connected.
 
-Typically, an external fault or estop input is connected to \\fBfault-in\\fR,
-\\fBiocontrol.0.user-request-enable\\fR is connected to \\fBreset\\fR,
-and \\fBok-out\\fR is connected to \\fBiocontrol.0.emc-enable-in\\fB.
+Typically, an external fault or estop input is connected to *fault-in*,
+*iocontrol.0.user-request-enable* is connected to *reset*,
+and *ok-out* is connected to *iocontrol.0.emc-enable-in*.
 
 In more complex systems, it may be more appropriate to use classicladder to
 manage the software portion of the estop chain.

--- a/src/hal/components/filter_kalman.comp
+++ b/src/hal/components/filter_kalman.comp
@@ -17,7 +17,7 @@
 
 component filter_kalman "Unidimensional Kalman filter, also known as linear quadratic estimation (LQE)";
 license "GPL-2.0-or-later";
-author "Dmian Wrobel <dwrobel@ertelnet.rybnik.pl>";
+author "Dmian Wrobel dwrobel.AT.ertelnet.rybnik.pl";
 
 description
 """
@@ -25,30 +25,30 @@ Useful for reducing input signal noise (e.g. from the voltage or temperature sen
 
 More information can be found at https://en.wikipedia.org/wiki/Kalman_filter.
 
-Adjusting \\fBQr\\fR and \\fBQk\\fR covariances:
+Adjusting *Qr* and *Qk* covariances:
 
-Default values of \\fBRk\\fR and \\fBQk\\fR are given for informational purpose only. The nature of the
+Default values of *Rk* and *Qk* are given for informational purpose only. The nature of the
 filter requires the parameters to be individually computed.
 
 One of the possible and quite practical method (probably far from being the best) of
-estimating the \\fBRk\\fR covariance is to collect the raw data from the sensor by
-either asserting the \\fBdebug\\fR pin or using \\fBhalscope\\fR and then compute the covariance
-using \\fBcov()\\fR function from \\fBOctave\\fR package. Ready to use script can be found at
+estimating the *Rk* covariance is to collect the raw data from the sensor by
+either asserting the *debug* pin or using *halscope* and then compute the covariance
+using *cov()* function from *Octave* package. Ready to use script can be found at
 https://github.com/dwrobel/TrivialKalmanFilter/blob/master/examples/DS18B20Test/covariance.m.
 
-Adjusting \\fBQk\\fR covariance mostly depends on the required response time of the filter.
-There is a relationship between \\fBQk\\fR and response time of the filter that the lower
-the \\fBQk\\fR covariance is the slower the response of the filter is.
+Adjusting *Qk* covariance mostly depends on the required response time of the filter.
+There is a relationship between *Qk* and response time of the filter that the lower
+the *Qk* covariance is the slower the response of the filter is.
 
-Common practice is also to conservatively set \\fBRk\\fR and \\fBQk\\fR slightly larger then computed
+Common practice is also to conservatively set *Rk* and *Qk* slightly larger then computed
 ones to get robustness.
 """;
 
 pin    in   bit  debug = FALSE             "When asserted, prints out measured and estimated values.";
 pin    in   bit  passthrough = FALSE       "When asserted, copies measured value into estimated value.";
 pin    in   bit  reset = FALSE
-"""When asserted, resets filter to its initial state and returns 0 as an estimated value (\\fBreset\\fR pin
-has higher priority than \\fBpassthrough\\fR pin).""";
+"""When asserted, resets filter to its initial state and returns 0 as an estimated value (*reset* pin
+has higher priority than *passthrough* pin).""";
 pin    in float     zk                     "Measured value.";
 pin   out float xk_out                     "Estimated value.";
 param  rw float     Rk = 1.17549e-38       "Estimation of the noise covariances (process).";
@@ -57,7 +57,7 @@ param  rw float     Qk = 1.17549e-38       "Estimation of the noise covariances 
 option extra_setup yes;
 option period no;
 
-function _ "Update \\fBxk-out\\fR based on \\fBzk\\fR input.";
+function _ "Update *xk-out* based on *zk* input.";
 
 variable float xk_last;
 variable float Pk_last;

--- a/src/hal/components/gantry.comp
+++ b/src/hal/components/gantry.comp
@@ -52,10 +52,10 @@ function read  fp "Update position-fb and home/limit outputs based on joint valu
 function write fp "Update joint pos-cmd outputs based on position-cmd in.";
 description """
 Drives multiple physical motors (joints) from a single axis input
-.LP
+
 The `personality' value is the number of joints to control.  Two is typical, but
 up to seven is supported (a three joint setup has been tested with hardware).
-.LP
+
 All controlled joints track the commanded position (with a per-joint offset) unless in the process of homing.
 Homing is when the commanded position is moving towards the homing switches
 (as determined by the sign of search-vel)
@@ -64,7 +64,7 @@ When the system is homing and a joint home switch activates,
 the command value sent to that joint is "frozen" and the joint offset value is updated instead.
 Once all home switches are active,
 there are no more adjustments made to the offset values and all joints run in lock-step once more.
-.LP
+
 For best results, set HOME_SEARCH_VEL and HOME_LATCH_VEL to the same direction and as slow as practical.
 When a joint home switch trips, the commanded velocity will drop immediately from HOME_SEARCH_VEL to zero, with no limit on acceleration.
 """;

--- a/src/hal/components/gearchange.comp
+++ b/src/hal/components/gearchange.comp
@@ -15,7 +15,7 @@ param rw float max1 = 100000 "Maximum allowed speed in gear range 1";
 param rw float min2 = 0 "Minimum allowed speed in gear range 2";
 param rw float max2 = 100000 "Maximum allowed speed in gear range 2";
 param rw float scale2 = 1.0 """Relative scale of gear 2 vs. gear 1.
-Since it is assumed that gear 2 is "high gear", \\fBscale2\\fR must be
+Since it is assumed that gear 2 is "high gear", *scale2* must be
 greater than 1, and will be reset to 1 if set lower.""";
 param rw bit reverse = 0 "Set to 1 to reverse the spindle in second gear.";
 

--- a/src/hal/components/histobins.comp
+++ b/src/hal/components/histobins.comp
@@ -1,38 +1,45 @@
 component histobins
-"""histogram bins utility for scripts/hal-histogram
+"""histogram bins utility for scripts/hal-histogram""";
+description """
+Read *availablebins* pin for the number of bins available. Set the *minvalue*,
+*binsize*, and *nbins* pins and ensure *nbins* ≤ *availablebins*.
 
-Usage:
-  Read availablebins pin for the number of bins available.
-  Set the minvalue, binsize, and nbins pins.
-    Ensure nbins <= availablebins
-    For nbins = N, the bins are numbered: 0 ... N-1
-  Iterate:
-    Set index pin to a bin number: 0 <= index < nbins.
-    Read check pin and verify that check pin == index pin.
-    Read outputs: binvalue, pextra, nextra pins.
-         (binvalue is count for the indexed bin)
-         (pextra   is count for all inputs > maxvalue)
-         (nextra   is count for all bins   < minvalue)
+For *nbins* = N, the bins are numbered: 0 ... N-1
 
- If index is out of range (index < 0 or index > maxbinnumber)
- then binvalue == -1.
- The input-error pin is set when input rules are violated
- and updates cease.
- The reset pin may be used to restart.
- The input used is selected based on pintype:
-   pintype  inputpin
-   -------  -----------
-         0  input
-         1  input-s32
-         2  input-u32
-         3  input-bit
- Additional output statistics pins:
-   input-min
-   input-max
-   nsamples
-   variance
-   mean
- The method input pin selects an alternate variance calculation.
+Iterate:
+
+* Set *index* pin to a bin number: 0 ≤ *index* < *nbins*.
+* Read check pin and verify that check pin == index pin.
+* Read outputs: binvalue, pextra, nextra pins. +
+  (*binvalue* is count for the indexed bin) +
+  (*pextra* is count for all inputs > maxvalue) +
+  (*nextra* is count for all bins   < minvalue)
+
+If *index* is out of range (*index* < 0 or *index* > *maxbinnumber* then
+binvalue == -1. The *input-error* pin is set when input rules are violated and
+updates cease. The reset pin may be used to restart.
+
+The input used is selected based on pintype:
+[options="header",cols="^1,1"]
+|===
+^h|pintype
+^h|inputpin
+
+|0|input
+|1|input-s32
+|2|input-u32
+|3|input-bit
+|===
+
+Additional output statistics pins:
+
+* *input-min*
+* *input-max*
+* *nsamples*
+* *variance*
+* *mean*
+
+The method input pin selects an alternate variance calculation.
 
 Maintainers note: hardcoded for MAXBINNUMBER==200
 """;

--- a/src/hal/components/homecomp.comp
+++ b/src/hal/components/homecomp.comp
@@ -4,7 +4,7 @@ description """
 Example of a homing module buildable with halcompile.
 Demonstrates required code for #includes, function definitions, etc.
 
-If \\fBHOMING_BASE\\fR is #defined and points to a valid homing.c file,
+If *HOMING_BASE* is #defined and points to a valid `homing.c` file,
 an example of a customized homing module is built.  This module
 creates input hal pins joint.n.request-custom-homing that enable an
 alternate joint homing state machine for requested joints.  A hal output
@@ -16,28 +16,38 @@ functions to add support for custom hal pins and custom joint homing
 state machines.  A user-built module will likely replace additional
 api functions or augment them with other customizations.
 
-If \\fBHOMING_BASE\\fR Is not #defined, an  actual homing scheme is
-\\fBnot\\fR implemented but all necessary functions are included as
+If *HOMING_BASE* is not #defined, an  actual homing scheme is
+*not* implemented but all necessary functions are included as
 skeleton code.   (All joints are effectively homed at all times and
 cannot be unhomed).
 
-See the source code file: src/emc/motion/homing.c for the baseline
-implementation that includes all functions for the default \\fBhomemod\\fR
+See the source code file: `src/emc/motion/homing.c` for the baseline
+implementation that includes all functions for the default *homemod*
 module.
 
 To avoid updates that overwrite homecomp.comp, best practice is
 to rename the file and its component name (example:
-\\fBuser_homecomp.comp, user_homecomp\\fR).
+*user_homecomp.comp*, *user_homecomp*).
 
 The (renamed) component can be built and installed with
 halcompile and then substituted for the default homing module
-(\\fBhomemod\\fR) using:\n
-  $ linuxcnc \\fB-m user_homecomp\\fR someconfig.ini\n
-or by inifile setting: \\fB[EMCMOT]HOMEMOD=user_homecomp\\fR
+(*homemod*) using:
 
-\\fBNote:\\fRIf using a deb install:\n
-1) halcompile is provided by the package linuxcnc-dev\n
-2) This source file for BRANCHNAME (master,2.9,etc) is downloadable from github:\n
+  $ linuxcnc -m user_homecomp someconfig.ini
+
+or by inifile setting:
+
+
+[source,ini]
+----
+[EMCMOT]
+HOMEMOD=user_homecomp
+----
+
+*Note*: If using a deb install:
+
+1. halcompile is provided by the package linuxcnc-dev\n
+2. This source file for BRANCHNAME (master,2.9,etc) is downloadable from github:
 https://github.com/LinuxCNC/linuxcnc/blob/BRANCHNAME/src/hal/components/homecomp.comp
 """;
 

--- a/src/hal/components/hypot.comp
+++ b/src/hal/components/hypot.comp
@@ -2,7 +2,7 @@ component hypot "Three-input hypotenuse (Euclidean distance) calculator";
 pin in float in0;
 pin in float in1;
 pin in float in2;
-pin out float out "out = sqrt(in0^2 + in1^2 + in2^2)";
+pin out float out "out = sqrt(*in0*^2^ + *in1*^2^ + *in2*^2^)";
 option period no;
 function _;
 license "GPL";

--- a/src/hal/components/ilowpass.comp
+++ b/src/hal/components/ilowpass.comp
@@ -15,7 +15,7 @@ desired.  Divide the **axis**.__N__.**jog-scale** values by
 
 pin in s32 in;
 
-pin out s32 out """*out* tracks *in*\**scale* through a low-pass
+pin out s32 out """*out* tracks *in* * *scale* through a low-pass
 filter of *gain* per period.""";
 
 param rw float scale = 1024 """A scale factor applied to the output

--- a/src/hal/components/ilowpass.comp
+++ b/src/hal/components/ilowpass.comp
@@ -3,20 +3,20 @@ description """While it may find other applications, this component was written
 to create smoother motion while jogging with an MPG.
 
 In a machine with high acceleration, a short jog can behave almost like a step
-function.  By putting the \\fBilowpass\\fR component between the MPG
-encoder \\fBcounts\\fR output and the axis \\fRjog-counts\\fR input,
+function.  By putting the *ilowpass* component between the MPG
+encoder *counts* output and the axis *jog-counts* input,
 this can be smoothed.
 
-Choose \\fBscale\\fR conservatively so that during a single session
-there will never be more than about 2e9/\\fBscale\\fR pulses seen
-on the MPG.  Choose \\fBgain\\fR according to the smoothing level
-desired.  Divide the \\fRaxis.\\fIN\\fR.jog-scale\\fR values by
-\\fBscale\\fR.""";
+Choose *scale* conservatively so that during a single session
+there will never be more than about 2e9 / *scale* pulses seen
+on the MPG.  Choose *gain* according to the smoothing level
+desired.  Divide the **axis**.__N__.**jog-scale** values by
+*scale*.""";
 
 pin in s32 in;
 
-pin out s32 out """\\fBout\\fR tracks \\fBin\\fR*\\fBscale\\fR through a low-pass
-filter of \\fBgain\\fR per period.""";
+pin out s32 out """*out* tracks *in*\**scale* through a low-pass
+filter of *gain* per period.""";
 
 param rw float scale = 1024 """A scale factor applied to the output
 value of the low-pass filter.""";

--- a/src/hal/components/invert.comp
+++ b/src/hal/components/invert.comp
@@ -14,13 +14,13 @@
 //   along with this program; if not, write to the Free Software
 //   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 component invert """Compute the inverse of the input signal
-The output will be the mathematical inverse of the input, ie \\fBout\\fR = 1/\\fBin\\fR.
-The parameter \\fBdeadband\\fR can be used to control how close to 0 the denominator can be
-before the output is clamped to 0.  \\fBdeadband\\fR must be at least 1e-8, and must be positive.""";
+The output will be the mathematical inverse of the input, ie *out* = 1 / *in*.
+The parameter *deadband* can be used to control how close to 0 the denominator can be
+before the output is clamped to 0. *deadband* must be at least 1e-8, and must be positive.""";
 
 pin in float in "Analog input value";
 pin out float out "Analog output value";
-param rw float deadband "The \\fBout\\fR will be zero if \\fBin\\fR is between -\\fBdeadband\\fR and +\\fBdeadband\\fR.";
+param rw float deadband "The *out* will be zero if *in* is between -*deadband* and +*deadband*.";
 
 option period no;
 function _;

--- a/src/hal/components/joyhandle.comp
+++ b/src/hal/components/joyhandle.comp
@@ -24,19 +24,19 @@ param rw float offset = 0.;
 param rw bit inverse = 0;	
 
 description """
-The component \\fBjoyhandle\\fR uses the following formula for a non linear joypad movements:
+The component *joyhandle* uses the following formula for a non linear joypad movements:
 
-\\fBy = (scale * (a*x^power + b*x)) + offset\\fR
+  y = (scale * (a * x^power + b * x)) + offset
 
 The parameters a and b are adjusted in such a way, that the function starts at (deadband,offset) and ends at (1,scale+offset).
 
 Negative values will be treated point symmetrically to origin. Values -deadband < x < +deadband will be set to zero.
 
-Values x > 1 and x < -1 will be skipped to \\(+-(scale+offset). Invert transforms the function to a progressive movement.
+Values x > 1 and x < -1 will be skipped to ±(scale+offset). Invert transforms the function to a progressive movement.
 
 With power one can adjust the nonlinearity (default = 2). Default for deadband is 0.
 
-Valid values are: power >= 1.0 (reasonable values are 1.x .. 4\\(hy5, take higher power\\(hyvalues for higher deadbands (>0.5), if you want to start with a nearly horizontal slope), 0 <= deadband < 0.99 (reasonable 0.1).
+Valid values are: power ≥ 1.0 (reasonable values are 1.x .. 4-5, take higher power-values for higher deadbands (>0.5), if you want to start with a nearly horizontal slope), 0 ≤ deadband < 0.99 (reasonable 0.1).
 
 An additional offset component can be set in special cases (default = 0).
 

--- a/src/hal/components/laserpower.comp
+++ b/src/hal/components/laserpower.comp
@@ -18,17 +18,19 @@ pin out float start_power "Power level when reqPower last changed";
 pin out float start_distance "Distance amount when reqPower last changed";
 pin out float vel_scale "Velocity related scaling component.";
 
-description """During operation laserpower must be scaled proportionally to actual velocity vs commanded velocity.
-               This prevents uneven laser power when rounding tight corners.
+description """
+During operation laserpower must be scaled proportionally to actual velocity vs
+commanded velocity. This prevents uneven laser power when rounding tight
+corners.
             
-            laserpower operates in 2 modes. 
-                Raster mode (when raster_mode = 1). 
-                    During raster mode raster_power is scaled between min_power and max_power proportionally to req_velocity and cur_velocity.
+Component laserpower operates in 2 modes. Raster mode (when *raster_mode*=1).
+During raster mode *raster_power* is scaled between *min_power* and *max_power*
+proportionally to *req_velocity* and *cur_velocity*.
 
-                Velocity mode (when raster_mode = 0). 
-                    During velocity mode vector_power corresponds to the power level desired when reaching the next control point.
-                    This allows vector power to be scaled along moves.
-            """;
+Velocity mode (when *raster_mode*=0). During velocity mode *vector_power*
+corresponds to the power level desired when reaching the next control point.
+This allows vector power to be scaled along moves.
+""";
 
 option period no;
 function _;

--- a/src/hal/components/latencybins.comp
+++ b/src/hal/components/latencybins.comp
@@ -1,30 +1,35 @@
 component latencybins
 """comp utility for scripts/latency-histogram
+""";
+description """
+Read *availablebins* pin for the number of bins available. Set the
+*maxbinnumber* pin for the number of ±;bins.
+Ensure *maxbinnumber* ≤ *availablebins*.
 
-Usage:
-  Read availablebins pin for the number of bins available.
-  Set the maxbinnumber pin for the number of \\(+- bins.
-    Ensure maxbinnumber <= availablebins
-    For maxbinnumber = N, the bins are numbered:
-       -N ... 0 ... + N bins
-    (the -0 bin is not populated)
-    (total effective bins = 2*maxbinnumber +1)
-  Set nsbinsize pin for the binsize (ns)
-  Iterate:
-    Set index pin to a bin number: 0 <= index <= maxbinnumber.
-    Read check pin and verify that check pin == index pin.
-    Read output pins:
-         pbinvalue is count for bin = +index
-         nbinvalue is count for bin = -index
-         pextra    is count for all bins > maxbinnumber
-         nextra    is count for all bins < maxbinnumber
-         latency-min is max negative latency
-         latency-max is max positive latency
+For *maxbinnumber* = N, the bins are numbered:
 
-   If index is out of range ( index < 0 or index > maxbinnumber)
-   then pbinvalue = nbinvalue = -1.
-   The reset pin may be used to restart.
-   The latency pin outputs the instantaneous latency.
+* -N ... 0 ... +N bins +
+  (the -0 bin is not populated) +
+  (total effective bins = 2 * maxbinnumber + 1)
+
+Set *nsbinsize* pin for the binsize (ns).
+
+Iterate:
+
+* Set *index* pin to a bin number: 0 ≤ *index* ≤ maxbinnumber.
+* Read check pin and verify that check pin == *index* pin.
+* Read output pins:
+** *pbinvalue* is count for bin = +*index*
+** *nbinvalue* is count for bin = -*index*
+** *pextra*    is count for all bins > *maxbinnumber*
+** *nextra*    is count for all bins < *maxbinnumber*
+** *latency-min* is max negative latency
+** *latency-max* is max positive latency
+
+If *index* is out of range (*index* < 0 or *index* > *maxbinnumber*)
+then *pbinvalue* = *nbinvalue* = -1. The reset pin may be used to restart.
+
+The latency pin outputs the instantaneous latency.
 
 Maintainers note: hardcoded for MAXBINNUMBER==1000
 """;

--- a/src/hal/components/limit2.comp
+++ b/src/hal/components/limit2.comp
@@ -1,7 +1,7 @@
 component limit2 "Limit the output signal to fall between min and max and limit its slew rate to less than maxv per second.  When the signal is a position, this means that position and velocity are limited.";
 pin in float in;
 pin out float out;
-pin in bit load "When TRUE, immediately set \\fBout\\fB to \\fBin\\fR, ignoring maxv";
+pin in bit load "When TRUE, immediately set *out* to *in*, ignoring maxv";
 pin in float min_=-1e20;
 pin in float max_=1e20;
 pin in float maxv=1e20;

--- a/src/hal/components/limit3.comp
+++ b/src/hal/components/limit3.comp
@@ -7,7 +7,7 @@ pin in float in;
 pin in bit enable = 1 "1: out follows in, 0: out returns to 0 (always per constraints)";
 pin out float out;
 pin in bit load=0
-    """When TRUE, immediately set \\fBout\\fB to \\fBin\\fR, ignoring maxv
+    """When TRUE, immediately set *out* to *in*, ignoring maxv
 and maxa""";
 pin in float min_=-1e20;
 pin in float max_=1e20;

--- a/src/hal/components/limit_axis.comp
+++ b/src/hal/components/limit_axis.comp
@@ -1,29 +1,38 @@
 component limit_axis "Dynamic range based axis limits";
 
-description """limit_axis.c
+description """
+Limit axis to certain limits at varying inputs.
 
-Limit axis to certain limits at varying inputs
-For example on a spindle with C rotation, to avoid hitting a
-gantry when the height is above Z-10
- - Use Z axis as feedback
- - Use 2 ranges (0,-10) (-10, -40)
- - When Z is above 10, C rotation is limited to range 0
- - When Z is below 10, C rotation is limited to range 1
+For example on a spindle with C rotation, to avoid hitting a gantry when the
+height is above Z-10.
 
- Usage:
- loadrt limit_axis count=3 personality=2,3,2
- or
- loadrt limit_axis names=limit_x,limit_y,limit_z personality=2,3,2
+* Use Z axis as feedback
+* Use 2 ranges (0,-10) (-10, -40)
+* When Z is above 10, C rotation is limited to range 0
+* When Z is below 10, C rotation is limited to range 1
 
- The "personality" argument defines how many ranges are supported by each instance.
- (Note that no spaces can be used in the names= and personality= parameters)
+Usage:
 
- Caveats
- - Searches ranges from 0 to 9 and will take the first range that matches
- - Ranges are inclusive min_range <= feedback <= max_range
- - Max can not be less than minimum for any group
- - Sticky indicates, to not check other ranges if the feedback is still in the current range
- - Enable allows for a range to be turned on/off, for cases such as avoiding a tool changer, but allowing sometimes""";
+[source,hal]
+----
+loadrt limit_axis count=3 personality=2,3,2
+# or
+loadrt limit_axis names=limit_x,limit_y,limit_z personality=2,3,2
+----
+
+The *personality* argument defines how many ranges are supported by each
+instance. Note that no spaces can be used in the *names*= and *personality*=
+parameters.
+
+Caveats:
+
+* Searches ranges from 0 to 9 and will take the first range that matches
+* Ranges are inclusive *min_range* ≤ feedback ≤ *max_range*
+* Max can not be less than minimum for any group
+* *sticky* indicates, to not check other ranges if the feedback is still in the current range
+* *enable* allows for a range to be turned on/off, for cases such as avoiding a tool changer, but allowing sometimes
+
+""";
 
 author "Chad Woitas";
 license "GPL";

--- a/src/hal/components/logic.comp
+++ b/src/hal/components/logic.comp
@@ -1,15 +1,14 @@
 component logic """LinuxCNC HAL component providing configurable logic functions
 
-.B loadrt logic
-.B [count=N|names=name1[,name2...]]
-.B personality=0xXXXX[,0xXXXX...]
+*loadrt* *logic* [*count*=_N_|*names*=_name1_[,_name2_...]] *personality*=_0xXXXX_[,_0xXXXX_...]
 
-.TP
-\\fBcount\\fR The number of logical gates.
-.TP
-\\fBnames\\fR The named logical gates to create.
-.TP
-\\fBpersonality\\fR Comma separated list of hexadecimal number.
+*count*::
+The number of logical gates.
+
+*names*::
+The named logical gates to create.
+
+*personality*:: Comma separated list of hexadecimal number.
 Each number defines the behaviour of the individual logic gate.  The
 list must have the same number of personalities as the N count.
 
@@ -24,58 +23,54 @@ function _ nofp "Read the inputs and toggle the output bit.";
 description """
 General `logic function' component.  Can perform `and', `or',
 `nand', `nor' and `xor' of up to 16 inputs.
-.LP
+
 Determine the proper value for `personality'
 by adding the inputs and outputs then convert to hex:
-.IP \\(bu 4
-The number of input pins, usually from 2 to 16
-.IP \\(bu
-256 (0x100)  if the `and' output is desired
-.IP \\(bu
-512 (0x200)  if the `or' output is desired
-.IP \\(bu
-1024 (0x400)  if the `xor' (exclusive or) output is desired
-.IP \\(bu
-2048 (0x800)  if the `nand' output is desired
-.IP \\(bu
-4096 (0x1000)  if the `nor' output is desired
-.LP
+
+* The number of input pins, usually from 2 to 16
+* 256 (0x100)  if the `and' output is desired
+* 512 (0x200)  if the `or' output is desired
+* 1024 (0x400)  if the `xor' (exclusive or) output is desired
+* 2048 (0x800)  if the `nand' output is desired
+* 4096 (0x1000)  if the `nor' output is desired
+
 Outputs can be combined, for example 2 + 256 + 1024 = 1282 converted to hex
 would be 0x502 and would have two inputs and have both `xor' and `and' outputs.
 """;
 examples """
-.PP
+
 This is an OR circuit connected to three different signals, two inputs
 named sig-in-0 and sig-in-1, and one output named sig-out.  First the
 circuit is defined, then its function is connected to the servo real
 time thread, last, its pins are connected to the wanted signals.
-.IP
-.nf
+
+[source,hal]
+----
 loadrt logic count=1 personality=0x202
 addf logic.0 servo-thread
 net sig-in-0 => logic.0.in-00
 net sig-in-1 => logic.0.in-01
 net sig-out  <= logic.0.or
-.fi
+----
 
-.PP
 This is a named AND circuit with two inputs and one output.
-.IP
-.nf
+
+[source,hal]
+----
 loadrt logic names=both personality=0x102
 addf both servo-thread
 net sig-in-0 => both.in-00
 net sig-in-1 => both.in-01
 net sig-out  <= both.and
-.fi
+----
 
 """;
 see_also """
-\\fBand2\\fR(9),
-\\fBlut5\\fR(9),
-\\fBnot\\fR(9),
-\\fBor2\\fR(9),
-\\fBxor2\\fR(9)
+*and2*(9),
+*lut5*(9),
+*not*(9),
+*or2*(9),
+*xor2*(9)
 """;
 license "GPL";
 author "Jeff Epler";

--- a/src/hal/components/lowpass.comp
+++ b/src/hal/components/lowpass.comp
@@ -1,44 +1,44 @@
 component lowpass "Low-pass filter";
 notes """
 
-\\fBgain\\fR pin setting
+*gain* pin setting
 
 The digital filter implemented is equivalent to a unity-gain
 continuous-time single-pole low-pass filter that is preceded
 by a zero-order-hold and sampled at a fixed period.  For a pole
-at \\fB-a\\fR (radians/seconds) the corresponding continuous-time
+at *-a* (radians/seconds) the corresponding continuous-time
 lowpass filter LaPlace transfer function is:
 
-\\fBH(s) = a/(s + a)\\fR
+H(s) = a/(s + a)
 
-For a sampling period \\fBT\\fR (seconds), the gain for this HAL lowpass component is:
+For a sampling period *T* (seconds), the gain for this HAL lowpass component is:
 
-\\fBgain = 1 - e^(-a * T)\\fR
+gain = 1 - e^(-a * T)
 
 e = 2.71828 https://en.wikipedia.org/wiki/E_(mathematical_constant)
 
-\\fBExamples:\\fR
+Examples:
      T = 0.001 seconds (typical servo thread period)
-     a = (2*pi*100)    (\\fB100Hz\\fR bandwidth single pole)
-  gain = \\fB0.466\\fR
+     a = (2 * pi * 100)    (*100Hz* bandwidth single pole)
+  gain = *0.466*
 
      T = 0.001 seconds (typical servo thread period)
-     a = (2*pi*10)     ( \\fB10Hz\\fR bandwidth single pole)
-  gain = \\fB0.0609\\fR
+     a = (2 * pi * 10)     ( *10Hz* bandwidth single pole)
+  gain = *0.0609*
 
      T = 0.001 seconds (typical servo thread period)
-     a = (2*pi*1)      ( \\fB1Hz\\fR bandwidth single pole)
-  gain = \\fB0.0063\\fR
+     a = (2 * pi * 1)      ( *1Hz* bandwidth single pole)
+  gain = *0.0063*
 """;
 pin in float in;
 pin out float out " out += (in - out) * gain ";
-pin in bit load "When TRUE, copy \\fBin\\fR to \\fBout\\fR instead of applying the filter equation.";
+pin in bit load "When TRUE, copy *in* to *out* instead of applying the filter equation.";
 param rw float gain;
 option period no;
 function _;
 license "GPL";
 author "Jeff Epler";
-notes "The effect of a specific \\fBgain\\fR value is dependent on the period of the function that \\fBlowpass.\\fIN\\fR is added to.";
+notes "The effect of a specific *gain* value is dependent on the period of the function that *lowpass.N* is added to.";
 ;;
 FUNCTION(_) {
     if(load)

--- a/src/hal/components/lut5.comp
+++ b/src/hal/components/lut5.comp
@@ -8,136 +8,87 @@ pin out bit out;
 param rw u32 function;
 function _ nofp;
 description """
-.B lut5
-constructs a logic function with up to 5 inputs using a \\fBl\\fRook-\\fBu\\fRp \\fBt\\fRable.
-The value for \\fBfunction\\fR can be determined by writing the truth table,
-and computing the sum of \\fBall\\fR the \\fBweights\\fR for which the output value would be \\fRTRUE\\fR.
+*lut5*
+constructs a logic function with up to 5 inputs using a **l**ook-**u**p **t**able.
+The value for *function* can be determined by writing the truth table,
+and computing the sum of *all* the *weights* for which the output value would be *TRUE*.
 The weights are hexadecimal not decimal so hexadecimal math must be used to sum the weights.
 A wiki page has a calculator to assist in computing the proper value for function.
-.PP
+
 https://wiki.linuxcnc.org/cgi-bin/wiki.pl?Lut5
-.PP
+
 Note that LUT5 will generate any of the 4,294,967,296
-logical functions of 5 inputs so \\fBAND\\fR, \\fBOR\\fR, \\fBNAND\\fR,
-\\fBNOR\\fR, \\fBXOR\\fR and every other combinatorial function is possible.
-.PP
-.SS Example Functions
-A 5-input
-\\fIand\\fR function is TRUE only when all the inputs are true, so the correct
-value for \\fBfunction\\fR is \\fB0x80000000\\fR.
-.PP
-A 2-input \\fIor\\fR function would be the sum of \\fB0x2\\fR + \\fB0x4\\fR +
-\\fB0x8\\fR, so the correct value for \\fBfunction\\fR is \\fB0xe\\fR.
-.PP
-A 5-input \\fIor\\fR
-function is TRUE whenever any of the inputs are true, so the correct value for
-\\fBfunction\\fR is \\fB0xfffffffe\\fR. Because every weight except \\fB0x1\\fR
+logical functions of 5 inputs so *AND*, *OR*, *NAND*,
+*NOR*, *XOR* and every other combinatorial function is possible.
+
+=== Example Functions
+A 5-input *and* function is TRUE only when all the inputs are true, so the
+correct value for *function* is *0x80000000*.
+
+A 2-input *or* function would be the sum of *0x2* + *0x4* + *0x8*, so the
+correct value for *function* is *0xe*.
+
+A 5-input *or* function is TRUE whenever any of the inputs are true, so the
+correct value for *function* is *0xfffffffe*. Because every weight except *0x1*
 is true the function is the sum of every line except the first one.
-.PP
-A 2-input \\fIxor\\fR function is
-TRUE whenever exactly one of the inputs is true, so the correct value for
-\\fBfunction\\fR is \\fB0x6\\fR.  Only \\fBin-0\\fR and \\fBin-1\\fR should be
-connected to signals, because if any other bit is \\fBTRUE\\fR then the output
-will be \\fBFALSE\\fR.
-.PP
-.ie '\\*[.T]'html' \\{\\
-.HTML \\
-<STYLE> \\
-#weight TD { text-align: center; padding-left: .5ex; padding-right: .5ex } \\
-#weight TH { text-align: center; padding-left: .5ex; padding-right: .5ex } \\
-#weight TD.W { text-align: right; } \\
-</STYLE> \\
-<TABLE ID="weight" STYLE="border: 1px solid black; border-collapse: collapse"> \\
-    <COL SPAN=5 STYLE="margin: .2ex"><COL SPAN=1 STYLE="border-left: 1px solid black"> \\
-<TR STYLE="border-bottom: 1px solid black"> \\
-    <TH COLSPAN=6>Weights for each line of truth table \\
-<TR STYLE="border-bottom: 1px solid black"> \\
-    <TH>Bit 4<TH>Bit 3<TH>Bit 2<TH>Bit 1<TH>Bit 0<TH> Weight \\
-<TR><TD>0<TD>0<TD>0<TD>0<TD>0<TD CLASS="w">0x1 \\
-<TR><TD>0<TD>0<TD>0<TD>0<TD>1<TD CLASS="w">0x2 \\
-<TR><TD>0<TD>0<TD>0<TD>1<TD>0<TD CLASS="w">0x4 \\
-<TR><TD>0<TD>0<TD>0<TD>1<TD>1<TD CLASS="w">0x8 \\
-<TR><TD>0<TD>0<TD>1<TD>0<TD>0<TD CLASS="w">0x10 \\
-<TR><TD>0<TD>0<TD>1<TD>0<TD>1<TD CLASS="w">0x20 \\
-<TR><TD>0<TD>0<TD>1<TD>1<TD>0<TD CLASS="w">0x40 \\
-<TR><TD>0<TD>0<TD>1<TD>1<TD>1<TD CLASS="w">0x80 \\
-<TR><TD>0<TD>1<TD>0<TD>0<TD>0<TD CLASS="w">0x100 \\
-<TR><TD>0<TD>1<TD>0<TD>0<TD>1<TD CLASS="w">0x200 \\
-<TR><TD>0<TD>1<TD>0<TD>1<TD>0<TD CLASS="w">0x400 \\
-<TR><TD>0<TD>1<TD>0<TD>1<TD>1<TD CLASS="w">0x800 \\
-<TR><TD>0<TD>1<TD>1<TD>0<TD>0<TD CLASS="w">0x1000 \\
-<TR><TD>0<TD>1<TD>1<TD>0<TD>1<TD CLASS="w">0x2000 \\
-<TR><TD>0<TD>1<TD>1<TD>1<TD>0<TD CLASS="w">0x4000 \\
-<TR><TD>0<TD>1<TD>1<TD>1<TD>1<TD CLASS="w">0x8000 \\
-<TR><TD>1<TD>0<TD>0<TD>0<TD>0<TD CLASS="w">0x10000 \\
-<TR><TD>1<TD>0<TD>0<TD>0<TD>1<TD CLASS="w">0x20000 \\
-<TR><TD>1<TD>0<TD>0<TD>1<TD>0<TD CLASS="w">0x40000 \\
-<TR><TD>1<TD>0<TD>0<TD>1<TD>1<TD CLASS="w">0x80000 \\
-<TR><TD>1<TD>0<TD>1<TD>0<TD>0<TD CLASS="w">0x100000 \\
-<TR><TD>1<TD>0<TD>1<TD>0<TD>1<TD CLASS="w">0x200000 \\
-<TR><TD>1<TD>0<TD>1<TD>1<TD>0<TD CLASS="w">0x400000 \\
-<TR><TD>1<TD>0<TD>1<TD>1<TD>1<TD CLASS="w">0x800000 \\
-<TR><TD>1<TD>1<TD>0<TD>0<TD>0<TD CLASS="w">0x1000000 \\
-<TR><TD>1<TD>1<TD>0<TD>0<TD>1<TD CLASS="w">0x2000000 \\
-<TR><TD>1<TD>1<TD>0<TD>1<TD>0<TD CLASS="w">0x4000000 \\
-<TR><TD>1<TD>1<TD>0<TD>1<TD>1<TD CLASS="w">0x8000000 \\
-<TR><TD>1<TD>1<TD>1<TD>0<TD>0<TD CLASS="w">0x10000000 \\
-<TR><TD>1<TD>1<TD>1<TD>0<TD>1<TD CLASS="w">0x20000000 \\
-<TR><TD>1<TD>1<TD>1<TD>1<TD>0<TD CLASS="w">0x40000000 \\
-<TR><TD>1<TD>1<TD>1<TD>1<TD>1<TD CLASS="w">0x80000000 \\
-</TABLE>
-\\}
-.el \\{\\
-.TS
-box tab(;);
-cb s s s s s
-cb cb cb cb cb | cb
-c  c  c  c  c  | r.
-Weights for each line of truth table
-_
-Bit 4;Bit 3;Bit 2;Bit 1;Bit 0; Weight
-_
-0;0;0;0;0;0x1
-0;0;0;0;1;0x2
-0;0;0;1;0;0x4
-0;0;0;1;1;0x8
-0;0;1;0;0;0x10
-0;0;1;0;1;0x20
-0;0;1;1;0;0x40
-0;0;1;1;1;0x80
-0;1;0;0;0;0x100
-0;1;0;0;1;0x200
-0;1;0;1;0;0x400
-0;1;0;1;1;0x800
-0;1;1;0;0;0x1000
-0;1;1;0;1;0x2000
-0;1;1;1;0;0x4000
-0;1;1;1;1;0x8000
-1;0;0;0;0;0x10000
-1;0;0;0;1;0x20000
-1;0;0;1;0;0x40000
-1;0;0;1;1;0x80000
-1;0;1;0;0;0x100000
-1;0;1;0;1;0x200000
-1;0;1;1;0;0x400000
-1;0;1;1;1;0x800000
-1;1;0;0;0;0x1000000
-1;1;0;0;1;0x2000000
-1;1;0;1;0;0x4000000
-1;1;0;1;1;0x8000000
-1;1;1;0;0;0x10000000
-1;1;1;0;1;0x20000000
-1;1;1;1;0;0x40000000
-1;1;1;1;1;0x80000000
-.TE
-\\}
+
+A 2-input *xor* function is TRUE whenever exactly one of the inputs is true, so
+the correct value for *function* is *0x6*.  Only *in-0* and *in-1* should be
+connected to signals, because if any other bit is *TRUE* then the output will
+be *FALSE*.
+
+[cols="^1,^1,^1,^1,^1,>1"]
+|===
+6+^h|Weights for each line of truth table
+
+^h|Bit 4
+^h|Bit 3
+^h|Bit 2
+^h|Bit 1
+^h|Bit 0
+2+^h|Weight
+
+|0|0|0|0|0|0x00000001
+|0|0|0|0|1|0x00000002
+|0|0|0|1|0|0x00000004
+|0|0|0|1|1|0x00000008
+|0|0|1|0|0|0x00000010
+|0|0|1|0|1|0x00000020
+|0|0|1|1|0|0x00000040
+|0|0|1|1|1|0x00000080
+|0|1|0|0|0|0x00000100
+|0|1|0|0|1|0x00000200
+|0|1|0|1|0|0x00000400
+|0|1|0|1|1|0x00000800
+|0|1|1|0|0|0x00001000
+|0|1|1|0|1|0x00002000
+|0|1|1|1|0|0x00004000
+|0|1|1|1|1|0x00008000
+|1|0|0|0|0|0x00010000
+|1|0|0|0|1|0x00020000
+|1|0|0|1|0|0x00040000
+|1|0|0|1|1|0x00080000
+|1|0|1|0|0|0x00100000
+|1|0|1|0|1|0x00200000
+|1|0|1|1|0|0x00400000
+|1|0|1|1|1|0x00800000
+|1|1|0|0|0|0x01000000
+|1|1|0|0|1|0x02000000
+|1|1|0|1|0|0x04000000
+|1|1|0|1|1|0x08000000
+|1|1|1|0|0|0x10000000
+|1|1|1|0|1|0x20000000
+|1|1|1|1|0|0x40000000
+|1|1|1|1|1|0x80000000
+|===
+
 """;
 see_also """
-\\fBand\\fR(9),
-\\fBlogic\\fR(9),
-\\fBnot\\fR(9),
-\\fBor2\\fR(9),
-\\fBxor2\\fR(9).
+*and*(9),
+*logic*(9),
+*not*(9),
+*or2*(9),
+*xor2*(9).
 """;
 license "GPL";
 author "Jeff Epler";

--- a/src/hal/components/matrixkins.comp
+++ b/src/hal/components/matrixkins.comp
@@ -22,15 +22,15 @@ The matrixkins component implements custom kinematics for 3-axis
 Cartesian machines that allows compensating minor alignment inaccuracies
 in software.
 
-\\fBKINEMATICS MODEL:\\fR
+=== KINEMATICS MODEL
 
 By default identity matrix is used, which is equal to trivial kinematics:
 
-.nf
+....
 | X_joint |   | 1 0 0 |   | X_axis |
 | Y_joint | = | 0 1 0 | * | Y_axis |
 | Z_joint |   | 0 0 1 |   | Z_axis |
-.fi
+....
 
 Adjusting the calibration matrix allows compensating out many
 mechanical issues, including:
@@ -43,16 +43,16 @@ mechanical issues, including:
 The matrix coefficients are set by parameters C_xx .. C_zz.
 For 3 axis machine, the equations become:
 
-.nf
+....
 X_joint = C_xx * X_axis + C_xy * Y_axis + C_xz * Z_axis
 Y_joint = C_yx * X_axis + C_yy * Y_axis + C_yz * Z_axis
 Z_joint = C_zx * X_axis + C_zy * Y_axis + C_zz * Z_axis
-.fi
+....
 
 If the machine has more than 3 axes, the rest are passed through
 without adjustment.
 
-\\fBCALIBRATION INSTRUCTIONS:\\fR
+=== CALIBRATION INSTRUCTIONS
 
 For a 3 axis milling machine, the following process can be used to accurately
 measure and compensate the mechanical alignment.
@@ -65,7 +65,7 @@ Tools required:
 
 Process:
 
-\\fB1. Head tramming\\fR
+==== 1. Head tramming
 
 Mechanically tram the spindle to the table surface as well as you can.
 The perpendicularity of spindle vs. table cannot be compensated in software,
@@ -74,7 +74,7 @@ and the spindle axis will act as the reference for all further steps.
 You can measure the perpendicularity by mounting the dial indicator on
 the spindle. Search for "mill tramming" online for detailed process.
 
-\\fB2. X and Y axis squaring\\fR
+==== 2. X and Y axis squaring
 
 Cut octagon out of some rigid material. It is best to cut a roughing path
 first and a thin finishing pass last, to get the best accuracy. Make the
@@ -90,14 +90,14 @@ Measure width along both diagonals.
 If the X and Y axes are square to each other, the readings should be identical.
 
 To compensate, set
-C_xy = (B^2 - A^2) / (2 * A * B)
+C_xy = (B^2^ - A^2^) / (2 * A * B)
 where A is the diagonal in X+/Y+ direction and B is the diagonal in X+/Y- direction.
 
 This adjusts Y axis direction while keeping X axis as it was.
 Alternatively you can set C_yx to adjust X axis instead.
 The choice affects alignment with respect to e.g. table slots.
 
-\\fB3. X axis squaring to spindle\\fR
+==== 3. X axis squaring to spindle
 
 Mount the dial indicator so that it rotates around the spindle axis, like in tramming measurement.
 Mark a spot on the table where the indicator touches when it is in positive X direction from spindle center.
@@ -111,7 +111,7 @@ To compensate, set
 C_zx = D / X
 where D is the new dial indicator reading, and X is the length moved along X axis.
 
-\\fB4. Y axis squaring to spindle\\fR
+==== 4. Y axis squaring to spindle
 
 Same as step 3, except move the machine in positive Y direction.
 
@@ -119,7 +119,7 @@ To compensate, set
 C_zy = D / Y
 where D is the new dial indicator reading, and Y is the length moved.
 
-\\fB5. Z axis parallelism to spindle in X direction\\fR
+==== 5. Z axis parallelism to spindle in X direction
 
 Mount straight rod to the spindle.
 Position dial indicator so that it measures horizontally against the positive X side of the rod, close to the spindle.
@@ -134,7 +134,7 @@ Set
 C_xz = - X / Z
 where X is the dial indicator difference between bottom and top and Z is the amount you raised the Z axis.
 
-\\fB6. Z axis parallelism to spindle in Y direction\\fR
+==== 6. Z axis parallelism to spindle in Y direction
 
 Same as step 5, except measure on the positive Y side of the rod.
 
@@ -142,28 +142,30 @@ Set
 C_yz = - Y / Z
 where Z is the dial indicator difference and Z is the amount you raised the Z axis.
 
-\\fBCONFIGURATION FILES:\\fR
+=== CONFIGURATION FILES
 
 Specify matrixkins in LinuxCNC INI file as:
 
-.nf
-\\fB[KINS]\\fR
-\\fBKINEMATICS=matrixkins\\fR
-.fi
+[source,hal]
+----
+[KINS]
+KINEMATICS=matrixkins
+----
 
 In your HAL configuration file, set the parameters C_xx .. C_zz:
 
-.nf
-\\fB setp matrixkins.C_xx 1 \\fR  # X axis scale
-\\fB setp matrixkins.C_xy 0 \\fR  # Skew Y axis towards X axis
-\\fB setp matrixkins.C_xz 0 \\fR  # Skew Z axis towards X axis
-\\fB setp matrixkins.C_yx 0 \\fR  # Skew X axis towards Y axis
-\\fB setp matrixkins.C_yy 1 \\fR  # Y axis scale
-\\fB setp matrixkins.C_yz 0 \\fR  # Skew Z axis towards Y axis
-\\fB setp matrixkins.C_zx 0 \\fR  # Skew X axis towards Z axis
-\\fB setp matrixkins.C_zy 0 \\fR  # Skew Y axis towards Z axis
-\\fB setp matrixkins.C_zz 1 \\fR  # Z axis scale
-.fi
+[source,hal]
+----
+setp matrixkins.C_xx 1  # X axis scale
+setp matrixkins.C_xy 0  # Skew Y axis towards X axis
+setp matrixkins.C_xz 0  # Skew Z axis towards X axis
+setp matrixkins.C_yx 0  # Skew X axis towards Y axis
+setp matrixkins.C_yy 1  # Y axis scale
+setp matrixkins.C_yz 0  # Skew Z axis towards Y axis
+setp matrixkins.C_zx 0  # Skew X axis towards Z axis
+setp matrixkins.C_zy 0  # Skew Y axis towards Z axis
+setp matrixkins.C_zz 1  # Z axis scale
+----
 
 The parameters can be modified during runtime using halcmd.
 To avoid sudden movements, it is better to turn off machine power before changes.

--- a/src/hal/components/max31855.comp
+++ b/src/hal/components/max31855.comp
@@ -2,17 +2,19 @@ component max31855 "Support for the MAX31855 Thermocouple-to-Digital converter u
 
 description """The component requires at least 3 pins to bitbang spi protocol, for example:
 
-\\fB loadrt max31855 personality=1\\fR
+[source,hal]
+----
+loadrt max31855 personality=1
 
-\\fB setp hm2_6i25.0.gpio.023.is_output true\\fR
-\\fB setp hm2_6i25.0.gpio.024.is_output true\\fR
+setp hm2_6i25.0.gpio.023.is_output true
+setp hm2_6i25.0.gpio.024.is_output true
 
-\\fB net spi.clk.in    hm2_6i25.0.gpio.023.out     max31855.0.clk.out\\fR
-\\fB net spi.cs.in     hm2_6i25.0.gpio.024.out     max31855.0.cs.out\\fR
-\\fB net spi.data0.in  hm2_6i25.0.gpio.033.in_not  max31855.0.data.0.in\\fR
+net spi.clk.in    hm2_6i25.0.gpio.023.out     max31855.0.clk.out
+net spi.cs.in     hm2_6i25.0.gpio.024.out     max31855.0.cs.out
+net spi.data0.in  hm2_6i25.0.gpio.033.in_not  max31855.0.data.0.in
 
-\\fB addf max31855.0.bitbang-spi servo-thread \\fR
-
+addf max31855.0.bitbang-spi servo-thread
+----
 
 The MAX31855 supports a range of -270C to 1800C, however linearization data 
 is only available for the -200C to 1350C range, beyond which raw temperature is returned.

--- a/src/hal/components/mesa_pktgyro_test.comp
+++ b/src/hal/components/mesa_pktgyro_test.comp
@@ -9,7 +9,10 @@ not used instead.
 For simplicity we test only one PktUART instance, therefore load the component
 like this:
 
-\\fB loadrt mesa_uart names=hm2_5i25.0.pktuart.0\\fR
+[source,hal]
+----
+loadrt mesa_uart names=hm2_5i25.0.pktuart.0
+----
 
 The PktUART instance names are printed to the dmesg buffer during the Hostmot2
 setup sequence, one for each PktUART instance included in the bitfile loaded to
@@ -19,17 +22,22 @@ If you want to work with more than one PktUART instance, consult Andy Pugh's
 mesa_uart.comp
 
 In order to compile and install do:
-\\fB halcompile --install src/hal/drivers/mesa_pktgyro_test.comp\\fR
+
+  halcompile --install src/hal/drivers/mesa_pktgyro_test.comp
 
 The component exports only one function, namely receive, which needs to be added
 to a realtime thread.
 To test this component  set DEBUG=5 before and execute this HAL script:
-\\fB loadrt hostmot2\\fR
-\\fB loadrt hm2_pci\\fR
-\\fB loadrt mesa_pktgyro_test names=hm2_5i25.0.pktuart.0\\fR
-\\fB loadrt threads name1=test1 period1=10000000\\fR
-\\fB addf hm2_5i25.0.pktuart.0.receive test1\\fR
-\\fB start\\fR
+
+[source,hal]
+----
+loadrt hostmot2
+loadrt hm2_pci
+loadrt mesa_pktgyro_test names=hm2_5i25.0.pktuart.0
+loadrt threads name1=test1 period1=10000000
+addf hm2_5i25.0.pktuart.0.receive test1
+start
+----
 
 Check linuxcnc.log for debug output.
 

--- a/src/hal/components/message.comp
+++ b/src/hal/components/message.comp
@@ -38,17 +38,20 @@
 component message "Display a message";
  
 description """Allows HAL pins to trigger a message. Example hal commands:
- loadrt message names=oillow,oilpressure,inverterfail messages="Slideway oil low,No oil
-pressure,Spindle inverter fault"
- addf oillow servo-thread
- addf oilpressure servo-thread
- addf inverterfail servo-thread
- 
- setp oillow.edge 0 #this pin should be active low
- net no-oil classicladder.0.out-21 oillow.trigger
- net no-pressure classicladder.0.out-22 oilpressure.trigger
- net no-inverter classicladder.0.out-23 inverterfail.trigger
- 
+
+[source,hal]
+----
+loadrt message names=oillow,oilpressure,inverterfail messages="Slideway oil low,No oil pressure,Spindle inverter fault"
+addf oillow servo-thread
+addf oilpressure servo-thread
+addf inverterfail servo-thread
+
+setp oillow.edge 0 #this pin should be active low
+net no-oil classicladder.0.out-21 oillow.trigger
+net no-pressure classicladder.0.out-22 oilpressure.trigger
+net no-inverter classicladder.0.out-23 inverterfail.trigger
+----
+
 When any pin goes active, the corresponding message will be displayed.""";
  
 pin in bit trigger =FALSE "signal that triggers the message";

--- a/src/hal/components/millturn.comp
+++ b/src/hal/components/millturn.comp
@@ -2,8 +2,6 @@ component millturn "Switchable kinematics for a mill-turn machine";
 
 description
 """
-.if \\n[.g] .mso www.tmac
-
 This is a switchable kinematics module using 3 cartesian linear joints (XYZ)
 and 1 angular joint (A). The module contains two kinematic models:
 

--- a/src/hal/components/moveoff.comp
+++ b/src/hal/components/moveoff.comp
@@ -9,12 +9,12 @@ Nine joints are supported.
 The axis offset pin values (offset-in-M) are continuously applied (respecting limits on value, velocity, and acceleration)
 to the output pins (offset-current-M, pos-plusoffset-M, fb-minusoffset-M) when both enabling input pins (apply-offsets and move-enable) are TRUE.
 The two enabling inputs are anded internally.
-A \\fBwarning\\fR pin is set and a message issued if the apply-offsets pin is deasserted while offsets are applied.
+A *warning* pin is set and a message issued if the apply-offsets pin is deasserted while offsets are applied.
 The warning pin remains TRUE until the offsets are removed or the apply-offsets pin is set.
 
 Typically, the move-enable pin is connected to external controls and the apply-offsets pin is connected to halui.program.is-paused (for offsets only while paused) or set to TRUE (for continuously applied offsets).
 
-Applied offsets are \\fBautomatically returned\\fR to zero (respecting limits) when either of the enabling inputs is deactivated.
+Applied offsets are *automatically returned* to zero (respecting limits) when either of the enabling inputs is deactivated.
 The zero value tolerance is specified by the epsilon input pin value.
 
 Waypoints are recorded when the moveoff component is enabled.
@@ -24,26 +24,26 @@ When the memory available for waypoints is exhausted, offsets are frozen and the
 This restriction applies regardless of the state of the backtrack-enable pin.
 An enabling pin must be deasserted to allow a return to the original (non-offset position).
 
-Backtracking through waypoints results in \\fBslower\\fR movement rates as the moves are point-to-point respecting velocity and acceleration settings.
+Backtracking through waypoints results in *slower* movement rates as the moves are point-to-point respecting velocity and acceleration settings.
 The velocity and acceleration limit pins can be managed dynamically to control offsets at all times.
 
-When backtrack-enable is FALSE, the auto-return move is \\fBNOT\\fR coordinated, each axis returns to zero at its own rate.
+When backtrack-enable is FALSE, the auto-return move is *NOT* coordinated, each axis returns to zero at its own rate.
 If a controlled path is wanted in this condition, each axis should be manually returned to zero before deasserting an enabling pin.
 
 The waypoint-sample-secs, waypoint-threshold, and epsilon pins are evaluated only when the component is idle.
 
 The offsets-applied output pin is provided to indicate the current state to a GUI so that program resumption can be managed.
 If the offset(s) are non-zero when the apply-offsets pin is deasserted (for example when resuming a program when offsetting during a pause),
-offsets are returned to zero (respecting limits) and an \\fBError\\fR message is issued.
+offsets are returned to zero (respecting limits) and an *Error* message is issued.
 
-\\fBCaution:\\fR If offsets are enabled and applied and the machine is turned off for any reason,
-any \\fBexternal\\fR HAL logic that manages the enabling pins and the offset-in-M inputs is responsible for their state when the machine is subsequently turned on again.
+*Caution:* If offsets are enabled and applied and the machine is turned off for any reason,
+any *external* HAL logic that manages the enabling pins and the offset-in-M inputs is responsible for their state when the machine is subsequently turned on again.
 
 This HAL-only means of offsetting is typically not known to LinuxCNC nor available in GUI preview displays.
-\\fBNo protection is provided\\fR for offset moves that exceed soft limits managed by LinuxCNC.
-Since soft limits are not honored, an offset move may encounter hard limits (or \\fBCRASH\\fR if there are no limit switches).
+*No protection is provided* for offset moves that exceed soft limits managed by LinuxCNC.
+Since soft limits are not honored, an offset move may encounter hard limits (or *CRASH* if there are no limit switches).
 Use of the offset-min-M and offset-max-M inputs to limit travel is recommended.
-Triggering a hard limit will turn off the machine -- see \\fBCaution\\fR above.
+Triggering a hard limit will turn off the machine -- see *Caution* above.
 
 The offset-in-M values may be set with inifile settings, controlled by a GUI, or managed by other HAL components and connections.
 Fixed values may be appropriate in simple cases where the direction and amount of offset is well-defined but a control method is required to deactivate an enabling pin in order to return offsets to zero.
@@ -51,17 +51,17 @@ GUIs may provide means for users to set, increment, decrement, and accumulate of
 
 The default values for accel, vel, min, max, epsilon, waypoint-sample-secs, and waypoint-threshold may not be suitable for any particular application.
 This HAL component is unaware of limits enforced elsewhere by LinuxCNC.
-Users should test usage in a simulator application and understand all hazards \\fBbefore\\fR use on hardware.
+Users should test usage in a simulator application and understand all hazards *before* use on hardware.
 
 The module personality item sets the number of joints supported (default==3, maximum is 9).
 
-Use of the names= option for naming is \\fBrequired\\fR for compatibility with the gui provided as scripts/moveoff_gui:
-  loadrt moveoff names=\\fBmv\\fR personality=number_of_joints
+Use of the names= option for naming is *required* for compatibility with the gui provided as scripts/moveoff_gui:
+  loadrt moveoff names=*mv* personality=number_of_joints
 
 """;
 
 see_also """
-\\fBmoveoff_gui\\fR(1)
+*moveoff_gui*(1)
 """;
 
 examples """
@@ -98,7 +98,7 @@ pin in  bit move_enable   "Enable offsets (Enabling requires apply-offset TRUE a
 pin in  bit apply_offsets "Enable offsets (Enabling requires move-enable TRUE also)";
 pin in  bit backtrack-enable = 1 "Enable backtrack on auto-return";
 
-pin in  float epsilon=0.0005 "When enabling pins are deactivated, return to un-offsetted position within epsilon units.  Warning: values that are too small in value may cause overshoot.  A minimum value of 0.0001 is \\fBsilently enforced\\fR.";
+pin in  float epsilon=0.0005 "When enabling pins are deactivated, return to un-offsetted position within epsilon units.  Warning: values that are too small in value may cause overshoot.  A minimum value of 0.0001 is *silently enforced*.";
 pin in float waypoint-threshold = 0.02 "Minimum distance (in a single axis) for a new waypoint";
 pin in float waypoint-sample-secs = 0.02 "Minimum sample interval (in seconds) for a new waypoint";
 

--- a/src/hal/components/multiswitch.comp
+++ b/src/hal/components/multiswitch.comp
@@ -41,7 +41,7 @@ option period no;
 variable int old_up = 0;
 variable int old_down = 0;
 
-author "ArcEye schooner30@tiscali.co.uk / Andy Pugh andy@bodgesoc.org";
+author "ArcEye schooner30.AT.tiscali.co.uk / Andy Pugh andy.AT.bodgesoc.org";
 license "GPL";
 ;;
 

--- a/src/hal/components/mux16.comp
+++ b/src/hal/components/mux16.comp
@@ -15,26 +15,43 @@ input must be stable this long before outputs changes. This
 helps to ignore 'noisy' switches.
 """;
 pin in bit sel#[4] """\
-Together, these determine which \\fBin\\fIN\\fR value is copied to \\fBout\\fR.
+Together, these determine which **in**__N__ value is copied to *out*.
 """;
 pin out float out_f;
 pin out s32 out_s """\
-Follows the value of one of the \\fBin\\fIN\\fR values according to the four \\fBsel\\fR values
+Follows the value of one of the **in**__N__ values according to the four *sel* values
 and whether use-graycode is active.
 The s32 value will be trunuated and limited to the max and min values of signed values. 
-.RS
-.TP
-\\fBsel3=FALSE\\fR, \\fBsel2=FALSE\\fR, \\fBsel1=FALSE\\fR, \\fBsel0=FALSE\\fR
-\\fBout\\fR follows \\fBin0\\fR
-.TP
-\\fBsel3=FALSE\\fR, \\fBsel2=FALSE\\fR, \\fBsel1=FALSE\\fR, \\fBsel0=TRUE\\fR
-\\fBout\\fR follows \\fBin1\\fR
-.TP
-etc.
-.RE
+
+[cols="^1,^1,^1,^1,1"]
+|===
+^h|sel3
+^h|sel2
+^h|sel1
+^h|sel0
+^h|out follows
+
+|0|0|0|0|*in00*
+|0|0|0|1|*in01*
+|0|0|1|0|*in02*
+|0|0|1|1|*in03*
+|0|1|0|0|*in04*
+|0|1|0|1|*in05*
+|0|1|1|0|*in06*
+|0|1|1|1|*in07*
+|1|0|0|0|*in08*
+|1|0|0|1|*in09*
+|1|0|1|0|*in10*
+|1|0|1|1|*in11*
+|1|1|0|0|*in12*
+|1|1|0|1|*in13*
+|1|1|1|0|*in14*
+|1|1|1|1|*in15*
+|===
+
 """;
-param r float elapsed "Current value of the internal debounce timer\n for debugging.";
-param r s32 selected "Current value of the internal selection variable after conversion\n for debugging";
+param r float elapsed "Current value of the internal debounce timer for debugging.";
+param r s32 selected "Current value of the internal selection variable after conversion for debugging";
 pin in float in##[16] "array of selectable outputs";
 variable double delaytime;
 variable int lastnum;

--- a/src/hal/components/mux2.comp
+++ b/src/hal/components/mux2.comp
@@ -1,6 +1,6 @@
 component mux2 "Select from one of two input values";
 pin in bit sel;
-pin out float out "Follows the value of in0 if sel is FALSE, or in1 if sel is TRUE";
+pin out float out "Follows the value of *in0* if *sel* is FALSE, or *in1* if *sel* is TRUE";
 pin in float in1;
 pin in float in0;
 option period no;

--- a/src/hal/components/mux4.comp
+++ b/src/hal/components/mux4.comp
@@ -1,24 +1,23 @@
 component mux4 "Select from one of four input values";
 pin in bit sel0;
 pin in bit sel1 """\
-Together, these determine which \\fBin\\fIN\\fR value is copied to \\fBout\\fR.
+Together, these determine which **in**__N__ value is copied to *out*.
 """;
 pin out float out """\
-Follows the value of one of the \\fBin\\fIN\\fR values according to the two \\fBsel\\fR values
-.RS
-.TP
-\\fBsel1=FALSE\\fR, \\fBsel0=FALSE\\fR
-\\fBout\\fR follows \\fBin0\\fR
-.TP
-\\fBsel1=FALSE\\fR, \\fBsel0=TRUE\\fR
-\\fBout\\fR follows \\fBin1\\fR
-.TP
-\\fBsel1=TRUE\\fR, \\fBsel0=FALSE\\fR
-\\fBout\\fR follows \\fBin2\\fR
-.TP
-\\fBsel1=TRUE\\fR, \\fBsel0=TRUE\\fR
-\\fBout\\fR follows \\fBin3\\fR
-.RE
+Follows the value of one of the **in**__N__ values according to the two *sel* values
+
+[cols="^1,^1,1"]
+|===
+^h|sel1
+^h|sel0
+^h|out follows
+
+|0|0|*in0*
+|0|1|*in1*
+|1|0|*in2*
+|1|1|*in3*
+|===
+
 """;
 pin in float in0;
 pin in float in1;

--- a/src/hal/components/mux8.comp
+++ b/src/hal/components/mux8.comp
@@ -2,36 +2,28 @@ component mux8 "Select from one of eight input values";
 pin in bit sel0;
 pin in bit sel1;
 pin in bit sel2 """\
-Together, these determine which \\fBin\\fIN\\fR value is copied to \\fBout\\fR.
+Together, these determine which **in**__N__ value is copied to *out*.
 """;
 pin out float out """\
-Follows the value of one of the \\fBin\\fIN\\fR values according to the three \\fBsel\\fR values
-.RS
-.TP
-\\fBsel2=FALSE\\fR, \\fBsel1=FALSE\\fR, \\fBsel0=FALSE\\fR
-\\fBout\\fR follows \\fBin0\\fR
-.TP
-\\fBsel2=FALSE\\fR, \\fBsel1=FALSE\\fR, \\fBsel0=TRUE\\fR
-\\fBout\\fR follows \\fBin1\\fR
-.TP
-\\fBsel2=FALSE\\fR, \\fBsel1=TRUE\\fR, \\fBsel0=FALSE\\fR
-\\fBout\\fR follows \\fBin2\\fR
-.TP
-\\fBsel2=FALSE\\fR, \\fBsel1=TRUE\\fR, \\fBsel0=TRUE\\fR
-\\fBout\\fR follows \\fBin3\\fR
-.TP
-\\fBsel2=TRUE\\fR, \\fBsel1=FALSE\\fR, \\fBsel0=FALSE\\fR
-\\fBout\\fR follows \\fBin4\\fR
-.TP
-\\fBsel2=TRUE\\fR, \\fBsel1=FALSE\\fR, \\fBsel0=TRUE\\fR
-\\fBout\\fR follows \\fBin5\\fR
-.TP
-\\fBsel2=TRUE\\fR, \\fBsel1=TRUE\\fR, \\fBsel0=FALSE\\fR
-\\fBout\\fR follows \\fBin6\\fR
-.TP
-\\fBsel2=TRUE\\fR, \\fBsel1=TRUE\\fR, \\fBsel0=TRUE\\fR
-\\fBout\\fR follows \\fBin7\\fR
-.RE
+Follows the value of one of the **in**__N__ values according to the three *sel* values
+
+[cols="^1,^1,^1,1"]
+|===
+^h|sel2
+^h|sel1
+^h|sel0
+^h|out follows
+
+|0|0|0|*in0*
+|0|0|1|*in1*
+|0|1|0|*in2*
+|0|1|1|*in3*
+|1|0|0|*in4*
+|1|0|1|*in5*
+|1|1|0|*in6*
+|1|1|1|*in7*
+|===
+
 """;
 pin in float in0;
 pin in float in1;

--- a/src/hal/components/near.comp
+++ b/src/hal/components/near.comp
@@ -4,10 +4,10 @@ pin in float in2_;
 param rw float scale=1;
 param rw float difference=0;
 pin out bit out """
-\\fBout\\fR is true if \\fBin1\\fR and \\fBin2\\fR are within a factor of
-\\fBscale\\fR (i.e., for in1 positive, in1/scale <= in2 <= in1*scale), OR
-if their absolute difference is no greater than \\fBdifference\\fR (i.e.,
-|in1-in2| <= difference).  \\fBout\\fR is false otherwise.""";
+*out* is true if *in1* and *in2* are within a factor of
+*scale* (i.e., for in1 positive, in1/scale ≤ in2 ≤ in1*scale), OR
+if their absolute difference is no greater than *difference* (i.e.,
+|in1-in2| ≤ difference).  *out* is false otherwise.""";
 option period no;
 function _;
 license "GPL";

--- a/src/hal/components/not.comp
+++ b/src/hal/components/not.comp
@@ -1,13 +1,16 @@
 component not "Inverter";
 pin in bit in;
 pin out bit out;
+description """
+The *out* output pin is set to the inverted logic level of the *in* input pin.
+""";
 function _ nofp;
 see_also """
-\\fBand2\\fR(9),
-\\fBlogic\\fR(9),
-\\fBlut5\\fR(9),
-\\fBor2\\fR(9),
-\\fBxor2\\fR(9).
+*and2*(9),
+*logic*(9),
+*lut5*(9),
+*or2*(9),
+*xor2*(9).
 """;
 license "GPL";
 author "Jeff Epler";

--- a/src/hal/components/ohmic.comp
+++ b/src/hal/components/ohmic.comp
@@ -3,56 +3,48 @@ component ohmic "LinuxCNC HAL component that uses a Mesa THCAD for ohmic sensing
 description
 """
 Mesa THCAD Card component to scale input and outputs from the Mesa THCAD2, THCAD5, THCAD10, and THCAD300 cards.
-.br
+
 Allows user configurable voltage thresholds for ohmic sensing.
 
 Output pins are provided for:
-.br
+
 ohmic-volts -the voltage sensed on ohmic sensing.
-.br
+
 thcad-volts -the actual voltage measured by the THCAD.
-.br
-ohmic-on    -true if ohmic-volts >= ohmic-threshold, false if ohmic-volts <= ohmic-low.
+
+ohmic-on    -true if ohmic-volts ≥ ohmic-threshold, false if ohmic-volts ≤ ohmic-low.
 
 A THCAD-5 would often be used for ohmic sensing in conjunction with a 24 Volt isolated power supply and a 390 kΩ series resistor resulting in a voltage divider of 4.9.
-.br
+
 This would result in a full scale reading of 24.5 Volts which is above the power supply output voltage.
-.br
+
 The circuit will remain protected by the THCAD's ability to tolerate a 500 Volt over-voltage indefinitely.
-.br
+
 It is optional that power to the ohmic sensing circuit be disconnected unless probing is in progress.
 """;
 
 examples """
-.br
 The below HAL example assumes a THCAD5 card using a 1/32 frequency setting and a voltage divider internal to the plasma cutter with range extended to 24.5 volts by a series 390K external resistor as per the manual.
 Additional information and wiring diagram is contained in the Plasma Primer in the LinuxCNC documentation.
-.br
+
 Example Calibration Data: 0V = 122.9 kHz, 10V = 925.7 kHz should be entered as 122900 and 925700.
 
+[source,hal]
+----
 loadrt ohmic names=ohmicsense
-.br
 addf ohmicsense servo-thread
-.br
 setp ohmicsense.thcad-0-volt-freq    122900
-.br
 setp ohmicsense.thcad-max-volt-freq  925700
-.br
 setp ohmicsense.thcad-divide         32
-.br
 setp ohmicsense.thcad-fullscale      5
-.br
 setp ohmicsense.volt-divider         4.9
-.br
 setp ohmicsense.threshold            22
-.br
 setp ohmicsense.ohmic-low            21
-.br
 net ohmic-vel    ohmicsense.velocity-in <= hm2_7i76e.0.encoder.00.velocity
-.br
 net ohmic-enable ohmicsense.is_probing  <= plasmac.ohmic-enable
-.br
 net ohmic-true   ohmicsense.ohmic-on    => plasmac.ohmic-probe
+----
+
 """;
 
 author "Rod Webster";

--- a/src/hal/components/oneshot.comp
+++ b/src/hal/components/oneshot.comp
@@ -17,11 +17,11 @@
 
 component oneshot "one-shot pulse generator";
 
-description """creates a variable-length output pulse when the input changes 
+description """creates a variable-length output pulse when the input changes
 state. This function needs to run in a thread which supports floating point
 (typically the servo thread). This means that the pulse length has to be a
-multiple of that thread period, typically 1mS. 
-For a similar function that can run in the base thread, and which offers higher 
+multiple of that thread period, typically 1ms.
+For a similar function that can run in the base thread, and which offers higher
 resolution, see "edge".""";
 
 pin in bit in "Trigger input";

--- a/src/hal/components/or2.comp
+++ b/src/hal/components/or2.comp
@@ -1,21 +1,29 @@
 component or2 "Two-input OR gate";
-pin in bit in0;
-pin in bit in1;
-pin out bit out r"""
-\fBout\fR is computed from the value of \fBin0\fR and \fBin1\fR according
-to the following rule:
-.RS
-.TP
-\fBin0=FALSE in1=FALSE\fB
-\fBout=FALSE\fR
-.TP
-Otherwise,
-\fBout=TRUE\fR
-.RE"""
+pin in bit in0 "First input";
+pin in bit in1 "Second input";
+pin out bit out "Output";
+
+description """
+The *out* pin is computed from the value of the *in0* and *in1* pins according
+to the following truth table:
+
+[options="header",cols="^1,^1,^1"]
+|===
+^h|in1
+^h|in0
+^h|out
+
+|0|0|0
+|0|1|1
+|1|0|1
+|1|1|1
+|===
+
+"""
 ;
 function _ nofp;
 see_also """
-\\fBlogic\\fR(9)
+*logic*(9)
 """;
 license "GPL";
 author "Jeff Epler";

--- a/src/hal/components/orient.comp
+++ b/src/hal/components/orient.comp
@@ -3,7 +3,7 @@ component orient "Provide a PID command input for orientation mode based on curr
 pin in  bit   enable      "enable angular output for orientation mode";
 pin in  s32   mode        "0: rotate - shortest move; 1: always rotate clockwise; 2: always rotate counterclockwise";
 pin in  float position    "spindle position input, unit 1 rev";
-pin in  float angle       "orient target position in degrees, 0 <= angle < 360";
+pin in  float angle       "orient target position in degrees, 0 ≤ angle < 360";
 pin out float command     "target spindle position, input to PID command";
 pin out float poserr      "in degrees - aid for PID tuning";
 pin out bit is-oriented   "This pin goes high when poserr < tolerance. Use to drive spindle.N.is-oriented";
@@ -15,53 +15,46 @@ variable int    debounce = 0; // to prevent the in-position triggering with the 
 option fp yes;
 option period no;
 
-function _ "Update \\fBcommand\\fR based on \\fBenable\\fR, \\fBposition\\fR, \\fBmode\\fR and \\fBangle\\fR.";
+function _ "Update *command* based on *enable*, *position*, *mode* and *angle*.";
 author "Michael Haberler";
 
 
 description """
-This component is designed to support a spindle orientation PID loop by providing a 
-command value, and fit with the motion spindle-orient support pins to support the M19 code.
+This component is designed to support a spindle orientation PID loop by
+providing a command value, and fit with the motion spindle-orient support pins
+to support the M19 code.
 
 The spindle is assumed to have stopped in an arbitrary position. The spindle
-encoder position is linked to the  \\fBposition\\fR pin.
-The  current value of the position pin is sampled on a positive edge on the \\fBenable\\fR pin, and 
-\\fBcommand\\fR is computed and set as follows: floor(number of 
-full spindle revolutions 
-in the \\fBposition\\fR sampled on positive edge) 
-plus \\fBangle\\fR/360 (the fractional revolution) +1/-1/0 depending on \\fBmode\\fR.
+encoder position is linked to the *position* pin.  The current value of the
+position pin is sampled on a positive edge on the *enable* pin, and *command*
+is computed and set as follows: +
+floor(number of full spindle revolutions in the *position* sampled on positive
+edge) plus *angle*/360 (the fractional revolution) +1/-1/0 depending on *mode*.
 
-The \\fBmode\\fR pin is interpreted as follows:
+The *mode* pin is interpreted as follows:
 
-0: the spindle rotates in the direction with the lesser angle, 
+* 0: the spindle rotates in the direction with the lesser angle,
 which may be clockwise or counterclockwise.
+* 1: the spindle rotates always rotates clockwise to the new angle.
+* 2: the spindle rotates always rotates counterclockwise to the new angle.
 
-1: the spindle rotates always rotates clockwise to the new angle.
+=== HAL USAGE
 
-2: the spindle rotates always rotates counterclockwise to the new angle.
- 
-
-.SH HAL USAGE
-
-On \\fBspindle.N.orient\\fR disconnect the spindle control and connect to the orient-pid 
+On *spindle.N.orient* disconnect the spindle control and connect to the orient-pid
 loop:
 
+[source,hal]
+----
 loadrt orient names=orient
-.br
 loadrt pid names=orient-pid
-.br
 net orient-angle spindle.N.orient-angle orient.angle
-.br
 net orient-mode spindle.N.orient-mode orient.mode
-.br
 net orient-enable spindle.N.orient orient.enable orient-pid.enable
-.br
 net spindle-in-pos orient.is-oriented spindle.N.is-oriented
-.br
 net spindle-pos encoder.position orient.position orient-pid.feedback
-.br
 net orient-command orient.command orient-pid.command
-.br
+----
+
 """;
 
 license "GPL";

--- a/src/hal/components/plasmac.comp
+++ b/src/hal/components/plasmac.comp
@@ -5,16 +5,16 @@ description
 
 A plasma cutting table control component for use with the LinuxCNC 2.10.
 
-.I VERSION:
-.br
+=== VERSION
+
 008
 
-.I SUMMARY:
-.br
+=== SUMMARY
+
 Usage of this component is demonstrated in the QtPlasmaC example configurations included with LinuxCNC.
 
-.I DISCLAIMER:
-.br
+=== DISCLAIMER
+
 THE AUTHOR OF THIS SOFTWARE ACCEPTS ABSOLUTELY NO LIABILITY FOR ANY HARM OR LOSS RESULTING FROM ITS USE.
 
 IT IS EXTREMELY UNWISE TO RELY ON SOFTWARE ALONE FOR SAFETY.

--- a/src/hal/components/raster.comp
+++ b/src/hal/components/raster.comp
@@ -20,41 +20,49 @@ pin out float previous_pixel_value = -1.0 "previously loaded pixel value";
 pin out signed current_pixel_index = -1 "currently loaded pixel index";
 pin out float fraction = 0.0;
 
-description """The raster component converts a single raster program line to laser output.
-               The position pin is slaved to the axis that the raster line maps too. 
-               The raster program must be programmed for each raster line that is to be executed.
-               The port must be programmed prior to a raster line being executed.
+description """
+The raster component converts a single raster program line to laser output.
+The position pin is slaved to the axis that the raster line maps too.
+The raster program must be programmed for each raster line that is to be executed.
+The port must be programmed prior to a raster line being executed.
 
-               A python component RasterProgrammer (lib/python/RasterProgrammer.py) is provided to ease programming of the raster component.
-               configs/sim/axis/laser shows an example of how these pieces could be integrated for a functional laser engraver config.
+A python component RasterProgrammer (`lib/python/RasterProgrammer.py`) is
+provided to ease programming of the raster component.
+An example `configs/sim/axis/laser` shows how these pieces could be integrated
+for a functional laser engraver config.
 
-               A program line format is as follows:
-               {program_offset};{bits_per_pixel};{pixels_per_unit};{number_of_ pixels};{pixel_data ....}
+A program line format is as follows:
 
-               program_offset: a float. It indicates the start position of the raster line relative to the current axis position. 
-                  A negative program_offset indicates that the raster sweeps from positive to negative
-                  A zero or positive program_offset indicates that the raster sweeps from negative to positive direction
+  {program_offset};{bits_per_pixel};{pixels_per_unit};{number_of_ pixels};{pixel_data ....}
 
-               bits_per_pixel: an integer. It indicates the precision of a pixel value and consequently the number of bytes consumed per pixel value.
-                  A bits per pixel of 4 takes 1 character (0-F) and scales out from from 0.0 to 1.0 (0 being 0 and E being 1.0). F corresponds to off or -1.0
-                  A bits per pixel of 8 takes 2 characters per pixel, 12 takes 3 characters per pixel etc...
+* *program_offset*: a float. It indicates the start position of the raster line
+  relative to the current axis position. A negative *program_offset* indicates
+  that the raster sweeps from positive to negative. A zero or positive
+  program_offset* indicates that the raster sweeps from negative to positive
+  direction.
+* *bits_per_pixel*: an integer. It indicates the precision of a pixel value and
+  consequently the number of bytes consumed per pixel value. A bits per pixel
+  of 4 takes 1 character (0-F) and scales out from from 0.0 to 1.0 (0 being 0
+  and E being 1.0). F corresponds to off or -1.0. A bits per pixel of 8 takes 2
+  characters per pixel, 12 takes 3 characters per pixel etc...
+* *pixels_per_unit*: a float that represents the size of a pixel in machine
+  units. 1 would correspond to 1 pixel per machine unit, 100 would correspond
+  to 100 pixels per machine unit.
 
-               pixels_per_unit: a float that represents the size of a pixel in machine units. 
-                   1 would correspond to 1 pixel per machine unit, 100 would correspond to 100 pixels per machine unit.
-
-               number_of_pixels: an integer that indicates the length of the raster line in pixels.
-                          The length of the rasterline in machine units would be number_of_pixels / pixels_per_unit
+* *number_of_pixels*: an integer that indicates the length of the raster line
+  in pixels. The length of the rasterline in machine units would be
+  number_of_pixels / pixels_per_unit
                
-               pixel_data: a series of hexadeicmal digits ([0-9][a-f][A-F]) the represents the pixel data.
-                       bits_per_pixel determines the resolution of a pixel and how many hexadecimal digits per pixel.
-                       pixel data characters have no delimiter between each pixel.
-                       4 bpp is one character per pixel
-                       8 bpp is 2 characters per pixel
-                       12 bpp is 3
-                       etc...
+* *pixel_data*: a series of hexadeicmal digits ([0-9][a-f][A-F]) the represents
+  the pixel data. *bits_per_pixel* determines the resolution of a pixel and how
+  many hexadecimal digits per pixel.  pixel data characters have no delimiter
+  between each pixel. +
+  4 bpp is one character per pixel +
+  8 bpp is 2 characters per pixel +
+  12 bpp is 3 +
+  etc...
+
 """;
-               
-            
 
 option period no;
 function _;

--- a/src/hal/components/reset.comp
+++ b/src/hal/components/reset.comp
@@ -56,7 +56,7 @@ Component to reset IO signals.
 
 This function works like a conditional sets - it is fed with a float
 and/or bit/s32/u32 pins that are I/O, but are save the value only if
-the "trigger" pin is set. The values assigned to those signals are
+the *trigger* pin is set. The values assigned to those signals are
 passed via the input pins reset_float/s32/u32/bit.
 """;
 license "GPL";

--- a/src/hal/components/sample_hold.comp
+++ b/src/hal/components/sample_hold.comp
@@ -4,7 +4,7 @@ pin in bit hold;
 pin out s32 out;
 option period no;
 function _ nofp;
-see_also "\\fBtristate\\fR(9)";
+see_also "*tristate*(9)";
 license "GPL";
 author "Stephen Wille Padnos";
 ;;

--- a/src/hal/components/select8.comp
+++ b/src/hal/components/select8.comp
@@ -4,7 +4,7 @@ pin in s32 sel "The number of the output to set TRUE.  All other outputs well be
 pin out bit out#[8] "Output bits.  If enable is set and the sel input is between 0 and 7, then the corresponding output bit will be set true.";
 option period no;
 function _ nofp;
-see_also "\\fBdemux\\fR(9)";
+see_also "*demux*(9)";
 license "GPL";
 author "Stephen Wille Padnos";
 ;;

--- a/src/hal/components/sim_home_switch.comp
+++ b/src/hal/components/sim_home_switch.comp
@@ -5,8 +5,8 @@ description
 After tripping home switch, travel in opposite direction is
 required (amount set by the hysteresis pin).
 A pin (index-enable) is provided for use when
-\\fB[JOINT_n]HOME_USE_INDEX\\fR is specified to reset
-the I/O pin \\fBjoint.N.index-enable\\fR.
+*[JOINT_n]HOME_USE_INDEX* is specified to reset
+the I/O pin *joint.N.index-enable*.
 """;
 pin in float cur_pos "Current position (typically: joint.n.motor-pos-fb)";
 pin in float home_pos = 1 "Home switch position";

--- a/src/hal/components/sim_parport.comp
+++ b/src/hal/components/sim_parport.comp
@@ -4,27 +4,27 @@ description
 """
 Sim_parport is used to replace the pins of a real parport without changing
 any of the pins names in the rest of the config.
-.br
+
 It has pass-through pins (ending in -fake) that allows connecting to other components.
 
 eg pin-02-in     will follow     pin-02-in-fake 's logic.
-.br
+
 pin_01_out-fake     will follow    pin_01_out (possibly modified by pin_01_out-invert)
 
 It creates all possible pins of both 'in' and 'out' options of the hal_parport component.
-.br
+
 This allows using other hardware I/O in place of the parport (without having to change the rest of the config)
-.br
+
 or simulating hardware such as limit switches.
-.br
+
 it's primary use is in Stepconf for building simulated configs.
-.br
+
 You must use the names= option to have the right pin names.
-.br
+
 eg. names=parport.0,parport.1
-.br
+
 The read and write functions pass the logic from pins to fake pins or vice vera
-.br
+
 The reset function is a no operation.
  
 """;

--- a/src/hal/components/sim_spindle.comp
+++ b/src/hal/components/sim_spindle.comp
@@ -2,12 +2,12 @@ component sim_spindle "Simulated spindle with index pulse";
 
 pin in float velocity-cmd "Commanded speed";
 pin out float position-fb "Feedback position, in revolutions";
-pin io bit index-enable "Reset \\fBposition-fb\\fP to 0 at the next full rotation";
+pin io bit index-enable "Reset *position-fb* to 0 at the next full rotation";
 param rw float scale = 1.0 
-"""factor applied to \\fBvelocity-cmd\\fP.
+"""factor applied to *velocity-cmd*.
 
-The result of '\\fBvelocity-cmd\\fP * \\fBscale\\fP' be in revolutions per second.
-For example, if \\fBvelocity-cmd\\fP is in revolutions/minute, \\fBscale\\fP should be set to 1/60 or 0.016666667.
+The result of '*velocity-cmd* * *scale*' be in revolutions per second.
+For example, if *velocity-cmd* is in revolutions/minute, *scale* should be set to 1/60 or 0.016666667.
 """;
 
 license "GPL";

--- a/src/hal/components/sphereprobe.comp
+++ b/src/hal/components/sphereprobe.comp
@@ -4,7 +4,7 @@ license "GPL";
 
 pin in signed px;
 pin in signed py;
-pin in signed pz "\\fBrawcounts\\fR position from software encoder";
+pin in signed pz "*rawcounts* position from software encoder";
 
 pin in signed cx;
 pin in signed cy;

--- a/src/hal/components/spindle.comp
+++ b/src/hal/components/spindle.comp
@@ -48,7 +48,7 @@ If a spindle encoder is available it is used to tailor the acceleration and dece
 If not the spindle speed is simulated. The component allows for gearboxes with up to 16 gears.
 Each gear has individual control of speeds, acceleration, driver gain and direction.""";
 
-see_also "\\fBmotion\\fR(9)";
+see_also "*motion*(9)";
 
 pin in unsigned select-gear
 """Select a gear. Must be in the range 0 -> number of available gears -1. If you use this, do not use the select.x input pins.""";
@@ -76,55 +76,45 @@ pin out bit zero-speed "TRUE when the spindle is stationary";
 pin out bit limited """TRUE when the commanded spindle speed is >max or <min.""";
 
 notes """
-.TP
-.B The following pins are created depending the 'numgears=' parameter.
+The following pins are created depending the 'numgears=' parameter.
 One of each pin is created for each gear. If no gears are specified then one gear will be created.
-For instance if you have gears=2 on your command line, you will have two scale pins:
- \\fBspindle.\\fP\\fIN\\fB.scale.0\\fP
- \\fBspindle.\\fP\\fIN\\fB.scale.1\\fP
+For instance if you have gears=2 on your command line, you will have two scale pins: +
+*spindle*._N_.*scale*.*0* +
+*spindle*._N_.*scale*.*1*
 
-.TP
-\\fBspindle.\\fP\\fIN\\fB.scale.\\fPx float in
+*spindle*._N_.*scale*.x float in::
 Scale the output. For multiple gears you would use a different scale for each gear.
 If you need to reverse the output for some gears, use a negative scale.
 
-.TP
-\\fBspindle.\\fP\\fIN\\fB.min.\\fPx float in
+*spindle*._N_.*min*.x float in::
 Set the minimum speed allowed (in RPM).
 The limit output will be TRUE while the commanded speed is between 0 RPM and the min speed.
 
-.TP
-\\fBspindle.\\fP\\fIN\\fB.max.\\fPx float in
+*spindle*._N_.*max*.x float in::
 Set the maximum speed allowed (in RPM).
 The limit output will be TRUE while the commanded speed is above this value.
 
-.TP
-\\fBspindle.\\fP\\fIN\\fB.accel.\\fPx float in
+*spindle*._N_.*accel*.x float in::
 Set the maximum acceleration.
 If you do not have a spindle encoder this is in RPM/second.
 If you do have an encoder the output is the actual speed plus this value.
 This way the acceleration can be dependent on the spindle load.
 
-.TP
-\\fBspindle.\\fP\\fIN\\fB.decel.\\fPx float in
+*spindle*._N_.*decel*.x float in::
 Set the minimum deceleration. If you do not have a spindle encoder this is in RPM/second.
 If you do have an encoder the output is the actual speed minus this value.
 
-.TP
-\\fBspindle.\\fP\\fIN\\fB.speed-tolerance.\\fPx float in
+*spindle*._N_.*speed-tolerance*.x float in::
 Tolerance for 'at-speed' signal (in RPM).
 Actual spindle speeds within this amount of the commanded speed will cause the at-speed signal to go TRUE.
 
-.TP
-\\fBspindle.\\fP\\fIN\\fB.zero-tolerance.\\fPx float in
+*spindle*._N_.*zero-tolerance*.x float in::
 Tolerance for 'zero-speed' signal (in RPM).
 
-.TP
-\\fBspindle.\\fP\\fIN\\fB.offset.\\fPx float in
+*spindle*._N_.*offset*.x float in::
 The output command is offset by this amount (in RPM).
 
-.TP
-\\fBspindle.\\fP\\fIN\\fB.select.\\fPx bit in
+*spindle*._N_.*select*.x bit in::
 Selects this gear. If no select inputs are active, gear 0 is selected.
 If multiple select inputs are active then the highest is selected.
 """;

--- a/src/hal/components/thc.comp
+++ b/src/hal/components/thc.comp
@@ -2,7 +2,8 @@ component thc "Torch Height Control";
 
 description 
 """
-Torch Height Control
+=== Torch Height Control
+
 Mesa THC > Encoder > LinuxCNC THC component
 
 The Mesa THC sends a frequency based on the voltage detected to the encoder.
@@ -12,7 +13,8 @@ parameter inside the THC component.
 The THCAD card sends a frequency at 0 volts so the scale offset parameter is
 used to zero the calculated voltage.
 
-Component Functions
+=== Component Functions
+
 If enabled and torch is on and X + Y velocity is within tolerance of set speed
 allow the THC to offset the Z axis as needed to maintain voltage.
 
@@ -24,28 +26,28 @@ pass the Z position and feed back untouched.
 
 If not enabled pass the Z position and feed back untouched.
 
-Physical Connections
-.br
+=== Physical Connections
+
 Plasma Torch Arc Voltage Signal => 6 x 487k 1% resistors => THC Arc Voltage In
-.br
+
 THC Frequency Signal => Encoder #0, pin A (Input)
-.br
+
 Plasma Torch Arc OK Signal => input pin
-.br
+
 output pin => Plasma Torch Start Arc Contacts
 
-HAL Plasma Connections
-.br
+=== HAL Plasma Connections
+
 encoder.nn.velocity => thc.encoder-vel (tip voltage)
-.br
+
 spindle.0.on => output pin (start the arc)
-.br
+
 thc.arc-ok <= motion.digital-in-00 <= input pin (arc ok signal)
 
-HAL Motion Connections
-.br
+=== HAL Motion Connections
+
 thc.requested-vel <= motion.requested-vel
-.br
+
 thc.current-vel <= motion.current-vel
 
 """;

--- a/src/hal/components/thcud.comp
+++ b/src/hal/components/thcud.comp
@@ -17,40 +17,43 @@ pass the Z position and feed back untouched.
 If not enabled pass the Z position and feed back untouched.
 
 Typical Physical Connections using a Parallel Port
-.br
+
 Parallel Pin 12 <= THC controller Plasma Up
-.br
+
 Parallel Pin 13 <= THC controller Plasma Down
-.br
+
 Parallel Pin 15  <= Plasma Torch Arc Ok Signal
-.br
+
 Parallel Pin 16 => Plasma Torch Start Arc Contacts
 
 HAL Plasma Connections
-.br
+
 net torch-up thcud.torch-up <= parport.0.pin-12-in
-.br
+
 net torch-down thcud.torch-down <= parport.0.pin-13-in
-.br
+
 net torch-on spindle.0.on => parport.0.pin-16-out (start the arc)
-.br
+
 net arc-ok thcud.arc-ok <= motion.digital-in-00 <= parport.0.pin-15-in (arc ok signal)
 
 HAL Motion Connections
-.br
+
 net requested-vel thcud.requested-vel <= motion.requested-vel
-.br
+
 net current-vel thcud.current-vel <= motion.current-vel
 
 PyVCP Connections
 In the XML file you need something like:
 
-  <pyvcp>
-  <checkbutton>
-    <text>"THC Enable"</text>
-    <halpin>"thc-enable"</halpin>
-  </checkbutton>
-  </pyvcp>
+[source,xml]
+----
+<pyvcp>
+<checkbutton>
+  <text>"THC Enable"</text>
+  <halpin>"thc-enable"</halpin>
+</checkbutton>
+</pyvcp>
+----
 
 Connect the PyVCP pins in the postgui.hal file like this:
 

--- a/src/hal/components/time.comp
+++ b/src/hal/components/time.comp
@@ -4,18 +4,20 @@ description
 """
 Time
 
-When either the time.N.start or time.N.pause bits goes true the cycle
-timer resets and starts to time until time.N.start AND time.N.pause go
-false. When the time.N.pause bit goes true timing is paused until
-time.N.pause goes false. If you connect time.N.start to
-halui.program.is-running and leave time.N.pause unconnected the timer
-will reset during a pause. See the example connections below for more
+When either the *time*._N_.*start* or *time*._N_.*pause* bits goes true the
+cycle timer resets and starts to time until *time*._N_.*start* AND *time*._N_.*pause*
+go false. When the *time*._N_.*pause* bit goes true timing is paused
+until *time*._N_.*pause* goes false. If you connect *time*._N_.*start*
+to *halui*.*program*.*is-running* and leave *time*._N_.*pause* unconnected the
+timer will reset during a pause. See the example connections below for more
 information.
 
-Time returns the hours, minutes, and seconds that time.N.start is true.
+Time returns the hours, minutes, and seconds that *time*._N_.*start* is true.
 
 Sample PyVCP code to display the hours:minutes:seconds.
 
+[source,xml]
+----
 <pyvcp>
   <hbox>
   <label>
@@ -47,12 +49,15 @@ Sample PyVCP code to display the hours:minutes:seconds.
   </u32>
   </hbox>
 </pyvcp>
+----
 
-In your post-gui.hal file you might use one of the following to connect
+In your `post-gui.hal` file you might use one of the following to connect
 this timer:
  
- For a new config:
+For a new config:
  
+[source,hal]
+----
  loadrt time
  addf time.0 servo-thread
  net cycle-timer        time.0.start <= halui.program.is-running
@@ -60,13 +65,15 @@ this timer:
  net cycle-seconds pyvcp.time-seconds <= time.0.seconds
  net cycle-minutes pyvcp.time-minutes <= time.0.minutes
  net cycle-hours pyvcp.time-hours <= time.0.hours
+----
 
+Previous to this version if you wanted the timer to continue running
+during a pause instead of resetting, you had to use a HAL NOT component
+to invert the *halui*.*program*.*is-idle* pin and connect
+to *time*._N_.*start* as shown below:
 
- Previous to this version if you wanted the timer to continue running
- during a pause instead of resetting, you had to use a HAL NOT component
- to invert the halui.program.is-idle pin and connect to time.N.start as
- shown below:
-
+[source,hal]
+----
  loadrt time
  loadrt not
  addf time.0 servo-thread
@@ -76,12 +83,15 @@ this timer:
  net cycle-seconds pyvcp.time-seconds <= time.0.seconds
  net cycle-minutes pyvcp.time-minutes <= time.0.minutes
  net cycle-hours pyvcp.time-hours <= time.0.hours
- 
- For those who have this setup already, you can simply add a net connecting
- time.N.pause to halui.program.is-paused:
+----
 
+For those who have this setup already, you can simply add a net
+connecting *time*._N_.*pause* to *halui*.*program*.*is-paused*:
+
+[source,hal]
+----
  net cycle-timer-pause time.0.pause <= halui.program.is-paused
-
+----
 
 """;
  

--- a/src/hal/components/timedelay.comp
+++ b/src/hal/components/timedelay.comp
@@ -1,13 +1,13 @@
 component timedelay "The equivalent of a time-delay relay";
 
 pin in bit in;
-pin out bit out """Follows the value of \\fBin\\fR after applying the delays
-\\fBon-delay\\fR and \\fBoff-delay\\fR.""";
+pin out bit out """Follows the value of *in* after applying the delays
+*on-delay* and *off-delay*.""";
 
-pin in float on-delay = 0.5 """The time, in seconds, for which \\fBin\\fR must be
-\\fBtrue\\fR before \\fBout\\fR becomes \\fBtrue\\fR""";
-pin in float off-delay = 0.5 """The time, in seconds, for which \\fBin\\fR must be
-\\fBfalse\\fR before \\fBout\\fR becomes \\fBfalse\\fR""";
+pin in float on-delay = 0.5 """The time, in seconds, for which *in* must be
+*true* before *out* becomes *true*""";
+pin in float off-delay = 0.5 """The time, in seconds, for which *in* must be
+*false* before *out* becomes *false*""";
 
 pin out float elapsed "Current value of the internal timer";
 variable double timer;

--- a/src/hal/components/toggle.comp
+++ b/src/hal/components/toggle.comp
@@ -2,13 +2,14 @@ component toggle "'push-on, push-off' from momentary pushbuttons";
 
 description
 """
+....
      ┐     ┌──┐        ┌──┐
-.br
 in : └─────┘  └────────┘  └──
-.br
+
      ┐     ┌───────────┐
-.br
 out: └─────┘           └─────
+....
+
 """;
 
 pin in bit in "button input";

--- a/src/hal/components/toggle2nist.comp
+++ b/src/hal/components/toggle2nist.comp
@@ -7,26 +7,22 @@ to control a device that has separate on and off inputs
 and an is-on output.
 A debounce delay in cycles can be set for 'in'. (default = 2)
 
-\\[bu] On a rising edge on pin \\fIin\\fR when \\fIis-on\\fR is low: It sets \\fIon\\fR until \\fIis-on\\fR becomes high.
+* On a rising edge on pin *in* when *is-on* is low: It sets *on* until *is-on* becomes high.
+* On a rising edge on pin *in* when *is-on* is high: It sets *off* until *is-on* becomes low.
 
-\\[bu] On a rising edge on pin \\fIin\\fR when \\fIis-on\\fR is high: It sets \\fIoff\\fR until \\fIis-on\\fR becomes low.
-
-
+....
        ┐     ┌─────xxxxxxxxxxxx┐           ┌─────xxxxxxxxxxxx┐
-.br
 in   : └─────┘     xxxxxxxxxxxx└───────────┘     xxxxxxxxxxxx└─────
-.br
+
        ┐     ┌───────────┐
-.br
 on   : └─────┘           └─────────────────────────────────────────
-.br
+
        ┐                                   ┌───────────┐
-.br
 off  : └───────────────────────────────────┘           └───────────
-.br
+
        ┐                 ┌─────────────────────────────┐
-.br
 is-on: └─────────────────┘                             └───────────
+....
 
 """;
 

--- a/src/hal/components/tpcomp.comp
+++ b/src/hal/components/tpcomp.comp
@@ -8,7 +8,7 @@ halcompile.
 The tpcomp.comp file (src/hal/components/tpcomp.comp)
 illustrates a method to use halcompile to build a
 trajectory planning module based on the files used for the
-default trajectory planner (\\fBtpmod\\fR).
+default trajectory planner (*tpmod*).
 
 The example tpcomp.comp is not usable until modified
 for the user environment.  To create a runnable tpcomp
@@ -18,18 +18,23 @@ code file names for all files used.
 
 To avoid updates that overwrite tpcomp.comp, best practice is
 to rename the file and its component name (example:
-\\fBuser_tpcomp.comp\\fR creates module: \\fBuser_tpcomp\\fR).
+*user_tpcomp.comp* creates module: *user_tpcomp*).
 
 The (renamed) component can be built and installed with
 halcompile and then substituted for the default tp module
-(\\fBtpmod\\fR) using:\n
-  $ linuxcnc \\fB-t user_tpcomp\\fR someconfig.ini\n
-or by inifile setting: \\fB[TRAJ]TPMOD=user_tpcomp\\fR
+(*tpmod*) using:
+....
+  $ linuxcnc *-t user_tpcomp* someconfig.ini
+....
+or by inifile setting: *[TRAJ]TPMOD=user_tpcomp*
 
-\\fBNote:\\fRIf using a deb install:\n
-1) halcompile is provided by the deb package linuxcnc-dev\n
-2) This source file for BRANCHNAME (master,2.9,etc) is downloadable from github:\n
+*Note:*If using a deb install:
+
+1. halcompile is provided by the deb package linuxcnc-dev
+2. This source file for BRANCHNAME (master,2.9,etc) is downloadable from github:
+
 https://github.com/LinuxCNC/linuxcnc/blob/BRANCHNAME/src/hal/components/tpcomp.comp
+
 """;
 
 pin out bit is_module=1; //one pin is required to use halcompile)

--- a/src/hal/components/tristate_bit.comp
+++ b/src/hal/components/tristate_bit.comp
@@ -5,7 +5,7 @@ pin io bit out "Output value";
 pin in bit enable "When TRUE, copy in to out";
 
 option period no;
-function _ nofp "If \\fBenable\\fR is TRUE, copy \\fBin\\fR to \\fBout\\fR.";
+function _ nofp "If *enable* is TRUE, copy *in* to *out*.";
 license "GPL";
 author "Jeff Epler";
 ;;

--- a/src/hal/components/tristate_float.comp
+++ b/src/hal/components/tristate_float.comp
@@ -5,7 +5,7 @@ pin io float out "Output value";
 pin in bit enable "When TRUE, copy in to out";
 
 option period no;
-function _  "If \\fBenable\\fR is TRUE, copy \\fBin\\fR to \\fBout\\fR.";
+function _  "If *enable* is TRUE, copy *in* to *out*.";
 license "GPL";
 author "Jeff Epler";
 ;;

--- a/src/hal/components/userkins.comp
+++ b/src/hal/components/userkins.comp
@@ -2,51 +2,60 @@ component userkins"Template for user-built kinematics";
 
 description
 """
-.if \\n[.g] .mso www.tmac
-
 The userkins.comp file is a template for creating kinematics that can be user-built using halcompile.
 
 The unmodified userkins component can be used as a kinematics file
 for a machine with identity kinematics for an xyz machine employing 3 joints (motors).
 
-\\fBUSAGE:\\fR
+=== USAGE
 
-  1) Copy the userkins.comp file to a user-owned directory (\\fBmydir\\fR).
+Copy the userkins.comp file to a user-owned directory (*mydir*). +
+Note: The userkins.comp file can be downloaded from:
+  `github.com/LinuxCNC/linuxcnc/raw/2.8/src/hal/components/userkins.comp`
+where '2.8' is the branch name (use 'master' for the master branch)
+For a RIP (run-in-place) build, the file is located in the git tree as:
+  `src/hal/components/userkins.comp`
 
-     Note: The userkins.comp file can be downloaded from:
-.URL https://github.com/LinuxCNC/linuxcnc/raw/2.8/src/hal/components/userkins.comp
-     where '2.8' is the branch name (use 'master' for the master branch)
+Edit the functions kinematicsForward() and kinematicsInverse() as required.
 
-     For a RIP (run-in-place) build, the file is located in
-     the git tree as:
-       src/hal/components/userkins.comp
+If required, add HAL pins following examples in the template code.
 
-  2) Edit the functions kinematicsForward() and kinematicsInverse() as required.
-  3) If required, add HAL pins following examples in the template code.
-  4) Build and install the component using halcompile:
-     $ cd \\fBmydir\\fR
-     $ [sudo] halcompile --install userkins.comp
-     # Note:
-     #      sudo is required when using a deb install
-     #      sudo is \\fBnot\\fR required for run-in-place builds
-     # $ man halcompile for more info
-  5) Specify userkins in an ini file as:
-     \\fB[KINS]\\fR
-     \\fBKINEMATICS=userkins\\fR
-     \\fBJOINTS=3\\fR
-     # the number of JOINTS must agree with the
-     # number of joints used in your modified userkins.comp
-  6) Note: the manpage for userkins is not updated by halcompile --install
-  7) To use a different component name, rename the file (example mykins.comp)
-     and change all instances of 'userkins' to 'mykins'.
+Build and install the component using halcompile:
 
-\\fBNOTES:\\fR
-  1  The \\fBfpin\\fR pin is included to satisfy the requirements of the
-     halcompile utility but it is not accessible to kinematics functions.
+[source,sh]
+----
+$ cd mydir
+$ [sudo] halcompile --install userkins.comp
+# Note:
+#      sudo is required when using a deb install
+#      sudo is *not* required for run-in-place builds
+# $ man halcompile for more info
+----
 
-  2  HAL pins and parameters needed in kinematics functions (kinematicsForward(),
-     kinematicsInverse()) must be setup in a function (\\fBuserkins_setup()\\fR)
-     invoked by the initial motion module call to kinematicsType().
+Specify userkins in an ini file as:
+
+[source,ini]
+----
+[KINS]
+KINEMATICS=userkins
+JOINTS=3
+# the number of JOINTS must agree with the
+# number of joints used in your modified userkins.comp
+----
+
+Note: the manpage for userkins is not updated by `halcompile --install`
+
+To use a different component name, rename the file (example mykins.comp) and
+change all instances of `userkins` to `mykins`.
+
+=== NOTES
+
+* The *fpin* pin is included to satisfy the requirements of the halcompile
+  utility but it is not accessible to kinematics functions.
+* HAL pins and parameters needed in kinematics functions (kinematicsForward(),
+  kinematicsInverse()) must be setup in a function (*userkins_setup()*) invoked
+  by the initial motion module call to kinematicsType().
+
 """;
 // The fpin pin is not accessible in kinematics functions.
 // Use the *_setup() function for pins and params used by kinematics.

--- a/src/hal/components/wcomp.comp
+++ b/src/hal/components/wcomp.comp
@@ -2,10 +2,10 @@ component wcomp "Window comparator";
 pin in float in "Value being compared";
 pin in float min_ "Low boundary for comparison";
 pin in float max_ "High boundary for comparison";
-pin out bit out "True if \\fBin\\fR is strictly between \\fBmin\\fR and \\fBmax\\fR";
-pin out bit under "True if \\fBin\\fR is less than or equal to \\fBmin\\fR";
-pin out bit over "True if \\fBin\\fR is greater than or equal to \\fBmax\\fR";
-notes "If \\fBmax\\fR <= \\fBmin\\fR then the behavior is undefined.";
+pin out bit out "True if *in* is strictly between *min* and *max*";
+pin out bit under "True if *in* is less than or equal to *min*";
+pin out bit over "True if *in* is greater than or equal to *max*";
+notes "If *max* <= *min* then the behavior is undefined.";
 
 option period no;
 function _;

--- a/src/hal/components/xhc_hb04_util.comp
+++ b/src/hal/components/xhc_hb04_util.comp
@@ -1,9 +1,9 @@
 component xhc_hb04_util "xhc-hb04 convenience utility";
 description """Provides logic for a start/pause button and an interface
-to \\fBhalui.program.is_paused\\fR, \\fBis_idle\\fR, \\fBis_running\\fR to generate outputs for \\fBhalui.program.pause\\fR, \\fBresume\\fR, \\fBrun\\fR.
+to *halui.program.is_paused*, *is_idle*, *is_running* to generate outputs for *halui.program.pause*, *resume*, *run*.
 
-Includes 4 simple lowpass filters with \\fBcoef\\fR and \\fBscale\\fR pins.  The coef value should
-be 0 <= coef <=1, smaller coef values slow response.  See the lowpass manpage for
+Includes 4 simple lowpass filters with *coef* and *scale* pins.  The coef value should
+be 0 ≤ coef ≤1, smaller coef values slow response.  See the lowpass manpage for
 calculating the filter time constant ($ man lowpass).
 
 """;

--- a/src/hal/components/xor2.comp
+++ b/src/hal/components/xor2.comp
@@ -1,25 +1,32 @@
 component xor2 "Two-input XOR (exclusive OR) gate";
-pin in bit in0;
-pin in bit in1;
-pin out bit out """\
-\\fBout\\fR is computed from the value of \\fBin0\\fR and \\fBin1\\fR according
-to the following rule:
-.RS
-.TP
-\\fBin0=TRUE in1=FALSE\\fR
-.TQ
-\\fBin0=FALSE in1=TRUE\\fR
-\\fBout=TRUE\\fR
-.TP
-Otherwise,
-\\fBout=FALSE\\fR""";
+pin in bit in0 "First input";
+pin in bit in1 "Second input";
+pin out bit out "Output";
+
+description """
+The *out* pin is computed from the value of the *in0* and *in1* pins according
+to the following truth table:
+
+[option="header",cols="^1,^1,^1"]
+|===
+^h|in1
+^h|in0
+^h|out
+
+|0|0|0
+|0|1|1
+|1|0|1
+|1|1|0
+|===
+
+""";
 function _ nofp;
 see_also """
-\\fBand2\\fR(9),
-\\fBlogic\\fR(9),
-\\fBlut5\\fR(9),
-\\fBnot\\fR(9),
-\\fBor2\\fR(9).
+*and2*(9),
+*logic*(9),
+*lut5*(9),
+*not*(9),
+*or2*(9).
 """;
 license "GPL";
 author "John Kasunich";

--- a/src/hal/components/xyzab_tdr_kins.comp
+++ b/src/hal/components/xyzab_tdr_kins.comp
@@ -28,7 +28,6 @@ document chapter (docs/src/motion/kinematics.txt) and for
 switchable kinematics in particular see the switchkins document
 chapter (docs/src/motion/switchkins.txt)
 
-.if \\n[.g] .mso www.tmac
 """;
 
 pin out s32 dummy=0"one pin needed to satisfy halcompile requirement";

--- a/src/hal/components/xyzacb_trsrn.comp
+++ b/src/hal/components/xyzacb_trsrn.comp
@@ -2,8 +2,7 @@ component xyzacb_trsrn "Switchable kinematics for 6 axis machine with a rotary t
 
 description
 """
-.if \\n[.g] .mso www.tmac
-
+FIXME
 
 """;
 // The fpin pin is not accessible in kinematics functions.

--- a/src/hal/components/xyzbca_trsrn.comp
+++ b/src/hal/components/xyzbca_trsrn.comp
@@ -2,8 +2,7 @@ component xyzbca_trsrn "Switchable kinematics for 6 axis machine with a rotary t
 
 description
 """
-.if \\n[.g] .mso www.tmac
-
+FIXME
 
 """;
 // The fpin pin is not accessible in kinematics functions.

--- a/src/hal/drivers/mesa_7i65.comp
+++ b/src/hal/drivers/mesa_7i65.comp
@@ -3,7 +3,10 @@ component mesa_7i65 "Support for the Mesa 7i65 Octuple Servo Card";
 description """The component takes parameters in the form of a comma-separated
 list of bspi (buffered SPI) instance names, for example:
 
-\\fB loadrt mesa_7i65 bspi_chans=hm2_5i23.0.bspi.0, hm2_5i23.0.bspi.1\\fR
+[source,hal]
+----
+loadrt mesa_7i65 bspi_chans=hm2_5i23.0.bspi.0, hm2_5i23.0.bspi.1
+----
 
 The BSPI instances are printed to the dmesg buffer during the Hostmot2 setup
 sequence, one for each bspi instance included in the bitfile loaded to each

--- a/src/hal/drivers/mesa_uart.comp
+++ b/src/hal/drivers/mesa_uart.comp
@@ -13,7 +13,10 @@ not used instead.
 The component takes parameters in the form of a comma-separated
 list of UART instance names, for example:
 
-\\fB loadrt mesa_uart names=hm2_5i23.0.uart.0,hm2_5i23.0.uart.7\\fR
+[source,hal]
+----
+loadrt mesa_uart names=hm2_5i23.0.uart.0,hm2_5i23.0.uart.7
+----
 
 Note that no spaces are allowed in the string unless it is delimited by double 
 quotes. 

--- a/src/hal/drivers/serport.comp
+++ b/src/hal/drivers/serport.comp
@@ -1,16 +1,19 @@
 component serport """Hardware driver for the digital I/O bits of the 8250 and 16550 serial port.
 
-.B loadrt serport io=\\fIaddr[,addr...]\\fR
-.PP
+*loadrt serport* *io*=_addr_[,_addr_...]
+
 The pin numbers refer to the 9-pin serial pinout.  Keep in mind that these ports generally use rs232 voltages, not 0/5V signals.
 
 Specify the I/O address of the serial ports using the module parameter
-\\fBio=\\fIaddr[,addr...]\\fR.  These ports must not be in use by the kernel.
+*io*=_addr_[,_addr_...]. These ports must not be in use by the kernel.
 To free up the I/O ports after bootup, install setserial and execute a command
 like:
-.RS 
+
+[source,sh]
+----
 sudo setserial /dev/ttyS0 uart none
-.RE
+----
+
 but it is best to ensure that the serial port is never used or configured by
 the Linux kernel by setting a kernel commandline parameter or not loading
 the serial kernel module if it is a modularized driver.

--- a/src/hal/user_comps/Submakefile
+++ b/src/hal/user_comps/Submakefile
@@ -93,8 +93,10 @@ $(patsubst ./hal/user_comps/%,../include/%,$(wildcard ./hal/user_comps/*.hh)): .
 
 $(USER_COMP_MANPAGES): ../docs/man/man1/%.1: hal/user_comps/%.comp ../bin/halcompile
 	$(ECHO) Making halcompile manpage $(notdir $@)
-	@mkdir -p $(dir $@)
-	$(Q)../bin/halcompile -U --userspace --document -o $@ $<
+	@mkdir -p $(dir $@) objects/man/man1
+	$(Q)../bin/halcompile -U --userspace --document --keep-adoc=$@.adoc -o $@ $<
+	$(Q)sed -i -e's/^\.als /.\\" .als /' $@
+	$(Q)mv -f $@.adoc objects/man/man1/
 
 $(USER_COMP_SRCS): objects/%.c: %.comp ../bin/halcompile
 	$(ECHO) "Preprocessing $(notdir $<)"

--- a/src/hal/user_comps/pi500_vfd/Submakefile
+++ b/src/hal/user_comps/pi500_vfd/Submakefile
@@ -17,8 +17,10 @@ hal/user_comps/pi500_vfd/pi500_vfd.c: hal/user_comps/pi500_vfd/pi500_vfd.comp ..
 	$(Q)../bin/halcompile -U --preprocess $<
 
 ../docs/man/man1/pi500_vfd.1: hal/user_comps/pi500_vfd/pi500_vfd.comp ../bin/halcompile
-	$(Q)../bin/halcompile -U -u --document $<
-	$(Q)install --mode=0644 hal/user_comps/pi500_vfd/pi500_vfd.1 $@
+	@mkdir -p $(dir $@) objects/man/man1
+	$(Q)../bin/halcompile -U -u --document --keep-adoc=$@.adoc -o $@ $<
+	$(Q)sed -i -e's/^\.als /.\\" .als /' $@
+	$(Q)mv -f $@.adoc objects/man/man1/
 
 clean: pi500_clean
 pi500_clean:

--- a/src/hal/user_comps/wj200_vfd/Submakefile
+++ b/src/hal/user_comps/wj200_vfd/Submakefile
@@ -17,8 +17,10 @@ hal/user_comps/wj200_vfd/wj200_vfd.c: hal/user_comps/wj200_vfd/wj200_vfd.comp ..
 	$(Q)../bin/halcompile -U --preprocess $<
 
 ../docs/man/man1/wj200_vfd.1: hal/user_comps/wj200_vfd/wj200_vfd.comp ../bin/halcompile
-	$(Q)../bin/halcompile -U -u --document $<
-	$(Q)install --mode=0644 hal/user_comps/wj200_vfd/wj200_vfd.1 $@
+	@mkdir -p $(dir $@) objects/man/man1
+	$(Q)../bin/halcompile -U -u --document --keep-adoc=$@.adoc -o $@ $<
+	$(Q)sed -i -e's/^\.als /.\\" .als /' $@
+	$(Q)mv -f $@.adoc objects/man/man1/
 
 clean: wj200_clean
 wj200_clean:

--- a/src/hal/utils/halcompile.g
+++ b/src/hal/utils/halcompile.g
@@ -872,10 +872,13 @@ def finddocs(section=None, name=None):
 ######
 
 def to_hal_man(s):
+    fn = s
     s = s.replace("_", "-")
     c = comp_name.replace("_", "-")
     if options.get("singleton"):
         s = "**%s**.**%s**" % (c, s)
+    elif "_" == fn:
+        s = "**%s**.__N__" % (c)
     else:
         s = "**%s**.__N__.**%s**" % (c, s)
     s = s.rstrip("-").rstrip(".")

--- a/src/hal/utils/halcompile.g
+++ b/src/hal/utils/halcompile.g
@@ -1066,24 +1066,34 @@ def document(filename, outfilebase):
 
 def make_manpage(fdir, fname):
     # Conversion to manpage format required
-    opts = ["--doctype=manpage",
-            "--destination-dir=" + fdir,
-            "-a", "mansource=LinuxCNC",
-            "-a", "manmanual=LinuxCNC Documentation" ]
     try:
         # Try asciidoctor
-        opts += ["--backend=manpage"]
-        subprocess.call(["asciidoctor"] + opts + [fname], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        args = ["asciidoctor",
+                "--doctype=manpage",
+                "--backend=manpage",
+                "--destination-dir=" + fdir,
+                "-a", "mansource=LinuxCNC",
+                "-a", "manmanual=LinuxCNC Documentation",
+                fname]
+        subprocess.call(args, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
     except:
         try:
             # Alternative, try a2x
-            opts += ["--format=manpage", "--xsltproc-opts=--nonet"]
-            subprocess.call(["a2x"] + opts + [fname], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+            #opts += ["--format=manpage", "--xsltproc-opts=--nonet"]
+            args = ["a2x",
+                    "--doctype=manpage",
+                    "--format=manpage",
+                    "--destination-dir=" + fdir,
+                    "--xsltproc-opts=--nonet",
+                    "-a", "mansource=LinuxCNC",
+                    "-a", "manmanual=LinuxCNC Documentation",
+                    fname]
+            subprocess.call(args, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
         except:
             raise SystemExit("Error: Missing asciidoctor or a2x for adoc-to-manpage conversion or use --adoc for asciidoc file only")
 
     # We should have a file with the extension removed
-    manfile = fname.removesuffix(".adoc")
+    manfile = os.path.join(fdir, os.path.basename(fname).removesuffix(".adoc"))
     if not os.access(manfile, os.R_OK):
         raise SystemExit("Error: Manpage '%s' not generated" % manfile)
     return manfile

--- a/src/hal/utils/halcompile.g
+++ b/src/hal/utils/halcompile.g
@@ -55,9 +55,9 @@ parser Hal:
 
     rule Header: STRING {{ return STRING }} | HEADER {{ return HEADER }}
 
-    rule String: TSTRING {{ return eval(TSTRING) }} 
+    rule String: TSTRING {{ return eval(TSTRING) }}
             | STRING {{ return eval(STRING) }}
- 
+
     rule OptPersonality: "if" Personality {{ return Personality }}
             | {{ return None }}
     rule Personality: {{ pp = [] }} (PersonalityPart {{ pp.append(PersonalityPart) }} )* {{ return " ".join(pp) }}
@@ -68,8 +68,8 @@ parser Hal:
     rule OptArray: "\\[" NUMBER OptArrayPersonality "\\]" {{ return OptArrayPersonality and (int(NUMBER), OptArrayPersonality) or int(NUMBER) }}
             | {{ return 0 }}
     rule OptArrayPersonality: ":" Personality {{ return Personality }}
-            | {{ return None }} 
-    rule OptString: TSTRING {{ return eval(TSTRING) }} 
+            | {{ return None }}
+    rule OptString: TSTRING {{ return eval(TSTRING) }}
             | STRING {{ return eval(STRING) }}
             | {{ return '' }}
     rule OptAssign: "=" Value {{ return Value; }}
@@ -77,15 +77,15 @@ parser Hal:
     rule OptSAssign: "=" SValue {{ return SValue; }}
                 | {{ return None }}
     rule OptFP: "fp" {{ return 1 }} | "nofp" {{ return 0 }} | {{ return 1 }}
-    rule Value: "yes" {{ return 1 }} | "no" {{ return 0 }}  
-                | "true" {{ return 1 }} | "false" {{ return 0 }}  
-                | "TRUE" {{ return 1 }} | "FALSE" {{ return 0 }}  
+    rule Value: "yes" {{ return 1 }} | "no" {{ return 0 }}
+                | "true" {{ return 1 }} | "false" {{ return 0 }}
+                | "TRUE" {{ return 1 }} | "FALSE" {{ return 0 }}
                 | NAME {{ return NAME }}
                 | FPNUMBER {{ return float(FPNUMBER.rstrip("f")) }}
                 | NUMBER {{ return int(NUMBER,0) }}
-    rule SValue: "yes" {{ return "yes" }} | "no" {{ return "no" }}  
-                | "true" {{ return "true" }} | "false" {{ return "false" }}  
-                | "TRUE" {{ return "TRUE" }} | "FALSE" {{ return "FALSE" }}  
+    rule SValue: "yes" {{ return "yes" }} | "no" {{ return "no" }}
+                | "true" {{ return "true" }} | "false" {{ return "false" }}
+                | "TRUE" {{ return "TRUE" }} | "FALSE" {{ return "FALSE" }}
                 | NAME {{ return NAME }}
                 | FPNUMBER {{ return FPNUMBER }}
                 | NUMBER {{ return NUMBER }}
@@ -98,6 +98,7 @@ parser Hal:
 %%
 
 import os, sys, tempfile, shutil, getopt, time
+import subprocess
 BASE = os.path.abspath(os.path.join(os.path.dirname(sys.argv[0]), ".."))
 BINDIR = os.getenv('USER_MODULE_DIR', None) or os.path.join(BASE, "bin")
 sys.path.insert(0, os.path.join(BASE, "lib", "python"))
@@ -201,7 +202,7 @@ def notes(doc):
 def type2type(type):
     # When we start warning about s32/u32 this is where the warning goes
     return typemap.get(type, type)
-    
+
 def checkarray(name, array):
     hashes = len(re.findall("#+", name))
     if array:
@@ -328,7 +329,7 @@ static int comp_id;
             if default: print("= %s;" % default, file=f)
             else: print(";", file=f)
             print("%s(%s, %s);" % (decl, name, q(doc)), file=f)
-            
+
     print("", file=f)
     print("struct __comp_state {", file=f)
     print("    struct __comp_state *_next;", file=f)
@@ -365,7 +366,7 @@ static int comp_id;
         print("#include <stdlib.h>", file=f)
 
     print("struct __comp_state *__comp_first_inst=0, *__comp_last_inst=0;", file=f)
-    
+
     print("", file=f)
     for name, fp in functions:
         if name in names:
@@ -868,33 +869,28 @@ def finddocs(section=None, name=None):
                 (name == None or name == item[1])):
                     yield item
 
-def to_hal_man_unnumbered(s):
-    s = "%s.%s" % (comp_name, s)
-    s = s.replace("_", "-")
-    s = s.rstrip("-")
-    s = s.rstrip(".")
-    s = re.sub("#+", lambda m: "\\fI" + "M" * len(m.group(0)) + "\\fB", s)
-    # s = s.replace("-", "\\-")
-    return s
-
+######
 
 def to_hal_man(s):
-    if options.get("singleton"):
-        s = "%s.%s" % (comp_name, s)
-    else:
-        s = "%s.\\fIN\\fB.%s" % (comp_name, s)
     s = s.replace("_", "-")
-    s = s.rstrip("-")
-    s = s.rstrip(".")
-    s = re.sub("#+", lambda m: "\\fI" + "M" * len(m.group(0)) + "\\fB", s)
-    # s = s.replace("-", "\\-")
+    c = comp_name.replace("_", "-")
+    if options.get("singleton"):
+        s = "%s.%s" % (c, s)
+    else:
+        s = "%s.__N__.%s" % (c, s)
+    s = s.rstrip("-").rstrip(".")
+    s = re.sub("#+", lambda m: "__" + "M" * len(m.group(0)) + "__", s)
     return s
 
-def document(filename, outfilename):
-
+# Generate an adoc file from the embedded declarations, defines and
+# documentation.
+def document(filename, outfilebase):
     a, b = parse(filename)
-    if outfilename is None:
-        outfilename = os.path.splitext(filename)[0] + ".1" if options.get("userspace") else ".9"
+    if outfilebase is None:
+        outfilename = os.path.splitext(filename)[0] + ".1.adoc" if options.get("userspace") else ".9.adoc"
+    else:
+        outfilename = outfilebase
+        outfilename += ".1.adoc" if options.get("userspace") else ".9.adoc"
 
     f = open(outfilename, "w")
 
@@ -906,57 +902,57 @@ def document(filename, outfilename):
         if personality: has_personality = True
         if isinstance(array, tuple): has_personality = True
 
-    print(""".\\" -*- mode: troff; coding: utf-8 -*-
-.\\"*******************************************************************
-.\\"
-.\\" This file was extracted from %s using halcompile.g.
-.\\" Modify the source file.
-.\\"
-.\\"*******************************************************************
+    print("""//
+// *******************************************************************
+//
+// This file was extracted from %s using halcompile.g.
+// Modify the source file.
+//
+// *******************************************************************
+//
 """ % filename, file=f)
 
-    print(".TH %s \"%s\" \"%s\" \"LinuxCNC Documentation\" \"HAL Component\"" % (
-        comp_name.upper(), "1" if options.get("userspace") else "9",
-        time.strftime("%F")), file=f)
+    # = manpage(section)
+    print("= {}({})".format(comp_name.upper(), "1" if options.get("userspace") else "9"), file=f)
 
-    print(".SH NAME\n", file=f)
-    doc = finddoc('component')    
+    print("\n== NAME\n", file=f)
+    doc = finddoc('component')
     if doc and doc[2]:
         if '\n' in doc[2]:
             firstline, rest = doc[2].split('\n', 1)
         else:
             firstline = doc[2]
             rest = ''
-        print("%s \\- %s" % (doc[1], firstline), file=f)
+        print("%s - %s" % (doc[1], firstline), file=f)
     else:
         rest = ''
-        print("%s" % doc[1], file=f)
+        # A valid NAME section is formatted like "compname - brief description"
+        # Missing the brief description would fail conversion
+        print("%s - ." % doc[1], file=f)
 
-
-    print(".SH SYNOPSIS", file=f)
+    print("\n== SYNOPSIS\n", file=f)
     if options.get("userspace"):
-        print(".B %s" % comp_name, file=f)
+        print("*%s*" % comp_name, file=f)
     else:
         if rest:
             print(rest, file=f)
         else:
-            print(".HP", file=f)
             if options.get("homemod"):
-                print("Custom Homing module loaded with \\fB[EMCMOT]HOMEMOD=%s\\fR"%comp_name, file=f)
+                print("Custom Homing module loaded with *[EMCMOT]HOMEMOD=_%s_*"%comp_name, file=f)
             elif options.get("tpmod"):
-                print("Custom Trajectory Planning module loaded with \\fB[TRAJ]TPMOD=%s\\fR"%comp_name, file=f)
+                print("Custom Trajectory Planning module loaded with *[TRAJ]TPMOD=_%s_*"%comp_name, file=f)
             elif options.get("singleton") or options.get("count_function"):
                 if has_personality:
-                    print(".B loadrt %s personality=\\fIP\\fB" % comp_name, end='', file=f)
+                    print("*loadrt %s* *personality*=_P_" % comp_name, end='', file=f)
                 else:
-                    print(".B loadrt %s" % comp_name, end='', file=f)
+                    print("*loadrt %s*" % comp_name, end='', file=f)
             else:
                 if has_personality:
-                    print(".B loadrt %s [count=\\fIN\\fB|names=\\fIname1\\fB[,\\fIname2...\\fB]] [personality=\\fIP1,P2,...\\fB]" % comp_name, end='', file=f)
+                    print("*loadrt %s* [*count*=_N_|*names*=_name1_[,_name2_...]] [*personality*=_P1_[,_P2_...]]" % comp_name, end='', file=f)
                 else:
-                    print(".B loadrt %s [count=\\fIN\\fB|names=\\fIname1\\fB[,\\fIname2...\\fB]]" % comp_name, end='', file=f)
+                    print("*loadrt %s* [*count*=_N_|*names*=_name1_[,_name2_...]]" % comp_name, end='', file=f)
             for type, name, default, doc in modparams:
-                print(" [%s=\\fIN\\fB]" % name, end='', file=f)
+                print(" [*%s*=_N_]" % name, end='', file=f)
             print("", file=f)
 
             hasparamdoc = False
@@ -964,41 +960,39 @@ def document(filename, outfilename):
                 if doc: hasparamdoc = True
 
             if hasparamdoc:
-                print(".RS 4", file=f)
                 for type, name, default, doc in modparams:
-                    print(".TP", file=f)
-                    print("\\fB%s\\fR" % name, end='', file=f)
+                    print("\n*%s*" % name, end='', file=f)
                     if default:
-                        print(" [default: %s]" % default, file=f)
+                        print(" [default: %s]::" % default, file=f)
                     else:
-                        print("", file=f)
+                        print("::", file=f)
                     print(doc, file=f)
-                print(".RE", file=f)
 
         if options.get("constructable") and not options.get("singleton"):
-            print(".PP\n.B newinst %s \\fIname\\fB" % comp_name, file=f)
+            print("\n*newinst %s* _name_" % comp_name, file=f)
 
-    doc = finddoc('descr')    
+    doc = finddoc('descr')
     if doc and doc[1]:
-        print(".SH DESCRIPTION\n", file=f)
+        print("\n== DESCRIPTION\n", file=f)
         print("%s" % doc[1], file=f)
 
     if functions:
-        print(".SH FUNCTIONS", file=f)
+        print("\n== FUNCTIONS\n", file=f)
         for _, name, fp, doc in finddocs('funct'):
-            print(".TP", file=f)
-            print("\\fB%s\\fR" % to_hal_man(name), end='', file=f)
+            print("%s" % to_hal_man(name), end='', file=f)
             if fp:
-                print(" (requires a floating-point thread)", file=f)
+                print(" (requires a floating-point thread)::", file=f)
             else:
-                print("", file=f)
-            print(doc, file=f)
+                print("::", file=f)
+            if doc:
+                print(doc, file=f)
+            else:
+                # Need something to follow ::
+                print("// missing description\n", file=f)
 
-    lead = ".TP"
-    print(".SH PINS", file=f)
+    print("\n== PINS\n", file=f)
     for _, name, type, array, dir, doc, value, personality in finddocs('pin'):
-        print(lead, file=f)
-        print(".B %s\\fR" % to_hal_man(name), end=' ', file=f)
+        print("%s" % to_hal_man(name), end=' ', file=f)
         print(type, dir, end=' ', file=f)
         if array:
             sz = name.count("#")
@@ -1009,21 +1003,19 @@ def document(filename, outfilename):
         if personality:
             print(" [if %s]" % personality, end=' ', file=f)
         if value:
-            print("\\fR(default: \\fI%s\\fR)" % value, file=f)
+            print("(default: _%s_)::" % value, file=f)
         else:
-            print("\\fR", file=f)
+            print("::", file=f)
         if doc:
             print(doc, file=f)
-            lead = ".TP"
         else:
-            lead = ".br\n.ns\n.TP"
+            # Need something to follow ::
+            print("// missing description\n", file=f)
 
-    lead = ".TP"
     if params:
-        print(".SH PARAMETERS", file=f)
+        print("\n== PARAMETERS\n", file=f)
         for _, name, type, array, dir, doc, value, personality in finddocs('param'):
-            print(lead, file=f)
-            print(".B %s\\fR" % to_hal_man(name), end=' ', file=f)
+            print("%s" % to_hal_man(name), end=' ', file=f)
             print(type, dir, end=' ', file=f)
             if array:
                 sz = name.count("#")
@@ -1034,39 +1026,68 @@ def document(filename, outfilename):
             if personality:
                 print(" [if %s]" % personality, end=' ', file=f)
             if value:
-                print("\\fR(default: \\fI%s\\fR)" % value, file=f)
+                print("(default: _%s_)::" % value, file=f)
             else:
-                print("\\fR", file=f)
+                print("::", file=f)
             if doc:
                 print(doc, file=f)
-                lead = ".TP"
             else:
-                lead = ".br\n.ns\n.TP"
+                # Need something to follow ::
+                print("// missing description\n", file=f)
 
     doc = finddoc('examples')
     if doc and doc[1]:
-        print(".SH EXAMPLES\n", file=f)
+        print("\n== EXAMPLES\n", file=f)
         print("%s" % doc[1], file=f)
 
-    doc = finddoc('see_also')    
+    doc = finddoc('see_also')
     if doc and doc[1]:
-        print(".SH SEE ALSO\n", file=f)
+        print("\n== SEE ALSO\n", file=f)
         print("%s" % doc[1], file=f)
 
-    doc = finddoc('notes')    
+    doc = finddoc('notes')
     if doc and doc[1]:
-        print(".SH NOTES\n", file=f)
+        print("\n== NOTES\n", file=f)
         print("%s" % doc[1], file=f)
 
-    doc = finddoc('author')    
+    doc = finddoc('author')
     if doc and doc[1]:
-        print(".SH AUTHOR\n", file=f)
+        print("\n== AUTHOR\n", file=f)
         print("%s" % doc[1], file=f)
 
-    doc = finddoc('license')    
+    doc = finddoc('license')
     if doc and doc[1]:
-        print(".SH LICENSE\n", file=f)
+        print("\n== LICENSE\n", file=f)
         print("%s" % doc[1], file=f)
+
+    f.close()
+    return outfilename
+######
+
+def make_manpage(fdir, fname):
+    # Conversion to manpage format required
+    opts = ["--doctype=manpage",
+            "--destination-dir=" + fdir,
+            "-a", "mansource=LinuxCNC",
+            "-a", "manmanual=LinuxCNC Documentation" ]
+    try:
+        # Try asciidoctor
+        opts += ["--backend=manpage"]
+        subprocess.call(["asciidoctor"] + opts + [fname], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    except:
+        try:
+            # Alternative, try a2x
+            opts += ["--format=manpage", "--xsltproc-opts=--nonet"]
+            subprocess.call(["a2x"] + opts + [fname], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        except:
+            raise SystemExit("Error: Missing asciidoctor or a2x for adoc-to-manpage conversion or use --adoc for asciidoc file only")
+
+    # We should have a file with the extension removed
+    manfile = fname.removesuffix(".adoc")
+    if not os.access(manfile, os.R_OK):
+        raise SystemExit("Error: Manpage '%s' not generated" % manfile)
+    return manfile
+######
 
 def process(filename, mode, outfilename):
     tempdir = tempfile.mkdtemp()
@@ -1126,13 +1147,13 @@ def process(filename, mode, outfilename):
                 build_rt(tempdir, outfilename, mode, filename)
 
     finally:
-        shutil.rmtree(tempdir) 
+        shutil.rmtree(tempdir)
 
 def usage(exitval=0):
     print("""%(name)s: Build, compile, and install LinuxCNC HAL components
 
 Usage:
-           %(name)s [--compile|--preprocess|--document|--view-doc] compfile...
+           %(name)s [--compile|--preprocess|--document|--adoc|--view-doc] compfile...
     [sudo] %(name)s [--install|--install-doc] compfile...
            %(name)s --compile --userspace cfile...
     [sudo] %(name)s --install --userspace cfile...
@@ -1159,14 +1180,16 @@ def main():
     global require_unix_line_endings
     require_unix_line_endings = False
     mode = PREPROCESS
+    adoc = False
+    keepadoc = None
     outfile = None
     userspace = False
     global options
     options = {}
     try:
-        opts, args = getopt.getopt(sys.argv[1:], "Uluijcpdo:h?P:",
+        opts, args = getopt.getopt(sys.argv[1:], "UluijJcpdak:o:h?P:",
                            ['unix', 'install', 'compile', 'preprocess', 'outfile=',
-                            'document', 'help', 'userspace', 'install-doc',
+                            'document', 'adoc', 'keep-adoc=', 'help', 'userspace', 'install-doc',
                             'view-doc', 'require-license', 'print-modinc',
                             'personalities=', "extra-compile-args=",
                             'extra-link-args='])
@@ -1185,9 +1208,16 @@ def main():
             mode = PREPROCESS
         if k in ("-d", "--document"):
             mode = DOCUMENT
+        if k in ("-a", "--adoc"):
+            mode = DOCUMENT
+            adoc = True
+        if k in ("-k", "--keep-adoc"):
+            if len(args) != 1:
+                raise SystemExit("Cannot specify -k with multiple input files")
+            keepadoc = v
         if k in ("-j", "--install-doc"):
             mode = INSTALLDOC
-        if k in ("-j", "--view-doc"):
+        if k in ("-J", "--view-doc"):
             mode = VIEWDOC
         if k in ("--print-modinc",):
             mode = MODINC
@@ -1196,7 +1226,7 @@ def main():
         if k in ("-o", "--outfile"):
             if len(args) != 1:
                 raise SystemExit("Cannot specify -o with multiple input files")
-            outfile = v 
+            outfile = v
         if k in ("-P", "--personalities"):
             try:
                 MAX_PERSONALITIES = int(v)
@@ -1224,22 +1254,47 @@ def main():
         try:
             basename = os.path.basename(os.path.splitext(f)[0])
             if f.endswith(".comp") and mode == DOCUMENT:
-                document(f, outfile)            
+                tempdir = tempfile.mkdtemp()
+                try:
+                    docfile = document(f, os.path.join(tempdir, basename))
+                    if adoc:    # Adoc is created
+                        if None == outfile:
+                            outfile = os.path.join(os.path.dirname(f), os.path.basename(docfile))
+                        shutil.move(docfile, outfile)
+                    else:       # Else we do manpage conversion
+                        manfile = make_manpage(tempdir, docfile)
+                        if None == outfile:
+                            outfile = os.path.join(os.path.dirname(f), os.path.basename(manfile))
+                        shutil.move(manfile, outfile)
+                        if keepadoc:
+                            shutil.move(docfile, keepadoc)
+                finally:
+                    shutil.rmtree(tempdir)
             elif f.endswith(".comp") and mode == VIEWDOC:
                 tempdir = tempfile.mkdtemp()
                 try:
-                    outfile = os.path.join(tempdir, basename + ".9")
-                    document(f, outfile)
-                    os.spawnvp(os.P_WAIT, "man", ["man", outfile])
+                    docfile = document(f, os.path.join(tempdir, basename))
+                    manfile = make_manpage(tempdir, docfile)
+                    os.spawnvp(os.P_WAIT, "man", ["man", manfile])
                 finally:
                     shutil.rmtree(tempdir)
             elif f.endswith(".comp") and mode == INSTALLDOC:
-                manpath = os.path.join(BASE, "share/man/man9")
-                if not os.path.isdir(manpath):
-                    manpath = os.path.join(BASE, "docs/man/man9")
-                outfile = os.path.join(manpath, basename + ".9")
+                tempdir = tempfile.mkdtemp()
                 print("INSTALLDOC", outfile)
-                document(f, outfile)            
+                try:
+                    docfile = document(f, os.path.join(tempdir, basename))
+                    manfile = make_manpage(tempdir, docfile)
+                    section = "1" if options.get("userspace") else "9"
+                    manpath = os.path.join(BASE, "share/man/man" + section)
+                    sharepath = manpath
+                    if not os.path.isdir(manpath):
+                        manpath = os.path.join(BASE, "docs/man/man" + section)
+                        if not os.path.isdir(manpath):
+                            raise SystemExit("Error: directory '%s' (nor alternative '%s') found" % (sharepath, manpath))
+                    outfile = os.path.join(manpath, basename + "." + section)
+                    shutil.move(manfile, outfile)
+                finally:
+                    shutil.rmtree(tempdir)
             elif f.endswith(".comp"):
                 process(f, mode, outfile)
             elif f.endswith(".py") and mode == INSTALL:
@@ -1261,7 +1316,7 @@ def main():
                     else:
                         build_rt(tempdir, os.path.join(tempdir, os.path.basename(f)), mode, f)
                 finally:
-                    shutil.rmtree(tempdir) 
+                    shutil.rmtree(tempdir)
             else:
                 raise SystemExit("Unrecognized file type for mode %s: %r" % (modename[mode], f))
         except Exception as e:
@@ -1273,4 +1328,4 @@ def main():
 if __name__ == '__main__':
     main()
 
-# vim:sw=4:sts=4:et
+# vim:sw=4:sts=4:et:syn=python

--- a/src/hal/utils/halcompile.g
+++ b/src/hal/utils/halcompile.g
@@ -875,9 +875,9 @@ def to_hal_man(s):
     s = s.replace("_", "-")
     c = comp_name.replace("_", "-")
     if options.get("singleton"):
-        s = "%s.%s" % (c, s)
+        s = "**%s**.**%s**" % (c, s)
     else:
-        s = "%s.__N__.%s" % (c, s)
+        s = "**%s**.__N__.**%s**" % (c, s)
     s = s.rstrip("-").rstrip(".")
     s = re.sub("#+", lambda m: "__" + "M" * len(m.group(0)) + "__", s)
     return s


### PR DESCRIPTION
This PR moves halcompile over from generating (t)roff format man-pages to adoc format. The generated adoc is automatically converted into (t)roff by halcompile to keep current operational compatibility. Additionally, generating man-pages in HTML format is now performed by asciidoc from the adoc formatted files from halcompile, which are stored for this use. Man-page aliases in HTML are symlinked to the target HTML man-page.

All components' documentation has been updated to be in adoc format, including tables and source-code listings. There still needs to be done some more work to make the look-and-feel of all the man-pages more uniform and properly linked. Several other man-pages had some warning/error fixes.

As a consequence, all HTML is now be generated from adoc format, making a move to asciidoctor possible.

Some fiddling needed to be performed to make this work. The translations using po4a are still based on the (t)roff formatted man-pages. Pulling this thread from the makefile made multiple other things unravel and will be handled in a future patch step. However, po4a does not like all input from asciidoc generated (t)roff format and lacks, for example, support for the troff alias (.als) command. These are not really necessary and are commented out with sed in post-processing to make it work.

Some small errors in the adoc format in other documents and generating scripts were also fixed to reduce the incredible amount of warnings when building documentation (and translations). This is still work-in-progress.