### PR TITLE
Fixed some typos, removed references to wiki as obsolete and outdated.

### DIFF
--- a/docs/AUTHORS
+++ b/docs/AUTHORS
@@ -13,6 +13,7 @@ Ordered alphabetically by the SF username:
 - jepler        (Jeff Epler)
 - jmelson       (Jon Elson)
 - jmkasunich    (John Kasunich)
+- johnobrien    (John O'Brien)
 - lerman        (Kenneth Lerman)
 - mhaberler     (Michael Haberler)
 - mkuhnle       (Martin Kuhnle)

--- a/docs/README.adoc
+++ b/docs/README.adoc
@@ -27,7 +27,7 @@ when invoking `src/configure`, and run "make" from `src`.
 
 == Notes about drawings
 
-Many of the documents include drawings. Most of them originally
+Many of the documents include drawings. Most of them were originally
 created using the non-free Windows app EasyCAD and then exported to .eps
 files and included in the the docs. The original 'source' files
 (EasyCad .FC7 format) were not usable on a free system.  To fix this
@@ -59,7 +59,7 @@ Because the original EPS files with filled lines and circles, wide lines,
 and dashed lines look so much nicer, they will remain in Git and should
 probably be used for the documents, however if they become inaccurate
 because of changes in the software, we will have to edit the DXF files,
-generate PostScript, and use the less pretty, but factually correct
+generate PostScript, and use the less pretty but factually correct
 images.
 
 Since QCAD itself is a GUI application, the DXF to PostScript conversion
@@ -144,7 +144,7 @@ the LinuxCNC community.
 == Provide translated documentation
 
 The complete set of documents are translated using gettext PO files
-using the https://po4a.alioth.debian.org/[po4a]po4a system.  If you
+using the https://po4a.alioth.debian.org/[po4a] system.  If you
 want to contribute a translation, please use the
 link:https://hosted.weblate.org/projects/linuxcnc/[web based
 translation editor Weblate].  Registered Weblate users can translate

--- a/docs/src/code/style-guide.adoc
+++ b/docs/src/code/style-guide.adoc
@@ -92,7 +92,7 @@ Microsoft makes buggy programs.
 
 LOCAL variable names should be short, and to the point. If you have
 some random integer loop counter, it should probably be called 'i'.
-Calling it 'loop_counter' is non-productive, if there is no chance of
+Calling it 'loop_counter' is non-productive if there is no chance of
 it being misunderstood. Similarly, 'tmp' can be just about any type of
 variable that is used to hold a temporary value.
 
@@ -152,14 +152,14 @@ indicate a change has been made and needs testing.
 == Shell Scripts & Makefiles
 
 Not everyone has the same tools and packages installed. Some people
-use vi, others emacs - A few even avoid having either package
+use vi, others emacs - a few even avoid having either package
 installed, preferring a lightweight text editor such as nano or the one
 built in to Midnight Commander.
 
-gawk versus mawk - Again, not everyone will have gawk installed, mawk
+gawk versus mawk: not everyone will have gawk installed. Mawk
 is nearly a tenth of the size and yet conforms to the POSIX AWK
 standard. If some obscure gawk specific command is needed that mawk
-does not provide, than the script will break for some users. The same
+does not provide, then the script will break for some users. The same
 would apply to mawk. In short, use the generic awk invocation in
 preference to gawk or mawk.
 

--- a/docs/src/common/overleaf.adoc
+++ b/docs/src/common/overleaf.adoc
@@ -5,7 +5,7 @@ writing, editing, or graphic preparation please contact any member
 of the writing team or join and send an email to
 emc-users@lists.sourceforge.net.
 
-Copyright © 2000-2020 LinuxCNC.org
+Copyright © 2000-2025 LinuxCNC.org
 
 Permission is granted to copy, distribute and/or modify this document
 under the terms of the GNU Free Documentation License, Version 1.1

--- a/docs/src/config/python-interface.adoc
+++ b/docs/src/config/python-interface.adoc
@@ -16,11 +16,11 @@ constants are located in src/emc/usr_intf/axis/extensions/emcmodule.cc
 ////
 
 == Introduction
-User interfaces control LinuxCNC activity by sending NML messages to the LinuxCNC task controller,
-and monitor results by observing the LinuxCNC status structure, as well as the error reporting channel.
+User interfaces control LinuxCNC activity by sending NML messages to the LinuxCNC task controller
+and monitor results by observing the LinuxCNC status structure as well as the error reporting channel.
 
-Programmatic access to NML is through a C++ API;
-however, the most important parts of the NML interface to LinuxCNC
+Programmatic access to NML is through a C++ API.
+However, the most important parts of the NML interface to LinuxCNC
 are also available to Python programs through the `linuxcnc` module.
 
 Beyond the NML interface to the command, status and error channels, the `linuxcnc` module also contains:

--- a/docs/src/getting-started/about-linuxcnc.adoc
+++ b/docs/src/getting-started/about-linuxcnc.adoc
@@ -64,14 +64,14 @@ Some IRC etiquette::
 * If you're really new to all this, think a bit about your question
   before typing it.  Make sure you give enough information so
   someone can answer your question or solve your problem.
-* Have some patience when waiting for an answer, sometimes it takes a
-  while to formulate an answer or everyone might be busy working or
+* Have some patience when waiting for an answer. Sometimes it takes a
+  while to formulate an answer, or everyone might be busy working or
   something.
 * Set up your IRC account with your unique name so people will know who
   you are.  If you use the java client, use the same name every time you
-  log in.  This helps people remember who you are and if you have been on
-  before many will remember the past discussions which
-  saves time on both ends.
+  log in.  This helps people remember who you are. If you have been on
+  before, many will remember past discussions with you which will
+  save time on both ends.
 
 Sharing Files::
 The most common way to share files on the IRC is to upload the file
@@ -101,13 +101,6 @@ the link at the top of the https://linuxcnc.org/ home page.
 This is quite active but the demographic is more user-biased than the
 mailing list.  If you want to be sure that your message is seen by the
 developers then the mailing list is to be preferred.
-
-=== LinuxCNC Wiki
-
-A Wiki site is a user maintained web site that anyone can add to or edit.
-
-The user maintained LinuxCNC Wiki site contains a
-wealth of information and tips at https://wiki.linuxcnc.org/.
 
 === Bug Reports
 

--- a/docs/src/getting-started/hardware-interface.adoc
+++ b/docs/src/getting-started/hardware-interface.adoc
@@ -45,7 +45,7 @@ __Disadvantages:__
 
 
 == Parallel Port FPGA Communication
-Realtime (time critical) tasks such as step generation are done in hardware (not on the computer)
+Realtime (time critical) tasks such as step generation are done in hardware (not on the computer).
 
 === Mesa via Parallel Port
 Mesa use Field-programmable gate array (FPGA) interfaced via parallel port - e.g. 7i43
@@ -60,7 +60,7 @@ https://pico-systems.com/univstep.html
 === Mesa Ethernet
 Mesa cards with a Field-programmable gate array (FPGA), interfaced to LinuxCNC computer via Ethernet. Time critical (realtime) tasks are performed on the FPGA card.
 
-Multiple ethernet interface FPGA cards are available, with many expansion cards
+Multiple ethernet interface FPGA cards are available as well as many expansion cards.
 
 Website: https://mesanet.com/    Store: https://store.mesanet.com/
 

--- a/docs/src/getting-started/system-requirements.adoc
+++ b/docs/src/getting-started/system-requirements.adoc
@@ -17,9 +17,6 @@ In addition LinuxCNC needs to be run on an operating system that uses a
 specially modified kernel,
 see <<sec:kernel_and_version_requirements,Kernel and Version Requirements>>.
 
-Additional information is on the LinuxCNC Wiki site:
-https://wiki.linuxcnc.org/cgi-bin/wiki.pl?Hardware_Requirements[Hardware Requirements]
-
 LinuxCNC and Debian Linux should run reasonably well on a computer with
 the following minimum hardware specification. These numbers are not the
 absolute minimum but will give reasonable performance for most stepper
@@ -49,7 +46,7 @@ unlikely to compile your source tree and produce chips at the same time.
 == Kernel and Version requirements
 
 LinuxCNC requires a kernel modified for realtime use to control real machine hardware.
-It can, however run on a standard kernel in simulation mode for purposes
+However, it can run on a standard kernel in simulation mode for purposes
 such as checking G-code, testing config files and learning the system.
 To work with these kernel versions there are two versions of LinuxCNC distributed.
 The package names are "linuxcnc" and "linuxcnc-uspace".

--- a/docs/src/user/user-concepts.adoc
+++ b/docs/src/user/user-concepts.adoc
@@ -18,7 +18,7 @@ This chapter covers important user concepts that should be understood before att
 [[sub:trajectory-planning]]
 === Trajectory Planning(((Trajectory Planning,TP)))
 
-Trajectory planning, in general, is the means by which LinuxCNC follows the path specified by your G-code program, while still operating within the limits of your machinery.
+Trajectory planning, in general, is the means by which LinuxCNC follows the path specified by your G-code program while still operating within the limits of your machinery.
 
 A G-code program can never be fully obeyed.
 For example, imagine you specify as a single-line program the following move:
@@ -30,7 +30,7 @@ G1 X1 F10 (G1 is linear move, X1 is the destination, F10 is the speed)
 
 In reality, the whole move can't be made at F10, since the machine must accelerate from a stop, move toward X=1, and then decelerate to stop again.
 Sometimes part of the move is done at F10, but for many moves, especially short ones, the specified feed rate is never reached at all.
-Having short moves in your G-code can cause your machine to slow down and speed up for the longer moves if the 'naive cam detector' is not employed with G64 P__n__.
+Having short moves in your G-code can cause your machine to slow down and speed up for the longer moves if the 'naive cam detector' is not employed with G64 P__n__ (the G64 Pn G-code command initiates constant velocity mode and specifies a blend tolerance for corner rounding on a CNC machine).
 
 The basic acceleration and deceleration described above is not complex and there is no compromise to be made.
 In the INI file the specified machine constraints, such as maximum axis velocity and axis acceleration, must be obeyed by the trajectory planner.
@@ -40,7 +40,7 @@ For more information on the Trajectory Planner INI options see the <<sub:ini:sec
 [[sub:path-following]]
 === Path Following(((Trajectory Planning:Path Following)))
 
-A less straightforward problem is that of path following.
+The path following problem is less straightforward than the trajectory planning problem.
 When you program a corner in G-code, the trajectory planner can do several things,
 all of which are right in some cases:
 
@@ -66,22 +66,22 @@ The trajectory control commands are as follows:
   The path will be followed exactly but complete feed stops can be destructive for the part or tool, depending on the specifics of the machining.
 
 `G64`:: (Blend Without Tolerance Mode) `G64` is the default setting when you start LinuxCNC.
-  G64 is just blending and the naive cam detector is not enabled.
-  G64 and G64 P0 tell the planner to sacrifice path following accuracy in order to keep the feed rate up.
-  This is necessary for some types of material or tooling where exact stops are harmful,
+  `G64` is just blending and the naive cam detector is not enabled.
+  `G64` and `G64 P0` tell the planner to sacrifice path following accuracy in order to keep the feed rate up.
+  This is necessary for some types of material or tooling where exact stops are harmful
   and can work great as long as the programmer is careful to keep in mind
   that the tool's path will be somewhat more curvy than the program specifies.
-  When using G0 (rapid) moves with G64 use caution on clearance moves and allow enough distance to clear obstacles based on the acceleration
+  When using `G0` (rapid) moves with `G64` use caution on clearance moves and allow enough distance to clear obstacles based on the acceleration
   capabilities of your machine.
 
 `G64 P- Q-`:: (Blend With Tolerance Mode) This enables the 'naive cam detector' and enables blending with a tolerance.
-  If you program G64 P0.05, you tell the planner that you want continuous feed,
+  If you program `G64 P0.05`, you tell the planner that you want continuous feed,
   but at programmed corners you want it to slow down enough so that the tool path can stay within 0.05 user units of the programmed path.
   The exact amount of slowdown depends on the geometry of the programmed corner and the machine constraints,
   but the only thing the programmer needs to worry about is the tolerance.
   This gives the programmer complete control over the path following compromise.
   The blend tolerance can be changed throughout the program as necessary.
-  Beware that a specification of G64 P0 has the same effect as G64 alone (above),
+  Beware that a specification of `G64 P0` has the same effect as `G64` alone (above),
   which is necessary for backward compatibility for old G-code programs.
   See the <<gcode:g64,G64 section>> of the G-code chapter.
 

--- a/docs/src/user/user-intro.adoc
+++ b/docs/src/user/user-intro.adoc
@@ -37,7 +37,6 @@ and a second signal that defines the speed at which that stepper motor rotates.
 
 While a stepper motor system under parallel port control is illustrated,
 a LinuxCNC system can also take advantage of a wide variety of dedicated hardware motion control interfaces for increased speed and I/O capabilities.
-A full list of interfaces supported by LinuxCNC can be found on the https://wiki.linuxcnc.org/cgi-bin/wiki.pl?LinuxCNC_Supported_Hardware[Supported Hardware] page of the Wiki.
 
 In most circumstances,
 users will create a configuration specific to their mill setup using either the <<cha:stepconf-wizard,Stepper Configuration Wizard>>


### PR DESCRIPTION
This is a rescue of many smallish changes that I liked in https://github.com/LinuxCNC/linuxcnc/pull/3597 .

The Wiki seems like "gone". It thus seems fair to also remove it from our documentation.