### PR TITLE
docs: clarification on python interface function 'wait_complete()'

### DIFF
--- a/docs/src/config/python-interface.adoc
+++ b/docs/src/config/python-interface.adoc
@@ -564,9 +564,12 @@ def ok_for_mdi():
 
 if ok_for_mdi():
     c.mode(linuxcnc.MODE_MDI)
-    c.wait_complete() # wait until mode switch executed
+    c.wait_complete() # wait until mode switch executed (or default timeout of 5s occurs!)
     c.mdi("G0 X10 Y20 Z30")
 ----
+
+[WARNING]
+Read important information on 'wait_complete()' in the `linuxcnc.command methods' section below.
 
 ==  Sending commands through `linuxcnc.command`
 
@@ -803,10 +806,13 @@ c.spindle.(linuxcnc.SPINDLE_OFF, 0)
   Unhome a given joint.
 
 `wait_complete([float])`::
-  Wait for completion of the last command sent.
-  If timeout in seconds not specified, default is 5 seconds.
-  Return -1 if timed out, return `RCS_DONE` or `RCS_ERROR` according to command execution status.
-
+  Wait for completion of the last command.
+   Takes an optional timeout value in seconds. +
+   Timeout defaults to 5 seconds if omitted. +
+   Returns -1 if timed out. +
+   Returns `RCS_DONE` or `RCS_ERROR` according to command execution status. +
+   Note that python execution will be blocked until this function returns.
+   
 == Reading the error channel
 
 To handle error messages, connect to the error channel and periodically poll() it.


### PR DESCRIPTION
Users frequently copy/paste the minimal example on how to use the 'wait_complete' method from this document which can lead to frustration when it does not do what they expect.

- adds a warning to the example code using it
<img width="1076" height="302" alt="warning_wait_complete" src="https://github.com/user-attachments/assets/88c7b7dd-ada4-4398-a65d-5c35b8ecae62" />

- adds more information to the 'wait_complete()' entry
<img width="1091" height="315" alt="info_wait_complete" src="https://github.com/user-attachments/assets/9f29ca0f-7126-4530-bef1-28d522ec2450" />
