### PR TITLE
axis.py: restore mdi queuing provision       #2460

### DIFF
--- a/src/emc/usr_intf/axis/scripts/axis.py
+++ b/src/emc/usr_intf/axis/scripts/axis.py
@@ -979,7 +979,6 @@ initiated action (whether an MDI command or a jog) is acceptable.
 This means this function returns True when the mdi tab is visible."""
     if do_poll: s.poll()
     if s.task_state != linuxcnc.STATE_ON: return False
-    if running(): return 0
     return s.interp_state == linuxcnc.INTERP_IDLE or (s.task_mode == linuxcnc.MODE_MDI and s.queued_mdi_commands < vars.max_queued_mdi_commands.get())
 
 # If LinuxCNC is not already in one of the modes given, switch it to the
@@ -3231,8 +3230,7 @@ jog_after = [None]  * linuxcnc.MAX_JOINTS
 jog_cont  = [False] * linuxcnc.MAX_JOINTS
 jogging   = [0]     * linuxcnc.MAX_JOINTS
 def jog_on(a, b):
-    if not manual_ok(): return
-    if not manual_tab_visible(): return
+    if not manual_ok() or not manual_tab_visible() or running(): return
     if a < 3 or a > 5:
         if vars.metric.get(): b = b / 25.4
         b = from_internal_linear_unit(b)


### PR DESCRIPTION
Needs user testing

301e3a1b28a fix for forum bug broke mdi queueing as noted by #2460

Notes:
1) function manual_ok() must include tests for queued mdi commands
   in order to allow their queuing.
   (See also code note re "deceptive function name")
2) The manual_tab can be raised (by click or F3) when
   function running() is true.
3) New: jog initiation (function jog_on) not allowed if running().