### PR TITLE
Do not initialize python if already initialized

### DIFF
--- a/src/emc/pythonplugin/python_plugin.cc
+++ b/src/emc/pythonplugin/python_plugin.cc
@@ -327,7 +327,9 @@ PythonPlugin::PythonPlugin(struct _inittab *inittab) :
       }
   }
   config.buffered_stdio = 0;
-  Py_InitializeFromConfig(&config);
+  if (!Py_IsInitialized()) {
+    Py_InitializeFromConfig(&config);
+  }
   PyConfig_Clear(&config);
   initialize();
 }


### PR DESCRIPTION
This PR fixes #3510 and replaces #3511.

See also discussion in #3510 for more details. Completely removing the initialization would cause tests to fail because the python plugin code is also used in standalone code where it is required. Now it is only called when python is not yet initialized.

This PR is the minimalist approach to fixing the bug (superseding #3514). There might be opportunity to cleanup some code too, but that would require more analysis of other distant code-paths.