### PR TITLE
Gmoccapy: Fix some warnings related to virual keyboard and panels on shutdown

### DIFF
--- a/src/emc/usr_intf/gmoccapy/gmoccapy.py
+++ b/src/emc/usr_intf/gmoccapy/gmoccapy.py
@@ -1864,7 +1864,6 @@ class gmoccapy(object):
             if type(child) == Gtk.Socket:
                 if self.onboard:
                     self._kill_keyboard()
-                    child.disconnect(child.get_id())
             else:
                 child.terminate()
 


### PR DESCRIPTION
This fixes some warnings on shutdown:
![shutdown current](https://github.com/user-attachments/assets/0f3664a8-d0ed-4580-953b-e32801e5e6dc)

there is still a warning when using custom tabs/ panels:

![shutdown now](https://github.com/user-attachments/assets/a45813b0-1daf-4f3a-91d1-960944e177cd)

I have tested the onboard keyboard reliably closing on shutting down Gmoccapy. 
