### PR TITLE
Allow for changing default G64 Value

### DIFF
--- a/docs/src/config/ini-config.adoc
+++ b/docs/src/config/ini-config.adoc
@@ -514,6 +514,10 @@ if __name__ == "__main__":
   The first matching subroutine file found in the search is used.
   Directories are specified relative to the current directory for the INI file or as absolute paths.
   The list must contain no intervening whitespace.
+* `G64_DEFAULT_TOLERANCE =` _n_ (Default: 0)
+  Default P value for G64 if P is not called out.
+* `G64_DEFAULT_NAIVETOLERANCE =` _n_ (Default: 0)
+  Default Q value for G64 if Q is not called out.
 * `CENTER_ARC_RADIUS_TOLERANCE_INCH =` _n_ (Default: 0.00005)
 * `CENTER_ARC_RADIUS_TOLERANCE_MM =` _n_ (Default: 0.00127)
 * `USER_M_PATH = myfuncs:/tmp/mcodes:experimentalmcodes` - (((USER M PATH)))

--- a/docs/src/gcode/g-code.adoc
+++ b/docs/src/gcode/g-code.adoc
@@ -1633,7 +1633,7 @@ G64 <P- <Q->>
 
 * 'P' - motion blending tolerance
 * 'Q' - naive cam tolerance
-* 'G64' - best possible speed. Without P means to keep the best speed
+* 'G64' - best possible speed. Without P (Or a default value in <<ini-config:rs274ngc,INI[RS274]>>) means to keep the best speed
   possible, no matter how far away from the programmed point you end up.
 * 'G64 P-' - Blend between best speed and deviation tolerance
 * 'G64 P- <Q- >' blending with tolerance.

--- a/src/emc/rs274ngc/interp_convert.cc
+++ b/src/emc/rs274ngc/interp_convert.cc
@@ -2195,21 +2195,26 @@ int Interp::convert_control_mode(
     SET_MOTION_CONTROL_MODE(CANON_EXACT_STOP, 0);
     settings->control_mode = CANON_EXACT_STOP;
   } else if (g_code == G_64) {
-      if (tolerance_in >= 0)
-	  tolerance = tolerance_in;
-      else
-	  tolerance = 0;
+      if (tolerance_in >= 0){
+	      tolerance = tolerance_in;
+      }
+      else{
+	      tolerance = _setup.tolerance_default;
+      }
       settings->control_mode = CANON_CONTINUOUS;
       settings->tolerance = tolerance;
       SET_MOTION_CONTROL_MODE(CANON_CONTINUOUS, tolerance);
 
-      if (naivecam_tolerance_in >= 0)
-	  naivecam_tolerance = naivecam_tolerance_in;
-      else if (tolerance_in >= 0)
-	  // if no naivecam_tolerance specified use same for both
-	  naivecam_tolerance = tolerance_in;
-      else
-	  naivecam_tolerance = 0;
+      if (naivecam_tolerance_in >= 0){
+	      naivecam_tolerance = naivecam_tolerance_in;
+      }
+      else if (tolerance_in >= 0){
+	      // if no naivecam_tolerance specified use same for both
+	      naivecam_tolerance = tolerance_in;
+      }
+      else{
+	      naivecam_tolerance = _setup.naivecam_tolerance_default;
+      }
       settings->naivecam_tolerance = naivecam_tolerance;
       SET_NAIVECAM_TOLERANCE(naivecam_tolerance);
 

--- a/src/emc/rs274ngc/interp_internal.hh
+++ b/src/emc/rs274ngc/interp_internal.hh
@@ -684,6 +684,8 @@ struct setup
   CANON_MOTION_MODE control_mode;       // exact path or cutting mode
     double tolerance;           // G64 blending tolerance
     double naivecam_tolerance;  // G64 naive cam tolerance
+    double tolerance_default;   // G64 P Default value, -1 to disable
+    double naivecam_tolerance_default; // G64 Q Default Value, -1 to disable 
   int current_pocket;             // carousel slot (index) number of current tool
   double current_x;             // current X-axis position
   double current_y;             // current Y-axis position

--- a/src/emc/rs274ngc/rs274ngc_pre.cc
+++ b/src/emc/rs274ngc/rs274ngc_pre.cc
@@ -869,6 +869,9 @@ int Interp::init()
   _setup.call_state = CS_NORMAL;
   _setup.num_spindles = 1;
 
+  _setup.tolerance_default = 0;
+  _setup.naivecam_tolerance_default = 0;
+
   // default arc radius tolerances
   // we'll try to override these from the INI file below
   _setup.center_arc_radius_tolerance_inch = CENTER_ARC_RADIUS_TOLERANCE_INCH;
@@ -891,6 +894,9 @@ int Interp::init()
           inifile.Find(&_setup.c_axis_wrapped, "WRAPPED_ROTARY", "AXIS_C");
           inifile.Find(&_setup.random_toolchanger, "RANDOM_TOOLCHANGER", "EMCIO");
           inifile.Find(&_setup.num_spindles, "SPINDLES", "TRAJ");
+
+          inifile.Find(&_setup.tolerance_default, "G64_DEFAULT_TOLERANCE", "RS274NGC");
+          inifile.Find(&_setup.naivecam_tolerance_default, "G64_DEFAULT_NAIVETOLERANCE", "RS274NGC");
 
           // First the features that default to ON
           opt = true;


### PR DESCRIPTION
Yes, I'm aware you should put it in your safety block. Yes, I'm aware [RS274NGC]Start-Up Code exists. On the other hand consider a shop with multiple machines and someone... not saying names... copies a program from Haas or Fanuc to Linuxcnc. Well I'd like to be able to use the same code cross platform, and not cut corners so to speak.

<img width="1440" height="1920" alt="image" src="https://github.com/user-attachments/assets/19d2e493-c946-4d6e-92c6-ad819688ad15" />


This defaults to the classic behaviour if you don't use it. If you do use it, calling G64 all by itself will give a reasonable answer. 