### PR TITLE
tests: PyVCP test, use script mode to avoid white space causing failures

### DIFF
--- a/tests/pyvcp/expected
+++ b/tests/pyvcp/expected
@@ -1,27 +1,24 @@
-Component Pins:
-Owner   Type  Dir         Value  Name
-     4  float OUT             0  mypanel.dial-a-out
-     4  float OUT             0  mypanel.dial-b-out
-     4  float IN              0  mypanel.dial-c-in
-     4  float OUT             0  mypanel.dial-c-out
-     4  float OUT             0  mypanel.dial.0.out
-     4  float IN              0  mypanel.dial.0.param_pin
-     4  float IN              0  mypanel.dial.1.param_pin
-     4  float IN              0  mypanel.dial.2.param_pin
-     4  float OUT             0  mypanel.scale-a-out-f
-     4  s32   OUT             0  mypanel.scale-a-out-i
-     4  float OUT             0  mypanel.scale-b-out-f
-     4  s32   OUT             0  mypanel.scale-b-out-i
-     4  float IN              0  mypanel.scale-c-in
-     4  float OUT             0  mypanel.scale-c-out-f
-     4  s32   OUT             0  mypanel.scale-c-out-i
-     4  float OUT             0  mypanel.scale.0-f
-     4  s32   OUT             0  mypanel.scale.0-i
-     4  float IN              0  mypanel.scale.2.param_pin
-     4  float OUT             0  mypanel.spinbox-a-out
-     4  float OUT             0  mypanel.spinbox-b-out
-     4  float IN              0  mypanel.spinbox-c-in
-     4  float OUT             0  mypanel.spinbox-c-out
-     4  float OUT             0  mypanel.spinbox.0
-     4  float IN              0  mypanel.spinbox.2.param_pin
-
+mypanel float OUT 0 mypanel.dial-a-out
+mypanel float OUT 0 mypanel.dial-b-out
+mypanel float IN 0 mypanel.dial-c-in
+mypanel float OUT 0 mypanel.dial-c-out
+mypanel float OUT 0 mypanel.dial.0.out
+mypanel float IN 0 mypanel.dial.0.param_pin
+mypanel float IN 0 mypanel.dial.1.param_pin
+mypanel float IN 0 mypanel.dial.2.param_pin
+mypanel float OUT 0 mypanel.scale-a-out-f
+mypanel s32   OUT 0 mypanel.scale-a-out-i
+mypanel float OUT 0 mypanel.scale-b-out-f
+mypanel s32   OUT 0 mypanel.scale-b-out-i
+mypanel float IN 0 mypanel.scale-c-in
+mypanel float OUT 0 mypanel.scale-c-out-f
+mypanel s32   OUT 0 mypanel.scale-c-out-i
+mypanel float OUT 0 mypanel.scale.0-f
+mypanel s32   OUT 0 mypanel.scale.0-i
+mypanel float IN 0 mypanel.scale.2.param_pin
+mypanel float OUT 0 mypanel.spinbox-a-out
+mypanel float OUT 0 mypanel.spinbox-b-out
+mypanel float IN 0 mypanel.spinbox-c-in
+mypanel float OUT 0 mypanel.spinbox-c-out
+mypanel float OUT 0 mypanel.spinbox.0
+mypanel float IN 0 mypanel.spinbox.2.param_pin

--- a/tests/pyvcp/test.sh
+++ b/tests/pyvcp/test.sh
@@ -2,6 +2,7 @@
 
 set -e
 
-xvfb-run halrun do-test.hal &
+xvfb-run halrun -s do-test.hal
+sed -i '/mypanel/!d' result
 
 exit 0


### PR DESCRIPTION
My local PC seems to format "show pin" differently to the Github runners or buildbots. 
Using the -s command in halrun simplifies the formatting. 