### PR TITLE
Gmoccapy: Add native hal pins to be used instead of halui

### DIFF
--- a/src/emc/usr_intf/gmoccapy/gmoccapy.py
+++ b/src/emc/usr_intf/gmoccapy/gmoccapy.py
@@ -5858,6 +5858,38 @@ class gmoccapy(object):
         LOG.debug("Received a signal from pin {0} with state = {1}".format(pin.name, pin.get()))
         self.command.set_optional_stop(pin.get())
 
+    def _program_start(self, pin):
+        LOG.debug("Received a signal from pin {0} with state = {1}".format(pin.name, pin.get()))
+        if not self.widgets.ntb_button.get_current_page() == _BB_AUTO:
+            return
+        button = self.builder.get_object("btn_run")
+        if button.get_sensitive() and pin.get():
+            self.on_btn_run_clicked(None)
+
+    def _program_stop(self, pin):
+        LOG.debug("Received a signal from pin {0} with state = {1}".format(pin.name, pin.get()))
+        if not self.widgets.ntb_button.get_current_page() == _BB_AUTO:
+            return
+        button = self.builder.get_object("btn_stop")
+        if button.get_sensitive() and pin.get():
+            self.on_btn_stop_clicked(None)
+
+    def _program_pause(self, pin):
+        LOG.debug("Received a signal from pin {0} with state = {1}".format(pin.name, pin.get()))
+        if not self.widgets.ntb_button.get_current_page() == _BB_AUTO:
+            return
+        button = self.builder.get_object("tbtn_pause")
+        if button.get_sensitive() and pin.get() and not button.get_active():
+            self.command.auto(linuxcnc.AUTO_PAUSE)
+
+    def _program_resume(self, pin):
+        LOG.debug("Received a signal from pin {0} with state = {1}".format(pin.name, pin.get()))
+        if not self.widgets.ntb_button.get_current_page() == _BB_AUTO:
+            return
+        button = self.builder.get_object("btn_stop")
+        if button.get_sensitive() and pin.get():
+            self.command.auto(linuxcnc.AUTO_RESUME)
+
 # =========================================================
 # The actions of the buttons
     def _button_pin_changed(self, pin):
@@ -6074,6 +6106,16 @@ class gmoccapy(object):
         hal_glib.GPin(pin).connect("value_changed", self._optional_blocks)
         pin = self.halcomp.newpin("blockdelete", hal.HAL_BIT, hal.HAL_IN)
         hal_glib.GPin(pin).connect("value_changed", self._blockdelete)
+
+        # make pins to be used instead of halui pins
+        pin = self.halcomp.newpin("program.start", hal.HAL_BIT, hal.HAL_IN)
+        hal_glib.GPin(pin).connect("value_changed", self._program_start)
+        pin = self.halcomp.newpin("program.stop", hal.HAL_BIT, hal.HAL_IN)
+        hal_glib.GPin(pin).connect("value_changed", self._program_stop)
+        pin = self.halcomp.newpin("program.pause", hal.HAL_BIT, hal.HAL_IN)
+        hal_glib.GPin(pin).connect("value_changed", self._program_pause)
+        pin = self.halcomp.newpin("program.resume", hal.HAL_BIT, hal.HAL_IN)
+        hal_glib.GPin(pin).connect("value_changed", self._program_resume)
 
 
 # Hal Pin Handling End


### PR DESCRIPTION
Halui pins are frequently used to interface hardware panel buttons  that are not aligned with Gmoccapy's screen buttons. Using halui pins together with any gui can cause unexpected behavior.
Example: starting program execution in program edit mode: 
https://forum.linuxcnc.org/gmoccapy/56544-gmoccapy-3-5-1?start=0#331201

By providing native hal pins the behavior can be controlled by the gui itself.
At this point only pins for program.start .stop .pause and .resume are added. 

![halpins](https://github.com/user-attachments/assets/81ce3cf9-cdba-424f-bc3f-7f2b210c84ce)
