### PR TITLE
Fix runtests races

### DIFF
--- a/scripts/runtests.in
+++ b/scripts/runtests.in
@@ -56,6 +56,41 @@ clean () {
 	-print0 | xargs -0 rm -f
 }
 
+wait_for_result_close() {
+    # Test for the 'result' and 'stderr' files in the current testdir to be
+    # closed. The 'checkresult' script cannot be run if these files are still
+    # in use and would cause a race condition.
+    # This function should be called with the test's directory as CWD.
+    presult="$(realpath -e -q "./result")"
+    pstderr="$(realpath -e -q "./stderr")"
+    if [ -z "$presult" ] || [ -z "$pstderr" ]; then
+        echo "Internal error: Missing 'result' or 'stderr' in wait_for_result_close()"
+        exit 2
+    fi
+    timeoutcnt=0
+    while true; do
+        lsof -- "$presult" > /dev/null 2>&1; resresult=$?
+        lsof -- "$pstderr" > /dev/null 2>&1; resstderr=$?
+        if [ $resresult -ne 0 ] && [ $resstderr -ne 0 ]; then
+            # Neither 'result' nor 'stderr' are open anymore
+            break
+        fi
+        if [ $timeoutcnt -ge 30 ]; then
+            if [ $resresult -eq 0 ]; then
+                echo "*** Timeout waiting for 'result' file to close"
+            fi
+            if [ $resstderr -eq 0 ]; then
+                echo "*** Timeout waiting for 'stderr' file to close"
+            fi
+            echo "*** Test results may be invalid when checked."
+            return 1
+        fi
+        sleep 1
+        timeoutcnt=$((timeoutcnt + 1))
+    done
+    return 0
+}
+
 run_shell_script () {
     testname=$(basename "$1")
     testdir=$(dirname "$1")
@@ -67,6 +102,7 @@ run_shell_script () {
         bash -x "$testname" > result 2> stderr
     fi
     exitcode=$?
+    wait_for_result_close
     popd > /dev/null || exit 2
     return "$exitcode"
 }
@@ -82,6 +118,7 @@ run_executable () {
         ./"$testname" > result 2> stderr
     fi
     exitcode=$?
+    wait_for_result_close
     popd > /dev/null || exit 2
     return "$exitcode"
 }
@@ -99,6 +136,7 @@ run_without_overruns () {
             halrun -f "$testname" > result 2> stderr
         fi
         exitcode=$?
+        wait_for_result_close
         popd > /dev/null || exit 2
 
         if ! grep -q '^overrun$' "$testdir/result"; then return "$exitcode"; fi

--- a/scripts/runtests.in
+++ b/scripts/runtests.in
@@ -175,7 +175,7 @@ run_tests () {
         exit 1;
     fi
 
-    find "$*" -name test.hal -or -name test.sh -or -name test \
+    find "$@" -name test.hal -or -name test.sh -or -name test \
 	| sort > "$TMPDIR/alltests"
 
     while read -r testname; do

--- a/src/hal/user_comps/mb2hal/mb2hal.c
+++ b/src/hal/user_comps/mb2hal/mb2hal.c
@@ -81,13 +81,13 @@ int main(int argc, char **argv)
         ERR(gbl.init_dbg, "Unable to create HAL pins");
         goto QUIT_CLEANUP;
     }
-    hal_ready(gbl.hal_mod_id);
-    OK(gbl.init_dbg, "HAL components created OK");
-
-    gbl.quit_flag = 0; //tell the threads to quit (SIGTERM o SIGQUIT) (unloadusr mb2hal).
+    gbl.quit_flag = 0; //tell the threads to quit (SIGTERM or SIGINT) (unloadusr mb2hal).
     signal(SIGINT, quit_signal);
     //unloadusr and unload commands of halrun
     signal(SIGTERM, quit_signal);
+
+    hal_ready(gbl.hal_mod_id);
+    OK(gbl.init_dbg, "HAL components created OK");
 
     /* Each link has it's own thread */
     pthread_attr_init(&thrd_attr);
@@ -149,7 +149,7 @@ void *link_loop_and_logic(void *thrd_link_num)
 
         for (tx_counter = 0; tx_counter < gbl.tot_mb_tx; tx_counter++) {
 
-            if (gbl.quit_flag != 0) { //tell the threads to quit (SIGTERM o SGIQUIT) (unloadusr mb2hal).
+            if (gbl.quit_flag != 0) {
                 return NULL;
             }
 
@@ -225,7 +225,7 @@ void *link_loop_and_logic(void *thrd_link_num)
                 break;
             }
 
-            if (gbl.quit_flag != 0) { //tell the threads to quit (SIGTERM o SGIQUIT) (unloadusr mb2hal).
+            if (gbl.quit_flag != 0) {
                 return NULL;
             }
 
@@ -441,7 +441,7 @@ void quit_signal(int signal)
 {
     char *fnct_name = "quit_signal";
 
-    gbl.quit_flag = 1; //tell the threads to quit (SIGTERM o SIGQUIT) (unloadusr mb2hal).
+    gbl.quit_flag = 1; //tell the threads to quit (SIGTERM or SIGINT) (unloadusr mb2hal).
     DBG(gbl.init_dbg, "signal [%d] received", signal);
 }
 

--- a/src/hal/user_comps/mb2hal/mb2hal.h
+++ b/src/hal/user_comps/mb2hal/mb2hal.h
@@ -153,7 +153,7 @@ typedef struct {
     int   tot_mb_links;
     //others
     const char *mb_tx_fncts[mbtxMAX];
-    int quit_flag;
+    volatile int quit_flag;
 } gbl_t;
 
 extern gbl_t gbl;


### PR DESCRIPTION
Fix the runtests race condition running `checkresult` before the `result` file is closed. This can happen when the test-process runs asynchronously and has not yet exited, keeping the from runtests redirected stdio descriptors in an open state.

The mb2hal process, which exhibited the race, has another race fixed, where the signal handlers were installed too late in the process. Additionally, the mb2hal internal `quit_flag` must be declared volatile because it is written in the signal handler and read in separate threads.

Finally, a longstanding bug in runtests prevented it to take multiple directories from the command-line when, for example, done using a wildcard. The expansion to find tests mistakenly used `$*` instead of `$@`.