### PR TITLE
probe_error_decel_no_inhibit - rebased for 2.9

### DIFF
--- a/src/emc/motion/control.c
+++ b/src/emc/motion/control.c
@@ -716,59 +716,63 @@ static void process_probe_inputs(void)
     } else if (!old_probeVal && emcmotStatus->probeVal) {
         // not probing, but we have a rising edge on the probe.
         // this could be expensive if we don't stop.
-        int i;
-        int aborted = 0;
 
         if(!GET_MOTION_INPOS_FLAG() && tpQueueDepth(&emcmotInternal->coord_tp)) {
             // running an command
-            tpAbort(&emcmotInternal->coord_tp);
-            reportError(_("Probe tripped during non-probe move."));
-	    SET_MOTION_ERROR_FLAG(1);
-        }
-
-        for(i=0; i<NO_OF_KINS_JOINTS; i++) {
-            emcmot_joint_t *joint = &joints[i];
-
-            if (!GET_JOINT_ACTIVE_FLAG(joint)) {
-                /* if joint is not active, skip it */
-                continue;
+            if (emcmotStatus->motionType != EMC_MOTION_TYPE_PROBING) {
+                tpAbort(&emcmotInternal->coord_tp);
+                reportError(_("Probe tripped during non-probe move."));
+                SET_MOTION_ERROR_FLAG(1);
             }
+        } else {
+            // not running a command
+            int i;
+            int aborted = 0;
 
-            // inhibit_probe_home_error is set by [TRAJ]->NO_PROBE_HOME_ERROR in the ini file
-            if (!emcmotConfig->inhibit_probe_home_error) {
-                // abort any homing
-                if(get_homing(i)) {
-                    do_cancel_homing(i);
-                    aborted=1;
+            for(i=0; i<NO_OF_KINS_JOINTS; i++) {
+                emcmot_joint_t *joint = &joints[i];
+
+                if (!GET_JOINT_ACTIVE_FLAG(joint)) {
+                    /* if joint is not active, skip it */
+                    continue;
+                }
+
+                // inhibit_probe_home_error is set by [TRAJ]->NO_PROBE_HOME_ERROR in the ini file
+                if (!emcmotConfig->inhibit_probe_home_error) {
+                    // abort any homing
+                    if(get_homing(i)) {
+                        do_cancel_homing(i);
+                        aborted=1;
+                    }
+                }
+
+                // inhibit_probe_jog_error is set by [TRAJ]->NO_PROBE_JOG_ERROR in the ini file
+                if (!emcmotConfig->inhibit_probe_jog_error) {
+                    // abort any joint jogs
+                    if(joint->free_tp.enable == 1) {
+                        joint->free_tp.enable = 0;
+                        // since homing uses free_tp, this protection of aborted
+                        // is needed so the user gets the correct error.
+                        if(!aborted) aborted=2;
+                    }
                 }
             }
-
-            // inhibit_probe_jog_error is set by [TRAJ]->NO_PROBE_JOG_ERROR in the ini file
             if (!emcmotConfig->inhibit_probe_jog_error) {
-                // abort any joint jogs
-                if(joint->free_tp.enable == 1) {
-                    joint->free_tp.enable = 0;
-                    // since homing uses free_tp, this protection of aborted
-                    // is needed so the user gets the correct error.
-                    if(!aborted) aborted=2;
+                if (axis_jog_abort_all(1)) {
+                    aborted = 3;
                 }
             }
-        }
-        if (!emcmotConfig->inhibit_probe_jog_error) {
-            if (axis_jog_abort_all(1)) {
-                aborted = 3;
+
+            if(aborted == 1) {
+                reportError(_("Probe tripped during homing motion."));
             }
-        }
 
-        if(aborted == 1) {
-            reportError(_("Probe tripped during homing motion."));
-        }
-
-        if(aborted == 2) {
-            reportError(_("Probe tripped during a joint jog."));
-        }
-        if(aborted == 3) {
-            reportError(_("Probe tripped during a coordinate jog."));
+            if(aborted == 2) {
+                reportError(_("Probe tripped during a joint jog."));
+            }
+            if(aborted == 3) {
+                reportError(_("Probe tripped during a coordinate jog."));
+            }
         }
     }
     old_probeVal = emcmotStatus->probeVal;


### PR DESCRIPTION
This is the bugfix for the probe deceleration error, rebased for the 2.9 branch.

The current state of this pull request is based on discussion from my previous pull request into master:
https://github.com/LinuxCNC/linuxcnc/pull/3534

The previous pull request kept the original behaviour (with the deceleration error) by default, but also included the ability to inhibit the error.

However, in this pull request the error is effectively permanently inhibited (so, fully patched) with no option to enable it, due to the determination that this error is definitely a bug which should be fully patched).