### PR TITLE
gmoccapy/hal_bridge -allow hal_bridge to call macros in gmoccapy

### DIFF
--- a/configs/sim/gmoccapy/gmoccapy_right_panel.ini
+++ b/configs/sim/gmoccapy/gmoccapy_right_panel.ini
@@ -31,6 +31,12 @@ INTRO_TIME = 5
 # list of selectable jog increments
 INCREMENTS = 1mm, 0.1mm, 0.01mm, 0.001mm, 1.2345in
 
+MACRO = i_am_lost
+MACRO = halo_world
+MACRO = jog_around
+MACRO = increment xinc yinc
+MACRO = go_to_position X-pos Y-pos Z-pos
+
 [FILTER]
 PROGRAM_EXTENSION = .png,.gif,.jpg Grayscale Depth Image
 PROGRAM_EXTENSION = .py Python Script
@@ -75,7 +81,7 @@ HALFILE = simulated_home.hal
 POSTGUI_HALFILE = gmoccapy_postgui.hal
 
 HALUI = halui
-
+HALBRIDGE = hal_bridge -d
 # Trajectory planner section --------------------------------------------------
 [HALUI]
 #No Content

--- a/configs/sim/gmoccapy/gmoccapy_right_panel.ini
+++ b/configs/sim/gmoccapy/gmoccapy_right_panel.ini
@@ -37,6 +37,11 @@ MACRO = jog_around
 MACRO = increment xinc yinc
 MACRO = go_to_position X-pos Y-pos Z-pos
 
+[MDI_COMMAND_LIST]
+# for macro buttons on main oage up to 10 possible
+MDI_COMMAND = G0 Z1;X0 Y0;Z0, Goto\nUser\nZero
+MDI_COMMAND_MACRO1 = G53 G0 Z0;G53 G0 X0 Y0,Goto\nMachn\nZero
+
 [FILTER]
 PROGRAM_EXTENSION = .png,.gif,.jpg Grayscale Depth Image
 PROGRAM_EXTENSION = .py Python Script

--- a/lib/python/common/iniinfo.py
+++ b/lib/python/common/iniinfo.py
@@ -564,6 +564,9 @@ class _IStat(object):
         # here we separate them to two lists (legacy) and one dict
         # action_button takes it from there.
         self.MDI_COMMAND_DICT={}
+        self.MDI_COMMAND_LIST = []
+        self.MDI_COMMAND_LABEL_LIST = []
+
         # suppress error message is there is no section at all
         if self.parser.has_section('MDI_COMMAND_LIST'):
             try:
@@ -573,25 +576,31 @@ class _IStat(object):
                     # in this case order matters in the INI
                     if key == 'MDI_COMMAND':
                         LOG.warning("INI file's MDI_COMMAND_LIST is using legacy 'MDI_COMMAND =' entries")
-                        self.MDI_COMMAND_LIST = []
-                        self.MDI_COMMAND_LABEL_LIST = []
                         temp = (self.INI.findall("MDI_COMMAND_LIST", "MDI_COMMAND")) or None
                         if temp is None:
-                            self.MDI_COMMAND_LABEL_LIST.append(None)
+                            self.MDI_COMMAND_LIST.append(None)
                             self.MDI_COMMAND_LABEL_LIST.append(None)
                         else:
-                            for i in temp:
+                            for count, i in enumerate(temp):
+                                mdidatadict = {}
                                 for num,k in enumerate(i.split(',')):
                                     if num == 0:
                                         self.MDI_COMMAND_LIST.append(k)
+                                        mdidatadict['cmd'] = k
                                         if len(i.split(',')) <2:
                                             self.MDI_COMMAND_LABEL_LIST.append(None)
+                                            mdidatadict['label'] = None
                                     else:
                                         self.MDI_COMMAND_LABEL_LIST.append(k)
+                                        mdidatadict['label'] = k
+                                self.MDI_COMMAND_DICT[str(count)] = mdidatadict
+                        break
 
                     # new way: 'MDI_COMMAND_SSS = XXXX' (SSS being any string)
                     # order of commands doesn't matter in the INI
                     else:
+                        self.MDI_COMMAND_LIST.append(None)
+                        self.MDI_COMMAND_LABEL_LIST.append(None)
                         try:
                             temp = self.INI.find("MDI_COMMAND_LIST",key)
                             name = (key.replace('MDI_COMMAND_',''))

--- a/lib/python/gladevcp/gtk_action.py
+++ b/lib/python/gladevcp/gtk_action.py
@@ -191,11 +191,11 @@ class _Lcnc_Action(object):
             self.ensure_mode(premode)
         return 0
 
-    def CALL_INI_MDI(self, number):
+    def CALL_INI_MDI(self, data):
         try:
-            mdi = INFO.MDI_COMMAND_LIST[number]
+            mdi = INFO.get_ini_mdi_command(data)
         except:
-            msg = 'MDI_COMMAND= # {} Not found under [MDI_COMMAND_LIST] in INI file'.format(number)
+            msg = 'MDI_COMMAND= # {} Not found under [MDI_COMMAND_LIST] in INI file'.format(data)
             LOG.error(msg)
             self.SET_ERROR_MESSAGE(msg)
             return
@@ -479,6 +479,7 @@ class _Lcnc_Action(object):
         return mode
 
     def RESTORE_RECORDED_MODE(self):
+        self.cmd.wait_complete()
         self.ensure_mode(self.last_mode)
 
     def SET_SELECTED_JOINT(self, data):

--- a/src/emc/usr_intf/gmoccapy/getiniinfo.py
+++ b/src/emc/usr_intf/gmoccapy/getiniinfo.py
@@ -393,7 +393,7 @@ class GetIniInfo:
 
     def get_macros(self):
         # lets look in the INI file, if there are any entries
-        macros = self.inifile.findall("MACROS", "MACRO")
+        macros = self.inifile.findall("DISPLAY", "MACRO")
         # If there are no entries we will return False
         if not macros:
             return False

--- a/src/emc/usr_intf/gmoccapy/gmoccapy.py
+++ b/src/emc/usr_intf/gmoccapy/gmoccapy.py
@@ -175,7 +175,8 @@ class gmoccapy(object):
         self.error_channel.poll()
 
         # set INI path for INI info class before widgets are loaded
-        INFO = Info(ini=argv[2])
+        self.INFO = Info(ini=argv[2])
+        self.ACTION = Action()
 
         self.builder = Gtk.Builder()
         # translation of the glade file will be done with
@@ -1324,7 +1325,17 @@ class gmoccapy(object):
 
     # call INI macro (from hal_glib message)
     def request_macro_call(self, data):
+        # if MDI command change to MDI and run
+        cmd = self.INFO.get_ini_mdi_command(data)
+        print('MDI command:',data,cmd)
+        if not cmd is None:
+            self.ACTION.RECORD_CURRENT_MODE()
+            LOG.debug("INI MDI COMMAND #: {} = {}".format(data, cmd))
+            self.ACTION.CALL_INI_MDI(data)
+            self.ACTION.RESTORE_RECORDED_MODE()
+            return
 
+        # run Macros
         # some error checking
         if not self.GSTAT.is_mdi_mode():
             message = _("You must be in MDI mode to run macros")
@@ -6154,7 +6165,7 @@ if __name__ == "__main__":
 
     # Some of these libraries log when imported so logging level must already be set.
     import gladevcp.makepins
-    from gladevcp.core import Info
+    from gladevcp.core import Info, Action
     from gladevcp.combi_dro import Combi_DRO  # we will need it to make the DRO
     from gmoccapy import widgets       # a class to handle the widgets
 

--- a/src/hal/user_comps/hal_bridge.py
+++ b/src/hal/user_comps/hal_bridge.py
@@ -90,6 +90,13 @@ class Bridge(object):
             self[i] = QHAL.newpin('macro-cmd-{}'.format(i),QHAL.HAL_BIT, QHAL.HAL_IN)
             self[i].pinValueChanged.connect(self.runMacroChanged)
 
+        for i in self.INFO.INI_MACROS:
+            name = i.split()[0]
+            LOG.debug('{} {}'.format(name,i))
+
+            self[name] = QHAL.newpin('macro-cmd-{}'.format(name),QHAL.HAL_BIT, QHAL.HAL_IN)
+            self[name].pinValueChanged.connect(self.runMacroChanged)
+
         QHAL.setUpdateRate(100)
         h.ready()
 


### PR DESCRIPTION
This is a proof of concept to allow 3rd party (hal_bridge) to call macros. The macros are run from Gmoccapy so no timing problems should occur and and pre checks or post changes can be covered.

There needs to be agreement on where to put macro definitions in the INI. Gmoccapy puts them under [MACROS], iniinfo under [DISPLAY] python ZMQ module package must be available for this to work