### PR TITLE
Fix homing bug when trying to home while a homing sequence is already in progress

### DIFF
--- a/src/emc/motion/command.c
+++ b/src/emc/motion/command.c
@@ -1363,7 +1363,10 @@ void emcmotCommandHandler_locked(void *arg, long servo_period)
 	                   joint_num);
                 return;
 	    }
-
+	    if ( get_homing_is_active() ) {
+	        reportError("Homing not possible until current homing process is finished.\n");
+	        return;
+	    }
 	    if (!GET_MOTION_ENABLE_FLAG()) {
 		break;
 	    }

--- a/src/emc/usr_intf/axis/scripts/axis.py
+++ b/src/emc/usr_intf/axis/scripts/axis.py
@@ -1949,6 +1949,11 @@ def all_homed():
     return isHomed
 
 def go_home(num):
+    s.poll()
+    for j in range(s.joints):
+        if s.joint[j]["homing"]:
+            print(_("Homing not possible until current homing process is finished."))
+            return
     set_motion_teleop(0)
     c.home(num)
     c.wait_complete()

--- a/src/emc/usr_intf/gmoccapy/gmoccapy.py
+++ b/src/emc/usr_intf/gmoccapy/gmoccapy.py
@@ -4016,6 +4016,11 @@ class gmoccapy(object):
     def _on_btn_home_clicked(self, widget):
         # home axis or joint?
         LOG.debug("on button home clicked = {0}".format(widget.get_property("name")))
+        self.stat.poll()
+        for j in range(self.stat.joints):
+            if self.stat.joint[j]["homing"]:
+                self._show_error((13, _("Homing not possible until current homing process is finished.")))
+                return
         if "axis" in widget.get_property("name"):
             value = widget.get_property("name")[-1]
             # now get the joint from directory by the value


### PR DESCRIPTION
Fixes https://github.com/LinuxCNC/linuxcnc/issues/3314 
The modification to 'command.c' prevents the homing process breaking where the joint would continue moving indefinitely.
The modifications to axis.py and gmoccapy.py prevent the gui freezing that occurs due to wait_complete() timing out to the default 5 seconds.