### PR TITLE
docs: fix typos in man pages

### DIFF
--- a/docs/src/man/man1/mesambccc.1.adoc
+++ b/docs/src/man/man1/mesambccc.1.adoc
@@ -458,7 +458,7 @@ writes at the specified interval.
     <pin name="humidity" />
     <description>Will become HAL pins:
        - (out) hm2_modbus.0.scd30.co2
-       - (out) hm2_modbus.0.scd30.temparature
+       - (out) hm2_modbus.0.scd30.temperature
        - (out) hm2_modbus.0.scd30.humidity
        Count will automatically be calculated (6 Modbus 16-bit registers).
     </description>

--- a/docs/src/man/man9/hostmot2.9.adoc
+++ b/docs/src/man/man9/hostmot2.9.adoc
@@ -353,7 +353,7 @@ no-clear-on-index (bit in)::
  When this pin is set to True, the count (and therefore also position) 
  are NOT reset to zero on the next Index (Phase\-Z) pulse.
  On an index event the latched count and position will be set to 
- indicate the count and position where the index occured.
+ indicate the count and position where the index occurred.
 probe-enable (bit in/out)::
  When this pin is set to True, the encoder count (and therefore also
  position) are latched on the the next probe active edge. At the same


### PR DESCRIPTION
Found via codespell