### PR TITLE
emc: fix user-facing typo

### DIFF
--- a/src/emc/usr_intf/qtplasmac/qtplasmac_gcode.py
+++ b/src/emc/usr_intf/qtplasmac/qtplasmac_gcode.py
@@ -1416,7 +1416,7 @@ class Filter():
                 else:
                     errorText = f'Conversational block header must be line 1, it is currently line {self.errorLines[0]}:\n'
             if self.errorBlockFormat:
-                msg = 'Conversational block code format is inconsistant with header or is invalid.\n'
+                msg = 'Conversational block code format is inconsistent with header or is invalid.\n'
                 errorText += self.message_set(self.errorBlockFormat, msg)
                 errorText = msg
         if self.codeWarn:


### PR DESCRIPTION
Fixed typo inconsistant->inconsistent within src/emc/usr_intf/qtplasmac/qtplasmac_gcode.py