### PR TITLE
Gmoccapy: Fix unwanted expansion of ComboBoxText for mouse-button-mode

### DIFF
--- a/src/emc/usr_intf/gmoccapy/gmoccapy.glade
+++ b/src/emc/usr_intf/gmoccapy/gmoccapy.glade
@@ -4416,6 +4416,10 @@ clicking on the DRO</property>
                                       <object class="GtkComboBoxText" id="cmb_mouse_button_mode">
                                         <property name="visible">True</property>
                                         <property name="can-focus">False</property>
+                                        <property name="active">0</property>
+                                        <property name="has-entry">True</property>
+                                        <property name="entry-text-column">1</property>
+                                        <property name="id-column">0</property>
                                         <items>
                                           <item id="0" translatable="yes">left rotate,  middle move,  right zoom</item>
                                           <item id="1" translatable="yes">left zoom,  middle move,  right rotate</item>

--- a/src/emc/usr_intf/gmoccapy/gmoccapy.glade
+++ b/src/emc/usr_intf/gmoccapy/gmoccapy.glade
@@ -4418,8 +4418,6 @@ clicking on the DRO</property>
                                         <property name="can-focus">False</property>
                                         <property name="active">0</property>
                                         <property name="has-entry">True</property>
-                                        <property name="entry-text-column">1</property>
-                                        <property name="id-column">0</property>
                                         <items>
                                           <item id="0" translatable="yes">left rotate,  middle move,  right zoom</item>
                                           <item id="1" translatable="yes">left zoom,  middle move,  right rotate</item>
@@ -4429,6 +4427,12 @@ clicking on the DRO</property>
                                           <item id="5" translatable="yes">left rotate,  middle zoom,  right move</item>
                                         </items>
                                         <signal name="changed" handler="on_cmb_mouse_button_mode_changed" swapped="no"/>
+                                        <child internal-child="entry">
+                                          <object class="GtkEntry">
+                                            <property name="can-focus">False</property>
+                                            <property name="editable">False</property>
+                                          </object>
+                                        </child>
                                       </object>
                                       <packing>
                                         <property name="expand">True</property>


### PR DESCRIPTION
This fixes issue with horizontal expansion of the ComboBoxText reported in #3489


![mouse-button-mode](https://github.com/user-attachments/assets/a5ce06c8-4bb8-4fae-87ed-86ebff3b213e)
