### PR TITLE
Add Stepping Status to emcmodule

### DIFF
--- a/docs/src/config/python-interface.adoc
+++ b/docs/src/config/python-interface.adoc
@@ -278,6 +278,9 @@ see <<python:reading-ini-values,ReadingINI file values>> for an example.
 *paused*:: '(returns boolean)' -
   `motion paused` flag.
 
+*stepping*:: '(returns boolean)' -
+  `motion stepping` flag.
+
 *pocket_prepped*:: '(returns integer)' -
   A Tx command completed, and this pocket is prepared. -1 if no
   prepared pocket.

--- a/src/emc/nml_intf/emc_nml.hh
+++ b/src/emc/nml_intf/emc_nml.hh
@@ -984,6 +984,7 @@ class EMC_TRAJ_STAT:public EMC_TRAJ_STAT_MSG {
     bool queueFull;		// non-zero means can't accept another motion
     int id;			// id of the currently executing motion
     bool paused;			// non-zero means motion paused
+    bool stepping;    // non-zero means motion stepping single block
     double scale;		// velocity scale factor
     double rapid_scale;		// rapid scale factor
     //double spindle_scale;	// moved to EMC_SPINDLE_STAT

--- a/src/emc/task/emctaskmain.cc
+++ b/src/emc/task/emctaskmain.cc
@@ -1174,6 +1174,7 @@ static int emcTaskPlan(void)
 		    break;
 
 		case EMC_TASK_PLAN_STEP_TYPE:
+			emcStatus->motion.traj.stepping = 1;
 		    stepping = 1;	// set stepping mode in case it's not
 		    steppingWait = 0;	// clear the wait
 		    break;
@@ -1249,6 +1250,7 @@ static int emcTaskPlan(void)
 		    break;
 
 		case EMC_TASK_PLAN_STEP_TYPE:
+			emcStatus->motion.traj.stepping = 1;
 		    stepping = 1;
 		    steppingWait = 0;
 		    if (emcStatus->motion.traj.paused &&
@@ -1324,6 +1326,7 @@ static int emcTaskPlan(void)
 		    break;
 
 		case EMC_TASK_PLAN_STEP_TYPE:
+			emcStatus->motion.traj.stepping = 1;
 		    stepping = 1;	// set stepping mode in case it's not
 		    steppingWait = 0;	// clear the wait
 		    break;
@@ -2123,6 +2126,7 @@ static int emcTaskIssueCommand(NMLmsg * cmd)
 		// clear out the interpreter state
 		emcStatus->task.interpState = EMC_TASK_INTERP::IDLE;
 		emcStatus->task.execState = EMC_TASK_EXEC::DONE;
+		emcStatus->motion.traj.stepping = 0;
 		stepping = 0;
 		steppingWait = 0;
 
@@ -2217,6 +2221,7 @@ static int emcTaskIssueCommand(NMLmsg * cmd)
 	break;
 
     case EMC_TASK_PLAN_EXECUTE_TYPE:
+	emcStatus->motion.traj.stepping = 0;
 	stepping = 0;
 	steppingWait = 0;
 	execute_msg = (EMC_TASK_PLAN_EXECUTE *) cmd;
@@ -2312,6 +2317,7 @@ static int emcTaskIssueCommand(NMLmsg * cmd)
             retval = -1;
             break;
         }
+	emcStatus->motion.traj.stepping = 0;
 	stepping = 0;
 	steppingWait = 0;
 	if (!taskplanopen && emcStatus->task.file[0] != 0) {
@@ -2360,6 +2366,7 @@ static int emcTaskIssueCommand(NMLmsg * cmd)
 	emcTrajResume();
 	emcStatus->task.interpState = interpResumeState;
 	emcStatus->task.task_paused = 0;
+	emcStatus->motion.traj.stepping = 0;
 	stepping = 0;
 	steppingWait = 0;
 	retval = 0;
@@ -2590,6 +2597,7 @@ static int emcTaskExecute(void)
 	// clear out the interpreter state
 	emcStatus->task.interpState = EMC_TASK_INTERP::IDLE;
 	emcStatus->task.execState = EMC_TASK_EXEC::DONE;
+	emcStatus->motion.traj.stepping = 0;
 	stepping = 0;
 	steppingWait = 0;
 
@@ -3497,6 +3505,7 @@ int main(int argc, char *argv[])
 	    // clear out the interpreter state
 	    emcStatus->task.interpState = EMC_TASK_INTERP::IDLE;
 	    emcStatus->task.execState = EMC_TASK_EXEC::DONE;
+		emcStatus->motion.traj.stepping = 0;
 	    stepping = 0;
 	    steppingWait = 0;
 

--- a/src/emc/usr_intf/axis/extensions/emcmodule.cc
+++ b/src/emc/usr_intf/axis/extensions/emcmodule.cc
@@ -466,6 +466,7 @@ static PyMemberDef Stat_members[] = {
     {(char*)"queue_full", T_BOOL, O(motion.traj.queueFull), READONLY, NULL},
     {(char*)"motion_id", T_INT, O(motion.traj.id), READONLY, NULL},
     {(char*)"paused", T_BOOL, O(motion.traj.paused), READONLY, NULL},
+    {(char*)"stepping", T_BOOL, O(motion.traj.stepping), READONLY, NULL},
     {(char*)"feedrate", T_DOUBLE, O(motion.traj.scale), READONLY, NULL},
     {(char*)"rapidrate", T_DOUBLE, O(motion.traj.rapid_scale), READONLY, NULL},
     {(char*)"velocity", T_DOUBLE, O(motion.traj.velocity), READONLY, NULL},


### PR DESCRIPTION
I don't see another way of doing this, but currently I can't see any feedback in any UI that shows the current Single Block mode (Stepping) or not.

It seems to be a flag you send with command.AUTO(AUTO_STEP) and you can just remember in your UI you set the flag...? I prefer polling to know the real answer.