### PR TITLE
Documentation-build review and prepare for tamil (some:documentation_review_and_prepare_for_tamil)

### DIFF
--- a/debian/.gitignore
+++ b/debian/.gitignore
@@ -12,7 +12,13 @@ linuxcnc-doc-*/
 
 # generated from `.in` by debian/configure
 linuxcnc-uspace.install
+linuxcnc-uspace.manpages
 
 *.debhelper
 shlibs.local
 linuxcnc-uspace.lintian-overrides
+
+autoreconf.after
+autoreconf.before
+debhelper-build-stamp
+

--- a/debian/configure
+++ b/debian/configure
@@ -99,7 +99,7 @@ DEBHELPER="debhelper (>= 12)"
 COMPAT="12"
 
 case $DISTRIB_NAME in
-    Ubuntu-25.*|Ubuntu-24.*|Ubuntu-21.*|Debian-11|Debian-11.*|Debian-12|Debian-12.*|Debian-testing|Debian-unstable)
+    Ubuntu-25.*|Ubuntu-24.*|Ubuntu-21.*|Debian-11|Debian-11.*|Debian-12|Debian-12.*|Debian-13|Debian-13.*|Debian-testing|Debian-unstable)
         LIBREADLINE_DEV=libeditreadline-dev
         COMPAT=""
         DEBHELPER="debhelper-compat (= 13)"


### PR DESCRIPTION
Also preparing for Debian-13, some copy'n'paste errors.

Tamil has translated a few variables like image paths that were not meant to be translated. po4a cannot deal with some syntax issues in the translations, which then breaks the build.