### PR TITLE
XHC-WHB04B-6: Add command line option -P for devices with ProductId other than 0xeb93

### DIFF
--- a/src/hal/user_comps/xhc-whb04b-6/main.cc
+++ b/src/hal/user_comps/xhc-whb04b-6/main.cc
@@ -114,9 +114,15 @@ static int printUsage(const char* programName, const char* deviceName, bool isEr
         << "    Force being silent and not printing any output except of errors. This will also inhibit messages "
             "prefixed with \"init\"." << endl
         << endl
+        << " -P " << endl
+        << "    Device ProductId in hex (defaults to 0xeb93 if omitted)." << endl
+        << endl
         << "EXAMPLES" << endl
         << programName << " -ue" << endl
         << "    Prints incoming USB data transfer and generated key pressed/released events." << endl
+        << endl
+        << programName << " -ue -P 0xeb91" << endl
+        << "    Same as above but for a device with a product id 'eb91'." << endl
         << endl
         << programName << " -p" << endl
         << "    Prints hal pin names and events distributed to HAL memory." << endl
@@ -168,7 +174,7 @@ int main(int argc, char** argv)
 {
     WhbComponent = new XhcWhb04b6::XhcWhb04b6Component();
 
-    const char* optargs = "phaeHuctsfBnU:v:";
+    const char* optargs = "phaeHuctsfBnUP:v:";
     for (int opt = getopt(argc, argv, optargs); opt != -1; opt = getopt(argc, argv, optargs))
     {
         switch (opt)
@@ -220,6 +226,9 @@ int main(int argc, char** argv)
                 break;
             case 'h':
                 return printUsage(basename(argv[0]), WhbComponent->getName());
+                break;
+            case 'P':
+                 WhbComponent->setUsbProductId(std::stoi(optarg, 0, 16));
                 break;
             default:
                 return printUsage(basename(argv[0]), WhbComponent->getName(), true);

--- a/src/hal/user_comps/xhc-whb04b-6/usb.cc
+++ b/src/hal/user_comps/xhc-whb04b-6/usb.cc
@@ -180,6 +180,11 @@ void Usb::setDoReconnect(bool doReconnect)
     this->mDoReconnect = doReconnect;
 }
 // ----------------------------------------------------------------------
+void Usb::setUsbProductId(uint16_t usbProductId)
+{
+    this->usbProductId = usbProductId;
+}
+// ----------------------------------------------------------------------
 Usb::Usb(const char* name, OnUsbInputPackageListener& onDataReceivedCallback, Hal& hal) :
     sleepState(),
     inputPackageBuffer(),

--- a/src/hal/user_comps/xhc-whb04b-6/usb.h
+++ b/src/hal/user_comps/xhc-whb04b-6/usb.h
@@ -281,6 +281,7 @@ public:
     ~Usb();
     uint16_t getUsbVendorId() const;
     uint16_t getUsbProductId() const;
+    void setUsbProductId(uint16_t usbProductId);
     bool isDeviceOpen() const;
     libusb_context** getContextReference();
     libusb_context* getContext();
@@ -308,7 +309,7 @@ public:
 
 private:
     const uint16_t usbVendorId{0x10ce};
-    const uint16_t usbProductId{0xeb93};
+    uint16_t usbProductId{0xeb93};
     libusb_context      * context{nullptr};
     libusb_device_handle* deviceHandle{nullptr};
     bool                mDoReconnect{false};

--- a/src/hal/user_comps/xhc-whb04b-6/xhc-whb04b6.cc
+++ b/src/hal/user_comps/xhc-whb04b-6/xhc-whb04b6.cc
@@ -619,6 +619,11 @@ void XhcWhb04b6Component::setWaitWithTimeout(uint8_t waitSecs)
     mUsb.setWaitWithTimeout(waitSecs);
 }
 // ----------------------------------------------------------------------
+void XhcWhb04b6Component::setUsbProductId(uint16_t usbProductId)
+{
+    mUsb.setUsbProductId(usbProductId);
+}
+// ----------------------------------------------------------------------
 bool XhcWhb04b6Component::isSimulationModeEnabled() const
 {
     return mIsSimulationMode;

--- a/src/hal/user_comps/xhc-whb04b-6/xhc-whb04b6.h
+++ b/src/hal/user_comps/xhc-whb04b-6/xhc-whb04b6.h
@@ -74,6 +74,7 @@ public:
     void setLeadModeSpindle(bool enable);
     void setLeadModeFeed(bool enable);
     void setStepMode_5_10(bool enable);
+    void setUsbProductId(uint16_t usbProductId);
 
 private:
     const char* mName;


### PR DESCRIPTION
ProductId defaults to 0xeb93 if the -P option is omitted.

Example use:
	xhc-whb04b-6 -ue -P 0xeb91

Also see:
https://github.com/LinuxCNC/linuxcnc/issues/3607