### PR TITLE
Gmoccapy: Fix arrow key up/down bug in tooleditor

### DIFF
--- a/src/emc/usr_intf/gmoccapy/gmoccapy.py
+++ b/src/emc/usr_intf/gmoccapy/gmoccapy.py
@@ -1924,7 +1924,9 @@ class gmoccapy(object):
         self.widgets.tooledit1.set_visible("abcxyzuvwijq", False)
         for axis in self.axis_list:
             self.widgets.tooledit1.set_visible("{0}".format(axis), True)
-
+        # disconnect the key_press handler in the widget
+        tv = self.widgets.tooledit1.wTree.get_object("treeview1")
+        tv.disconnect_by_func(self.widgets.tooledit1.on_tree_navigate_key_press)
         # if it's a lathe config we show lathe related columns
         if self.lathe_mode:
             self.widgets.tooledit1.set_visible("ijq", True)


### PR DESCRIPTION
The key_press handler inside 'tooledit_widget.py' interferes when using the arrow up/down keys (one keypress results in moving two rows ):

![Recording_current](https://github.com/user-attachments/assets/1abe6dea-94f0-4e5b-8bf8-f1cd2b5d5667)


New (fixed) behavior:
![Recording](https://github.com/user-attachments/assets/68c29a01-de8b-4218-83c6-fff0833f339d)
