### PR TITLE
Gmoccapy fix various bugs

### DIFF
--- a/lib/python/gladevcp/calculatorwidget.py
+++ b/lib/python/gladevcp/calculatorwidget.py
@@ -170,17 +170,15 @@ class Calculator( Gtk.Box ):
 
     def compute( self ):
         qualified = ''
-        # print"string:",self.eval_string
         temp = self.eval_string.strip( " " ).replace("Pi", "math.pi")
         # this loop adds only spaces around the mentioned operators 
         for i in( '-', '+', '/', '*', 'math.pi', '(', ')' ):
             new = " %s " % i
             temp = temp.replace( i, new )
         for i in temp.split():
-#            print ( "i in compute = ", i )
             try:
+                # convert to decimal dot format
                 i = str( locale.atof( i ) )
-#                print ( "converted i in compute = ", i )
             except:
                 pass
             if i.isdigit():
@@ -194,16 +192,13 @@ class Calculator( Gtk.Box ):
                 b = str( eval( qualified ) )
         except:
             b = "Error"
-            print("Calculator widget error, string:", self.eval_string, sys.exc_info()[0])
             self.eval_string = ''
-        else  : self.eval_string = b
-        # if locale.localeconv()["decimal_point" = comma ,
-        # we have to replace the internal dot by a comma,
-        # otherwise it will be interpreted as an thousend separator
         try:
             b = locale.format_string( "%f", float( b ) ).rstrip( "0" )
             if b[-1] == locale.localeconv()["decimal_point"]:
                 b = b.rstrip( locale.localeconv()["decimal_point"] )
+            else:
+                self.eval_string = b
         except:
             b = "Error"
         self.entry.set_text( b )

--- a/lib/python/gladevcp/offsetpage_widget.py
+++ b/lib/python/gladevcp/offsetpage_widget.py
@@ -200,15 +200,13 @@ class OffsetPage(Gtk.Box):
         else:
             tmpl = self.imperial_text_template
 
-        degree_tmpl = "%11.2f"
-
         # fill each row of the liststore from the offsets arrays
         for row, i in enumerate([tool, g28, g30, g92]):
             for column in range(0, 11):
                 if column > 8:
                     self.store[row][column + 1] = " " # Blank R column
                 else:
-                    self.store[row][column + 1] = locale.format_string(tmpl, i[column])
+                    self.store[row][column + 1] = tmpl % i[column]
             # set the current system's label's color - to make it stand out a bit
             if self.store[row][0] == self.current_system:
                 if isinstance(self.foreground_color, str):
@@ -226,7 +224,7 @@ class OffsetPage(Gtk.Box):
 
         for row, i in enumerate([g54, g55, g56, g57, g58, g59, g59_1, g59_2, g59_3]):
             for column in range(0, 10):
-                self.store[row+4][column + 1] = locale.format_string(tmpl, i[column])
+                self.store[row+4][column + 1] = tmpl % i[column]
             # set the current system's label's color - to make it stand out a bit
             if self.store[row+4][0] == self.current_system:
                 if isinstance(self.foreground_color, str):
@@ -387,7 +385,7 @@ class OffsetPage(Gtk.Box):
 
         # set the text in the table
         try:
-            self.store[row][col] = locale.format_string("%10.4f", locale.atof(new_text))
+            self.store[row][col] = "%10.4f" % locale.atof(new_text)
         except Exception as error:
             print('new_text: ', new_text, error)
             print(_("offsetpage widget error: unrecognized float input"))

--- a/lib/python/gladevcp/tooledit_widget.py
+++ b/lib/python/gladevcp/tooledit_widget.py
@@ -476,7 +476,7 @@ class ToolEdit(Gtk.Box):
         # validate input for float columns
         elif col in range(3,15):
             try:
-                self.model[path][col] = f"{float(new_text.replace(',', '.')):10.4f}"
+                self.model[path][col] =  "%10.4f" % locale.atof(new_text)
             except:
                 pass
         # validate input for orientation: check if int and valid range

--- a/src/emc/usr_intf/gmoccapy/gmoccapy.py
+++ b/src/emc/usr_intf/gmoccapy/gmoccapy.py
@@ -123,7 +123,7 @@ TCLPATH = os.environ['LINUXCNC_TCL_DIR']
 ALERT_ICON = "dialog_warning"
 INFO_ICON = "dialog_information"
 
-AXISLIST = ['offset', 'X', 'Y', 'Z', 'A', 'B', 'C', 'U', 'V', 'W', 'name']
+AXISLIST = ['offset', 'X', 'Y', 'Z', 'A', 'B', 'C', 'U', 'V', 'W', 'Rot', 'name']
 
 class gmoccapy(object):
     def __init__(self, argv):
@@ -2275,7 +2275,7 @@ class gmoccapy(object):
             names.append([system, name])
         self.widgets.offsetpage1.set_names(names)
         for col, name in enumerate(AXISLIST):
-            if col > 9:break
+            if col > 10:break
             temp = self.widgets.offsetpage1.wTree.get_object("cell_%s" % name)
             temp.connect('editing-started', self.on_offset_col_edit_started, col)
 


### PR DESCRIPTION
- Calculator_widget: Fix locale handling
- Offsetpage_widget: force display of unlocalized float values, remove unused format template
- Tooledit_widget: use local.atof() instead of replacing commas with dot
- Gmoccapy offsetpage: Fix 'Rot' column not calling the calculator on editing


