### PR TITLE
[ci] publish releases with artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,10 +92,11 @@ jobs:
         # Note that the package build covers html docs
 
   package-arch:
-    runs-on: ubuntu-24.04
+    runs-on: ${{ matrix.runner }}
     strategy:
       matrix:
-        image: ["debian:bookworm", "debian:sid"]
+        runner: ["ubuntu-24.04", "ubuntu-24.04-arm"]
+        image: ["debian:bookworm", "debian:trixie", "debian:sid"]
     container:
       image: ${{ matrix.image }}
       # IPC_OWNER is needed for shmget IPC_CREAT
@@ -129,7 +130,7 @@ jobs:
         DEBIAN_FRONTEND: noninteractive
       run: |
         case "${{matrix.image}}" in
-            debian:sid|debian:bookworm)
+            debian:sid|debian:bookworm|debian:trixie)
                 exit 0
                 ;;
             *)
@@ -171,12 +172,37 @@ jobs:
         eatmydata adduser testrunner sudo
         chmod 0777 $(find tests/ -type d) # make test dirs world-writable for the testrunner
         su -c "eatmydata ./scripts/runtests -p ./tests" testrunner
+    - name: Gather build artifacts
+      run: |
+        set -e
+        set -x
+        ARCH=$(dpkg --print-architecture)
+        DIST=$(echo ${{ matrix.image }} | cut -d : -f 2)
+        OUTDIR="artifacts/${DIST}/${ARCH}"
+        mkdir -p "$OUTDIR"
+        cp -v ../*.deb ../*.changes ../*.buildinfo "$OUTDIR" || true
+        (cd "$OUTDIR" && sha256sum * > SHA256SUMS.txt)
+        echo "DIST=$DIST" >> "$GITHUB_ENV"
+        echo "ARCH=$ARCH" >> "$GITHUB_ENV"
+    - name: Compute artifact metadata
+      id: meta
+      run: |
+        echo "dist=$(echo ${{ matrix.image }} | cut -d : -f 2)" >> $GITHUB_OUTPUT
+        echo "arch=$(dpkg --print-architecture)" >> $GITHUB_OUTPUT
+
+    - name: Upload build artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: linuxcnc-${{ steps.meta.outputs.dist }}-${{ steps.meta.outputs.arch }}
+        path: artifacts/${{ steps.meta.outputs.dist }}/${{ steps.meta.outputs.arch }}
+        if-no-files-found: error
+
 
   package-indep:
     runs-on: ubuntu-24.04
     strategy:
       matrix:
-        image: ["debian:bookworm", "debian:sid"]
+        image: ["debian:bookworm", "debian:trixie", "debian:sid"]
     container:
       image: ${{ matrix.image }}
       # IPC_OWNER is needed for shmget IPC_CREAT
@@ -211,7 +237,7 @@ jobs:
         DEBIAN_FRONTEND: noninteractive
       run: |
         case "${{matrix.image}}" in
-            debian:sid|debian:bookworm)
+            debian:sid|debian:bookworm|debian:trixie)
                 exit 0
                 ;;
             *)
@@ -247,6 +273,31 @@ jobs:
         set -e
         set -x
         eatmydata apt-get --yes --quiet install ../*.deb
+    - name: Gather build artifacts
+      run: |
+        set -e
+        set -x
+        DIST=$(echo ${{ matrix.image }} | cut -d : -f 2)
+        ARCH=all
+        OUTDIR="artifacts/${DIST}/${ARCH}"
+        mkdir -p "$OUTDIR"
+        cp -v ../*.deb ../*.changes ../*.buildinfo "$OUTDIR" || true
+        (cd "$OUTDIR" && sha256sum * > SHA256SUMS.txt)
+        echo "DIST=$DIST" >> "$GITHUB_ENV"
+        echo "ARCH=$ARCH" >> "$GITHUB_ENV"
+    - name: Compute artifact metadata
+      id: meta
+      run: |
+        echo "dist=$(echo ${{ matrix.image }} | cut -d : -f 2)" >> $GITHUB_OUTPUT
+        echo "arch=all" >> $GITHUB_OUTPUT
+
+    - name: Upload build artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: linuxcnc-${{ steps.meta.outputs.dist }}-${{ steps.meta.outputs.arch }}
+        path: artifacts/${{ steps.meta.outputs.dist }}/${{ steps.meta.outputs.arch }}
+        if-no-files-found: error
+
 
   cppcheck:
     runs-on: ubuntu-24.04
@@ -266,3 +317,63 @@ jobs:
       continue-on-error: true
       run: |
         scripts/shellcheck.sh
+
+
+  release:
+    name: Release packages
+    needs:
+      - package-arch
+      - package-indep
+    if: (github.event_name == 'release' && github.event.action == 'published') || startsWith(github.ref, 'refs/tags/')
+    permissions:
+      contents: write
+    runs-on: ubuntu-24.04
+    steps:
+    - name: Download artifacts
+      uses: actions/download-artifact@v4
+      with:
+        path: release_artifacts
+    - name: Prepare upload assets
+      run: |
+        set -e
+        mkdir -p upload
+        echo "Downloaded artifacts layout:" && find release_artifacts -maxdepth 3 -print | sed 's/^/  /'
+        for d in release_artifacts/*; do
+          [ -d "$d" ] || continue
+          name=$(basename "$d")
+          # Expect name like linuxcnc-bookworm-amd64 or linuxcnc-trixie-all
+          dist=${name#linuxcnc-}
+          dist=${dist%-*}
+          arch=${name##*-}
+          echo "Processing artifact: $name (dist=$dist arch=$arch)"
+          # Copy .deb files with distro suffix (arch is already in Debian filename)
+          for f in "$d"/*.deb; do
+            [ -f "$f" ] || continue
+            base=$(basename "$f")
+            base_no_ext="${base%.deb}"
+            dest="upload/${base_no_ext}_${dist}.deb"
+            echo "  + $base -> $(basename "$dest")"
+            cp "$f" "$dest"
+          done
+        done
+
+        echo "Upload dir contents:" && ls -l upload | sed 's/^/  /'
+        # Single combined checksums file for all assets, deterministic order
+        if ls upload/*.deb >/dev/null 2>&1; then
+          (
+            cd upload
+            : > SHA256SUMS.txt
+            # sort file list for stable output
+            for f in $(ls -1 *.deb | LC_ALL=C sort); do
+              sha256sum "$f" >> SHA256SUMS.txt
+            done
+            echo "Preview of SHA256SUMS.txt:" && sed -n '1,200p' SHA256SUMS.txt | sed 's/^/  /'
+          )
+        fi
+    - name: Create GitHub Release and upload assets
+      uses: softprops/action-gh-release@v2
+      with:
+        files: |
+          upload/*
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/scripts/get-version-from-git
+++ b/scripts/get-version-from-git
@@ -9,10 +9,18 @@ fi
 githelper "$1"
 
 if [ "$DEB_COMPONENT" = "scratch" ]; then
-    # unknown branches get the VERSION file, plus the branch name (with any
-    # characters that are invalid in debian version numbers replaced with
-    # dashes '-'), plus the HEAD commit SHA1
-    echo "v$(git show HEAD:VERSION | cut -d ' ' -f 1)~${GIT_BRANCH//[^-.+:~a-z0-9]/-}~$(git show --pretty=format:%h HEAD | head -1)"
+    DESCRIBE=$(git describe --tags --exact-match 2>/dev/null)
+    if [ -n "$DESCRIBE" ]; then
+        echo "$DESCRIBE"
+    else
+        DESCRIBE=$(git describe --tags 2>/dev/null)
+        if [ -n "$DESCRIBE" ]; then
+            echo "$DESCRIBE"
+        else
+            BR=$(printf '%s' "$GIT_BRANCH" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^-.+:~a-z0-9]/-/g; s/-{2,}/-/g; s/^-//; s/-$//')
+            echo "v$(git show HEAD:VERSION | cut -d ' ' -f 1)~${BR:-head}~$(git show --pretty=format:%h HEAD | head -1)"
+        fi
+    fi
 else
     # known branches get the "describe" of the most recent signed git tag,
     # or of the most recent unsigned tag if no signed tags are found

--- a/scripts/githelper.sh
+++ b/scripts/githelper.sh
@@ -17,10 +17,9 @@
 
 function githelper() {
     if [ -z "$1" ]; then
-        GIT_BRANCH=$(git branch | grep -E '^\*' | cut -d ' ' -f 2)
-        if [ "$GIT_BRANCH" = "(no" ]; then
-            echo "'git branch' says we're not on a branch, pass one in as an argument" > /dev/null 1>&2
-            return
+        GIT_BRANCH=$(git symbolic-ref -q --short HEAD 2>/dev/null)
+        if [ -z "$GIT_BRANCH" ]; then
+            GIT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
         fi
     else
         GIT_BRANCH="$1"
@@ -28,7 +27,8 @@ function githelper() {
 
     case $GIT_BRANCH in
         master)
-            GIT_TAG_GLOB="v2.10.*"
+            MM=$(git show HEAD:VERSION | sed -E 's/^([0-9]+)\.([0-9]+).*/\1.\2/')
+            GIT_TAG_GLOB="v${MM}.*"
             DEB_COMPONENT="master"
             ;;
         # release branches have names matching "number.number", which is awkward to express as a glob


### PR DESCRIPTION
* before this, CI built packages but didn’t create a release with downloadable .deb's, now it does, for both amd64 and arm64 architectures and three Debian versions: bookworm, trixie and sid.
* in order to make the .deb versioning better, version detection has been changed - on tagged commits, packages use the tag verbatim; otherwise the prevous logic is preserved.
* tag matching on master is derived from VERSION (major.minor) instead of hard‑coded. This yields versions that align with release tags and clearer pre‑release identifiers.