### PR TITLE
Add Joint to Axis Translator

### DIFF
--- a/src/hal/components/joint_axis_mapper.comp
+++ b/src/hal/components/joint_axis_mapper.comp
@@ -1,4 +1,4 @@
-component translate """Translate from Joint to Axis""";
+component joint_axis_mapper """Translate from Joint to Axis""";
 
 license "GPL";
 
@@ -28,7 +28,7 @@ char fault_letter[16];
 
 int rtapi_app_main(void) {
     int r = 0;
-    comp_id = hal_init("translate");
+    comp_id = hal_init("joint_axis_mapper");
     char buf[HAL_NAME_LEN + 1];
 
     if(comp_id < 0) return comp_id;
@@ -36,7 +36,7 @@ int rtapi_app_main(void) {
     number_joints = strlen(coord);
     faults_in = hal_malloc(sizeof(faults_in_t));
 
-    rtapi_print_msg(RTAPI_MSG_INFO, "Translate - Initializing with coords %s\n", coord);
+    rtapi_print_msg(RTAPI_MSG_INFO, "Joint Axis Mapper - Initializing with coords %s\n", coord);
 
     int this_count = 0;
     for(int i =0; i < strlen(coord); i++){
@@ -65,19 +65,19 @@ int rtapi_app_main(void) {
         if(coord[i] == 'W' || coord[i] == 'w'){ axis_counts[8]++; this_count = axis_counts[8];  }
 
         if(this_count == 1){
-            hal_pin_bit_newf(HAL_IN,  &(faults_in->fault_in[i]),  comp_id, "translate.%c-fault", coord[i]);
-            hal_pin_bit_newf(HAL_OUT, &(faults_in->fault_out[i]), comp_id, "translate.%c-fault-latched", coord[i]);
+            hal_pin_bit_newf(HAL_IN,  &(faults_in->fault_in[i]),  comp_id, "jam.%c-fault", coord[i]);
+            hal_pin_bit_newf(HAL_OUT, &(faults_in->fault_out[i]), comp_id, "jam.%c-fault-latched", coord[i]);
         }
         else if(this_count > 1){
-            hal_pin_bit_newf(HAL_IN, &(faults_in->fault_in[i]), comp_id, "translate.%c%d-fault", coord[i], this_count);
-            hal_pin_bit_newf(HAL_OUT, &(faults_in->fault_out[i]), comp_id, "translate.%c%d-fault-latched", coord[i], this_count);
+            hal_pin_bit_newf(HAL_IN,  &(faults_in->fault_in[i]),  comp_id, "jam.%c%d-fault", coord[i], this_count);
+            hal_pin_bit_newf(HAL_OUT, &(faults_in->fault_out[i]), comp_id, "jam.%c%d-fault-latched", coord[i], this_count);
         }
         else {
-            rtapi_print_msg(RTAPI_MSG_ERR, "Translate - %c Axis not found in coord string\n", coord[i]);
+            rtapi_print_msg(RTAPI_MSG_ERR, "Joint Axis Mapper - %c axis not found in coord string\n", coord[i]);
         }
     }
 
-    hal_export_funct("translate", (void(*))_, 0, 1, 0, comp_id);
+    hal_export_funct("joint_axis_mapper", (void(*))_, 0, 1, 0, comp_id);
     hal_ready(comp_id);
     return 0;
 }
@@ -90,7 +90,7 @@ void rtapi_app_exit(void) {
 FUNCTION(_) {
         for(int i = 0; i < number_joints; i++) {
             if(*faults_in->fault_in[i] && ! *faults_in->fault_out[i]){
-                rtapi_print_msg(RTAPI_MSG_ERR, "Translate - %c Axis fault detected\n", fault_letter[i]);
+                rtapi_print_msg(RTAPI_MSG_ERR, "%c Axis fault detected\n", fault_letter[i]);
             }
             *(faults_in->fault_out[i]) = *(faults_in->fault_in[i]);
         }


### PR DESCRIPTION
Open to comments. 

Motivation is some guys can't memorize Joint 0 - X Joint 1 is Y etc. This is a brute force way off adding a popup for which Axis has faulted, while being flexible enough for a variety of kinematics.

The other options I seen for doing this was in one of the 3 modules:
- Motion only has the fault data
- Kinematics only has the axis-to-joint mapping
- RS274 only has the INI data
So without adding spaghetti of plumbing those three modules I opted for a halcomp

Also naming things is hard... is this too generic of a name.?