### PR TITLE
PNCconf - integration of default values for G64 in *.ini file

### DIFF
--- a/src/emc/usr_intf/pncconf/build_INI.py
+++ b/src/emc/usr_intf/pncconf/build_INI.py
@@ -172,8 +172,13 @@ class INI:
             else:
                 unit = 20
                 p =.001
-            print ("RS274NGC_STARTUP_CODE = G{} G40 G90 G94 G97 G64 P{}".format(unit,p), file=file)
-
+            print("RS274NGC_STARTUP_CODE = G{} G40 G90 G94 G97 G64".format(unit), file=file)
+            print("", file=file)
+            print("# Default P value for G64 if P is not called out", file=file)
+            print("G64_DEFAULT_TOLERANCE = {}".format(p), file=file)
+            print("# Default Q value for G64 if Q is not called out", file=file)
+            print("G64_DEFAULT_NAIVETOLERANCE = 0", file=file)
+            print("", file=file)
         if self.d.frontend == _PD._GMOCCAPY:
             print("SUBROUTINE_PATH = ./macros", file=file)
             print("REMAP=M6  modalgroup=6 prolog=change_prolog ngc=change_g43 epilog=change_epilog", file=file)


### PR DESCRIPTION
@satiowadahc made new functionality, so I integrete it to mesa wizard PNCconf 
https://github.com/LinuxCNC/linuxcnc/pull/3525/

<img width="691" height="249" alt="g64-default" src="https://github.com/user-attachments/assets/ea3b039b-c264-4e47-892d-5b001f180cc0" />
