### PR TITLE
debian/docs: Do not (yet) prepare UK docs package

### DIFF
--- a/debian/control.docs.in
+++ b/debian/control.docs.in
@@ -12,19 +12,19 @@ Description: motion controller for CNC machines and robots (German documentation
  .
  This package contains the documentation in German.
 
-Package: linuxcnc-doc-uk
-Provides: linuxcnc-doc
-Architecture: all
-Multi-Arch: foreign
-Depends: ${misc:Depends}
-Recommends: xdg-utils
-Suggests: pdf-viewer
-Description: motion controller for CNC machines and robots (Ukrainian documentation)
- LinuxCNC is the next-generation Enhanced Machine Controller which
- provides motion control for CNC machine tools and robotic
- applications (milling, cutting, routing, etc.).
- .
- This package contains the documentation in Ukrainian.
+#Package: linuxcnc-doc-uk
+#Provides: linuxcnc-doc
+#Architecture: all
+#Multi-Arch: foreign
+#Depends: ${misc:Depends}
+#Recommends: xdg-utils
+#Suggests: pdf-viewer
+#Description: motion controller for CNC machines and robots (Ukrainian documentation)
+# LinuxCNC is the next-generation Enhanced Machine Controller which
+# provides motion control for CNC machine tools and robotic
+# applications (milling, cutting, routing, etc.).
+# .
+# This package contains the documentation in Ukrainian.
 
 # Preparing for Tamil
 #Package: linuxcnc-doc-ta


### PR DESCRIPTION
Any change to the packages provided that would be uploaded to Debian then triggers a manual review with an uncertain delay for the update to make it to the archive. Also, we still have a build-problem that we possibly want to understand prior to relying on the UK docs to work with our Debian updates.

This PR is also an attempt to address the lintian error about an empty package.