### PR TITLE
Presumed final translation-associated weirdnesses (smoe:docs_fixes_20250812)

### DIFF
--- a/docs/src/config/core-components.adoc
+++ b/docs/src/config/core-components.adoc
@@ -95,8 +95,7 @@ unlock_joints_mask=0x38 selects joints 3,4,5
 [[sec:motion-pins]]
 === Pins(((motion:HAL pins)))
 
-These pins, parameters, and functions are created by the realtime 'motmod'
-module.
+These pins, parameters, and functions are created by the realtime 'motmod' module.
 
 * 'motion.adaptive-feed' - (float, in) When adaptive feed is enabled with 'M52 P1' , the
   commanded velocity is multiplied by this value. This effect is
@@ -109,13 +108,10 @@ module.
   controlled by M67 or M68.
 * 'motion.coord-error' - (bit, out) TRUE when motion has encountered an error, such as
   exceeding a soft limit
-* 'motion.coord-mode' - (bit, out) TRUE when motion is in 'coordinated mode', as opposed to
-  'teleop mode'
+* 'motion.coord-mode' - (bit, out) TRUE when motion is in 'coordinated mode', as opposed to 'teleop mode'
 * 'motion.current-vel' - (float, out) The current tool velocity in user units per second.
-* 'motion.digital-in-00' - (bit, in) These pins (00, 01, 02, 03 or more if configured) are
-  controlled by M62-65.
-* 'motion.digital-out-00' - (bit, out) These pins (00, 01, 02, 03 or more if configured) are
-  controlled by the 'M62-65'.
+* 'motion.digital-in-00' - (bit, in) These pins (00, 01, 02, 03 or more if configured) are controlled by M62-65.
+* 'motion.digital-out-00' - (bit, out) These pins (00, 01, 02, 03 or more if configured) are controlled by the 'M62-65'.
 * 'motion.distance-to-go' - (float,out) The distance remaining in the current move.
 * 'motion.enable' - (bit, in) If this bit is driven FALSE, motion stops, the machine is
   placed in the 'machine off' state, and a message is displayed for the
@@ -147,32 +143,18 @@ module.
 * 'motion.teleop-mode' - (bit, out) TRUE when motion is in 'teleop mode', as opposed to 'coordinated mode'
 * 'motion.tooloffset.x ... motion.tooloffset.w' - (float, out, one per axis) shows the tool offset in effect;
   it could come from the tool table ('G43' active), or it could come from the G-code ('G43.1' active)
-
-* 'motion.on-soft-limit' -
-  (bit, out) TRUE when the machine is on a soft limit.
-* 'motion.probe-input' -
-  (bit, in) 'G38.n'  uses the value on this pin to determine when the
-  probe has made contact.
+* 'motion.on-soft-limit' - (bit, out) TRUE when the machine is on a soft limit.
+* 'motion.probe-input' - (bit, in) 'G38.n'  uses the value on this pin to determine when the probe has made contact.
   TRUE for probe contact closed (touching),
   FALSE for probe contact open.
-* 'motion.program-line' -
-  (s32, out) The current program line while executing. Zero if not
-  running or between lines while single stepping.
-* 'motion.requested-vel' -
-  (float, out) The current requested velocity in user units per
-  second.  This value is the F-word setting from the G-code file,
-  possibly reduced to accommodate machine velocity and acceleration
-  limits. The value on this pin does not reflect the feed override or
-  any other adjustments.
-
-* 'motion.teleop-mode' -
-  (bit, out) TRUE when motion is in 'teleop mode', as opposed to
-  'coordinated mode'
-
-* 'motion.tooloffset.x ... motion.tooloffset.w' -
-  (float, out, one per axis) shows the tool offset in effect;
-  it could come from the tool table ('G43' active), or it could
-  come from the G-code ('G43.1' active)
+* 'motion.program-line' - (s32, out) The current program line while executing.
+  Zero if not running or between lines while single stepping.
+* 'motion.requested-vel' - (float, out) The current requested velocity in user units per second.
+  This value is the F-word setting from the G-code file, possibly reduced to accommodate machine velocity and acceleration limits.
+  The value on this pin does not reflect the feed override or any other adjustments.
+* 'motion.teleop-mode' - (bit, out) TRUE when motion is in 'teleop mode', as opposed to 'coordinated mode'
+* 'motion.tooloffset.x ... motion.tooloffset.w' - (float, out, one per axis) shows the tool offset in effect;
+  it could come from the tool table ('G43' active), or it could come from the G-code ('G43.1' active)
 
 === Parameters
 
@@ -191,10 +173,9 @@ change or removal at any time.
 * 'motion.debug-float-3' - (float, RO) This is used for debugging purposes.
 * 'motion.debug-s32-0' - (s32, RO) This is used for debugging purposes.
 * 'motion.debug-s32-1' - (s32, RO) This is used for debugging purposes.
-* 'motion.servo.last-period' - (u32, RO) The number of CPU cycles between invocations of the servo
-  thread. Typically, this number divided by the CPU speed gives the time
-  in seconds, and can be used to determine whether the realtime motion
-  controller is meeting its timing constraints
+* 'motion.servo.last-period' - (u32, RO) The number of CPU cycles between invocations of the servo thread.
+  Typically, this number divided by the CPU speed gives the time in seconds,
+  and can be used to determine whether the realtime motion controller is meeting its timing constraints
 * 'motion.servo.last-period-ns' - (float, RO)
 
 === Functions
@@ -316,7 +297,7 @@ See the motion man page 'motion(9)' for details on the pins and parameters.
 
 == iocontrol
 
-iocontrol - accepts non-realtime I/O commands via NML, interacts with HAL .
+iocontrol - accepts non-realtime I/O commands via NML, interacts with HAL.
 
 iocontrol's HAL pins are turned on and off in non-realtime context.  If you have strict timing requirements or simply need more I/O, consider using the realtime synchronized I/O provided by <<sec:motion,motion>> instead.
 

--- a/docs/src/config/python-interface.adoc
+++ b/docs/src/config/python-interface.adoc
@@ -321,7 +321,8 @@ see <<python:reading-ini-values,ReadingINI file values>> for an example.
 *settings*:: '(returns tuple of floats)' -
   current interpreter settings: +
   settings[0] = sequence number, +
-  settings[1] = feed rate, settings[2] = speed, +
+  settings[1] = feed rate, +
+  settings[2] = speed, +
   settings[3] = `G64 P` blend tolerance, +
   settings[4] = `G64 Q` naive CAM tolerance.
 

--- a/docs/src/gcode/coordinates.adoc
+++ b/docs/src/gcode/coordinates.adoc
@@ -148,7 +148,7 @@ command would not have been modal and any commands issued after it would
 have returned to using the G55 offsets because that coordinate system
 would still be in effect.
 
-[source,{ngc}]
+[source,{ngc}](((G54)))(((G55)))(((G56)))(((G57)))(((G58)))(((G59)))(((G59.1)))(((G59.2)))(((G59.3)))
 ----
 G54	uses parameters of coordinate system 1
 G55	uses parameters of coordinate system 2

--- a/docs/src/gui/gui-dev-reference.adoc
+++ b/docs/src/gui/gui-dev-reference.adoc
@@ -12,18 +12,17 @@
 :css: {basebackend@docbook:'':css}
 
 This document attempts to be a 'best practices' reference for general use screen development. +
-While it's possible to program just about anything to work with linuxcnc, using common frame work,
- language and configuration requirements allows easier transition between screens and more developers 
-to maintain them. +
+While it is possible to program just about anything to work with LinuxCNC, using a common frame work,
+language and configuration requirements allows easier transition between screens and more developers to maintain them. +
 That said, nothing in this document is written in stone.
 
 == Language
-Python is currently the preferred language of linuxcnc's screen code. +
+Python is currently the preferred language of LinuxCNC's screen code. +
 Python has a low entry bar for new users to modify the screens to suit them. +
-Python has a rich array of documentation, tutorials and libraries to pull from. + 
-It is already used and integrated into linuxcnc's system requirements. +
+Python has a rich array of documentation, tutorials and libraries to pull from. +
+It is already used and integrated into LinuxCNC's system requirements. +
 While C or C\++ could be used, it severely limits who can maintain and develop them. +
-It would be better to extend python with C/C++ modules for whatever function that requires it.
+It would be better to extend Python with C/C++ modules for whatever function that requires it.
 
 == Localization of float numbers in GUIs
 Different locales use different decimal separators and thousands separators. Locale-specific
@@ -37,16 +36,16 @@ are suggested if parsing float to string and vice-versa:
 
 == Basic Configuration
 Currently, most screens use a combination of INI file and preference file entries to configure their functions. +
-INi text files are usually used for the common machine controller settings, while text based preference files 
+INI text files are usually used for the common machine controller settings, while text based preference files
 are used for more GUI related properties (such as sounds, size, colors). +
-There can be other files used for translations, stylizing and function customization. These are highly dependent 
+There can be other files used for translations, stylizing and function customization. These are highly dependent
 on the underlying widget toolkit.
 
 === INI [DISPLAY]
 The *[DISPLAY]* section of the INI is for specifying screen related settings. +
 
 ==== Display
-The most important of is specifying the name of the screen that the linuxcnc script will use to load. +
+The most important of is specifying the name of the screen that the LinuxCNC script will use to load. +
 The screen program usually recognizes switches such as to set full screen. +
 Title is for the window title and icon is used for iconizing the window.
 
@@ -93,7 +92,7 @@ ANGULAR_INCREMENTS = continuous, .5, 1, 45, 90, 360
 ----
 
 ==== Machine Type Hint
-The screen often needs to be adjusted based on machine type. Lathes have different controls and display DROs 
+The screen often needs to be adjusted based on machine type. Lathes have different controls and display DROs
 differently. Foam machine display the plot differently. +
 The old way to do this was adding switches LATHE = 1, FOAM = 1 etc
 
@@ -124,15 +123,15 @@ DEFAULT_LINEAR_VELOCITY =
 MIN_LINEAR_VELOCITY =
 MAX_LINEAR_VELOCITY =
 
-DEFAULT_ANGULAR_VELOCITY = 
-MIN_ANGULAR_VELOCITY = 
-MAX_ANGULAR_VELOCITY = 
+DEFAULT_ANGULAR_VELOCITY =
+MIN_ANGULAR_VELOCITY =
+MAX_ANGULAR_VELOCITY =
 ----
 
 ==== Spindle Manual Controls
 Manual controls for spindle control could be, (or a combinations of) buttons, sliders or dials +
 You can set limits that are less then the what the machine controller can utilize by setting these entries. +
-If your screen is capable of running multiple spindles, then should accept entries higher then the shown '_0_'
+If your screen is capable of running multiple spindles, then should accept entries higher then the shown '_0_'.
 
 [source,{ini}]
 ----
@@ -156,8 +155,8 @@ MDI_COMMAND_MACRO1 = G53 G0 Z0;G53 G0 X0 Y0,Goto\nMachn\nZero
 ----
 
 === INI [FILTER]
-This section allows setting of what files are shown in the file chooser and 
-what filter programs will preprocess its output before sending it to linuxcnc. +
+This section allows setting of what files are shown in the file chooser and
+what filter programs will preprocess its output before sending it to LinuxCNC. +
 The extensions follow this pattern: +
 PROGRAM_EXTENSION = .extension,.extension2[space]Description of extensions +
 The filter program definitions are such: +
@@ -179,7 +178,7 @@ py = python3
 ----
 
 === INI [HAL]
-Most screens will need some HAL pins. They need to be connected after the screen creates them.+
+Most screens will need some HAL pins. They need to be connected after the screen creates them.
 
 ==== Postgui Halfile
 These files should be run one after another in order, after all the GUI HAL pins have been made.
@@ -204,8 +203,8 @@ POSTGUI_HALCMD = loadusr halmeter
 == Extended Configuration
 
 === Embedding GUI Elements
-Allowing users to build small panels independently, that can be embedded into the main screen 
-is a common and very useful customization. Some screens allow embedding of 3rd party foreign programs, 
+Allowing users to build small panels independently, that can be embedded into the main screen
+is a common and very useful customization. Some screens allow embedding of 3rd party foreign programs,
 others only the native widget toolkit based panels. +
 Usually these are embedded in tabs or side panel widgets. +
 This is how to describe the optional title, loading command and location widget name: +
@@ -233,7 +232,7 @@ MESSAGE_ICON = INFO
 ----
 
 This style gives multiple messages defined by a number. +
-This example shows 3 possible messages based around a VFD error nuumber.
+This example shows 3 possible messages based around a VFD error number.
 
 [source,{ini}]
 ----

--- a/docs/src/gui/qtvcp-libraries.adoc
+++ b/docs/src/gui/qtvcp-libraries.adoc
@@ -652,7 +652,7 @@ as the widgets get a reference to the `MainWindow` from the `_hal_init()` functi
 from qtvcp.qt_makegui import VCPWindow
 ----
 
-* *Instantiate `VCPWindow` module*+
+* *Instantiate `VCPWindow` module* +
   Add this Python code to your instantiate section:
 +
 [source,python]

--- a/docs/src/gui/qtvcp-vismach.adoc
+++ b/docs/src/gui/qtvcp-vismach.adoc
@@ -409,7 +409,7 @@ Sets the _display color of the part based on a designated HAL bit pin state_. +
   `hal_comp`;; The _HAL component Object_ or None. +
     In QtVCP if you are reading _system pins_ directly, then the component argument is set to `None`. +
   `hal_pin`;; The _name of the BIT HAL IN pin_ that will change the color. +
-    if hal_comp is 'None' then this must be the full name of a system pin other wise this is the pin name excluding the component name
+    if hal_comp is 'None' then this must be the full name of a system pin other wise this is the pin name excluding the component name.
 
 === HALColorRGB
 Sets the _display color of the part based on a designated HAL U32 pin value_. +
@@ -424,7 +424,7 @@ combined as 0xXXBBGGRR +
   `hal_comp`;; The _HAL component Object_ or None. +
     In QtVCP if you are reading _system pins_ directly, then the component argument is set to `None`. +
   `hal_pin`;; The _name of the U32 HAL IN pin_ that will change the color. +
-    if hal_comp is 'None' then this must be the full name of a system pin other wise this is the pin name excluding the component name +
+    if hal_comp is 'None' then this must be the full name of a system pin other wise this is the pin name excluding the component name. +
   `alpha=`;; Sets the opacity. (0-1.0)
 
 === Heads Up Display
@@ -477,11 +477,10 @@ chuckassembly = HideCollection([chuckassembly],comp,'hide-chuck')
 chuckassembly = HideCollection([chuckassembly],None,'myvismach.hide-chuck') 
 ----
 
-=== Plot Color Based on Mtotion Type
-If you wish to plot different colors for different motions you need to add some more python code. +
+=== Plot Color Based on Motion Type
+If you wish to plot different colors for different motions you need to add some more Python code.
 
-
-add this at the top of the file:
+Add this at the top of the file:
 
 [source,python]
 ----
@@ -499,7 +498,8 @@ and this to the Window class:
         #v.setColorsAttribute('FEED',(0,1,0))
         #print(v.colors)
 ----
-You can set DEFAULT, FEED, TRAVERSE, ARC, PROBE, ROTARYINDEX, TOOLCHANGE colors with setColorsAttribute()
+
+You can set DEFAULT, FEED, TRAVERSE, ARC, PROBE, ROTARYINDEX, TOOLCHANGE colors with setColorsAttribute().
 
 === Capture
 This sets the current position in the model.
@@ -603,7 +603,7 @@ class Window(QWidget):
 
         # uncomment to change feed color
         #v.setColorsAttribute('FEED',(0,1,0))
-        #  and to see all colors printed to the terminal
+        # and to see all colors printed to the terminal
         #print(v.colors)
 
         v.model = Collection([model, world])

--- a/docs/src/gui/qtvcp-vismach.adoc
+++ b/docs/src/gui/qtvcp-vismach.adoc
@@ -309,7 +309,7 @@ Either by adding the component object as the first variable and substituting the
 by substituting the full component/pinname string for a coordinate. +
 
 This example creates a _rectangular prism with opposite corners_ at the specified positions and edges parallel to the XYZ axes. +
-the Z start coordinate will be controlled by the HAL pin 'Zstart'
+The Z start coordinate will be controlled by the HAL pin 'Zstart'.
 
 [source,python]
 ----

--- a/docs/src/gui/qtvcp-widgets.adoc
+++ b/docs/src/gui/qtvcp-widgets.adoc
@@ -457,7 +457,7 @@ Allows one to *adjust a HAL pin value using a sliding pointer*.
 
 [[sub:qtvcp:widgets:tabwidget]]
 === `TabWidget` - Tab Widget
-This widget allows the tab height to be adjusted with stylesheets
+This widget allows the tab height to be adjusted with stylesheets.
 
 The `TabWidget` properties can be defined in a _stylesheet_ with the following code added to the `.qss` file. +
 `name_of_tab` being the widget name defined in Qt Designer's editor. +
@@ -719,22 +719,22 @@ usually this is selected from the screenOptions widget.
 *`halpin_option`*::
   Will set a HAL pin true when the axis is selected.
 *`joint_number`*::
-  Should be set to the appropriate joint number
+  Should be set to the appropriate joint number.
 *`axis_letter`*::
-  Should be set to the appropriate axis letter
+  Should be set to the appropriate axis letter.
 
 These are the click-and-hold menu properties: +
 
 *`showLast`*::
-  show the 'Set to last' action
+  Show the 'Set to last' action.
 *`showDivide`*::
-  show the 'Divide by 2' action
+  Show the 'Divide by 2' action.
 *`showGotoOrigin`*::
-  show the 'Go to G53/G5x origin' action
+  Show the 'Go to G53/G5x origin' action.
 *`showZeroOrigin`*::
-  show the 'Zero Origin' action
+  Show the 'Zero Origin' action.
 *`showSetOrigin`*::
-  show the 'Set Origin' action
+  Show the 'Set Origin' action.
 *`dialog_code_string`*::
   Sets which dialog will pop up with numerical entry,
   i.e. 'ENTRY' or 'CALCULATOR' to call a typing only entry dialog or a touch/typing calculator type entry dialog.
@@ -811,15 +811,15 @@ You can also click on the label and see a list of actions. +
 These are the click-on-menu options:
 
 *`showLast`*::
-  show the 'Set to last' action
+  Show the 'Set to last' action.
 *`showDivide`*::
-  show the 'Divide by 2' action
+  Show the 'Divide by 2' action.
 *`showGotoOrigin`*::
-  show the 'Go to G53/G5x origin' action
+  Show the 'Go to G53/G5x origin' action.
 *`showZeroOrigin`*::
-  show the 'Zero Origin' action
+  Show the 'Zero Origin' action.
 *`showSetOrigin`*::
-  show the 'Set Origin' action
+  Show the 'Set Origin' action.
 *`dialogName`*::
   Sets which dialog window will pop up with numerical entry, i.e. ENTRY or CALCULATOR.
 

--- a/docs/src/gui/qtvcp.adoc
+++ b/docs/src/gui/qtvcp.adoc
@@ -233,7 +233,7 @@ Subclassing just means our handler file first loads the original handler file an
 This is useful for changing/adding behaviour while still retaining standard handler updates from LinuxCNC repositories.
 
 You may still need to use the handler copy dialog to copy the original handler file to decide how to patch it.
-See 'custom handler file'
+See 'custom handler file'.
 
 There should be a folder in the config folder; for screens: named '<CONFIG FOLDER>/qtvcp/screens/<SCREEN NAME>/' +
 add the handle patch file there, named like so <ORIGINAL SCREEN NAME>_handler.py, +
@@ -304,8 +304,8 @@ This file will be read and executed as Python code in the *handler file context*
 *Only local functions and local attributes* can be referenced. +
 Global libraries defined in the screen's handler file can be referenced by importing the handler file. +
 These are usually seen as all capital words with no preceding self. +
-'self' references the window class functions +
-'self.w' typically references the widgets
+'self' references the window class functions. +
+'self.w' typically references the widgets.
 
 What can be used can vary by screen and development cycle.
 

--- a/docs/src/gui/qtvcp.adoc
+++ b/docs/src/gui/qtvcp.adoc
@@ -974,8 +974,8 @@ If QtVCP finds these it will call them, if not it will silently ignore them.
   _Class patching_, also known as _monkey patching_, allows to *override function calls in an imported module*. +
   Class patching must be done _before the module is instantiated_, and it _modifies all instances_ made after that. +
   An example might be patching button calls from the G-code editor to call functions in the handler file instead. +
-  Class patching function redefined here, will be called with the HandlerClass instance as 'self' rather then +
-  the patched class instance. This can make access to the patched class function/variables more difficult. +
+  Class patching function redefined here, will be called with the HandlerClass instance as 'self' rather than the patched class instance.
+  This can make access to the patched class function/variables more difficult. +
   When class patching outside of the HandlerClass class, the function call will use the patched class instance as 'self'. 
 
 *`initialized__(self):`*::

--- a/docs/src/man/man1/halreport.1.adoc
+++ b/docs/src/man/man1/halreport.1.adoc
@@ -12,7 +12,7 @@ halreport - creates a report on the status of the HAL
 
 *halreport*
 
-. Supports components made by halcompile and numerous legacy components
+. Supports components made by halcompile and numerous legacy components.
 . Known unhandled components:
 at_pid:: naming conflicts with pid, seldom used
 boss_plc:: no manpage or docs (any users?)

--- a/docs/src/man/man1/halrmt.1.adoc
+++ b/docs/src/man/man1/halrmt.1.adoc
@@ -12,7 +12,7 @@ halrmt - remote-control interface for LinuxCNC
 
 --port _port_:: Waits for socket connections (telnet) on specified
 socket, without port specification it uses default port 5006.
-(note: linuxcncrsh uses 5007 as default)
+(Note: linuxcncrsh uses 5007 as default.)
 --name _server_name_:: Sets the server name to specified name for Hello.
 --connectpw _password_:: Sets the connection password to 'password'. Default: EMC.
 --enablepw _password_:: Sets the enable password to _password_. Default EMCTOO.

--- a/docs/src/man/man1/halshow.1.adoc
+++ b/docs/src/man/man1/halshow.1.adoc
@@ -20,7 +20,7 @@ For format see https://www.tcl.tk/man/tcl8.6.11/TclCmd/format.html[]
 
 Example: "%.5f" displays a float with 5 digits right of the decimal point.
 
---noprefs:: Don't use preference file to save settings
+--noprefs:: Don't use preference file to save settings.
 
 == DESCRIPTION
 
@@ -39,8 +39,8 @@ LinuxCNC 2.9::
  - Added buttons for pin/parameter/signal manipulation.
  - Added menu entries for setting update interval, adding manually.
  - Added right-click menu for copy, set, unlink pin and remove from view.
- - Added button to expand/collapse the tree view
- - Added search entry
+ - Added button to expand/collapse the tree view.
+ - Added search entry.
 
 == BUGS
 

--- a/docs/src/man/man1/lineardelta.1.adoc
+++ b/docs/src/man/man1/lineardelta.1.adoc
@@ -7,8 +7,7 @@ lineardelta - Vismach Virtual Machine GUI
 == DESCRIPTION
 
 *lineardelta* is one of the sample *Vismach* GUIs for LinuxCNC,
-simulating a delta robot with linear actuators
-
+simulating a delta robot with linear actuators.
 
 == SEE ALSO
 

--- a/docs/src/man/man1/mitsub_vfd.1.adoc
+++ b/docs/src/man/man1/mitsub_vfd.1.adoc
@@ -15,7 +15,7 @@ connector.
 __number1__:: is the slave number that was set on the VFD. Must be two digits (Parameter 117).
 name__N__=number__N__:: can be repeated for multiple VFD's connected together.
 *--baud* _baudrate_:: is optional as it defaults to 9600, all networked vfds must be set to the same baudrate.
-*--port* _devicename_:: is optional as it defaults to `ttyS0``, a common alternative is `/dev/ttyUSB0`.
+*--port* _devicename_:: is optional as it defaults to `ttyS0`, a common alternative is `/dev/ttyUSB0`.
 
 == DESCRIPTION
 
@@ -99,7 +99,7 @@ _VFD_NAME_**.stat-bit-3** (bit, out):: Raw status bit. Configure the VFD so that
 _VFD_NAME_**.stat-bit-4** (bit, out):: Raw status bit
 _VFD_NAME_**.stat-bit-5** (bit, out):: Raw status bit
 _VFD_NAME_**.stat-bit-6** (bit, out):: Raw status bit
-_VFD_NAME_**.stat-bit-7** (bit, out):: Raw status bit. Configure the VFD so that the function 'alarm' is assigned to status bit 7 (parameter 195 for 700 series)
+_VFD_NAME_**.stat-bit-7** (bit, out):: Raw status bit. Configure the VFD so that the function 'alarm' is assigned to status bit 7 (parameter 195 for 700 series).
 
 == SAMPLE HAL
 

--- a/docs/src/man/man1/sim_pin.1.adoc
+++ b/docs/src/man/man1/sim_pin.1.adoc
@@ -21,14 +21,14 @@ supported.
 If the named input is a numerical type, the GUI displays:
 
 *Entry* Entry widget for value or a valid Tcl expression. +
-*Set* Pushbutton to set new value from Entry (or use <RETURN>) +
+*Set* Pushbutton to set new value from Entry (or use <RETURN>). +
 *Reset* Pushbutton to reset to the value present on initiation If the
 input is a *bit* type, the GUI shows a single pushbutton that is
 controlled by radio-button selectors:
 
-mode=**pulse** Pulse input to 1 for each pushbutton press +
-mode=**toggle** Toggle input for each pushbutton press +
-mode=**hold** Set input to 1 while pushbutton pressed
+mode=**pulse** Pulse input to 1 for each pushbutton press. +
+mode=**toggle** Toggle input for each pushbutton press. +
+mode=**hold** Set input to 1 while pushbutton pressed.
 
 If the bit item mode begins with an uppercase letter, the radio buttons
 for selecting other modes are not shown

--- a/docs/src/man/man1/vfs11_vfd.1.adoc
+++ b/docs/src/man/man1/vfs11_vfd.1.adoc
@@ -156,7 +156,7 @@ This component reads and writes to the vfs11 via a Modbus connection.
   Do-not-exceed soft limit for motor RPM (defaults to __nameplate-RPM__).
 
 <name>.tolerance (float, RW)::
-  Speed tolerance (default 0.01) for determining whether spindle is at speed (0.01 meaning: output frequency is within 1% of target frequency)
+  Speed tolerance (default 0.01) for determining whether spindle is at speed (0.01 meaning: output frequency is within 1% of target frequency).
 
 == USAGE
 
@@ -169,7 +169,7 @@ Operating parameters are still read while bus control is disabled.
 Exiting the vfs11_vfd driver in a controlled will release the VFD from the bus and restore panel control.
 
 See the LinuxCNC Integrators Manual for more information.
-For a detailed register description of the Toshiba VFD's,
+For a detailed register description of the Toshiba VFDs,
 see the "TOSVERT VF-S11 Communications Function Instruction Manual" (Toshiba document number E6581222)
 and the "TOSVERT VF-S11 Instruction manual" (Toshiba document number E6581158).
 

--- a/docs/src/man/man1/xyzbc-trt-gui.1.adoc
+++ b/docs/src/man/man1/xyzbc-trt-gui.1.adoc
@@ -7,7 +7,7 @@ xyzbc-trt-gui - Vismach Virtual Machine GUI
 == DESCRIPTION
 
 *xyzbc-trt-gui* is one of the sample *Vismach* GUIs for LinuxCNC,
-simulating a 5-axis milling machine with tool-point kinematics
+simulating a 5-axis milling machine with tool-point kinematics.
 
 See the main LinuxCNC documentation for more details.
 

--- a/docs/src/man/man9/hostmot2.9.adoc
+++ b/docs/src/man/man9/hostmot2.9.adoc
@@ -328,11 +328,9 @@ count_64 (s64 out)::
 position (float out)::
  Encoder position in position units (count / scale).
 position-interpolated (float out)::
- Encoder interpolated position in position units (count / scale). Only
- valid when velocity is approximately constant and the time between
- counts is less than the velocity timeout parameter value. Do not use
- for position control. Useful for spindle synchronized moves with low
- resolution encoders.
+ Encoder interpolated position in position units (count / scale).
+ Only valid when velocity is approximately constant and the time between counts is less than the velocity timeout parameter value.
+ Do not use for position control. Useful for spindle synchronized moves with low resolution encoders.
 position-latched (float out)::
  Encoder latched position in position units (count / scale).
 velocity (float out)::
@@ -340,29 +338,22 @@ velocity (float out)::
 velocity-rpm (float out)::
  Estimated encoder velocity in position units per minute.
 reset (bit in)::
- When this pin is True, the count and position pins are set to 0 (the
- value of the velocity pin is not affected by this). The driver does
- not reset this pin to FALSE after resetting the count to 0, that is
- the user's job.
+ When this pin is True, the count and position pins are set to 0 (the value of the velocity pin is not affected by this).
+ The driver does not reset this pin to FALSE after resetting the count to 0, that is the user's job.
 index-enable (bit in/out)::
  When this pin is set to True, (and no-clear-on-index is false) 
- the count (and therefore also position) are reset to zero on the next 
- Index (Phase-Z) pulse. At the same time, index-enable is reset to zero
-  to indicate that the pulse has occurred.
+ the count (and therefore also position) are reset to zero on the next Index (Phase-Z) pulse.
+ At the same time, index-enable is reset to zero to indicate that the pulse has occurred.
 no-clear-on-index (bit in)::
- When this pin is set to True, the count (and therefore also position) 
- are NOT reset to zero on the next Index (Phase\-Z) pulse.
- On an index event the latched count and position will be set to 
- indicate the count and position where the index occurred.
+ When this pin is set to True, the count (and therefore also position) are NOT reset to zero on the next Index (Phase\-Z) pulse.
+ On an index event the latched count and position will be set to indicate the count and position where the index occured.
 probe-enable (bit in/out)::
- When this pin is set to True, the encoder count (and therefore also
- position) are latched on the the next probe active edge. At the same
- time, probe-enable is reset to zero to indicate that latch event has
- occurred (only present if supported by firmware).
+ When this pin is set to True, the encoder count (and therefore also position) are latched on the the next probe active edge.
+ At the same time, probe-enable is reset to zero to indicate that latch event has occurred.
+ (only present if supported by firmware)
 probe-invert (bit r/w)::
- If set to True, the rising edge of the probe input pin triggers the
- latch event (if probe-enable is True). If set to False, the falling
- edge triggers (only present if supported by firmware).
+ If set to True, the rising edge of the probe input pin triggers the latch event (if probe-enable is True).
+ If set to False, the falling edge triggers. (only present if supported by firmware)
 rawcounts (s32 out)::
  Total number of encoder counts since the start, not adjusted for index or reset.
 rawcounts_64 (s64 out)::
@@ -374,8 +365,8 @@ count_latch_64 (s64 out)::
 input-a, input-b, input-index (bit out)::
  Real time filtered values of A,B,Index encoder signals
 quad-error-enable (bit in)::
- When this pin is True quadrature error reporting is enabled. When
- False, existing quadrature errors are cleared and error reporting is disabled.
+ When this pin is True quadrature error reporting is enabled.
+ When False, existing quadrature errors are cleared and error reporting is disabled.
 quad-error (bit out)::
  This bit indicates that a quadrature sequence error has been detected.
  It can only be set if the corresponding quad-error-enable bit is True.
@@ -388,12 +379,11 @@ hm2_XXXX.N.encoder.muxed-sample-frequency (u32 in)::
  This also sets the encoder multiplexing frequency.
 hm2_XXXX.N.encoder.muxed-skew (float in)::
  This sets the muxed encoder sample time delay (in ns) from the multiplex signal.
- Setting this properly can increase the usable
- multiplex frequency and compensate for cable delays (suggested value
- is 3* cable length in feet +20).
+ Setting this properly can increase the usable multiplex frequency and compensate for cable delays
+ (suggested value is 3* cable length in feet +20).
 hm2_XXXX.N.encoder.hires-timestamp (bit in)::
- When this pin is True the encoder timestamp counter frequency is
- ca. 10&#8201;MHz when False the timestamp counter frequency is ca. 2&#8201;MHz.
+ When this pin is True the encoder timestamp counter frequency is ca. 10 MHz.
+ When False the timestamp counter frequency is ca. 2&#8201;MHz.
  This should be set True for frequency counting applications to improve the resolution.
  It should be set False when servo thread periods longer than 1&#8201;ms are used.
 
@@ -512,23 +502,19 @@ e: (Encoder):: (s32, out) hm2_XXXX.N.ssi.MM.<name>.count. +
  (bit, in) (bit, out) hm2_XXXX.N.ssi.MM.<name>.reset. +
  When this pin is set high the counts and position pins are zeroed.
 h: (Split encoder, high-order bits)::
- Some encoders (Including Fanuc) place the encoder part-turn counts and
- full-turn counts in separate, non-contiguous fields. This tag defines
- the high-order bits of such an encoder module. There can be only one h
- and one l tag per channel, the behaviour with multiple such channels
- will be undefined.
+ Some encoders (Including Fanuc) place the encoder part-turn counts and full-turn counts in separate, non-contiguous fields.
+ This tag defines the high-order bits of such an encoder module.
+ There can be only one h and one l tag per channel, the behaviour with multiple such channels will be undefined.
 l: (Split encoder, low-order bits)::
  Low order bits (see "h")
 g: (Gray-code):: This is a modifier that indicates that the following format string is gray-code encoded.
  This is only valid for encoders (e, h l) and unsigned (u) data types.
 m: (Multi-turn)::
- This is a modifier that indicates that the following
- format string is a multi-turn encoder. This is only valid for encoders
- (e, h l). A jump in encoder position of more than half the full scale
- is interpreted as a full turn and the counts are wrapped. With a
- multi-turn encoder this is only likely to be a data glitch and will
- lead to a permanent offset. This flag endures that such encoders will
- never wrap.
+ This is a modifier that indicates that the following format string is a multi-turn encoder.
+ This is only valid for encoders (e, h l).
+ A jump in encoder position of more than half the full scale is interpreted as a full turn and the counts are wrapped.
+ With a multi-turn encoder this is only likely to be a data glitch and will lead to a permanent offset.
+ This flag endures that such encoders will never wrap.
 
 *Parameters*
 
@@ -630,9 +616,8 @@ velocity-rpm (float, out)::
 count (s32, out)::
  This pins outputs a simulated encoder count at 2^24^ counts per rev (16777216 counts).
 rawcounts (s32, out)::
- This is identical to the counts pin, except it is not reset by the
- "index" or "reset" pins. This is the pin which would be linked to the
- bldc HAL component if the resolver was being used to commutate a motor.
+ This is identical to the counts pin, except it is not reset by the "index" or "reset" pins.
+ This is the pin which would be linked to the bldc HAL component if the resolver was being used to commutate a motor.
 reset (bit, in)::
  Resets the position and counts pins to zero immediately.
 joint-pos-fb (bit, in)::
@@ -648,13 +633,11 @@ joint-pos-fb (bit, in)::
  This feature will only work properly if the machine is initially homed to "index"
  and if the axis home positions are exactly zero.
 index-enable (bit, in/out)::
- When this pin is set high the position and counts pins will be reset
- the next time the resolver passes through the zero position. At the
- same time the pin is driven low to indicate to connected modules that
- the index has been seen, and that the counters have been reset.
+ When this pin is set high the position and counts pins will be reset the next time the resolver passes through the zero position.
+ At the same time the pin is driven low to indicate to connected modules that the index has been seen, and that the counters have been reset.
 error (bit, out)::
- Indicates an error in the particular channel. If this value is "True"
- then the reported position and velocity are invalid.
+ Indicates an error in the particular channel.
+ If this value is "True" then the reported position and velocity are invalid.
 
 *Parameters:*
 
@@ -673,14 +656,12 @@ index-divisor (default 1) (u32, read/write)::
  It is not appropriate to use this parameter for index-homing of axis drives.
 
 excitation-khz (float, read/write)::
- This pin sets the excitation frequency for the resolver. This pin is
- module-level rather than instance-level as all resolvers share the
- same excitation frequency. Valid values are 10 (ca. 10 kHz), 5 (ca. 5 kHz)
- and 2.5 (ca. 2.5 kHz). The actual frequency depends on the FPGA
- frequency, and they correspond to CLOCK_LOW/5000, CLOCK_LOW/10000 and
- CLOCK_LOW/20000 respectively. The parameter will be set to the closest
- available of the three frequencies. A value of -1 (the default)
- indicates that the current setting should be retained.
+ This pin sets the excitation frequency for the resolver.
+ This pin is module-level rather than instance-level as all resolvers share the same excitation frequency.
+ Valid values are 10 (ca. 10 kHz), 5 (ca. 5 kHz) and 2.5 (ca. 2.5 kHz).
+ The actual frequency depends on the FPGA frequency, and they correspond to CLOCK_LOW/5000, CLOCK_LOW/10000 and CLOCK_LOW/20000 respectively.
+ The parameter will be set to the closest available of the three frequencies.
+ A value of -1 (the default) indicates that the current setting should be retained.
 
 use-position-file (bit, read/write)::
  In conjunction with *joint-pos-fb* (qv) emulate absolute encoders.

--- a/docs/src/man/man9/hostmot2.9.adoc
+++ b/docs/src/man/man9/hostmot2.9.adoc
@@ -477,13 +477,12 @@ There is a limit of 64 bits in total.
 
 The valid format characters and the pins they create are:
 
-p: (Pad)::
- Does not create any pins, used to ignore sections of the bit stream that are not required.
+p: (Pad):: Does not create any pins, used to ignore sections of the bit stream that are not required.
 
-b: (Boolean).:: (bit, out) hm2_XXXX.N.ssi.MM.<name>.
- If any bits in the designated field width are non-zero then the HAL pin will be "True".
- (bit, out) hm2_XXXX.N.ssi.MM.<name>-not. An inverted version of the above, the
- HAL pin will be "True" if all bits in the field are zero.
+b: (Boolean).:: (bit, out) hm2_XXXX.N.ssi.MM.<name>. +
+ If any bits in the designated field width are non-zero then the HAL pin will be "True". +
+ (bit, out) hm2_XXXX.N.ssi.MM.<name>-not. +
+ An inverted version of the above, the HAL pin will be "True" if all bits in the field are zero.
 
 u: (Unsigned):: (float, out) hm2_XXXX.N.ssi.MM.<name>.
  The value of the bits
@@ -492,35 +491,26 @@ u: (Unsigned):: (float, out) hm2_XXXX.N.ssi.MM.<name>.
  example if the field is 8 bits wide and the scalmax parameter was 20
  then a value of 255 would return 20, and 0 would return 0.
 
-s: (Signed):: (float, out) hm2_XXXX.N.ssi.MM.<name>.
- The value of the bits
- interpreted as a 2s complement signed number then scaled similarly to
+s: (Signed):: (float, out) hm2_XXXX.N.ssi.MM.<name>. +
+ The value of the bits interpreted as a 2s complement signed number then scaled similarly to
  the unsigned variant, except symmetrical around zero.
 
-f: (bitField):: (bit, out) hm2_XXXX.N.ssi.MM.<name>-NN.
- The value of each individual
- bit in the data field. NN starts at 00 up to the number of bits in the
- field. (bit, out) hm2_XXXX.N.ssi.MM.<name>-NN-not. An inverted version
- of the individual bit values.
+f: (bitField):: (bit, out) hm2_XXXX.N.ssi.MM.<name>-NN. +
+ The value of each individual bit in the data field.
+ NN starts at 00 up to the number of bits in the field. +
+ (bit, out) hm2_XXXX.N.ssi.MM.<name>-NN-not. +
+ An inverted version of the individual bit values.
 
-e: (Encoder):: (s32, out) hm2_XXXX.N.ssi.MM.<name>.count.
-The lower 32 bits of the
- total encoder counts. This value is reset both by the ...reset and the
- ...index-enable pins. (s32, out) hm2_XXXX.N.ssi.MM.<name>.rawcounts.
- The lower 32 bits of the total encoder counts. The pin is not affected
- by reset and index. (float, out) hm2_XXXX.N.ssi.MM.<name>.position.
- The encoder position in machine units. This is calculated from the
- full 64-bit buffers so will show a True value even after the counts
- pins have wrapped. It is zeroed by reset and index enable. (bit, IO)
- hm2_XXXX.N.ssi.MM.<name>.index-enable. When this pin is set "True" the
- module will wait until the raw encoder counts next passes through an
- integer multiple of the number of counts specified by counts-per-rev
- parameter and then it will zero the counts and position pins, and set
- the index-enable pin back to "False" as a signal to the system that
- "index" has been passed. this pin is used for spindle-synchronised
- motion and index-homing. (bit, in) (bit, out)
- hm2_XXXX.N.ssi.MM.<name>.reset. When this pin is set high the counts
- and position pins are zeroed.
+e: (Encoder):: (s32, out) hm2_XXXX.N.ssi.MM.<name>.count. +
+ The lower 32 bits of the total encoder counts. This value is reset both by the ...reset and the ...index-enable pins. +
+ (s32, out) hm2_XXXX.N.ssi.MM.<name>.rawcounts. +
+ The lower 32 bits of the total encoder counts. The pin is not affected by reset and index. +
+ (float, out) hm2_XXXX.N.ssi.MM.<name>.position. +
+ The encoder position in machine units. This is calculated from the full 64-bit buffers so will show a True value even after the counts pins have wrapped.  It is zeroed by reset and index enable. +
+ (bit, IO) hm2_XXXX.N.ssi.MM.<name>.index-enable. +
+ When this pin is set "True" the module will wait until the raw encoder counts next passes through an integer multiple of the number of counts specified by counts-per-rev parameter and then it will zero the counts and position pins, and set the index-enable pin back to "False" as a signal to the system that "index" has been passed. this pin is used for spindle-synchronised motion and index-homing. +
+ (bit, in) (bit, out) hm2_XXXX.N.ssi.MM.<name>.reset. +
+ When this pin is set high the counts and position pins are zeroed.
 h: (Split encoder, high-order bits)::
  Some encoders (Including Fanuc) place the encoder part-turn counts and
  full-turn counts in separate, non-contiguous fields. This tag defines
@@ -545,11 +535,10 @@ m: (Multi-turn)::
 Two parameters are universally created for all SSI instances
 
 hm2_XXXX.N.ssi.MM.frequency-khz (float r/w)::
- This parameter sets the SSI clock frequency. The units are kHz, so 500
- will give a clock frequency of 500,000 Hz.
+ This parameter sets the SSI clock frequency. The units are kHz, so 500 will give a clock frequency of 500,000 Hz.
 hm2_XXXX.N.ssi.timer-number-num (s32 r/w)::
- This parameter allocates the SSI module to a specific hm2dpll timer
- instance. This pin is only of use in firmwares which contain a hm2dpll
+ This parameter allocates the SSI module to a specific hm2dpll timer instance.
+ This pin is only of use in firmwares which contain a hm2dpll
  function and will default to 1 in cases where there is such a
  function, and 0 if there is not. The pin can be used to disable reads
  of the encoder, by setting to a nonexistent timer number, or to 0.

--- a/docs/src/man/man9/sserial.9.adoc
+++ b/docs/src/man/man9/sserial.9.adoc
@@ -32,8 +32,7 @@ three per-port pins and three parameters.
 
 *Pins:*
 
-.sserial.port-__N__.run (bit, in)::
-  Enables the specific Smart Serial module.
+.sserial.port-__N__.run (bit, in):: Enables the specific Smart Serial module.
   Setting this pin low will disable all boards on the port and puts the
   port in a pass-through mode where device parameter setting is possible.
   It is necessary to toggle the state of this pin if there is a
@@ -42,28 +41,20 @@ three per-port pins and three parameters.
   However, toggling the pin low-to-high will re-enable a faulted drive,
   so the pin could usefully be connected to the `iocontrol.0.user-enable-out` pin.
 
-.run_state (u32, ro)::
-  Shows the state of the sserial communications state-machine.
-  This pin will generally show a value of 0x03 in normal operation,
-  0x07 in setup mode and 0x00 when the "run" pin is false.
+.run_state (u32, ro):: Shows the state of the sserial communications state-machine.
+  This pin will generally show a value of 0x03 in normal operation, 0x07 in setup mode and 0x00 when the "run" pin is false.
 
-.error-count (u32, ro)::
-  Indicates the state of the Smart Serial error handler,
-  see the parameters section for more details.
+.error-count (u32, ro):: Indicates the state of the Smart Serial error handler, see the parameters section for more details.
 
 *Parameters:*
 
-.fault-inc (u32 r/w)::
-  Any over-run or handshaking error in the
+.fault-inc (u32 r/w):: Any over-run or handshaking error in the
   SmartSerial communications will increment the .fault-count pin by the
   amount specified by this parameter. Default = 10.
 
-.fault-dec (u32 r/w)::
-  Every successful read/write cycle decrements the
-  fault counter by this amount. Default = 1.
+.fault-dec (u32 r/w):: Every successful read/write cycle decrements the fault counter by this amount. Default = 1.
 
-.fault-lim (u32 r/w)::
-  When the fault counter reaches this threshold the
+.fault-lim (u32 r/w):: When the fault counter reaches this threshold the
   Smart Serial interface on the corresponding port will be stopped and an
   error printed in dmesg. Together these three pins allow for control over
   the degree of fault- tolerance allowed in the interface. The default
@@ -71,8 +62,8 @@ three per-port pins and three parameters.
   times, then a hard error will be raised. If the increment were to be set
   to zero then no error would ever be raised, and the system would carry
   on regardless. Conversely setting decrement to zero, threshold to 1 and
-  limit to 1 means that absolutely no errors will be tolerated. (This
-  structure is copied directly from vehicle ECU practice.)
+  limit to 1 means that absolutely no errors will be tolerated.
+  (This structure is copied directly from vehicle ECU practice.)
 
 Any other parameters than the ones above are created by the card itself
 from data in the remote firmware. They may be set in the HAL file using
@@ -80,10 +71,8 @@ from data in the remote firmware. They may be set in the HAL file using
 
 [NOTE]
 ====
-Because a Smart-Serial remote can only communicate non-process
-data to the host card in setup mode, it is necessary to stop and
-re-start the smart-serial port associated with the card to alter the
-value of a parameter.
+Because a Smart-Serial remote can only communicate non-process data to the host card in setup mode,
+it is necessary to stop and re-start the smart-serial port associated with the card to alter the value of a parameter.
 ====
 
 NOTE: In the case of parameters beginning with "nv" (which are stored in non-volatile memory) the effect will not be seen until after the next power cycle of the drive.
@@ -93,9 +82,8 @@ Unchanged values will not be re-written so it is safe to leave the
 
 == DEVICES
 
-The other pins and parameters created in HAL depend on the devices
-detected. The following list of Smart Serial devices is by no means
-exhaustive.
+The other pins and parameters created in HAL depend on the devices detected.
+The following list of Smart Serial devices is by no means exhaustive.
 
 === 8I20
 
@@ -110,24 +98,24 @@ correlate in layout or number to the physical ports on the card.
 *Pins:*
 
 angle (float in)::
- The rotor angle of the motor in fractions of a full *phase* revolution.
- An angle of 0.5 indicates that the motor is half a turn / 180 degrees / π radians from the zero position.
- The zero position is taken to be the position that the motor adopts under no load with a
- positive voltage applied to the A (or U) phase and both B and C (or V and W) connected to -V or 0 V.
- A 6 pole motor will have 3 zero positions per physical rotation.
- Note that the 8I20 drive automatically adds the phase lead/lag angle, and that this pin should see the raw rotor angle.
- There is a HAL module (bldc) which handles the complexity of differing motor and drive types.
+  The rotor angle of the motor in fractions of a full *phase* revolution.
+  An angle of 0.5 indicates that the motor is half a turn / 180 degrees / π radians from the zero position.
+  The zero position is taken to be the position that the motor adopts under no load with a
+  positive voltage applied to the A (or U) phase and both B and C (or V and W) connected to -V or 0 V.
+  A 6 pole motor will have 3 zero positions per physical rotation.
+  Note that the 8I20 drive automatically adds the phase lead/lag angle, and that this pin should see the raw rotor angle.
+  There is a HAL module (bldc) which handles the complexity of differing motor and drive types.
 current (float, in)::
- The phase current command to the drive.
- This is scaled from -1 to +1 for forwards and reverse maximum currents.
- The absolute value of the current is set by the max_current parameter.
-
-bus-voltage (float, ro):: The drive bus voltage in V.
- This will tend to show 25.6 V when the drive is unpowered and the drive will not operate below about 50 V.
+  The phase current command to the drive.
+  This is scaled from -1 to +1 for forwards and reverse maximum currents.
+  The absolute value of the current is set by the max_current parameter.
+bus-voltage (float, ro)::
+  The drive bus voltage in V.
+  This will tend to show 25.6 V when the drive is unpowered and the drive will not operate below about 50 V.
 temp (float, ro):: The temperature of the driver in degrees C.
 comms (u32, ro):: The communication status of the drive. See the manual for more details.
 status and fault. (bit, ro):: The following fault/status bits are exported.
- For further details see the 8I20 manual: +
+  For further details see the 8I20 manual: +
   fault.U-current / fault.U-current-not fault.V-current
   / fault.V-current-not fault.W-current / fault.W-current-not
   fault.bus-high / fault.bus-high-not fault.bus-overv /
@@ -144,9 +132,7 @@ status and fault. (bit, ro):: The following fault/status bits are exported.
   status.pid-on / status.pid-on-not status.sw-reset / status.sw-reset-not
   status.wd-reset / status.wd-reset-not
 
-*Parameters:*::
- The following parameters are exported.
- See the PDF documentation downloadable from Mesa for further details:
+*Parameters:*:: The following parameters are exported. See the PDF documentation downloadable from Mesa for further details:
 
 hm2_5i25.0.8i20.0.1.angle-maxlim::
 hm2_5i25.0.8i20.0.1.angle-minlim::
@@ -173,11 +159,10 @@ hm2_5i25.0.8i20.0.1.swrevision::
 hm2_5i25.0.8i20.0.1.unitnumber::
 
 max_current (float, rw):: Sets the maximum drive current in Amps.
- The default value is the maximum current programmed into the drive EEPROM.
- The value must be positive, and an error will be raised if a current in excess of the
- drive maximum is requested.
-serial_number (u32, ro):: The serial number of the connected drive.
- This is also shown on the label on the drive.
+  The default value is the maximum current programmed into the drive EEPROM.
+  The value must be positive, and an error will be raised if a current in excess of the
+  drive maximum is requested.
+serial_number (u32, ro):: The serial number of the connected drive. This is also shown on the label on the drive.
 
 === 7I64
 
@@ -188,24 +173,23 @@ for example `hm2_5i23.0.7i64.1.3.output-01`.
 *Pins:*
 
 7i64.0.0.output-__NN__ (bit, in)::
- Writing a 1 or TRUE to this pin will enable output driver _NN_.
- Note that the outputs are drivers (switches) rather than voltage outputs.
- The LED adjacent to the connector on the board shows the status.
- The output can be inverted by setting a parameter.
+  Writing a 1 or TRUE to this pin will enable output driver _NN_.
+  Note that the outputs are drivers (switches) rather than voltage outputs.
+  The LED adjacent to the connector on the board shows the status.
+  The output can be inverted by setting a parameter.
 
 7i64.0.0.input-__NN__ (bit, out):: The value of input _NN_.
- Note that the inputs are isolated and both pins of each input must be connected,
- typically to signal and the ground of the signal.
- (This need not be the ground of the board.)
+  Note that the inputs are isolated and both pins of each input must be connected,
+  typically to signal and the ground of the signal.
+  (This need not be the ground of the board.)
 
 7i64.0.0.input-__NN__-not (bit, out):: An inverted copy of the corresponding input.
 7i64.0.0.analog0 & 7i64.0.0.analog1 (float, out):: The two analogue inputs (0 to 3.3 V) on the board.
 
 *Parameters:*
 
-7i64.0.0.output-__NN__-invert (bit, rw):: Setting this parameter to 1 / TRUE
- will invert the output value, such that writing 0 to `.gpio.NN.out` will
- enable the output and vice-versa.
+7i64.0.0.output-__NN__-invert (bit, rw):: Setting this parameter to 1 / TRUE will invert the output value,
+  such that writing 0 to `.gpio.NN.out` will enable the output and vice-versa.
 
 === 7I76
 
@@ -222,42 +206,32 @@ whereas the smart-serial pins are associated with the 7I76 (`hm2_5i25.0.7i76.0.0
 .7i76.0.0.spindir (bit in):: This pin provides a means to drive the spindle VFD direction terminals on the 7I76 board.
 .7i76.0.0.spinena (bit in):: This pin drives the spindle-enable terminals on the 7I76 board.
 .7i76.0.0.spinout (float in):: This controls the analogue output of the 7I76.
- This is intended as a speed control signal for a VFD.
+  This is intended as a speed control signal for a VFD.
 .7i76.0.0.output-__NN__ (bit out):: (_NN_ = 0 to 15). 16 digital outputs.
- The sense of the signal can be set via a parameter.
+  The sense of the signal can be set via a parameter.
 .7i76.0.0.input-__NN__ (bit out):: (_NN_ = 0 to 31) 32 digital inputs.
 .7i76.0.0.input-__NN__-not (bit in):: (_NN_ = 0 to 31) An inverted copy of the inputs provided for convenience.
- The two complementary pins may be connected to different signal nets.
+  The two complementary pins may be connected to different signal nets.
 
 *Parameters:*
 
 .7i76.0.0.nvbaudrate (u32 ro):: Indicates the vbaud rate. This probably should not be altered.
-
-.7i76.0.0.nvunitnumber (u32 ro)::
-  Indicates the serial number of the device and should match a sticker on the card.
+.7i76.0.0.nvunitnumber (u32 ro):: Indicates the serial number of the device and should match a sticker on the card.
   This can be useful for working out which card is which.
-
-.7i76.0.0.nvwatchdogtimeout (u32 ro)::
-  The sserial remote watchdog timeout.
+.7i76.0.0.nvwatchdogtimeout (u32 ro):: The sserial remote watchdog timeout.
   This is separate from the Anything-IO card timeout.
   This is unlikely to need to be changed.
-
 .7i76.0.0.output-__NN__-invert (bit rw):: Invert the sense of the corresponding output pin.
-
 .7i76.0.0.spindir-invert (bit rw):: Invert the senseof the spindle direction pin.
-
 .7i76.0.0.spinena-invert (bit rw):: Invert the sense of the spindle-enable pin.
-
 .7i76.0.0.spinout-maxlim (float rw):: The maximum speed request allowable
-
 .7i76.0.0.spinout-minlim (float rw):: The minimum speed request.
-
 .7i76.0.0.spinout-scalemax (float rw):: The spindle speed scaling.
   This is the speed request which would correspond to full-scale output from the spindle control pin.
   For example with a 10 V drive voltage and a 10000 RPM scalemax a value of 10,000 RPM on the spinout pin would produce 10 V output.
   However, if spinout-maxlim were set to 5000 RPM then no voltage above 5 V would be output.
-
-.7i76.0.0.swrevision (u32 ro):: The onboard firmware revision number.  Utilities (man setsserial for details) exist to update and change this firmware.
+.7i76.0.0.swrevision (u32 ro):: The onboard firmware revision number.
+  Utilities (man setsserial for details) exist to update and change this firmware.
 
 === 7I77
 
@@ -269,10 +243,10 @@ encoders and further details of them may be found in the hostmot2 manpage.
 
 .7i77.0.0.input-__NN__ (bit out):: (_NN_ = 0 to 31) 32 digital inputs.
 .7i77.0.0.input-__NN__-not (bit in):: (_NN_ = 0 to 31) An inverted copy of the inputs provided for convenience. The two complementary pins may be connected to different signal nets.
-.7i77.0.0.output-__NN__ (bit out):: (_NN_ = 0 to 15). 16 digital outputs.  The sense of the signal can be set via a parameter.
+.7i77.0.0.output-__NN__ (bit out):: (_NN_ = 0 to 15). 16 digital outputs. The sense of the signal can be set via a parameter.
 .7i77.0.0.spindir (bit in):: This pin provides a means to drive the spindle VFD direction terminals on the 7I76 board.
 .7i77.0.0.spinena (bit in):: This pin drives the spindle-enable terminals on the 7I76 board.
-.7i77.0.0.spinout (float in):: This controls the analog output of the 7I77.  This is intended as a speed control signal for a VFD.
+.7i77.0.0.spinout (float in):: This controls the analog output of the 7I77. This is intended as a speed control signal for a VFD.
 .7i77.0.1.analogena (bit in):: This pin drives the analog enable terminals on the 7I77 board.
 .7i77.0.1.analogout__N__ (float in):: (_N_ = 0 to 5) This controls the analog output of the 7I77.
 
@@ -283,8 +257,7 @@ encoders and further details of them may be found in the hostmot2 manpage.
 .7i77.0.0.spinena-invert (bit rw):: Invert the sense of the spindle-enable pin.
 .7i77.0.0.spinout-maxlim (float rw):: The maximum speed request allowable
 .7i77.0.0.spinout-minlim (float rw):: The minimum speed request.
-.7i77.0.0.spinout-scalemax (float rw)::
-  The spindle speed scaling.
+.7i77.0.0.spinout-scalemax (float rw):: The spindle speed scaling.
   This is the speed request which would correspond to full-scale output from the spindle control pin.
   For example with a 10&#8201;V drive voltage and a 10000&#8201;RPM scalemax a value of 10000&#8201;RPM on the spinout pin would produce 10&#8201;V output.
   However, if spinout-maxlim were set to 5000&#8201;RPM then no voltage above 5&#8201;V would be output.
@@ -308,25 +281,21 @@ MODE 4:: Bidirectional mode (48 bits in 48 bits out) plus 4 MPG encoder channels
 
 *Pins:*
 
-.7i69.0.0.output-__NN__ (bit in):: Digital output. Sense can be inverted with
-the corresponding Parameter.
-
+.7i69.0.0.output-__NN__ (bit in):: Digital output. Sense can be inverted with the corresponding Parameter.
 .7i69.0.0.input-__NN__ (bit out):: Digital input
-
 .7i69.0.0.input-__NN__-not (bit out):: Digital input, inverted.
 
 *Parameters:*
 
-.7i69.0.0.nvbaudrate (u32 ro):: Indicates the vbaud rate.  This probably should not be altered.
+.7i69.0.0.nvbaudrate (u32 ro):: Indicates the vbaud rate. This probably should not be altered.
 .7i69.0.0.nvunitnumber (u32 ro)::
   Indicates the serial number of the device and should match a sticker on the card.
   This can be useful for working out which card is which.
-
 .7i69.0.0.nvwatchdogtimeout (u32 ro):: The sserial remote watchdog timeout.
   This is separate from the Anything-IO card timeout.
   This is unlikely to need to be changed.
 .7i69.0.0.output-__NN__-invert (bit rw):: Invert the sense of the corresponding output pin.
-.7i69.0.0.swrevision (u32 ro):: The onboard firmware revision number.  Utilities exist to update and change this firmware.
+.7i69.0.0.swrevision (u32 ro):: The onboard firmware revision number. Utilities exist to update and change this firmware.
 
 === 7I70
 
@@ -351,16 +320,14 @@ MODE 2:: Input plus field voltage
 .7i70.0.0.analog__N__ (modes 1 and 2 only) (float out):: Analogue input values.
 .7i70.0.0.fieldvoltage (mode 2 only) (float out):: Field voltage monitoring pin.
 .7i70.0.0.input-__NN__ (bit out):: (_NN_ = 0 to 47) 48 digital inputs.
-.7i70.0.0.input-__NN__-not (bit in):: (_NN_ = 0 to 47) An inverted copy of the
-inputs provided for convenience. The two complementary pins may be
-connected to different signal nets.
+.7i70.0.0.input-__NN__-not (bit in):: (_NN_ = 0 to 47) An inverted copy of the inputs provided for convenience. The two complementary pins may be connected to different signal nets.
 
 *Parameters:*
 
-.7i70.0.0.nvbaudrate (u32 ro):: Indicates the vbaud rate.  This probably should not be altered.
-.7i70.0.0.nvunitnumber (u32 ro):: Indicates the serial number of the device and should match a sticker on the card.  This can be useful for working out which card is which.
-.7i70.0.0.nvwatchdogtimeout (u32 ro):: The sserial remote watchdog timeout.  This is separate from the Anything-IO card timeout.  This is unlikely to need to be changed.
-.7i69.0.0.swrevision (u32 ro):: The onboard firmware revision number.  Utilities exist to update and change this firmware.
+.7i70.0.0.nvbaudrate (u32 ro):: Indicates the vbaud rate. This probably should not be altered.
+.7i70.0.0.nvunitnumber (u32 ro):: Indicates the serial number of the device and should match a sticker on the card. This can be useful for working out which card is which.
+.7i70.0.0.nvwatchdogtimeout (u32 ro):: The sserial remote watchdog timeout. This is separate from the Anything-IO card timeout. This is unlikely to need to be changed.
+.7i69.0.0.swrevision (u32 ro):: The onboard firmware revision number. Utilities exist to update and change this firmware.
 
 === 7I71
 
@@ -380,18 +347,17 @@ MODE 1:: Outputs plus read back field voltage
 .7i71.0.0.fieldvoltage (mode 2 only) (float out):: Field voltage monitoring pin.
 
 .7i71.0.0.output-__NN__ (bit out):: (_NN_ = 0 to 47) 48 digital outputs.
- The sense may be inverted by the invert parameter.
-
+  The sense may be inverted by the invert parameter.
 .7i71.0.0.output-__NN__ (bit out):: (_NN_ = 0 to 47) 48 digital outputs.
- The sense may be inverted by the invert parameter.
+  The sense may be inverted by the invert parameter.
 
 *Parameters:*
 
 .7i71.0.0.output-__NN__-invert (bit rw):: Invert the sense of the corresponding output pin.
-.7i71.0.0.nvbaudrate (u32 ro):: Indicates the vbaud rate.  This probably should not be altered.
-.7i71.0.0.nvunitnumber (u32 ro):: Indicates the serial number of the device and should match a sticker on the card.  This can be useful for determining which card is which.
-.7i71.0.0.nvwatchdogtimeout (u32 ro):: The sserial remote watchdog timeout.  This is separate from the Anything-IO card timeout.  This is unlikely to need to be changed.
-.7i69.0.0.swrevision (u32 ro):: The onboard firmware revision number.  Utilities exist to update and change this firmware.
+.7i71.0.0.nvbaudrate (u32 ro):: Indicates the vbaud rate. This probably should not be altered.
+.7i71.0.0.nvunitnumber (u32 ro):: Indicates the serial number of the device and should match a sticker on the card. This can be useful for determining which card is which.
+.7i71.0.0.nvwatchdogtimeout (u32 ro):: The sserial remote watchdog timeout. This is separate from the Anything-IO card timeout. This is unlikely to need to be changed.
+.7i69.0.0.swrevision (u32 ro):: The onboard firmware revision number. Utilities exist to update and change this firmware.
 
 === 7I73
 
@@ -415,17 +381,15 @@ MODE 2:: I/O + ENCODER + ANALOG IN FAST DISPLAY
 
 *Pins:*
 
-.7i73.0.0.analogin__N__ (float out)::
-  Analogue inputs. Up to 8 channels may
-  be available dependent on software and hardware configuration modes
+.7i73.0.0.analogin__N__ (float out):: Analogue inputs.
+  Up to 8 channels may be available dependent on software and hardware configuration modes
   (see the PDF manual downloadable from https://www.mesanet.com).
 
-.7i73.0.1.display (modes 1 and 2) (u32 in)::
-  Data for LCD display.
+.7i73.0.1.display (modes 1 and 2) (u32 in):: Data for LCD display.
   This pin may be conveniently driven by the HAL "lcd" component which allows
   the formatted display of the values any number of HAL pins and textual content.
 
-.7i73.0.1.display32 (mode 2 only) (u32 in):: 4 bytes of data for LCD display.  This mode is not supported by the HAL "lcd" component.
+.7i73.0.1.display32 (mode 2 only) (u32 in):: 4 bytes of data for LCD display. This mode is not supported by the HAL "lcd" component.
 .7i73.0.1.encN (s32 out):: The position of the MPG encoder counters.
 .7i73.0.1.input-__NN__ (bit out):: Up to 24 digital inputs (dependent on config)
 .7i73.0.1.input-__NN__-not (bit out):: Inverted copy of the digital inputs

--- a/docs/src/man/man9/sserial.9.adoc
+++ b/docs/src/man/man9/sserial.9.adoc
@@ -311,7 +311,7 @@ and the 7I70 during real time process data exchanges. For high speed
 applications, choosing the correct mode can reduced the data transfer
 sizes, resulting in higher maximum update rates.
 
-MODE 0:: Input mode (48 bits input data only
+MODE 0:: Input mode (48 bits input data only)
 MODE 1:: Input plus analog mode (48 bits input data plus 6 channels of analog data)
 MODE 2:: Input plus field voltage
 

--- a/docs/src/motion/switchkins.adoc
+++ b/docs/src/motion/switchkins.adoc
@@ -311,15 +311,15 @@ requirements.
 
 === External offset considerations 
 
-External offsets (set to an axis (_L_) via axis.L.eoffset-request) are preserved during 
-kinematics switches. When an offset is active on an axis before the switch
-(visible in axis.L.eoffset), the trajectory planner maintains that same 
-offset after the switch, similar to how it maintains the commanded 
-position from a G-code. This ensures consistent machine behavior regardless
-of the active kinematics.
+External offsets (set to an axis (_L_) via axis._L_.eoffset-request)
+are preserved during kinematics switches. When an offset is active on
+an axis before the switch (visible in axis._L_.eoffset), the trajectory
+planner maintains that same offset after the switch, similar to how it
+maintains the commanded position from a G-code. This ensures consistent
+machine behavior regardless of the active kinematics.
 
 If maintaining the offset will be an issue due to axis limit changes or other concerns,
-be sure to clear and possibly disable the eoffset before making a kinematics switch
+be sure to clear and possibly disable the eoffset before making a kinematics switch.
 
 == Simulation configs
 

--- a/docs/src/plasma/qtplasmac.adoc
+++ b/docs/src/plasma/qtplasmac.adoc
@@ -4266,7 +4266,7 @@ $ ./langlink xx
 ----
 
 [NOTE]
-this command is a script which creates a link in both qtplasmac_4x3/languages and qtplasmac_9x16/languages to the above .qm file and then renames the link to match the GUI name.
+This command is a script which creates a link in both qtplasmac_4x3/languages and qtplasmac_9x16/languages to the above .qm file and then renames the link to match the GUI name.
 
 QtPlasmaC will be translated to the language of the current locale on the next start so long as a .qm file exists in that language.
 

--- a/docs/src/plasma/qtplasmac.adoc
+++ b/docs/src/plasma/qtplasmac.adoc
@@ -4109,8 +4109,8 @@ Therefore, the length of the wiggle and the feed rate need to be considered in c
 
 For example:
 
-* A feed rate of 1080 mm/min (18 mm/s)
-* A wiggle movement of 4 mm for 3 oscillations
+* A feed rate of 1080 mm/min (18 mm/s).
+* A wiggle movement of 4 mm for 3 oscillations.
 
 This means that the length of the wiggle is 4 x 3 = 12 mm. At the 18 mm/s feed rate, the pierce delay needs to be approx 0.7 seconds to support the wiggle distance at pierce height.
 

--- a/docs/src/remap/remap.adoc
+++ b/docs/src/remap/remap.adoc
@@ -1146,7 +1146,7 @@ Note that the interpreter instance is available here as `this`, so you could als
 ;py,print(this.tool_table[0].toolno)
 ----
 
-Here is an approach to use an O word subroutine to read a preference file entry and add it as a Gcode parameter.
+Here is an approach to use an O-word subroutine to read a preference file entry and add it as a G-code parameter.
 
 [source,{ngc}]
 ----


### PR DESCRIPTION
po4a seems picky with line breaks witn indentation in descriptions/itemizations. Have removed line breaks when possible and also fixed the number of blanks for an indentation toward consistency within the same `description::` over all its blocks.