### PR TITLE
Gmoccapy: Fix gtk warnings on mdi buttons (next/previous) pagination

### DIFF
--- a/src/emc/usr_intf/gmoccapy/gmoccapy.py
+++ b/src/emc/usr_intf/gmoccapy/gmoccapy.py
@@ -847,7 +847,8 @@ class gmoccapy(object):
 
     def _remove_button(self, dic, box):
         for child in dic:
-            box.remove(dic[child])
+            if dic[child].get_parent():
+                box.remove(dic[child])
 
     def _on_btn_next_clicked(self, widget):
         # remove all buttons from container


### PR DESCRIPTION
Fixes these recurring warnings when changing the macro button page:
![previous](https://github.com/user-attachments/assets/cce1d015-bee6-45d1-b6e9-a0a2dbce0d17)

![pagination_warnings](https://github.com/user-attachments/assets/570b99a3-76d8-4f69-8001-3afea640b775)
