### PR TITLE
Gmoccapy - change spindle => spindle_0 in *.ini files

### DIFF
--- a/configs/sim/gmoccapy/6_axis.ini
+++ b/configs/sim/gmoccapy/6_axis.ini
@@ -1,6 +1,6 @@
 [EMC]
 VERSION = 1.1
-MACHINE = gmoccapy_9_axis
+MACHINE = gmoccapy_6_axis
   DEBUG = 0
 
 [DISPLAY]
@@ -15,10 +15,12 @@ GEOMETRY = XYZABC
 
 # Values that will be allowed for override, 1.0 = 100%
 MAX_FEED_OVERRIDE    =  1.5
-MAX_SPINDLE_OVERRIDE =  1.2
-MIN_SPINDLE_OVERRIDE =  0.5
+MAX_SPINDLE_0_OVERRIDE =  1.2
+MIN_SPINDLE_0_OVERRIDE =  0.5
 
-DEFAULT_SPINDLE_SPEED = 500
+# The value will be used the first time Gmoccapy is loaded.
+# It will then be overwritten by the *.pref file.
+DEFAULT_SPINDLE_0_SPEED = 500
 
 # list of selectable jog increments
 INCREMENTS = 1.000 mm, 0.100 mm, 0.010 mm, 0.001 mm ,1.2345 in

--- a/configs/sim/gmoccapy/7_axis.ini
+++ b/configs/sim/gmoccapy/7_axis.ini
@@ -1,6 +1,6 @@
 [EMC]
 VERSION = 1.1
-MACHINE = gmoccapy_9_axis
+MACHINE = gmoccapy_7_axis
   DEBUG = 0
 
 [DISPLAY]
@@ -15,10 +15,12 @@ GEOMETRY = XYZABCUVW
 
 # Values that will be allowed for override, 1.0 = 100%
 MAX_FEED_OVERRIDE    =  1.5
-MAX_SPINDLE_OVERRIDE =  1.2
-MIN_SPINDLE_OVERRIDE =  0.5
+MAX_SPINDLE_0_OVERRIDE =  1.2
+MIN_SPINDLE_0_OVERRIDE =  0.5
 
-DEFAULT_SPINDLE_SPEED = 500
+# The value will be used the first time Gmoccapy is loaded.
+# It will then be overwritten by the *.pref file.
+DEFAULT_SPINDLE_0_SPEED = 500
 
 # list of selectable jog increments
 INCREMENTS = 1.000 mm, 0.100 mm, 0.010 mm, 0.001 mm ,1.2345 in

--- a/configs/sim/gmoccapy/7_axis_tool.ini
+++ b/configs/sim/gmoccapy/7_axis_tool.ini
@@ -1,6 +1,6 @@
 [EMC]
 VERSION = 1.1
-MACHINE = gmoccapy_9_axis
+MACHINE = gmoccapy_7_axis_tool
   DEBUG = 0
 
 [DISPLAY]
@@ -15,10 +15,12 @@ GEOMETRY = XYZABCUVW
 
 # Values that will be allowed for override, 1.0 = 100%
 MAX_FEED_OVERRIDE    =  1.5
-MAX_SPINDLE_OVERRIDE =  1.2
-MIN_SPINDLE_OVERRIDE =  0.5
+MAX_SPINDLE_0_OVERRIDE =  1.2
+MIN_SPINDLE_0_OVERRIDE =  0.5
 
-DEFAULT_SPINDLE_SPEED = 500
+# The value will be used the first time Gmoccapy is loaded.
+# It will then be overwritten by the *.pref file.
+DEFAULT_SPINDLE_0_SPEED = 500
 
 # list of selectable jog increments
 INCREMENTS = 1.000 mm, 0.100 mm, 0.010 mm, 0.001 mm ,1.2345 in

--- a/configs/sim/gmoccapy/8_axis.ini
+++ b/configs/sim/gmoccapy/8_axis.ini
@@ -1,6 +1,6 @@
 [EMC]
 VERSION = 1.1
-MACHINE = gmoccapy_9_axis
+MACHINE = gmoccapy_8_axis
   DEBUG = 0
 
 [DISPLAY]
@@ -15,10 +15,12 @@ GEOMETRY = XYZABCUVW
 
 # Values that will be allowed for override, 1.0 = 100%
 MAX_FEED_OVERRIDE    =  1.5
-MAX_SPINDLE_OVERRIDE =  1.2
-MIN_SPINDLE_OVERRIDE =  0.5
+MAX_SPINDLE_0_OVERRIDE =  1.2
+MIN_SPINDLE_0_OVERRIDE =  0.5
 
-DEFAULT_SPINDLE_SPEED = 500
+# The value will be used the first time Gmoccapy is loaded.
+# It will then be overwritten by the *.pref file.
+DEFAULT_SPINDLE_0_SPEED = 500
 
 # list of selectable jog increments
 INCREMENTS = 1.000 mm, 0.100 mm, 0.010 mm, 0.001 mm ,1.2345 in

--- a/configs/sim/gmoccapy/9_axis.ini
+++ b/configs/sim/gmoccapy/9_axis.ini
@@ -15,10 +15,12 @@ GEOMETRY = XYZABCUVW
 
 # Values that will be allowed for override, 1.0 = 100%
 MAX_FEED_OVERRIDE    =  1.5
-MAX_SPINDLE_OVERRIDE =  1.2
-MIN_SPINDLE_OVERRIDE =  0.5
+MAX_SPINDLE_0_OVERRIDE =  1.2
+MIN_SPINDLE_0_OVERRIDE =  0.5
 
-DEFAULT_SPINDLE_SPEED = 500
+# The value will be used the first time Gmoccapy is loaded.
+# It will then be overwritten by the *.pref file.
+DEFAULT_SPINDLE_0_SPEED = 500
 
 # list of selectable jog increments
 INCREMENTS = 1.000 mm, 0.100 mm, 0.010 mm, 0.001 mm ,1.2345 in

--- a/configs/sim/gmoccapy/gmoccapy.ini
+++ b/configs/sim/gmoccapy/gmoccapy.ini
@@ -22,11 +22,13 @@ CYCLE_TIME = 100
 
 # Values that will be allowed for override, 1.0 = 100%
 MAX_FEED_OVERRIDE    = 1.5
-MAX_SPINDLE_OVERRIDE = 1.2
-MIN_SPINDLE_OVERRIDE = 0.5
+MAX_SPINDLE_0_OVERRIDE = 1.2
+MIN_SPINDLE_0_OVERRIDE = 0.5
 
 # Initial value for spindle speed
-DEFAULT_SPINDLE_SPEED = 450
+# The value will be used the first time Gmoccapy is loaded.
+# It will then be overwritten by the *.pref file.
+DEFAULT_SPINDLE_0_SPEED = 450
 
 # The following are not used, added here to suppress warnings (from qt_istat/logger).
 DEFAULT_LINEAR_VELOCITY = 35

--- a/configs/sim/gmoccapy/gmoccapy_4_axis.ini
+++ b/configs/sim/gmoccapy/gmoccapy_4_axis.ini
@@ -13,8 +13,13 @@ CYCLE_TIME =            100
 
 # Highest value that will be allowed for feed override, 1.0 = 100%
 MAX_FEED_OVERRIDE =     1.5
-MAX_SPINDLE_OVERRIDE =  1.2
-MIN_SPINDLE_OVERRIDE = .5
+MAX_SPINDLE_0_OVERRIDE =  1.2
+MIN_SPINDLE_0_OVERRIDE = .5
+
+# Initial value for spindle speed
+# The value will be used the first time Gmoccapy is loaded.
+# It will then be overwritten by the *.pref file.
+DEFAULT_SPINDLE_0_SPEED = 450
 
 # Prefix to be used
 PROGRAM_PREFIX = ../../nc_files/

--- a/configs/sim/gmoccapy/gmoccapy_800x600.ini
+++ b/configs/sim/gmoccapy/gmoccapy_800x600.ini
@@ -22,14 +22,18 @@ CYCLE_TIME = 100
 
 # Values that will be allowed for override, 1.0 = 100%
 MAX_FEED_OVERRIDE    = 1.5
-MAX_SPINDLE_OVERRIDE = 1.2
-MIN_SPINDLE_OVERRIDE = 0.5
+MAX_SPINDLE_0_OVERRIDE = 1.2
+MIN_SPINDLE_0_OVERRIDE = 0.5
+
+# Initial value for spindle speed
+# The value will be used the first time Gmoccapy is loaded.
+# It will then be overwritten by the *.pref file.
+DEFAULT_SPINDLE_0_SPEED = 450
 
 # Max and default jog speeds in units per second
 MAX_LINEAR_VELOCITY     = 166
 DEFAULT_LINEAR_VELOCITY = 100
 MAX_ANGULAR_VELOCITY    = 234
-DEFAULT_SPINDLE_SPEED   = 450
 
 # Prefix to be used
 PROGRAM_PREFIX = ../../nc_files/

--- a/configs/sim/gmoccapy/gmoccapy_XYZAB.ini
+++ b/configs/sim/gmoccapy/gmoccapy_XYZAB.ini
@@ -35,8 +35,13 @@ CYCLE_TIME =            100
 
 # Highest value that will be allowed for feed override, 1.0 = 100%
 MAX_FEED_OVERRIDE =     1.5
-MAX_SPINDLE_OVERRIDE =  1.2
-MIN_SPINDLE_OVERRIDE = .5
+MAX_SPINDLE_0_OVERRIDE =  1.2
+MIN_SPINDLE_0_OVERRIDE = .5
+
+# Initial value for spindle speed
+# The value will be used the first time Gmoccapy is loaded.
+# It will then be overwritten by the *.pref file.
+DEFAULT_SPINDLE_0_SPEED = 450
 
 # Max and default jog speeds in units per second
 MAX_LINEAR_VELOCITY =   166

--- a/configs/sim/gmoccapy/gmoccapy_XYZAC.ini
+++ b/configs/sim/gmoccapy/gmoccapy_XYZAC.ini
@@ -26,8 +26,13 @@ CYCLE_TIME =            100
 
 # Highest value that will be allowed for feed override, 1.0 = 100%
 MAX_FEED_OVERRIDE =     1.5
-MAX_SPINDLE_OVERRIDE =  1.2
-MIN_SPINDLE_OVERRIDE = .5
+MAX_SPINDLE_0_OVERRIDE =  1.2
+MIN_SPINDLE_0_OVERRIDE = .5
+
+# Initial value for spindle speed
+# The value will be used the first time Gmoccapy is loaded.
+# It will then be overwritten by the *.pref file.
+DEFAULT_SPINDLE_0_SPEED = 450
 
 # Max and default jog speeds in units per second
 MAX_LINEAR_VELOCITY =   166

--- a/configs/sim/gmoccapy/gmoccapy_XYZCW.ini
+++ b/configs/sim/gmoccapy/gmoccapy_XYZCW.ini
@@ -9,7 +9,7 @@
 [EMC]
 
 VERSION = 1.1
-MACHINE =               gmoccapy XYZAB
+MACHINE =               gmoccapy XYZCW
 DEBUG = 0
 #DEBUG =               0x7FFFFFFF
 
@@ -22,8 +22,13 @@ CYCLE_TIME =            100
 
 # Highest value that will be allowed for feed override, 1.0 = 100%
 MAX_FEED_OVERRIDE =     1.5
-MAX_SPINDLE_OVERRIDE =  1.2
-MIN_SPINDLE_OVERRIDE = .5
+MAX_SPINDLE_0_OVERRIDE =  1.2
+MIN_SPINDLE_0_OVERRIDE = .5
+
+# Initial value for spindle speed
+# The value will be used the first time Gmoccapy is loaded.
+# It will then be overwritten by the *.pref file.
+DEFAULT_SPINDLE_0_SPEED = 450
 
 # Max and default jog speeds in units per second
 MAX_LINEAR_VELOCITY =   166

--- a/configs/sim/gmoccapy/gmoccapy_blockdelete.ini
+++ b/configs/sim/gmoccapy/gmoccapy_blockdelete.ini
@@ -22,14 +22,18 @@ CYCLE_TIME =            100
 
 # Values that will be allowed for override, 1.0 = 100%
 MAX_FEED_OVERRIDE    =  1.5
-MAX_SPINDLE_OVERRIDE =  1.2
-MIN_SPINDLE_OVERRIDE = 0.5
+MAX_SPINDLE_0_OVERRIDE =  1.2
+MIN_SPINDLE_0_OVERRIDE = 0.5
+
+# Initial value for spindle speed
+# The value will be used the first time Gmoccapy is loaded.
+# It will then be overwritten by the *.pref file.
+DEFAULT_SPINDLE_0_SPEED = 450
 
 # Max and default jog speeds in units per second
 MAX_LINEAR_VELOCITY =   166
 DEFAULT_LINEAR_VELOCITY = 100
 MAX_ANGULAR_VELOCITY = 234
-DEFAULT_SPINDLE_SPEED = 450
 
 # Prefix to be used
 PROGRAM_PREFIX = ../../nc_files/

--- a/configs/sim/gmoccapy/gmoccapy_left_panel.ini
+++ b/configs/sim/gmoccapy/gmoccapy_left_panel.ini
@@ -22,8 +22,13 @@ CYCLE_TIME =            100
 
 # Highest value that will be allowed for feed override, 1.0 = 100%
 MAX_FEED_OVERRIDE =     1.5
-MAX_SPINDLE_OVERRIDE =  1.2
-MIN_SPINDLE_OVERRIDE = .5
+MAX_SPINDLE_0_OVERRIDE =  1.2
+MIN_SPINDLE_0_OVERRIDE = .5
+
+# Initial value for spindle speed
+# The value will be used the first time Gmoccapy is loaded.
+# It will then be overwritten by the *.pref file.
+DEFAULT_SPINDLE_0_SPEED = 450
 
 # Prefix to be used
 PROGRAM_PREFIX = ../../nc_files/

--- a/configs/sim/gmoccapy/gmoccapy_messages.ini
+++ b/configs/sim/gmoccapy/gmoccapy_messages.ini
@@ -18,8 +18,13 @@ CYCLE_TIME =            100
 
 # Highest value that will be allowed for feed override, 1.0 = 100%
 MAX_FEED_OVERRIDE =     1.5
-MAX_SPINDLE_OVERRIDE =  1.2
-MIN_SPINDLE_OVERRIDE = .5
+MAX_SPINDLE_0_OVERRIDE =  1.2
+MIN_SPINDLE_0_OVERRIDE = .5
+
+# Initial value for spindle speed
+# The value will be used the first time Gmoccapy is loaded.
+# It will then be overwritten by the *.pref file.
+DEFAULT_SPINDLE_0_SPEED = 450
 
 # Max and default jog speeds in units per second
 MAX_LINEAR_VELOCITY =   166

--- a/configs/sim/gmoccapy/gmoccapy_pedant.ini
+++ b/configs/sim/gmoccapy/gmoccapy_pedant.ini
@@ -22,8 +22,13 @@ CYCLE_TIME =            100
 
 # Highest value that will be allowed for feed override, 1.0 = 100%
 MAX_FEED_OVERRIDE =     1.5
-MAX_SPINDLE_OVERRIDE =  1.2
-MIN_SPINDLE_OVERRIDE = .5
+MAX_SPINDLE_0_OVERRIDE =  1.2
+MIN_SPINDLE_0_OVERRIDE = .5
+
+# Initial value for spindle speed
+# The value will be used the first time Gmoccapy is loaded.
+# It will then be overwritten by the *.pref file.
+DEFAULT_SPINDLE_0_SPEED = 450
 
 # Prefix to be used
 PROGRAM_PREFIX = /home/emcmesa/linuxcnc/nc_files

--- a/configs/sim/gmoccapy/gmoccapy_pyngcgui.ini
+++ b/configs/sim/gmoccapy/gmoccapy_pyngcgui.ini
@@ -50,14 +50,18 @@ CYCLE_TIME =            100
 
 # Values that will be allowed for override, 1.0 = 100%
 MAX_FEED_OVERRIDE    =  1.5
-MAX_SPINDLE_OVERRIDE =  1.2
-MIN_SPINDLE_OVERRIDE = 0.5
+MAX_SPINDLE_0_OVERRIDE =  1.2
+MIN_SPINDLE_0_OVERRIDE = 0.5
+
+# Initial value for spindle speed
+# The value will be used the first time Gmoccapy is loaded.
+# It will then be overwritten by the *.pref file.
+DEFAULT_SPINDLE_0_SPEED = 450
 
 # Max and default jog speeds in units per second
 MAX_LINEAR_VELOCITY =   166
 DEFAULT_LINEAR_VELOCITY = 100
 MAX_ANGULAR_VELOCITY = 234
-DEFAULT_SPINDLE_SPEED = 450
 
 # Prefix to be used
 PROGRAM_PREFIX = ../../nc_files/

--- a/configs/sim/gmoccapy/gmoccapy_pyngcgui_gcmc.ini
+++ b/configs/sim/gmoccapy/gmoccapy_pyngcgui_gcmc.ini
@@ -62,14 +62,18 @@ CYCLE_TIME =            100
 
 # Values that will be allowed for override, 1.0 = 100%
 MAX_FEED_OVERRIDE    =  1.5
-MAX_SPINDLE_OVERRIDE =  1.2
-MIN_SPINDLE_OVERRIDE = 0.5
+MAX_SPINDLE_0_OVERRIDE =  1.2
+MIN_SPINDLE_0_OVERRIDE = 0.5
+
+# Initial value for spindle speed
+# The value will be used the first time Gmoccapy is loaded.
+# It will then be overwritten by the *.pref file.
+DEFAULT_SPINDLE_0_SPEED = 450
 
 # Max and default jog speeds in units per second
 MAX_LINEAR_VELOCITY =   166
 DEFAULT_LINEAR_VELOCITY = 100
 MAX_ANGULAR_VELOCITY = 234
-DEFAULT_SPINDLE_SPEED = 450
 
 # Introductory graphic
 INTRO_GRAPHIC = linuxcnc.gif

--- a/configs/sim/gmoccapy/gmoccapy_qt_messages.ini
+++ b/configs/sim/gmoccapy/gmoccapy_qt_messages.ini
@@ -22,14 +22,19 @@ CYCLE_TIME = 100
 
 # Values that will be allowed for override, 1.0 = 100%
 MAX_FEED_OVERRIDE    = 1.5
-MAX_SPINDLE_OVERRIDE = 1.2
-MIN_SPINDLE_OVERRIDE = 0.5
+MAX_SPINDLE_0_OVERRIDE = 1.2
+MIN_SPINDLE_0_OVERRIDE = 0.5
+
+# Initial value for spindle speed
+# The value will be used the first time Gmoccapy is loaded.
+# It will then be overwritten by the *.pref file.
+DEFAULT_SPINDLE_0_SPEED = 450
 
 # Max and default jog speeds in units per second
 MAX_LINEAR_VELOCITY     = 166
 DEFAULT_LINEAR_VELOCITY = 100
 MAX_ANGULAR_VELOCITY    = 234
-DEFAULT_SPINDLE_SPEED   = 450
+
 
 # Prefix to be used
 PROGRAM_PREFIX = ../../nc_files/

--- a/configs/sim/gmoccapy/gmoccapy_right_panel.ini
+++ b/configs/sim/gmoccapy/gmoccapy_right_panel.ini
@@ -18,8 +18,13 @@ CYCLE_TIME =            100
 
 # Highest value that will be allowed for feed override, 1.0 = 100%
 MAX_FEED_OVERRIDE =     1.5
-MAX_SPINDLE_OVERRIDE =  1.2
-MIN_SPINDLE_OVERRIDE = .5
+MAX_SPINDLE_0_OVERRIDE =  1.2
+MIN_SPINDLE_0_OVERRIDE = .5
+
+# Initial value for spindle speed
+# The value will be used the first time Gmoccapy is loaded.
+# It will then be overwritten by the *.pref file.
+DEFAULT_SPINDLE_0_SPEED = 450
 
 # Prefix to be used
 PROGRAM_PREFIX = ../../nc_files/

--- a/configs/sim/gmoccapy/gmoccapy_sim_hardware_button.ini
+++ b/configs/sim/gmoccapy/gmoccapy_sim_hardware_button.ini
@@ -25,8 +25,13 @@ CYCLE_TIME =            100
 
 # Highest value that will be allowed for feed override, 1.0 = 100%
 MAX_FEED_OVERRIDE =     1.5
-MAX_SPINDLE_OVERRIDE =  1.2
-MIN_SPINDLE_OVERRIDE = .5
+MAX_SPINDLE_0_OVERRIDE =  1.2
+MIN_SPINDLE_0_OVERRIDE = .5
+
+# Initial value for spindle speed
+# The value will be used the first time Gmoccapy is loaded.
+# It will then be overwritten by the *.pref file.
+DEFAULT_SPINDLE_0_SPEED = 450
 
 # Prefix to be used
 PROGRAM_PREFIX = ../../nc_files/

--- a/configs/sim/gmoccapy/gmoccapy_tool_sensor.ini
+++ b/configs/sim/gmoccapy/gmoccapy_tool_sensor.ini
@@ -30,10 +30,13 @@ CYCLE_TIME =            100
 
 # Highest value that will be allowed for feed override, 1.0 = 100%
 MAX_FEED_OVERRIDE =     1.5
-MAX_SPINDLE_OVERRIDE =  1.2
-MIN_SPINDLE_OVERRIDE = .5
+MAX_SPINDLE_0_OVERRIDE =  1.2
+MIN_SPINDLE_0_OVERRIDE = .5
 
-DEFAULT_SPINDLE_SPEED = 450
+# Initial value for spindle speed
+# The value will be used the first time Gmoccapy is loaded.
+# It will then be overwritten by the *.pref file.
+DEFAULT_SPINDLE_0_SPEED = 450
 
 # Prefix to be used
 PROGRAM_PREFIX = ../../../nc_files/

--- a/configs/sim/gmoccapy/gmoccapy_with_user_tabs.ini
+++ b/configs/sim/gmoccapy/gmoccapy_with_user_tabs.ini
@@ -42,8 +42,13 @@ CYCLE_TIME =            100
 
 # Highest value that will be allowed for feed override, 1.0 = 100%
 MAX_FEED_OVERRIDE =     1.5
-MAX_SPINDLE_OVERRIDE =  1.2
-MIN_SPINDLE_OVERRIDE = .5
+MAX_SPINDLE_0_OVERRIDE =  1.2
+MIN_SPINDLE_0_OVERRIDE = .5
+
+# Initial value for spindle speed
+# The value will be used the first time Gmoccapy is loaded.
+# It will then be overwritten by the *.pref file.
+DEFAULT_SPINDLE_0_SPEED = 450
 
 # Prefix to be used
 PROGRAM_PREFIX = ../../nc_files/

--- a/src/emc/usr_intf/gmoccapy/getiniinfo.py
+++ b/src/emc/usr_intf/gmoccapy/getiniinfo.py
@@ -278,27 +278,27 @@ class GetIniInfo:
             LOG.warning("No MIN_ANGULAR_VELOCITY entry found in [DISPLAY] of INI file. Using default value of 0.1 degree / min.")
         return float(temp)
 
-    def get_default_spindle_speed(self):
+    def get_default_spindle_0_speed(self):
         # check for default spindle speed settings
-        temp = self.inifile.find("DISPLAY", "DEFAULT_SPINDLE_SPEED")
+        temp = self.inifile.find("DISPLAY", "DEFAULT_SPINDLE_0_SPEED")
         if not temp:
             temp = 300
-            LOG.warning("No DEFAULT_SPINDLE_SPEED entry found in [DISPLAY] of INI file")
+            LOG.warning("No DEFAULT_SPINDLE_0_SPEED entry found in [DISPLAY] of INI file")
         return float(temp)
 
-    def get_max_spindle_override(self):
+    def get_max_spindle_0_override(self):
         # check for override settings
-        temp = self.inifile.find("DISPLAY", "MAX_SPINDLE_OVERRIDE")
+        temp = self.inifile.find("DISPLAY", "MAX_SPINDLE_0_OVERRIDE")
         if not temp:
             temp = 1.0
-            LOG.warning("No MAX_SPINDLE_OVERRIDE entry found in [DISPLAY] of INI file")
+            LOG.warning("No MAX_SPINDLE_0_OVERRIDE entry found in [DISPLAY] of INI file")
         return float(temp)
 
-    def get_min_spindle_override(self):
-        temp = self.inifile.find("DISPLAY", "MIN_SPINDLE_OVERRIDE")
+    def get_min_spindle_0_override(self):
+        temp = self.inifile.find("DISPLAY", "MIN_SPINDLE_0_OVERRIDE")
         if not temp:
             temp = 0.1
-            LOG.warning("No MIN_SPINDLE_OVERRIDE entry found in [DISPLAY] of INI file")
+            LOG.warning("No MIN_SPINDLE_0_OVERRIDE entry found in [DISPLAY] of INI file")
         return float(temp)
 
     def get_max_feed_override(self):

--- a/src/emc/usr_intf/gmoccapy/gmoccapy.py
+++ b/src/emc/usr_intf/gmoccapy/gmoccapy.py
@@ -582,8 +582,8 @@ class gmoccapy(object):
         self.rabbit_jog = self.get_ini_info.get_jog_vel()
         self.jog_rate_max = self.get_ini_info.get_max_jog_vel()
 
-        self.spindle_override_max = self.get_ini_info.get_max_spindle_override()
-        self.spindle_override_min = self.get_ini_info.get_min_spindle_override()
+        self.spindle_override_max = self.get_ini_info.get_max_spindle_0_override()
+        self.spindle_override_min = self.get_ini_info.get_min_spindle_0_override()
         self.feed_override_max = self.get_ini_info.get_max_feed_override()
         self.dro_actual = self.get_ini_info.get_position_feedback_actual()
 
@@ -627,7 +627,7 @@ class gmoccapy(object):
 
         # if there is a INI Entry for default spindle speed, we will use that one as default
         # but if there is a setting in our preference file, that one will beet the INI entry
-        default_spindle_speed = self.get_ini_info.get_default_spindle_speed()
+        default_spindle_speed = self.get_ini_info.get_default_spindle_0_speed()
         self.spindle_start_rpm = self.prefs.getpref( 'spindle_start_rpm', default_spindle_speed, float )
 
         self.kbd_height = self.prefs.getpref("kbd_height", 250, int)

--- a/src/emc/usr_intf/pncconf/build_INI.py
+++ b/src/emc/usr_intf/pncconf/build_INI.py
@@ -78,12 +78,20 @@ class INI:
         if self.d.position_feedback == 1: temp ="ACTUAL"
         else: temp = "COMMANDED"
         print("POSITION_FEEDBACK = %s"% temp, file=file)
+        print(file=file)
+        print("# Highest value that will be allowed for feed override, 1.0 = 100%", file=file)
         print("MAX_FEED_OVERRIDE = %f"% self.d.max_feed_override, file=file)
 
-        if self.d.frontend == _PD._QTDRAGON:
+        if self.d.frontend == _PD._QTDRAGON or self.d.frontend == _PD._GMOCCAPY:
             print("MAX_SPINDLE_0_OVERRIDE = %f"% self.d.max_spindle_override, file=file)
             print("MIN_SPINDLE_0_OVERRIDE = %f"% self.d.min_spindle_override, file=file)
+            print(file=file)
+            print("# Initial value for spindle speed", file=file)
+            if self.d.frontend == _PD._GMOCCAPY:
+                print("# The value will be used the first time Gmoccapy is loaded", file=file)
+                print("# # It will then be overwritten by the *.pref file", file=file)
             print("DEFAULT_SPINDLE_0_SPEED = 500", file=file)
+            print(file=file)
             print("MIN_SPINDLE_0_SPEED = 100", file=file)
             print("MAX_SPINDLE_0_SPEED = 2500", file=file)
         # qtplasmac doesn't use spindle override
@@ -91,13 +99,20 @@ class INI:
             print("MAX_SPINDLE_OVERRIDE = %f"% self.d.max_spindle_override, file=file)
             print("MIN_SPINDLE_OVERRIDE = %f"% self.d.min_spindle_override, file=file)
 
+        print(file=file)
+        print("# Introductory graphic", file=file)
         print("INTRO_GRAPHIC = linuxcnc.gif", file=file)
         print("INTRO_TIME = 5", file=file)
+        print(file=file)
+        print("# Prefix to be used", file=file)
         print("PROGRAM_PREFIX = %s" % \
                                     os.path.expanduser("~/linuxcnc/nc_files"), file=file)
+        print(file=file)
         if self.d.pyvcp:
             print("PYVCP = pyvcp-panel.xml", file=file)
+            print(file=file)
         # these are for AXIS GUI and QtPlasmaC
+        print("# list of selectable jog increments", file=file)
         if self.d.units == _PD._METRIC:
             if self.d.frontend == _PD._QTPLASMAC:
                 print("INCREMENTS = %s"% self.d.increments_metric_qtplasmac, file=file)
@@ -108,6 +123,7 @@ class INI:
                 print("INCREMENTS = %s"% self.d.increments_imperial_qtplasmac, file=file)
             else:
                 print("INCREMENTS = %s"% self.d.increments_imperial, file=file)
+        print(file=file)
         if self.d.axes == 2:
             print("LATHE = 1", file=file)
         print("POSITION_FEEDBACK = %s"% temp, file=file)
@@ -121,6 +137,8 @@ class INI:
         if self.d.frontend != _PD._QTPLASMAC:
             print("EDITOR = %s"% self.d.editor, file=file)
         print("GEOMETRY = %s"% self.d.geometry, file=file)
+        print(file=file)
+        print("# Cycle time, in milliseconds, that display will sleep between polls", file=file)
         print("CYCLE_TIME = 100", file=file)
 
         # set up MDI macro buttons


### PR DESCRIPTION
RIP installation
LCNC 2.10
GUI Gmoccapy

How did it start?
I had a clean configuration from PncConf and after starting LCNC it gave me these error messages:
```
[Gmoccapy.QTVCP.QT_ISTAT][WARNING]  INI Parsing Error, No MIN_SPINDLE_0_SPEED Entry in DISPLAY, Using: 100 (qt_istat.py:676)
[Gmoccapy.QTVCP.QT_ISTAT][WARNING]  INI Parsing Error, No MAX_SPINDLE_0_SPEED Entry in DISPLAY, Using: 2500 (qt_istat.py:676)
[Gmoccapy.QTVCP.QT_ISTAT][WARNING]  INI Parsing Error, No MAX_SPINDLE_0_OVERRIDE Entry in DISPLAY, Using: 1 (qt_istat.py:676)
[Gmoccapy.QTVCP.QT_ISTAT][WARNING]  INI Parsing Error, No MIN_SPINDLE_0_OVERRIDE Entry in DISPLAY, Using: 0.5 (qt_istat.py:676)
```

So I edited spindle => spindle_0 in the INI files.
The problem was that the QT_ISTAT error messages disappeared, but the Gmoccapy error messages appeared.
So I had to edit Gmoccapy to require spindle_0.
Finally, I edited PncConf to generate spindle_0 for Gmoccapy.
While I was playing with PncConf, I added more comments to the generated INI files.