### PR TITLE
Fix hm2 modbus

### DIFF
--- a/docs/src/man/man1/mesambccc.1.adoc
+++ b/docs/src/man/man1/mesambccc.1.adoc
@@ -97,6 +97,7 @@ needs to be covered. Differences are primarily byte-ordering.
 
 The byte-ordering is specified with one of the following suffixes:
 
+* `_A`, `_B`
 * `_AB`, `_BA`
 * `_ABCD`, `_BADC`, `_CDAB`, `_DCBA`
 * `_ABCDEFGH`, `_BADCFEHG`, `_CDABGHEF`, `_DCBAHGFE`,
@@ -107,6 +108,18 @@ Modbus standard byte-ordering is big-endian, which is the first in each list
 may use any of the byte-orderings necessary and required because some device
 vendors have not paid attention to the proper on-wire ordering.
 
+The orderings `_A` and `_B` are single byte values from a modbus register. A
+single byte will be taken from the register value. You cannot access successive
+bytes from the same register using these types. (You require a second component
+that de-multiplexes the HAL value(s) into individual bytes from the data stream
+using the hm2_modbus presented pin values.) +
+The ordering `_A` will use the the least significant byte (LSB), with respect
+to the default big endian order for Modbus. Ordering `_B` will use the most
+significant byte (MSB). Note that there is no floating point type when only
+using sizes of one single byte. +
+Single byte values have the additional restriction that they cannot be used as
+data values in '<initlist>/<command>/<data>'.
+
 The byte-ordering suffix is prefixed with S (signed), U (unsigned) or F (float)
 to complete the 'modbustype' attribute value. For example, a 32-bit float in
 big-endian is named `F_ABCD`. A 64-bit signed integer value in little-endian is
@@ -115,6 +128,9 @@ S_HGFEDCBA.
 The types have following ranges and will be clamped to the min/max values if
 the 'clamp' attribute is set in the '<command>':
 
+* 8-bit:
+ ** signed integer [-128..+127] (`S_A`, `S_B`)
+ ** unsigned integer [0..255] (`U_A`, `U_B`)
 * 16-bit:
  ** float16 [-65504.0..+65504.0] (`F_AB`, `F_BA`)
  ** signed integer [-32768..+32767] (`S_AB`, `S_BA`)
@@ -177,9 +193,11 @@ other setup values as attributes:
   and reply sizes. The 'timeout' value can be overridden in the '<command>'
   definitions. Default auto.
 *writeflush* [Boolean]::
-  Set to true when the _very first_ round of write commands must be flushed to
-  synchronize the internal state to the pin state. This flush happens either
-  once when the module starts or each time the module comes out of 'suspend'. +
+  Set to true when the first round of write commands must synchronize the
+  internal state to the pin state. The writes are calculated but not sent to
+  the Modbus device (i.e. flushed). This flush happens either once when the
+  module starts, each time when the module comes out of 'suspend', or
+  specifically for a command when it gets re-enabled. +
   The write flush is necessary when you need to ensure proper and correct pin
   data is present _before_ the Modbus commands start sending potentially
   harmful or invalid data because the pins have not yet been initialized to
@@ -496,6 +514,15 @@ Recognized '<commands>/<command>' attributes:
   The Modbus device to communicate with. The 'device' attribute
   references '<device>[name]'. +
   The device name '`broadcast`' will send the command to all devices on the bus.
+*disabled* [Boolean]::
+  Start the command in disabled state when set, preventing it from being
+  executed. Using the 'disabled' flag is a fine grain per command control.
+  In contrast, 'suspend' works on the entire state machine and controls
+  operation of all commands in an all-or-nothing way. A command in the disabled
+  state can be enabled by toggling the reset pin of the command. Using 'disable'
+  can be particularly useful when you need to delay one particular command
+  while others may already be run. The 'writeflush' setting is honored when
+  coming out of the disabled state. Default false.
 *function* [see link:#_modbus_functions[*MODBUS FUNCTIONS*]]::
   The attribute value is one of the supported Modbus functions.
 *haltype* [see link:#_hal_types[*HAL TYPES*]]::

--- a/docs/src/man/man1/mesambccc.1.adoc
+++ b/docs/src/man/man1/mesambccc.1.adoc
@@ -591,6 +591,14 @@ Recognized '<commands>/<command>' attributes:
   should be emitted when it does. This differs from 'noanswer' in that a reply
   may be expected within the timeout period but not after the timeout expires.
   This may be required for flaky devices. Default false.
+*unaligned* [Boolean]::
+  Set to true to suppress the alignment warning in multi-register reads or
+  writes where 32-bit or 64-bit values are not aligned to their natural Modbus
+  address boundaries. This is useful for devices that do not care about
+  alignment or do not use Modbus addresses in conventional ways. +
+  Setting 'unaligned' is purely a cosmetic attribute to suppress console
+  clutter when compiling the mbccs file. It has no functional effect on the
+  communication with the device. Default false.
 *writeflush* [Boolean]::
   The override the 'writeflush' value. See '<mesamodbus>[writeflush]' for
   details. Default '<mesamodbus>[writeflush]'.

--- a/docs/src/man/man9/hm2_modbus.9.adoc
+++ b/docs/src/man/man9/hm2_modbus.9.adoc
@@ -142,6 +142,9 @@ Each command in the MBCCB file (not init commands) will generate a set of pins
 to reflect the current state, where `MM` is the command number counting from zero
 (00):
 
+hm2_modbus.N.command.MM.disable (bit, input)::
+  Disable this command on the rising edge of this pin. You need to use the
+  command's corresponding reset pin to re-enable it.
 hm2_modbus.N.command.MM.disabled (bit, output)::
   Set if the command is no longer sent in the commands loop.
 hm2_modbus.N.command.MM.error-code (u32, output)::
@@ -149,6 +152,7 @@ hm2_modbus.N.command.MM.error-code (u32, output)::
 
   ** 5,  0x05 (EIO): The receiver detected an overrun, a false start-bit or wrong parity.
   ** 9,  0x09 (EBADF): The reply returned an unsupported function.
+  ** 11, 0x0b (EAGAIN): The command was manually disabled in the mbccb or via the disable pin.
   ** 22, 0x16 (EINVAL): An invalid value was detected (internal error).
   ** 27, 0x1b (EFBIG): The received data packet size exceeds the internally allocated buffer.
   ** 34, 0x22 (ERANGE): The received data packet was too small or the message's length indicator was wrong.
@@ -166,7 +170,9 @@ hm2_modbus.N.command.MM.errors (u32, output)::
   when the command succeeds.
 hm2_modbus.N.command.MM.reset (bit, input)::
   Reset this command's error counter and re-enable the command on the rising
-  edge of the input pin.
+  edge of the input pin. +
+  Note: Re-enabling the command will honor the 'writeflush' setting of the
+  command.
 
 Each mbccb file will generate a set of pins as defined in the mbccb file. See
 *mesambccc*(1) for details.

--- a/src/hal/drivers/mesa-hostmot2/hm2_modbus.c
+++ b/src/hal/drivers/mesa-hostmot2/hm2_modbus.c
@@ -1472,9 +1472,9 @@ static int build_data_frame(hm2_modbus_inst_t *inst)
 		for(unsigned i = 0; i < cc->cmd.cpincnt; i++) {
 			// Stuff empty space with zeros.
 			// The device must allow writes at the address(es).
-			while(regpos != cc->typeptr[i].regofs) {
+			while(regpos < cc->typeptr[i].regofs) {
 				CHK_RV(ch_append16(cc, 0));
-				regpos += 2;
+				regpos++;
 			}
 			switch(cc->typeptr[i].htype) {
 			case HAL_BIT:
@@ -1546,6 +1546,7 @@ static int build_data_frame(hm2_modbus_inst_t *inst)
 				// Oops...
 				break;
 			}
+			regpos += mtypesize(cc->typeptr[i].mtype);
 			p++;
 		}
 		break;

--- a/src/hal/drivers/mesa-hostmot2/hm2_modbus.h
+++ b/src/hal/drivers/mesa-hostmot2/hm2_modbus.h
@@ -25,7 +25,7 @@
 // Max one minute delay between init commands (in microseconds)
 #define MAXDELAY 60000000
 // Max chars for a name
-#define MAXPINNAME 24
+#define MAXPINNAME 32
 //
 // 16*4 byte structure
 // All values in Big-Endian

--- a/src/hal/drivers/mesa-hostmot2/hm2_modbus.h
+++ b/src/hal/drivers/mesa-hostmot2/hm2_modbus.h
@@ -80,12 +80,13 @@ typedef struct {
 #define MBCCB_CMDF_BCANSWER  0x0002	// Broadcasts will get an answer, ignore it
 #define MBCCB_CMDF_NOANSWER  0x0004	// Don't expect an answer
 #define MBCCB_CMDF_RESEND    0x0008	// Resend the write even if no pins are changed
-#define MBCCB_CMDF_WFLUSH    0x0010 // Don't write initial pin values but flush the output
+#define MBCCB_CMDF_WFLUSH    0x0010	// Don't write initial pin values but flush the output
+#define MBCCB_CMDF_DISABLED  0x0020	// Start this command in disabled mode and must be reset
 #define MBCCB_CMDF_PARITYEN  0x0100	// Init-only parity change
 #define MBCCB_CMDF_PARITYODD 0x0200	// Init-only parity change
 #define MBCCB_CMDF_STOPBITS2 0x0400	// Init-only stopbits change
 #define MBCCB_CMDF_INITMASK  0x0707	// sum of allowed flags in init
-#define MBCCB_CMDF_MASK      0x001f	// sum of allowed normal command flags
+#define MBCCB_CMDF_MASK      0x003f	// sum of allowed normal command flags
 
 #define MBCCB_PINF_SCALE	0x01	// Add scale/offset pins
 #define MBCCB_PINF_CLAMP	0x02	// Clamp values to fit target

--- a/src/hal/drivers/mesa-hostmot2/mesambccc.py
+++ b/src/hal/drivers/mesa-hostmot2/mesambccc.py
@@ -304,11 +304,12 @@ MBCCB_CMDF_BCANSWER = 0x0002
 MBCCB_CMDF_NOANSWER = 0x0004
 MBCCB_CMDF_RESEND   = 0x0008
 MBCCB_CMDF_WFLUSH   = 0x0010
+MBCCB_CMDF_DISABLED = 0x0020
 MBCCB_CMDF_PARITYEN = 0x0100
 MBCCB_CMDF_PARITYODD= 0x0200
 MBCCB_CMDF_STOPBITS2= 0x0400
 MBCCB_CMDF_INITMASK = 0x0707 # sum of allowed flags in init
-MBCCB_CMDF_MASK     = 0x001f # sum of allowed normal command flags
+MBCCB_CMDF_MASK     = 0x003f # sum of allowed normal command flags
 
 # Allowed attributes in <mesamodbus>
 MESAATTRIB = [ 'baudrate', 'drivedelay', 'duplex',   'icdelay', 'interval',
@@ -316,10 +317,10 @@ MESAATTRIB = [ 'baudrate', 'drivedelay', 'duplex',   'icdelay', 'interval',
                'txdelay',  'writeflush' ]
 
 # Allowed attributes in <commands>/<command>
-CMDSATTRIB = [ 'address',     'bcanswer', 'clamp',   'count',    'delay',
-               'device',      'function', 'haltype', 'interval', 'modbustype',
-               'name',        'noanswer', 'resend',  'scale',    'timeout',
-               'timeoutbits', 'timesout', 'writeflush' ]
+CMDSATTRIB = [ 'address',    'bcanswer',    'clamp',    'count',   'delay',
+               'device',     'disabled',    'function', 'haltype', 'interval',
+               'modbustype', 'name',        'noanswer', 'resend',  'scale',
+               'timeout',    'timeoutbits', 'timesout', 'writeflush' ]
 
 # Allowed attributes in <commands>/<command>/<pin>
 PINSATTRIB = [ 'clamp', 'name', 'haltype', 'modbustype', 'scale' ]
@@ -492,7 +493,7 @@ def cflagList(flags):
         return "<none>"
     l = { MBCCB_CMDF_TIMESOUT: 'timesout', MBCCB_CMDF_BCANSWER: 'bcanswer',
           MBCCB_CMDF_NOANSWER: 'noanswer', MBCCB_CMDF_RESEND:   'resend',
-          MBCCB_CMDF_WFLUSH:   'writeflush' }
+          MBCCB_CMDF_DISABLED: 'disabled', MBCCB_CMDF_WFLUSH:   'writeflush' }
     return ','.join([l[v] for v in l.keys() if flags & v])
 
 def pflagList(flags):
@@ -625,6 +626,7 @@ def parseOptFlags(dev, attrs, cflags, pflags, ers):
     cflags |= MBCCB_CMDF_BCANSWER if getBoolean(attrs, 'bcanswer') else 0
     cflags |= MBCCB_CMDF_NOANSWER if getBoolean(attrs, 'noanswer') else 0
     cflags |= MBCCB_CMDF_RESEND   if getBoolean(attrs, 'resend')   else 0
+    cflags |= MBCCB_CMDF_DISABLED if getBoolean(attrs, 'disabled') else 0
     # The default of writeflush depends on the global setting
     cflags |= MBCCB_CMDF_WFLUSH   if getBoolean(attrs, 'writeflush') else 0
     cflags &= ~MBCCB_CMDF_WFLUSH  if False == getBoolean(attrs, 'writeflush') else ~0

--- a/src/hal/drivers/mesa-hostmot2/mesambccc.py
+++ b/src/hal/drivers/mesa-hostmot2/mesambccc.py
@@ -317,10 +317,10 @@ MESAATTRIB = [ 'baudrate', 'drivedelay', 'duplex',   'icdelay', 'interval',
                'txdelay',  'writeflush' ]
 
 # Allowed attributes in <commands>/<command>
-CMDSATTRIB = [ 'address',    'bcanswer',    'clamp',    'count',   'delay',
-               'device',     'disabled',    'function', 'haltype', 'interval',
-               'modbustype', 'name',        'noanswer', 'resend',  'scale',
-               'timeout',    'timeoutbits', 'timesout', 'writeflush' ]
+CMDSATTRIB = [ 'address',    'bcanswer',    'clamp',    'count',     'delay',
+               'device',     'disabled',    'function', 'haltype',   'interval',
+               'modbustype', 'name',        'noanswer', 'resend',    'scale',
+               'timeout',    'timeoutbits', 'timesout', 'unaligned', 'writeflush' ]
 
 # Allowed attributes in <commands>/<command>/<pin>
 PINSATTRIB = [ 'clamp', 'name', 'haltype', 'modbustype', 'scale' ]
@@ -1323,8 +1323,9 @@ def handleCommands(commands):
 
             if ((mbtOrderSize(pmtype[0]) == 4 and 0 != ((address + regofs) & 1))
                 or (mbtOrderSize(pmtype[0]) == 8 and 0 != ((address + regofs) & 3))):
-                pwarn("Multi-register type '{0}' not aligned to natural boundary (address={1}/0x{1:04x}, regoffset={2}/0x{2:02x}) in {3}"
-                        .format(MBNAMES[pmtype[0]], address, regofs, lpl))
+                if not getBoolean(cmd.attrib, 'unaligned'):
+                    pwarn("Multi-register type '{0}' not aligned to natural boundary (address={1}/0x{1:04x}, regoffset={2}/0x{2:02x}) in {3}"
+                            .format(MBNAMES[pmtype[0]], address, regofs, lpl))
 
             pinlist.append({'pin': pintag, 'mtype': pmtype[0], 'htype': phtype, 'flags': pf, 'regofs': regofs})
             pinlistall.append(pintag)


### PR DESCRIPTION
This PR is a set of changes to the hm2_modbus driver:
* fix a bug trying to overflow the transmission buffer (and failing) due to a wrong condition and counter
* add some more return value checks where they were missing
* assure using the correct command list when flushing write commands

The driver is also slightly extended:
* add byte-sized values to support sign extension for the hal types. The device tested uses Modbus addresses differently and reads/writes records with varying data (see https://forum.linuxcnc.org/38-general-linuxcnc-questions/56506-how-to-write-multipule-data-byte-mesambccc)
* add per-command run-time controllable disable pin and add a 'disabled' attribute to set the default at start. The command can be (re)activated using the command's reset pin when in the disabled state.
* add an 'unaligned' attribute to suppress alignment warnings when compiling the mbccs. Devices that don't use traditional Modbus addressing may use the address-space differently and the warnings are then noise.