### PR TITLE
Modify TCLLIBPATH appendations in scripts/linuxcnc.in and scripts/rip-environment.in

### DIFF
--- a/scripts/linuxcnc.in
+++ b/scripts/linuxcnc.in
@@ -98,7 +98,7 @@ if test "xyes" != "x@RUN_IN_PLACE@"; then
     if [ -z "$TCLLIBPATH" ]; then
          TCLLIBPATH=$LINUXCNC_HOME/lib/tcltk
     else
-        TCLLIBPATH=$LINUXCNC_HOME/lib/tcltk:"$TCLLIBPATH"
+        TCLLIBPATH="$LINUXCNC_HOME/lib/tcltk $TCLLIBPATH"
     fi
     export TCLLIBPATH
 fi

--- a/scripts/rip-environment.in
+++ b/scripts/rip-environment.in
@@ -76,7 +76,7 @@ GLADE_ICON_THEME_PATH=$EMC2_HOME/share/glade/pixmaps:"$GLADE_ICON_THEME_PATH"; e
 if [ -z "$TCLLIBPATH" ]; then
     TCLLIBPATH=$EMC2_HOME/tcl
 else
-    TCLLIBPATH=$EMC2_HOME/tcl:$TCLLIBPATH
+    TCLLIBPATH="$EMC2_HOME/tcl $TCLLIBPATH"
 fi
 
 if [ -z "$LD_LIBRARY_PATH" ]; then


### PR DESCRIPTION
Hey,

I noticed that the current `TCLLIBPATH` appendations in scripts/linuxcnc.in and scripts/rip-environment.in are not working, since they are not in TCL list style but in PATH style (see https://www.tcl-lang.org/man/tcl8.4/TclCmd/library.htm#M26). In PATH style, the current appendation causes the `Linuxcnc` TCL package not to be found if there is already a `TCLLIBPATH` definition. The error  message of a fresh installation and a demonstrating minimal example then is

```
$ TCLLIBPATH=/usr/lib/tcltk linuxcnc
LINUXCNC - 2.10.0~pre0
Machine configuration directory is '/home/server/linuxcnc/configs/sim.axis'
Machine configuration file is 'minimal_xyz.ini'
can't find package Linuxcnc
    while executing
"package require Linuxcnc "
    (file "/usr/share/linuxcnc/hallib/check_config.tcl" line 187)
check_config validation failed
LinuxCNC terminated with an error.  You can find more information in the log:
    /home/server/linuxcnc_debug.txt
and
    /home/server/linuxcnc_print.txt
as well as in the output of the shell command 'dmesg' and in the terminal
```

This should solve #3348 .