### PR TITLE
docs: bump linuxcnc version, details on dd for image handling, (((index))) not in header (smoe:docs image handling)

### DIFF
--- a/docs/src/common/emc-history.adoc
+++ b/docs/src/common/emc-history.adoc
@@ -2,8 +2,9 @@
 :toc:
 
 [[cha:linuxcnc-history]]
-= Origin(((History)))
+= Origin
 
+(((History)))
 EMC (the Enhanced Machine Controller) was created by
 https://www.nist.gov/index.html[NIST] , the National Institute of Standards
 and Technology, which is an agency of the Commerce Department of the United

--- a/docs/src/common/linux-faq.adoc
+++ b/docs/src/common/linux-faq.adoc
@@ -2,13 +2,16 @@
 :toc:
 
 [[cha:linux-faq]]
-= Linux FAQ(((Linux FAQ)))
+= Linux FAQ
 
+(((Linux FAQ)))
 These are some basic Linux commands and techniques for new to Linux
 users. More complete information can be found on the web or by using
 the man pages.
 
-== Automatic Login(((Automatic Login)))
+== Automatic Login
+
+(((Automatic Login)))
 
 === Debian
 
@@ -70,8 +73,9 @@ make sure your right clicking on a blank area or a directory not a file name.
 Most OS's have the terminal as a menu item, usually in Accessories.
 
 [[faq:man-pages]]
-== Man Pages(((Man Pages)))
+== Man Pages
 
+(((Man Pages)))
 A man page (short for manual page) is a form of software documentation
 usually found on a Unix or Unix-like operating system like Linux.
 
@@ -154,8 +158,9 @@ pwd
 ----
 
 [[faq:cd]]
-=== Changing Directories(((Changing Directories)))(((cd)))
+=== Changing Directories
 
+(((Changing Directories)))(((cd)))
 To change the working directory to the one one level up, i.e., the parent directory, in the terminal window type:
 
 ----

--- a/docs/src/config/core-components.adoc
+++ b/docs/src/config/core-components.adoc
@@ -2,7 +2,7 @@
 :toc:
 
 [[cha:core-components]]
-= Core Components(((Core components)))
+= Core Components
 
 // Custom lang highlight
 // must come after the doc title, to work around a bug in asciidoc 8.6.6
@@ -10,11 +10,13 @@
 :hal: {basebackend@docbook:'':hal}
 :ngc: {basebackend@docbook:'':ngc}
 
+(((Core components)))
 See also the man pages 'motion(9)'.
 
 [[sec:motion]]
-== Motion (((Motion)))
+== Motion
 
+(((Motion)))
 These pins and parameters are created by the realtime 'motmod' module.
 
 This module provides a HAL interface for LinuxCNC's motion planner.
@@ -93,8 +95,9 @@ unlock_joints_mask=0x38 selects joints 3,4,5
 ----
 
 [[sec:motion-pins]]
-=== Pins(((motion (HAL pins))))
+=== Pins
 
+(((HAL,pins,motion))))
 These pins, parameters, and functions are created by the realtime 'motmod'
 module.
 
@@ -197,8 +200,9 @@ Motion will produce the following pins:
 The __N__ (integer between 0 and 7) substitutes the spindle number.
 
 [[sec:spindle-pins]]
-=== Pins(((spindle (HAL pins))))
+=== Pins
 
+(((HAL,pins,spindle)))
 * 'spindle.__N__.at-speed' - (bit, in)
   Motion will pause until this pin is TRUE, under the following conditions:
 ** before the first feed move after each spindle start or speed change;
@@ -305,8 +309,8 @@ iocontrol - accepts non-realtime I/O commands via NML, interacts with HAL .
 
 iocontrol's HAL pins are turned on and off in non-realtime context.  If you have strict timing requirements or simply need more I/O, consider using the realtime synchronized I/O provided by <<sec:motion,motion>> instead.
 
-=== Pins (((iocontrol (HAL pins))))
-
+=== Pins
+(((HAL,pins,iocontrol)))
 * 'iocontrol.0.coolant-flood' (bit, out) TRUE when flood coolant is requested.
 * 'iocontrol.0.coolant-mist' (bit, out) TRUE when mist coolant is requested.
 * 'iocontrol.0.emc-enable-in' (bit, in) Should be driven FALSE when an external E-Stop condition exists.
@@ -325,7 +329,10 @@ iocontrol's HAL pins are turned on and off in non-realtime context.  If you have
 
 A number of INI settings are made available as HAL input pins.
 
-=== Pins (((INI settings (HAL pins))))
+=== Pins
+
+(((HAL,pins,INI settings)))
+(((INI settings (HAL pins)))
 
 _N_ refers to a joint number, _L_ refers to an axis letter.
 

--- a/docs/src/config/ini-config.adoc
+++ b/docs/src/config/ini-config.adoc
@@ -2,7 +2,9 @@
 :toc:
 
 [[cha:ini-configuration]]
-= INI Configuration(((INI Configuration)))
+= INI Configuration
+
+(((INI Configuration)))
 
 // Custom lang highlight
 // must come after the doc title, to work around a bug in asciidoc 8.6.6
@@ -10,8 +12,9 @@
 :hal: {basebackend@docbook:'':hal}
 :ngc: {basebackend@docbook:'':ngc}
 
-== The INI File Components(((INI File,Components)))
+== The INI File Components
 
+(((INI File,Components)))
 A typical INI file follows a rather simple layout that includes;
 
 * comments
@@ -21,8 +24,9 @@ A typical INI file follows a rather simple layout that includes;
 Each of these elements is separated on single lines.
 Each end of line or newline character creates a new element.
 
-=== Comments(((INI File,Components,Comments)))
+=== Comments
 
+(((INI File,Components,Comments)))
 A comment line is started with a ; or a # mark.
 When the INI reader sees either of these marks at the start a line, the rest of the line is ignored by the software.
 Comments can be used to describe what an INI element will do.
@@ -56,8 +60,9 @@ CORRECT = value
 ----
 
 [[sub:ini:sections]]
-=== Sections(((INI File,Components,Sections)))
+=== Sections
 
+(((INI File, Components, Sections)))
 Related parts of an INI file are separated into sections.
 A section name is enclosed in brackets like this: `[THIS_SECTION]`.
 The order of sections is unimportant.
@@ -81,8 +86,9 @@ The following sections are used by LinuxCNC:
 * <<sub:ini:sec:emcio,`[EMCIO]`>> settings used by the I/O Controller
 
 [[sub:ini:variables]]
-=== Variables(((INI File,Components,Variables)))
+=== Variables
 
+(((INI File, Components, Variables)))
 A variable line is made up of a variable name, an equals sign (`=`), and a value.
 Everything from the first non-white space character after the `=` up to the end of the line is passed as the value,
 so you can embed spaces in string symbols if you want to or need to.
@@ -121,8 +127,9 @@ The following sections detail each section of the configuration file, using samp
 Variables that are used by LinuxCNC must always use the section names and variable names as shown.
 
 [[sub:ini:custom]]
-=== Custom Sections and Variables(((INI File,Components,Custom sections and variables)))
+=== Custom Sections and Variables
 
+(((INI File, Components, Custom sections and variables)))
 Most sample configurations use custom sections and variables to put all of the settings into one location for convenience.
 
 To add a custom variable to an existing LinuxCNC section, simply include the variable in that section.
@@ -173,8 +180,9 @@ G10 L20 P0 Z#<_ini[probe]z_offset>
 ----
 
 [[sub:ini:include]]
-=== Include Files(((INI File,Components,Include)))
+=== Include Files
 
+(((INI File, Components,Include)))
 An INI file may include the contents of another file by using a #INCLUDE directive.
 
 .#INCLUDE Format
@@ -207,11 +215,14 @@ The recommended file extension is '.inc'.
 Do _not_ use a file extension of '.ini' for included files.
 
 [[sec:ini:sections]]
-== INI File Sections(((INI File,Sections)))
+== INI File Sections
+
+(((INI File, Sections)))
 
 [[sub:ini:sec:emc]]
-=== [EMC] Section(((INI File,Sections,[EMC] Section)))
+=== [EMC] Section
 
+(((INI File, Sections, [EMC] Section)))
 * `VERSION = 1.1` - The version number for the configuration.
   Any value other than 1.1 will cause the configuration checker to run and try to update the configuration to the new style joint axes type of configuration.
 * `MACHINE = My Controller` - This is the name of the controller, which is printed out at the top of most graphical interfaces.
@@ -220,8 +231,9 @@ Do _not_ use a file extension of '.ini' for included files.
   Debug flags are usually only useful to developers. See src/emc/nml_intf/debugflags.h for other settings.
 
 [[sub:ini:sec:display]]
-=== [DISPLAY] Section(((INI File,Sections,[DISPLAY] Section)))
+=== [DISPLAY] Section
 
+(((INI File, Sections, [DISPLAY] Section)))
 Different user interface programs use different options, and not every option is supported by every user interface.
 There are several interfaces, like AXIS, GMOCCAPY, Touchy, QtVCP's QtDragon and Gscreen.
 AXIS is an interface for use with normal computer and monitor, Touchy is for use with touch screens.
@@ -386,8 +398,9 @@ The following `[DISPLAY]` item is used by the TKLinuxCNC interface only.
 * `HELP_FILE = tklinucnc.txt` - Path to help file.
 
 [[sub:ini:sec:filter]]
-=== [FILTER] Section(((INI File,Sections,[FILTER] Section)))
+=== [FILTER] Section
 
+(((INI File, Sections, [FILTER] Section)))
 AXIS and GMOCCAPY have the ability to send loaded files through a filter program.
 This filter can do any desired task: Something as simple as making sure the file ends with M2,
 or something as complicated as detecting whether the input is a depth image, and generating G-code to mill the shape it defines.
@@ -484,8 +497,9 @@ if __name__ == "__main__":
   This feature should be used by any filter that runs for a long time.
 
 [[sub:ini:sec:rs274ngc]]
-=== [RS274NGC] Section(((INI File,Sections,[RS274NGC] Section)))
+=== [RS274NGC] Section
 
+(((INI File, Sections, [RS274NGC] Section)))
 * `PARAMETER_FILE = myfile.var` - (((PARAMETER FILE)))
   The file located in the same directory as the INI file which contains the parameters used by the interpreter (saved between runs).
 * `ORIENT_OFFSET = 0` - (((ORIENT OFFSET)))
@@ -571,8 +585,9 @@ FEATURES & 0x20 -> OWORD_WARNONLY
   See <<cha:remap,Remap Extending G-code>> chapter for details.
 
 [[sub:ini:sec:emcmot]]
-=== [EMCMOT] Section(((INI File,Sections,[EMCMOT] Section)))
+=== [EMCMOT] Section
 
+(((INI File,Sections,[EMCMOT] Section)))
 This section is a custom section and is not used by LinuxCNC directly.
 Most configurations use values from this section to load the motion controller.
 For more information on the motion controller see the <<sec:motion,Motion>> section.
@@ -588,8 +603,9 @@ For more information on the motion controller see the <<sec:motion,Motion>> sect
   The setting may be overridden from the command line using the -m option ($ linuxcnc -h).
 
 [[sub:ini:sec:task]]
-=== [TASK] Section(((INI File,Sections,[TASK] Section)))
+=== [TASK] Section
 
+(((INI File, Sections, [TASK] Section)))
 * `TASK = milltask` -
   Specifies the name of the 'task' executable.
   The 'task' executable does various things, such as
@@ -603,8 +619,9 @@ For more information on the motion controller see the <<sec:motion,Motion>> sect
   There is usually no need to change this number.
 
 [[sub:ini:sec:hal]]
-=== [HAL] section(((INI File,Sections,[HAL] Section)))
+=== [HAL] section
 
+(((INI File, Sections, [HAL] Section)))
 * `HALFILE = example.hal` - Execute the file 'example.hal' at start up.
 +
 --
@@ -678,14 +695,16 @@ For more information see the <<cha:hal-twopass,HAL TWOPASS>> chapter.
   For more information see the <<cha:hal-user-interface,HAL User Interface>> chapter.
 
 [[sub:ini:sec:halui]]
-=== [HALUI] section(((INI File,Sections,[HALUI] Section)))
+=== [HALUI] section
 
+(((INI File, Sections, [HALUI] Section)))
 * `MDI_COMMAND = G53 G0 X0 Y0 Z0` -
   An MDI command can be executed by using `halui.mdi-command-00`. Increment the number for each command listed in the [HALUI] section.
 
 [[sub:ini:sec:applications]]
-=== [APPLICATIONS] Section(((INI File,Sections,[APPLICATIONS] Section)))
+=== [APPLICATIONS] Section
 
+(((INI File, Sections, [APPLICATIONS] Section)))
 LinuxCNC can start other applications before the specified GUI is started.
 The applications can be started after a specified delay to allow for GUI-dependent actions (like creating GUI-specific HAL pins).
 
@@ -724,7 +743,9 @@ APP = halscope -i my.halscope
 ----
 
 [[sub:ini:sec:traj]]
-=== [TRAJ] Section(((INI File,Sections,[TRAJ] Section)))
+=== [TRAJ] Section
+
+(((INI File, Sections, [TRAJ] Section)))
 
 [WARNING]
 ====
@@ -869,8 +890,9 @@ LinuxCNC will not know your joint travel limits when using `NO_FORCE_HOMING = 1`
 
 
 [[sub:ini:sec:kins]]
-=== [KINS] Section(((INI File,Sections,KINS Section)))
+=== [KINS] Section
 
+(((INI File, Sections, KINS Section)))
 * `JOINTS = 3` - Specifies the number of joints (motors) in the system.
   For example, a trivkins XYZ machine with a single motor for each axis has 3 joints.
   A gantry machine with one motor on each of two of the axes, and two motors on the third axis, has 4 joints.
@@ -880,8 +902,9 @@ LinuxCNC will not know your joint travel limits when using `NO_FORCE_HOMING = 1`
   For more information on kinematics modules see the manpage: `$ man kins`.
 
 [[sub:ini:sec:axis-letter]]
-=== [AXIS_<letter>] Section(((INI File,Sections,[AXIS_<letter>] Sections)))
+=== [AXIS_<letter>] Section
 
+(((INI File, Sections, [AXIS_<letter>] Sections)))
 The _<letter>_ specifies one of: X Y Z A B C U V W
 
 * `TYPE = LINEAR` - The type of this axis, either `LINEAR` or `ANGULAR`.
@@ -929,8 +952,9 @@ axis.<letter>.eoffset-scale
 See the chapter: <<cha:external-offsets,'External Axis Offsets'>> for usage information.
 
 [[sub:ini:sec:joint-num]]
-=== [JOINT_<num>] Sections(((INI File,Sections,[JOINT_<num>] Sections)))
+=== [JOINT_<num>] Sections
 
+(((INI File,Sections,[JOINT_<num>] Sections)))
 The _<num>_ specifies the joint number 0 ... (num_joints-1)
 The value of 'num_joints' is set by `[KINS]JOINTS=`.
 
@@ -1296,8 +1320,9 @@ image::images/encoder-scale.png[align="center"]
   Subsequent testing has shown that use of `STEPGEN_MAXVEL` does not improve the tuning of StepGen's position loop.
 
 [[sub:ini:sec:spindle-num]]
-=== [SPINDLE_<num>] Section(s)(((INI File,Sections,[SPINDLE_<num>] Section(s))))
+=== [SPINDLE_<num>] Section(s)
 
+(((INI File, Sections, [SPINDLE_<num>] Section(s))))
 The _<num>_ specifies the spindle number 0 ... (num_spindles-1) +
 The value of _num_spindles_ is set by `[TRAJ]SPINDLES=` . +
 By default maximum velocity of the spindle in forward and reverse is approximately 2147483000 RPM. +
@@ -1338,8 +1363,9 @@ Control screens can limit these settings further.
   Set the `HOME_SEARCH_VELOCITY` to zero to avoid spindle rotation during the homing sequence.
 
 [[sub:ini:sec:emcio]]
-=== [EMCIO] Section(((INI File,Sections,[EMCIO] Section)))
+=== [EMCIO] Section
 
+(((INI File, Sections, [EMCIO] Section)))
 * `EMCIO = io` - Name of IO controller program.
 * `CYCLE_TIME = 0.100` - The period, in seconds, at which EMCIO will run.
   Making it 0.0 or a negative number will tell EMCIO not to sleep at all.

--- a/docs/src/config/ini-homing.adoc
+++ b/docs/src/config/ini-homing.adoc
@@ -123,8 +123,9 @@ They are defined in an [JOINT_n] section of the INI file.
 [NOTE]
 Any other combinations may result in an error.
 
-=== HOME_SEARCH_VEL(((HOME SEARCH VEL)))
+=== HOME_SEARCH_VEL
 
+(((HOME SEARCH VEL)))
 This variable has units of machine-units per second.
 
 The default value is zero. A value of zero causes LinuxCNC to assume that
@@ -140,8 +141,9 @@ The amount of overshoot depends on the speed.
 If it is too high, the joint might overshoot enough to hit a limit switch or crash into the end of travel.
 On the other hand, if HOME_SEARCH_VEL is too low, homing can take a long time.
 
-=== HOME_LATCH_VEL(((HOME LATCH VEL)))
+=== HOME_LATCH_VEL
 
+(((HOME LATCH VEL)))
 This variable has units of machine-units per second.
 
 Specifies the speed and direction that LinuxCNC uses when it makes its final accurate determination of the home switch (if present) and index pulse location (if present).
@@ -163,8 +165,9 @@ HOME_OFFSET to the HOME position. If the HOME_FINAL_VEL is missing from
 the INI file, then the maximum joint speed is used to make this move.
 The value must be a positive number.
 
-=== HOME_IGNORE_LIMITS(((HOME IGNORE LIMITS)))
+=== HOME_IGNORE_LIMITS
 
+(((HOME IGNORE LIMITS)))
 Can hold the values YES / NO. The default value for this parameter is NO.
 This flag determines whether LinuxCNC will ignore the limit switch input for this joint while homing.
 This setting will not ignore limit inputs for other joints.
@@ -172,8 +175,9 @@ If you do not have a separate home switch set this to YES and connect the limit 
 LinuxCNC will ignore the limit switch input for this joint while homing.
 To use only one input for all homing and limits you will have to block the limit signals of the joints not homing in HAL and home one joint at a time.
 
-=== HOME_USE_INDEX(((HOME USE INDEX)))
+=== HOME_USE_INDEX
 
+(((HOME USE INDEX)))
 Specifies whether or not there is an index pulse.
 If the flag is true (HOME_USE_INDEX = YES), LinuxCNC will latch on the rising edge of the index pulse.
 If false, LinuxCNC will latch on either the rising or falling edge of the home switch (depending on the signs of HOME_SEARCH_VEL and HOME_LATCH_VEL).
@@ -182,14 +186,16 @@ The default value is NO.
 [NOTE]
 HOME_USE_INDEX requires connections in your HAL file to `joint.n.index-enable` from the `encoder.n.index-enable`.
 
-=== HOME_INDEX_NO_ENCODER_RESET(((HOME INDEX NO ENCODER RESET)))
+=== HOME_INDEX_NO_ENCODER_RESET
 
+(((HOME INDEX NO ENCODER RESET)))
 Default is NO.
 Use YES if the encoder used for this joint does not reset its counter when an index pulse is detected after assertion of the joint index_enable HAL pin.
 Applicable only for HOME_USE_INDEX = YES.
 
-=== HOME_OFFSET(((HOME OFFSET)))
+=== HOME_OFFSET
 
+(((HOME OFFSET)))
 This defines the location of the origin zero point of the G53 machine coordinate system.
 It is the distance (offset), in joint units, from the machine origin to the home switch trip point or index pulse.
 After detecting the switch trip point/index pulse, LinuxCNC sets the joint coordinate position to HOME_OFFSET, thus defining the origin, which the soft limits references from.
@@ -198,8 +204,9 @@ The default value is zero.
 NOTE: The home switch location, as indicated by the HOME_OFFSET variable, can be inside or outside the soft limits.
 They will be shared with or inside the hard limit switches.
 
-=== HOME(((HOME)))
+=== HOME
 
+(((HOME)))
 The position that the joint will go to upon completion of the homing sequence.
 After detecting the home switch or home switch then index pulse (depending on configuration),
 and setting the coordinate of that point to HOME_OFFSET, LinuxCNC makes a move to HOME as the final step of the homing process.
@@ -212,13 +219,15 @@ This final move will be made at the joint's maximum velocity unless HOME_FINAL_V
 The distinction between 'HOME_OFFSET' and 'HOME' is that 'HOME_OFFSET' first establishes the origin location and scale on the machine
 by applying the 'HOME_OFFSET' value to the location where home was found, and then 'HOME' says where the joint should move to on that scale.
 
-=== HOME_IS_SHARED(((HOME IS SHARED)))
+=== HOME_IS_SHARED
 
+(((HOME IS SHARED)))
 If there is not a separate home switch input for this joint, but a number of momentary switches wired to the same pin, set this value to 1 to prevent homing from starting if one of the shared switches is already closed.
 Set this value to 0 to permit homing even if the switch is already closed.
 
-=== HOME_ABSOLUTE_ENCODER(((HOME ABSOLUTE ENCODER)))
+=== HOME_ABSOLUTE_ENCODER
 
+(((HOME ABSOLUTE ENCODER)))
 Use for absolute encoders.  When a request is made to home the joint, the current joint position is set to the '[JOINT_n]HOME_OFFSET' value.
 
 The final move to the '[JOINT_n]HOME' position is optional according to the 'HOME_ABSOLUTE_ENCODER' setting:
@@ -236,8 +245,9 @@ A HOME_IS_SHARED setting is silently ignored.
 A request to rehome the joint is silently ignored.
 
 [[sec:homing-section]]
-=== HOME_SEQUENCE(((HOME SEQUENCE)))
+=== HOME_SEQUENCE
 
+(((HOME SEQUENCE)))
 Used to define a multi-joint homing sequence *HOME ALL* and enforce homing order (e.g., Z may not be homed if X is not yet homed).
 A joint may be homed after all joints with a lower (absolute value) HOME_SEQUENCE have already been homed and are at the HOME_OFFSET.
 If two joints have the same HOME_SEQUENCE, they may be homed at the same time.
@@ -307,18 +317,21 @@ One sequence, all joints synchronized
 [JOINT_2]HOME_SEQUENCE = -1
 ----
 
-=== VOLATILE_HOME(((VOLATILE HOME)))
+=== VOLATILE_HOME
 
+(((VOLATILE HOME)))
 If this setting is true, this joint becomes unhomed whenever the machine transitions into the OFF state.
 This is appropriate for any joint that does not maintain position when the joint drive is off.
 Some stepper drives, especially microstep drives, may need this.
 
-=== LOCKING_INDEXER(((LOCKING INDEXER)))
+=== LOCKING_INDEXER
 
+(((LOCKING INDEXER)))
 If this joint is a locking rotary indexer, it will unlock before homing, and lock afterward.
 
-=== Immediate Homing(((Immediate Homing)))
+=== Immediate Homing
 
+(((Immediate Homing)))
 If a joint does not have home switches or does not have a logical home position like a rotary joint and you want that joint to home at the current position when the "Home All" button is pressed in the AXIS GUI,
 then the following INI entries for that joint are needed.
 
@@ -334,8 +347,9 @@ HOME_SEQUENCE = 0 (or other valid sequence number)
 The default values for unspecified HOME_SEARCH_VEL, HOME_LATCH_VEL, HOME_USE_INDEX, HOME, and HOME_OFFSET are *zero*, so they may be omitted when requesting immediate homing.
 A valid HOME_SEQUENCE number should usually be included since omitting a HOME_SEQUENCE eliminates the joint from *HOME ALL* behavior as noted above.
 
-=== Inhibiting Homing(((Inhibiting Homing)))
+=== Inhibiting Homing
 
+(((Inhibiting Homing)))
 A HAL pin (motion.homing-inhibit) is provided to disallow homing initiation for both "Home All" and individual joint homing.
 
 Some systems take advantage of the provisions for synchronizing final joint homing moves as controlled by negative [JOINT_N]HOME_SEQUENCE= INI file items.

--- a/docs/src/config/moveoff.adoc
+++ b/docs/src/config/moveoff.adoc
@@ -2,7 +2,7 @@
 :toc:
 
 [[cha:moveoff]]
-= Moveoff Component(((Moveoff)))
+= Moveoff Component
 
 // Custom lang highlight
 // must come after the doc title, to work around a bug in asciidoc 8.6.6

--- a/docs/src/config/stepconf.adoc
+++ b/docs/src/config/stepconf.adoc
@@ -2,10 +2,11 @@
 :toc:
 
 [[cha:stepconf-wizard]]
-= Stepper Configuration Wizard(((Stepper Configuration Wizard)))
+= Stepper Configuration Wizard
 
 == Introduction
 
+(((Stepper Configuration Wizard)))
 LinuxCNC is capable of controlling a wide range of machinery
 using many different hardware interfaces.
 
@@ -106,8 +107,9 @@ The LinuxCNC Configuration Selector has configs for Sherline already configured.
   based on the driver characteristics entered and latency test result.
 
 [[sub:latency-test]]
-== Latency Test(((Latency Test)))
+== Latency Test
 
+(((Latency Test)))
 While the test is running, you should 'abuse' the computer. Move
 windows around on the screen. Surf the web. Copy some large files
 around on the disk. Play some music. Run an OpenGL program such as
@@ -192,7 +194,9 @@ You may select in or out to maximizes the number of input/output pins that are a
 You may specify the address as a hexadecimal (often 0x378) or as linux's default port number (probably 1).
 
 [[sec:Axis-Configuration]]
-== Axis Configuration(((Axis Configuration)))
+== Axis Configuration
+
+(((Axis, Configuration)))
 
 .Axis Configuration Screen
 image::images/stepconf-axis-x_en.png["Axis X Configuration Page",align="center"]
@@ -247,8 +251,9 @@ is required. If your driver has a charge pump you will have to bypass it.
 Test this axis does not react to limit switch inputs. Use with caution.
 
 [[sub:finding-maximum-velocity]]
-=== Finding Maximum Velocity(((Finding Maximum Velocity)))
+=== Finding Maximum Velocity
 
+(((Finding Maximum Velocity)))
 Begin with a low Acceleration
 // comment out latexmath until a fix is found for the html docs
 // (e.g., latexmath:[ 2 in/s^2 ] or latexmath:[ 50 mm/s^2 ])
@@ -291,8 +296,9 @@ Once you have found a speed at which the axis does not stall or lose steps
 during this testing procedure, reduce it by 10% and use that as the axis 'Maximum Velocity'.
 
 [[sub:finding-maximum-acceleration]]
-=== Finding Maximum Acceleration(((Finding Maximum Acceleration)))
+=== Finding Maximum Acceleration
 
+(((Finding Maximum Acceleration)))
 With the Maximum Velocity you found in the previous step,
 enter the acceleration value to test.
 Using the same procedure as above,
@@ -310,8 +316,9 @@ image::images/stepconf-spindle_en.png["Spindle Configuration Page",align="center
 
 This page only appears when 'Spindle PWM' is chosen in the 'Parallel Port Pinout' page for one of the outputs.
 
-=== Spindle Speed Control(((Spindle Speed Control)))
+=== Spindle Speed Control
 
+(((Spindle Speed Control)))
 If 'Spindle PWM' appears on the pinout, the following information should be entered:
 
 * 'PWM Rate' - The 'carrier frequency' of the PWM signal to the spindle. Enter
@@ -322,8 +329,9 @@ If 'Spindle PWM' appears on the pinout, the following information should be ente
   values are not known, they can be determined. For more information see
   <<sub:determining-spindle-calibration,Determining Spindle Calibration>>.
 
-=== Spindle-synchronized motion(((Spindle-synchronized motion)))
+=== Spindle-synchronized motion
 
+(((Spindle-synchronized motion)))
 When the appropriate signals from a spindle encoder are connected to
 LinuxCNC via HAL, LinuxCNC supports lathe threading.
 These signals are:
@@ -350,8 +358,9 @@ on the pinout, the following information should be entered:
   of 'BASE_PERIOD' is required.
 
 [[sub:determining-spindle-calibration]]
-=== Determining Spindle Calibration(((Determining Spindle Calibration)))
+=== Determining Spindle Calibration
 
+(((Determining Spindle Calibration)))
 Enter the following values in the Spindle Configuration page:
 
 [width="80%",cols="^,^,^,^"]
@@ -397,8 +406,9 @@ image::images/stepconf-options_en.png["Advanced Options Configuration",align="ce
   pause and prompt you to change the tool when 'M6' is encountered. This feature
   is usually only useful if you have presettable tools.
 
-== Complete Machine Configuration(((Complete Machine Configuration)))
+== Complete Machine Configuration
 
+(((Complete Machine Configuration)))
 Click 'Apply' to write the configuration files.
 Later, you can re-run this program and tweak the settings you entered before.
 
@@ -448,8 +458,9 @@ A machine can be operated without limit switches. In this case, only
 the soft limits stop the machine from reaching the hard stop.
 Soft limits only operate after the machine has been homed.
 
-=== Operating without Home Switches(((Operating without Home Switches)))
+=== Operating without Home Switches
 
+(((Operating without Home Switches)))
 A machine can be operated without home switches.
 If the machine has limit switches, but no home switches,
 it is best to use a limit switch as the home switch

--- a/docs/src/config/stepper-diagnostics.adoc
+++ b/docs/src/config/stepper-diagnostics.adoc
@@ -2,7 +2,7 @@
 :toc:
 
 [[cha:stepper-diagnostics]]
-= Stepper Diagnostics(((Stepper Diagnostics)))
+= Stepper Diagnostics
 
 // Custom lang highlight
 // must come after the doc title, to work around a bug in asciidoc 8.6.6
@@ -10,6 +10,7 @@
 :hal: {basebackend@docbook:'':hal}
 :ngc: {basebackend@docbook:'':ngc}
 
+(((Stepper Diagnostics)))
 If what you get is not what you expect many times you just got some
 experience. Learning from the experience increases your understanding
 of the whole. Diagnosing problems is best done by divide and conquer.

--- a/docs/src/config/stepper-quickstart.adoc
+++ b/docs/src/config/stepper-quickstart.adoc
@@ -18,15 +18,17 @@ This is the first thing you need to do.
 Follow the instructions <<sec:latency-test,here>> to run the latency test.
 
 [[sec:sherline]]
-== Sherline(((Sherline)))
+== Sherline
 
+(((Sherline)))
 If you have a Sherline several predefined configurations are provided.
 This is on the main menu CNC/EMC then pick the Sherline configuration
 that matches yours and save a copy.
 
 [[sec:xylotex]]
-== Xylotex(((Xylotex)))
+== Xylotex
 
+(((Xylotex)))
 If you have a Xylotex you can skip the following sections and go
 straight to the <<cha:stepconf-wizard,Stepper Config Wizard>>.
 LinuxCNC has provided quick setup for the Xylotex machines.

--- a/docs/src/config/stepper.adoc
+++ b/docs/src/config/stepper.adoc
@@ -2,7 +2,7 @@
 :toc:
 
 [[cha:stepper-config]]
-= Stepper Configuration(((Stepper Configuration)))
+= Stepper Configuration
 
 // Custom lang highlight
 // must come after the doc title, to work around a bug in asciidoc 8.6.6
@@ -12,6 +12,7 @@
 
 == Introduction
 
+(((Stepper Configuration)))
 The preferred way to set up a standard stepper machine is with the Step Configuration Wizard.
 See the <<cha:stepconf-wizard,Stepper Configuration Wizard>> Chapter.
 

--- a/docs/src/drivers/gs2.adoc
+++ b/docs/src/drivers/gs2.adoc
@@ -2,7 +2,7 @@
 :toc:
 
 [[cha:gs2-vfd-driver]]
-= GS2 VFD Driver(((GS2 VFD Driver)))
+= GS2 VFD Driver
 
 // Custom lang highlight
 // must come after the doc title, to work around a bug in asciidoc 8.6.6
@@ -10,6 +10,7 @@
 :hal: {basebackend@docbook:'':hal}
 :ngc: {basebackend@docbook:'':ngc}
 
+(((GS2 VFD Driver)))
 This is a non-realtime HAL program for the GS2 series of VFDs at Automation Direct. footnote:[In Europe the equivalent can be found under the brand name Omron.]
 
 This component is loaded using the halcmd "loadusr" command:

--- a/docs/src/drivers/pluto-p.adoc
+++ b/docs/src/drivers/pluto-p.adoc
@@ -155,7 +155,8 @@ This driver features:
 * 'GND' - Ground
 * 'VCC' - +3.3V regulated DC
 
-.Pluto-Servo Pinout(((pluto-servo pinout)))
+(((pluto-servo pinout)))
+.Pluto-Servo Pinout
 image::images/pluto-pinout.png["Pluto-Servo Pinout",align="center"]
 
 .Pluto-Servo Alternate Pin Functions
@@ -218,8 +219,9 @@ voltages, some users have reported success with International
 Rectifier's integrated high-side/low-side drivers.
 
 [[sec:Pluto-step:-Hardware-step]]
-== Pluto Step(((pluto-step)))
+== Pluto Step
 
+(((pluto-step)))
 Pluto-step is suitable for control of a 3- or 4-axis CNC mill with
 stepper motors. The large number of inputs allows for a full set of
 limit switches.

--- a/docs/src/examples/spindle.adoc
+++ b/docs/src/examples/spindle.adoc
@@ -16,8 +16,9 @@ control pins with names like 'spindle.0..'.
 In the case of a multiple spindle machine all that changes is that
 additional pins exist with names such as 'spindle.6..'.
 
-== 0-10 Volt Spindle Speed(((0-10 Volt Spindle Speed Example)))
+== 0-10 Volt Spindle Speed
 
+(((0-10 Volt Spindle Speed Example)))
 If your spindle speed is controlled by an analog signal,
 (for example, by a VFD with a 0 V to 10 V signal) and
 you're using a DAC card like the m5i20 to output the control signal:
@@ -40,8 +41,9 @@ net spindle-speed-scale spindle.0.speed-out => scale.0.in
 net spindle-speed-DAC scale.0.out => <your DAC pin name>
 ----
 
-== PWM Spindle Speed(((PWM Spindle Speed Example)))
+== PWM Spindle Speed
 
+(((PWM Spindle Speed Example)))
 If your spindle can be controlled by a PWM signal,
 use the 'pwmgen' component to create the signal:
 
@@ -62,8 +64,9 @@ This assumes that the spindle controller's response to PWM is simple:
 PWM required to get the spindle to turn, follow the example in the
 nist-lathe sample configuration to use a scale component.
 
-== Spindle Enable(((Spindle Enable Example)))
+== Spindle Enable
 
+(((Spindle Enable Example)))
 If you need a spindle enable signal,
 link your output pin to _spindle.0.on_.
 To link these pins to a parallel port pin put something like
@@ -75,8 +78,9 @@ pin that is connected to your control device.
 net spindle-enable spindle.0.on => parport.0.pin-14-out
 ----
 
-== Spindle Direction(((Spindle Direction Example)))
+== Spindle Direction
 
+(((Spindle Direction Example)))
 If you have direction control of your spindle, then the HAL pins
 'spindle._N_.forward' and 'spindle._N_.reverse' are controlled by the G-codes
 M3 and M4. Spindle speed S__n__ must be set to a positive non-zero value for
@@ -92,8 +96,9 @@ net spindle-fwd spindle.0.forward => parport.0.pin-16-out
 net spindle-rev spindle.0.reverse => parport.0.pin-17-out
 ----
 
-== Spindle Soft Start(((Spindle Soft Start Example)))
+== Spindle Soft Start
 
+(((Spindle Soft Start Example)))
 If you need to ramp your spindle speed command and your control does
 not have that feature it can be done in HAL. Basically you need to
 hijack the output of 'spindle._N_.speed-out' and run it through a
@@ -160,8 +165,9 @@ net spindle-ready <= spindle-at-speed.out => spindle.0.at-speed
 
 == Spindle Feedback
 
-=== Spindle Synchronized Motion(((Spindle Synchronized Motion Example)))
+=== Spindle Synchronized Motion
 
+(((Spindle Synchronized Motion Example)))
 Spindle feedback is needed by LinuxCNC to perform any spindle coordinated
 motions like threading and constant surface speed.
 LinuxCNC can perform synchronized motion and CSS with any of up to 8
@@ -216,8 +222,9 @@ net spindle-index encoder.3.phase-Z <= parport.0.pin-11-in
 ----
 
 [[sec:spindle-at-speed]]
-=== Spindle At Speed(((Spindle At Speed Example)))
+=== Spindle At Speed
 
+(((Spindle At Speed Example)))
 To enable LinuxCNC to wait for the spindle to be at speed before executing
 a series of moves, the spindle._N_.at-speed needs to turn true at the moment
 the spindle is at the commanded speed. To achieve this you need spindle

--- a/docs/src/gcode/coordinates.adoc
+++ b/docs/src/gcode/coordinates.adoc
@@ -2,7 +2,7 @@
 :toc:
 
 [[cha:coordinate-system]]
-= Coordinate Systems(((Coordinate Systems)))
+= Coordinate Systems
 
 // Custom lang highlight
 // must come after the doc title, to work around a bug in asciidoc 8.6.6
@@ -12,6 +12,7 @@
 
 == Introduction
 
+(((Coordinate Systems)))
 In this chapter, we will try to demystify coordinate systems.
 It is a very important concept to understand the operation of a CNC
 machine, its configuration and its use.

--- a/docs/src/gcode/g-code.adoc
+++ b/docs/src/gcode/g-code.adoc
@@ -53,8 +53,9 @@ If 'L-' is written in a prototype the '-' will often be referred to
 as the 'L number', and so on for any other letter.
 
 [[gcode:quick-reference-table]]
-== G-Code Quick Reference Table(((G-Code Table)))
+== G-Code Quick Reference Table
 
+(((G-Code Table)))
 [width="75%",options="header",cols="2^,5<"]
 |===
 |Code                              |Description
@@ -119,13 +120,15 @@ as the 'L number', and so on for any other letter.
 |===
 
 [[gcode:g0]]
-== G0 Rapid Move(((G0 Rapid Move)))
+== G0 Rapid Move
+
 
 [source,{ngc}]
 ----
 G0 <axes>
 ----
 
+(((G0 Rapid Move)))
 For rapid motion, program 'G0 axes', where all the axis words are
 optional. The 'G0' is optional if the current motion mode is 'G0'. This
 will produce coordinated motion to the destination point at the maximum
@@ -175,7 +178,9 @@ It is an error if:
 * An axis letter is used that is not configured.
 
 [[gcode:g1]]
-== G1 Linear Move(((G1 Linear Move)))
+== G1 Linear Move
+
+(((G1 Linear Move)))
 
 [source,{ngc}]
 -------------------
@@ -215,7 +220,9 @@ It is an error if:
 * An axis letter is used that is not configured
 
 [[gcode:g2-g3]]
-== G2, G3 Arc Move(((G2, G3 Arc Move)))
+== G2, G3 Arc Move
+
+(((G2, G3 Arc Move)))
 
 [source,{ngc}]
 ----
@@ -509,7 +516,9 @@ of Z is 5, this is an arc of a circle parallel to the XY-plane;
 otherwise it is a helical arc.
 
 [[gcode:g4]]
-== G4 Dwell(((G4 Dwell)))
+== G4 Dwell
+
+(((G4 Dwell)))
 
 [source,{ngc}]
 ----
@@ -534,7 +543,9 @@ It is an error if:
 * the P number is negative or not specified.
 
 [[gcode:g5]]
-== G5 Cubic Spline(((G5 Cubic spline)))
+== G5 Cubic Spline
+
+(((G5 Cubic spline)))
 
 [source,{ngc}]
 ----
@@ -584,7 +595,9 @@ It is an error if:
 * The active plane is not G17.
 
 [[gcode:g5.1]]
-== G5.1 Quadratic Spline(((G5.1 Quadratic spline)))
+== G5.1 Quadratic Spline
+
+(((G5.1 Quadratic spline)))
 
 [source,{ngc}]
 ----
@@ -616,7 +629,9 @@ It is an error if:
 * The active plane is not G17
 
 [[gcode:g5.2-g5.3]]
-== G5.2 G5.3 NURBS Block(((G5.2 G5.3 NURBS Block)))
+== G5.2 G5.3 NURBS Block
+
+(((G5.2 G5.3 NURBS Block)))
 
 [source,{ngc}]
 ----
@@ -667,7 +682,9 @@ More information on NURBS can be found here:
 https://wiki.linuxcnc.org/cgi-bin/wiki.pl?NURBS[https://wiki.linuxcnc.org/cgi-bin/wiki.pl?NURBS]
 
 [[gcode:g7]]
-== G7 Lathe Diameter Mode(((G7 Lathe Diameter Mode)))
+== G7 Lathe Diameter Mode
+
+(((G7 Lathe Diameter Mode)))
 
 [source,{ngc}]
 ----
@@ -680,7 +697,9 @@ to the center of the lathe. For example X1 would move the cutter to
 0.500" from the center of the lathe thus giving a 1" diameter part.
 
 [[gcode:g8]]
-== G8 Lathe Radius Mode(((G8 Lathe Radius Mode)))
+== G8 Lathe Radius Mode
+
+(((G8 Lathe Radius Mode)))
 
 [source,{ngc}]
 ----
@@ -693,7 +712,9 @@ center. Thus a cut at X1 would result in a part that is 2" in diameter.
 G8 is default at power up.
 
 [[gcode:g10-l0]]
-== G10 L0 Reload Tool Table Data(((G10 L0 Reload Tool Table Data)))
+== G10 L0 Reload Tool Table Data
+
+(((G10 L0 Reload Tool Table Data)))
 
 [source,{ngc}]
 ----
@@ -712,7 +733,9 @@ commands. Existing G43 tool length compensation values will
 remain in effect until updated by new G43 commands.
 
 [[gcode:g10-l1]]
-== G10 L1 Set Tool Table(((G10 L1 Tool Table)))
+== G10 L1 Set Tool Table
+
+(((G10 L1 Tool Table)))
 
 [source,{ngc}]
 ----
@@ -749,7 +772,9 @@ For more information on cutter orientation used by the 'Q' word,
 see the <<sec:lathe-tool-orientation,Lathe Tool Orientation>> diagram.
 
 [[gcode:g10-l2]]
-== G10 L2 Set Coordinate System(((G10 L2 Coordinate System)))
+== G10 L2 Set Coordinate System
+
+(((G10 L2 Coordinate System)))
 
 [source,{ngc}]
 ----
@@ -837,7 +862,9 @@ The coordinate system is described in the
 <<cha:coordinate-system,Coordinate System>> section.
 
 [[gcode:g10-l10]]
-== G10 L10 Set Tool Table(((G10 L10 Set Tool Table)))
+== G10 L10 Set Tool Table
+
+(((G10 L10 Set Tool Table)))
 
 [source,{ngc}]
 ----
@@ -877,7 +904,9 @@ It is an error if:
 * The P number is 0
 
 [[gcode:g10-l11]]
-== G10 L11 Set Tool Table(((G10 L11 Set Tool Table)))
+== G10 L11 Set Tool Table
+
+(((G10 L11 Set Tool Table)))
 
 [source,{ngc}]
 ----
@@ -913,7 +942,9 @@ It is an error if:
 * The P number is 0
 
 [[gcode:g10-l20]]
-== G10 L20 Set Coordinate System(((G10 L20 Set Coordinate System)))
+== G10 L20 Set Coordinate System
+
+(((G10 L20 Set Coordinate System)))
 
 [source,{ngc}]
 ----
@@ -938,7 +969,9 @@ It is an error if:
 * An axis is programmed that is not defined in the configuration.
 
 [[gcode:g17-g19.1]]
-== G17 - G19.1 Plane Select(((G17 - G19.1 Plane Select)))
+== G17 - G19.1 Plane Select
+
+(((G17 - G19.1 Plane Select)))
 
 These codes set the current plane as follows:
 
@@ -958,7 +991,9 @@ The effects of having a plane selected are discussed in section
 <<gcode:g2-g3,G2 G3 Arcs>> and section <<gcode:g80-g89,G81 G89>>.
 
 [[gcode:g20-g21]]
-== G20, G21 Units(((G20 Units)))
+== G20, G21 Units
+
+(((G20 Units)))
 
 * 'G20' - to use inches for length units.
 * 'G21' - to use millimeters for length units.
@@ -967,7 +1002,9 @@ It is a good idea to include units in the preamble
 of each G-code file.
 
 [[gcode:g28-g28.1]]
-== G28, G28.1 Go/Set Predefined Position(((G28 Go/Set Predefined Position)))
+== G28, G28.1 Go/Set Predefined Position
+
+(((G28 Go/Set Predefined Position)))
 
 [WARNING]
 Only use G28 when your machine is homed to a repeatable position and the
@@ -1001,7 +1038,9 @@ It is an error if :
 * Cutter Compensation is turned on
 
 [[gcode:g30-g30.1]]
-== G30, G30.1 Go/Set Predefined Position(((G30 Go/Set Predefined Position)))
+== G30, G30.1 Go/Set Predefined Position
+
+(((G30 Go/Set Predefined Position)))
 
 [WARNING]
 Only use G30 when your machine is homed to a repeatable position and the
@@ -1040,7 +1079,9 @@ It is an error if :
 * Cutter Compensation is turned on
 
 [[gcode:g33]]
-== G33 Spindle Synchronized Motion(((G33 Spindle Synchronized Motion)))
+== G33 Spindle Synchronized Motion
+
+(((G33 Spindle Synchronized Motion)))
 
 [source,{ngc}]
 ----
@@ -1117,7 +1158,9 @@ It is an error if:
   due to the spindle speed.
 
 [[gcode:g33.1]]
-== G33.1 Rigid Tapping(((G33.1 Rigid Tapping)))
+== G33.1 Rigid Tapping
+
+(((G33.1 Rigid Tapping)))
 
 [source,{ngc}]
 ----
@@ -1183,7 +1226,9 @@ It is an error if:
   due to the spindle speed
 
 [[gcode:g38]]
-== G38.n Straight Probe(((G38.n Probe)))
+== G38.n Straight Probe
+
+(((G38.n Probe)))
 
 [source,{ngc}]
 ----
@@ -1288,7 +1333,9 @@ It is an error if:
 * the probe is already in the target state
 
 [[gcode:g40]]
-== G40 Compensation Off(((G40 Cutter Compensation Off)))
+== G40 Compensation Off
+
+(((G40 Cutter Compensation Off)))
 
 * 'G40' - turn cutter compensation off. If tool compensation was on the
   next move must be a linear move and longer than the tool diameter.
@@ -1312,7 +1359,9 @@ It is an error if:
   diameter.
 
 [[gcode:g41-g42]]
-== G41, G42 Cutter Compensation(((G41 G42 Cutter Compensation)))
+== G41, G42 Cutter Compensation
+
+(((G41 G42 Cutter Compensation)))
 
 [source,{ngc}]
 ----
@@ -1367,7 +1416,9 @@ It is an error if:
 * Cutter compensation is commanded to turn on when it is already on.
 
 [[gcode:g41.1-g42.1]]
-== G41.1, G42.1 Dynamic Cutter Compensation(((G41.1 G42.1 Dynamic Compensation)))
+== G41.1, G42.1 Dynamic Cutter Compensation
+
+(((G41.1 G42.1 Dynamic Compensation)))
 
 [source,{ngc}]
 ----
@@ -1390,7 +1441,9 @@ It is an error if:
 * Cutter compensation is commanded to turn on when it is already on.
 
 [[gcode:g43]]
-== G43 Tool Length Offset(((G43 Tool Length Offset)))
+== G43 Tool Length Offset
+
+(((G43 Tool Length Offset)))
 
 [source,{ngc}]
 ----
@@ -1438,7 +1491,9 @@ It is an error if:
   currently in the spindle")
 
 [[gcode:g43.1]]
-== G43.1 Dynamic Tool Length Offset(((G43.1 Dynamic Tool Length Offset)))
+== G43.1 Dynamic Tool Length Offset
+
+(((G43.1 Dynamic Tool Length Offset)))
 
 [source,{ngc}]
 ----
@@ -1470,7 +1525,9 @@ It is an error if:
 G43.1 does not write to the tool table.
 
 [[gcode:g43.2]]
-== G43.2 Apply additional Tool Length Offset(((G43.2 Apply additional Tool Length Offset)))
+== G43.2 Apply additional Tool Length Offset
+
+(((G43.2 Apply additional Tool Length Offset)))
 
 [source,{ngc}]
 ----
@@ -1522,7 +1579,9 @@ It is an error if:
 NOTE: G43.2 does not write to the tool table.
 
 [[gcode:g49]]
-== G49 Cancel Tool Length Compensation(((G49 Cancel Tool Length Offset)))
+== G49 Cancel Tool Length Compensation
+
+(((G49 Cancel Tool Length Offset)))
 
 * 'G49' - cancels tool length compensation
 
@@ -1531,7 +1590,9 @@ OK to program using no tool length offset if none is currently being
 used.
 
 [[gcode:g52]]
-== G52 Local Coordinate System Offset(((Local Offsets)))
+== G52 Local Coordinate System Offset
+
+(((Local Offsets)))
 
 [source,{ngc}]
 ----
@@ -1544,7 +1605,9 @@ offset" within the workpiece coordinate system. For more information about
 <<sec:g52-and-g92-offsets,Local and Global Offsets.>>
 
 [[gcode:g53]]
-== G53 Move in Machine Coordinates(((G53 Machine Coordinates)))
+== G53 Move in Machine Coordinates
+
+(((G53 Machine Coordinates)))
 
 [source,{ngc}]
 ----
@@ -1574,7 +1637,9 @@ It is an error if:
 * or G53 is used while cutter compensation is on.
 
 [[gcode:g54-g59.3]]
-== G54-G59.3 Select Coordinate System(((G54-G59.3 Select Coordinate System)))
+== G54-G59.3 Select Coordinate System
+
+(((G54-G59.3 Select Coordinate System)))
 
 * 'G54'   - select coordinate system 1
 * 'G55'   - select coordinate system 2
@@ -1612,20 +1677,28 @@ See the <<cha:coordinate-system,Coordinate System>> section for an
 overview of coordinate systems.
 
 [[gcode:g61]]
-== G61 Exact Path Mode(((G61 Exact Path Mode)))(((Trajectory Control)))
+== G61 Exact Path Mode
+
+(((G61 Exact Path Mode)))
+(((Trajectory Control)))
 
 * 'G61' - Exact path mode, movement exactly as programmed.
   Moves will slow or stop as needed to reach every programmed point. If
   two sequential moves are exactly co-linear movement will not stop.
 
 [[gcode:g61.1]]
-== G61.1 Exact Stop Mode(((G61.1 Exact Stop Mode)))(((Trajectory Control)))
+== G61.1 Exact Stop Mode
+
+(((G61.1 Exact Stop Mode)))
+(((Trajectory Control)))
 
 * 'G61.1' - Exact stop mode, movement will stop at the end of each
   programmed segment.
 
 [[gcode:g64]]
-== G64 Path Blending(((G64 Path Blending)))(((Trajectory Control)))
+== G64 Path Blending
+
+(((G64 Path Blending)))(((Trajectory Control)))
 
 [source,{ngc}]
 ----
@@ -1671,7 +1744,9 @@ It is a good idea to include a path control specification in the preamble
 of each G-code file.
 
 [[gcode:g70]]
-== G70 Lathe finishing cycle(((G70 Lathe finishing cycle)))
+== G70 Lathe finishing cycle
+
+(((G70 Lathe finishing cycle)))
 
 [source,{ngc}]
 ----
@@ -1715,7 +1790,9 @@ It is an error if:
 * <<gcode:g17-g19.1>> has not been used to select the ZX plane.
 
 [[gcode:g71-g72]]
-== G71 G72 Lathe roughing cycles(((G71 G72 Lathe roughing cycles)))
+== G71 G72 Lathe roughing cycles
+
+(((G71 G72 Lathe roughing cycles)))
 
 [NOTE]
 The G71 and G72 cycles are currently somewhat fragile.
@@ -1784,7 +1861,9 @@ It is an error if:
 * <<gcode:g41-g42>> is active.
 
 [[gcode:g73]]
-== G73 Drilling Cycle with Chip Breaking(((G73 Drilling Cycle with Chip Break)))
+== G73 Drilling Cycle with Chip Breaking
+
+(((G73 Drilling Cycle with Chip Break)))
 
 [source,{ngc}]
 ----
@@ -1815,7 +1894,9 @@ It is an error if:
 * the R number is not specified
 
 [[gcode:g74]]
-== G74 Left-hand Tapping Cycle with Dwell(((G74 Left-hand Tapping Cycle with Dwell)))
+== G74 Left-hand Tapping Cycle with Dwell
+
+(((G74 Left-hand Tapping Cycle with Dwell)))
 
 [source,{ngc}]
 ----
@@ -1852,7 +1933,9 @@ In example S100 with 1.25MM per revolution thread pitch gives a feed of
 F125.
 
 [[gcode:g76]]
-== G76 Threading Cycle(((G76 Threading Cycle)))
+== G76 Threading Cycle
+
+(((G76 Threading Cycle)))
 
 [source,{ngc}]
 ----
@@ -1973,7 +2056,9 @@ are the cutting moves.
 image::images/g76-01.png["G76 Example",align="center"]
 
 [[gcode:g80-g89]]
-== G80-G89 Canned Cycles(((G80-G89 Canned Cycles)))
+== G80-G89 Canned Cycles
+
+(((G80-G89 Canned Cycles)))
 
 The canned cycles 'G81' through 'G89' and the canned cycle stop 'G80'
 are described in this section.
@@ -2039,7 +2124,9 @@ the R position and the retract mode is 'G98', OLD_Z), or otherwise to
 the R position. See the <<gcode:g98-g99,G98 G99>> section.
 
 [[gcode:canned-cycle-errors]]
-=== Canned Cycle Errors(((Canned Cycle Errors)))
+=== Canned Cycle Errors
+
+(((Canned Cycle Errors)))
 
 It is an error if:
 
@@ -2146,7 +2233,9 @@ preliminary moves and returns that you can anticipate and control
 regardless of the start point of the canned cycle.
 
 [[gcode:g80]]
-== G80 Cancel Canned Cycle(((G80 Cancel Modal Motion)))
+== G80 Cancel Canned Cycle
+
+(((G80 Cancel Modal Motion)))
 
 * 'G80' - cancel canned cycle modal motion. 'G80' is part of modal group 1,
   so programming any other G-code from modal group 1 will also
@@ -2216,7 +2305,9 @@ is not so obvious that all of the blocks between N120 and N200 belong
 to the canned cycle.
 
 [[gcode:g81]]
-== G81 Drilling Cycle(((G81 Drilling Cycle)))
+== G81 Drilling Cycle
+
+(((G81 Drilling Cycle)))
 
 [source,{ngc}]
 ----
@@ -2352,7 +2443,9 @@ Then the final Z depth being 0.6 below the R value. The repeat function
 would make the Z move in the same location again.
 
 [[gcode:g82]]
-== G82 Drilling Cycle, Dwell(((G82 Drilling Cycle Dwell)))
+== G82 Drilling Cycle, Dwell
+
+(((G82 Drilling Cycle Dwell)))
 
 [source,{ngc}]
 ----
@@ -2382,7 +2475,9 @@ This will be similar to example 3 above, just with an added dwell of 2
 seconds at the bottom of the hole.
 
 [[gcode:g83]]
-== G83 Peck Drilling Cycle(((G83 Peck Drilling)))
+== G83 Peck Drilling Cycle
+
+(((G83 Peck Drilling)))
 
 [source,{ngc}]
 ----
@@ -2412,7 +2507,9 @@ It is an error if:
 * the Q number is negative or zero.
 
 [[gcode:g84]]
-== G84 Right-hand Tapping Cycle, Dwell(((G84 Right-hand Tapping Cycle Dwell)))
+== G84 Right-hand Tapping Cycle, Dwell
+
+(((G84 Right-hand Tapping Cycle Dwell)))
 
 [source,{ngc}]
 ----
@@ -2449,7 +2546,9 @@ In example S100 with 1.25MM per revolution thread pitch gives a feed of
 F125.
 
 [[gcode:g85]]
-== G85 Boring Cycle, Feed Out(((G85 Boring, Feed Out)))
+== G85 Boring Cycle, Feed Out
+
+(((G85 Boring, Feed Out)))
 
 [source,{ngc}]
 ----
@@ -2468,7 +2567,9 @@ drilling or milling.
 * Retract at the traverse rate to clear Z.
 
 [[gcode:g86]]
-== G86 Boring Cycle, Spindle Stop, Rapid Move Out(((G86 Boring, Spindle Stop, Rapid Move Out)))
+== G86 Boring Cycle, Spindle Stop, Rapid Move Out
+
+(((G86 Boring, Spindle Stop, Rapid Move Out)))
 
 [source,{ngc}]
 ----
@@ -2492,19 +2593,25 @@ It is an error if:
 * the spindle is not turning before this cycle is executed.
 
 [[gcode:g87]]
-== G87 Back Boring Cycle(((G87 Back Boring Cycle)))
+== G87 Back Boring Cycle
+
+(((G87 Back Boring Cycle)))
 
 This code is currently unimplemented in LinuxCNC. It is accepted, but
 the behavior is undefined.
 
 [[gcode:g88]]
-== G88 Boring Cycle, Spindle Stop, Manual Out(((G88 Boring Cycle, Spindle Stop, Manual Out)))
+== G88 Boring Cycle, Spindle Stop, Manual Out
+
+(((G88 Boring Cycle, Spindle Stop, Manual Out)))
 
 This code is currently unimplemented in LinuxCNC. It is accepted, but
 the behavior is undefined.
 
 [[gcode:g89]]
-== G89 Boring Cycle, Dwell, Feed Out(((G89 Boring, Dwell, Feed Out)))
+== G89 Boring Cycle, Dwell, Feed Out
+
+(((G89 Boring, Dwell, Feed Out)))
 
 [source,{ngc}]
 ----
@@ -2522,7 +2629,9 @@ where P specifies the number of seconds to dwell.
 * Retract the Z-axis at the current feed rate to clear Z.
 
 [[gcode:g90-g91]]
-== G90, G91 Distance Mode(((G90, G91 Distance Mode)))
+== G90, G91 Distance Mode
+
+(((G90, G91 Distance Mode)))
 
 * 'G90' - absolute distance mode In absolute distance mode, axis numbers
   (X, Y, Z, A, B, C, U, V, W) usually represent positions in terms of
@@ -2548,7 +2657,9 @@ G0 X2.5 (rapid move 2.5 from current position along the X axis)
 * See <<gcode:g0,G0>> section for more information.
 
 [[gcode:g90.1-g91.1]]
-== G90.1, G91.1 Arc Distance Mode(((Arc Distance Mode)))
+== G90.1, G91.1 Arc Distance Mode
+
+(((Arc Distance Mode)))
 
 * 'G90.1' - absolute distance mode for I, J & K offsets.
   When G90.1 is in effect I and J both must be specified with G2/3
@@ -2557,7 +2668,9 @@ G0 X2.5 (rapid move 2.5 from current position along the X axis)
   `G91.1` Returns I, J & K to their default behavior.
 
 [[gcode:g92]]
-== G92 Coordinate System Offset(((G92 Coordinate System Offset)))
+== G92 Coordinate System Offset
+
+(((G92 Coordinate System Offset)))
 
 [source,{ngc}]
 ----
@@ -2611,7 +2724,9 @@ See the <<cha:coordinate-system,Coordinate System>> section for an overview of c
 See the <<sec:overview-parameters,Parameters>> section for more information.
 
 [[gcode:g92.1-g92.2]]
-== G92.1, G92.2 Reset G92 Offsets(((G92.1, G92.2 Reset G92 Offsets)))
+== G92.1, G92.2 Reset G92 Offsets
+
+(((G92.1, G92.2 Reset G92 Offsets)))
 
 * 'G92.1' - turn off G92 offsets and reset <<sub:numbered-parameters,parameters>> 5211 - 5219 to zero.
 * 'G92.2' - turn off G92 offsets but keep <<sub:numbered-parameters,parameters>> 5211 - 5219 available.
@@ -2620,7 +2735,9 @@ See the <<sec:overview-parameters,Parameters>> section for more information.
 G92.1 only clears G92 offsets, to change G53-G59.3 coordinate system offsets in G-code use either <<gcode:g10-l2,G10 L2>> or <<gcode:g10-l20,G10 L20>>.
 
 [[gcode:g92.3]]
-== G92.3 Restore G92 Offsets(((G92.3 Restore G92 Offsets)))
+== G92.3 Restore G92 Offsets
+
+(((G92.3 Restore G92 Offsets)))
 
 * 'G92.3' - set the `G92` offset to the values saved in parameters 5211 to 5219
 
@@ -2633,7 +2750,9 @@ Use `G92.3` near the beginning of the second program.
 That will restore the offsets saved in the first program.
 
 [[gcode:g93-g94-g95]]
-== G93, G94, G95 Feed Rate Mode(((G93, G94, G95 Feed Rate Mode)))
+== G93, G94, G95 Feed Rate Mode
+
+(((G93, G94, G95 Feed Rate Mode)))
 
 * 'G93' - is Inverse Time Mode.
   In inverse time feed rate mode, an F word means the move should be
@@ -2666,7 +2785,9 @@ It is an error if:
 * A new feed rate is not specified after switching to `G94` or `G95`
 
 [[gcode:g96-g97]]
-== G96, G97 Spindle Control Mode(((G96, G97 Spindle Control Mode)))
+== G96, G97 Spindle Control Mode
+
+(((G96, G97 Spindle Control Mode)))
 
 [source,{ngc}]
 ----
@@ -2704,7 +2825,9 @@ It is an error if:
 * A feed move is specified in G96 mode while the spindle is not turning
 
 [[gcode:g98-g99]]
-== G98, G99 Canned Cycle Return Level(((G98, G99 Canned Cycle Return)))
+== G98, G99 Canned Cycle Return Level
+
+(((G98, G99 Canned Cycle Return)))
 
 When spindle retracts during canned cycles, there are two options
 to choose from for the way it does it:

--- a/docs/src/gcode/m-code.adoc
+++ b/docs/src/gcode/m-code.adoc
@@ -39,8 +39,9 @@
 |===
 
 [[mcode:m0-m1]]
-== M0, M1 Program Pause(((M0, M1 Program Pause)))(((M0 Mandatory Program Pause)))(((M1 Optional Program Pause)))
+== M0, M1 Program Pause
 
+(((M0, M1 Program Pause)))(((M0 Mandatory Program Pause)))(((M1 Optional Program Pause)))
 * 'M0' - pause a running program temporarily. LinuxCNC remains in the Auto Mode
   so MDI and other manual actions are not enabled. Pressing the resume
   button will restart the program at the following line.
@@ -56,8 +57,9 @@ because normal behavior in MDI mode is
 to stop after each line of input anyway.
 
 [[mcode:m2-m30]]
-== M2, M30 Program End(((M2 Program End)))(((M30 Pallet Exchange and Program End)))
+== M2, M30 Program End
 
+(((M2 Program End)))(((M30 Pallet Exchange and Program End)))
 * 'M2' - end the program. Pressing `Cycle Start` ("R" in the Axis GUI)
   will restart the program at the beginning of the file.
 * 'M30' - exchange pallet shuttles and end the program.
@@ -86,16 +88,18 @@ See the section on <<gcode:file-requirements,File Requirements>> for more inform
 on what using % does not do.
 
 [[mcode:m60]]
-== M60 Pallet Change Pause(((M60 Pallet Change Pause)))
+== M60 Pallet Change Pause
 
+(((M60 Pallet Change Pause)))
 * 'M60' - exchange pallet shuttles and then pause a running program
   temporarily (regardless of the setting of the optional stop
   switch). Pressing the cycle start button
   will restart the program at the following line.
 
 [[mcode:m3-m4-m5]]
-== M3, M4, M5 Spindle Control(((M3, M4, M5 Spindle Control)))
+== M3, M4, M5 Spindle Control
 
+(((M3, M4, M5 Spindle Control)))
 * 'M3 [$n]' - start the selected spindle clockwise at the 'S' speed.
 * 'M4 [$n]' - start the selected spindle counterclockwise at the 'S' speed.
 * 'M5 [$n]' - stop the selected spindle.
@@ -144,10 +148,11 @@ It is OK to use 'M3' or 'M4' when the spindle is already
 turning or to use 'M5' when the spindle is already stopped.
 
 [[mcode:m6]]
-== M6 Tool Change(((M6-Tool-Change)))
+== M6 Tool Change
 
 === Manual Tool Change
 
+(((M6-Tool-Change)))
 If the HAL component 'hal_manualtoolchange' is loaded,
 M6 will stop the spindle and prompt the user to change the tool
 based on the last 'T-' number programmed.
@@ -191,8 +196,9 @@ changer will have to be setup to perform the tool change in HAL and possibly
 ClassicLadder.
 
 [[mcode:m7-m8-m9]]
-== M7, M8, M9 Coolant Control(((M7, M8, M9 Coolant Control)))
+== M7, M8, M9 Coolant Control
 
+(((M7, M8, M9 Coolant Control)))
 * 'M7' - turn mist coolant on. M7 controls iocontrol.0.coolant-mist pin.
 * 'M8' - turn flood coolant on. M8 controls iocontrol.0.coolant-flood pin.
 * 'M9' - turn both M7 and M8 off.
@@ -204,7 +210,9 @@ It is OK to use any of these commands, regardless of the current coolant
 state.
 
 [[mcode:m19]]
-== M19 Orient Spindle(((M19 Orient Spindle)))
+== M19 Orient Spindle
+
+(((M19 Orient Spindle)))
 
 [source,{ngc}]
 ----
@@ -253,8 +261,9 @@ INI Settings in the [RS274NGC] section:
    Spindle orient complete pin. Cleared by any of M3,M4,M5.
 
 [[mcode:m48-m49]]
-== M48, M49 Speed and Feed Override Control(((M48, M49 Speed and Feed Override Control)))
+== M48, M49 Speed and Feed Override Control
 
+(((M48, M49 Speed and Feed Override Control)))
 * 'M48' - enable the spindle speed and feed rate override controls.
 * 'M49' - disable both controls.
 
@@ -269,8 +278,9 @@ They also can be be toggled individually using 'M50' and 'M51',
 see below.
 
 [[mcode:m50]]
-== M50 Feed Override Control(((M50 Feed Override Control)))
+== M50 Feed Override Control
 
+(((M50 Feed Override Control)))
 * 'M50 <P1>' - enable the feed rate override control. The P1
   is optional.
 * 'M50 P0' - disable the feed rate control.
@@ -280,8 +290,9 @@ and the motion will be executed at programmed feed rate.
 (unless there is an adaptive feed rate override active).
 
 [[mcode:m51]]
-== M51 Spindle Speed Override Control(((M51 Spindle Speed Override)))
+== M51 Spindle Speed Override Control
 
+(((M51 Spindle Speed Override)))
 * 'M51 <P1> <$->'- enable the spindle speed override control for the
   selected spindle. The  P1 is optional.
 * 'M51 P0 <$->'  - disable the spindle speed override control program.
@@ -292,8 +303,9 @@ exact program specified value of the S-word
 (described in the <<sec:set-spindle-speed,Spindle Speed>> section).
 
 [[mcode:m52]]
-== M52 Adaptive Feed Control(((M52 Adaptive Feed Control)))
+== M52 Adaptive Feed Control
 
+(((M52 Adaptive Feed Control)))
 * 'M52 <P1>' - use an adaptive feed. The P1 is optional.
 * 'M52 P0' - stop using adaptive feed.
 
@@ -310,8 +322,9 @@ feature and is not very well tested as yet. The intended use is for plasma
 cutters and wire spark eroders but it is not limited to such applications.
 
 [[mcode:m53]]
-== M53 Feed Stop Control(((M53 Feed Stop Control)))
+== M53 Feed Stop Control
 
+(((M53 Feed Stop Control)))
 * 'M53 <P1>' - enable the feed stop switch. The P1 is optional.
   Enabling the feed stop switch will allow motion to be
   interrupted by means of the feed stop control. In LinuxCNC,
@@ -321,8 +334,9 @@ cutters and wire spark eroders but it is not limited to such applications.
   will have no effect on feed when M53 is not active.
 
 [[mcode:m61]]
-== M61 Set Current Tool(((M61 Set Current Tool)))
+== M61 Set Current Tool
 
+(((M61 Set Current Tool)))
 * 'M61 Q-' - change the current tool number while in MDI or Manual mode without
   a tool change. One use is when you power up LinuxCNC with a tool
   currently in the spindle you can set that tool number without
@@ -337,8 +351,9 @@ It is an error if:
 * Q- is not 0 or greater
 
 [[mcode:m62-m65]]
-== M62 - M65 Digital Output Control(((M62 - M65 Digital Output Control)))
+== M62 - M65 Digital Output Control
 
+(((M62 - M65 Digital Output Control)))
 * 'M62 P-' - turn on digital output synchronized with motion.
 * 'M63 P-' - turn off digital output synchronized with motion.
 * 'M64 P-' - turn on digital output immediately.
@@ -369,8 +384,9 @@ M62-65 will not function unless the appropriate motion.digital-out-_nn_ pins are
 connected in your HAL file to outputs.
 
 [[mcode:m66]]
-== M66 Wait on Input(((M66 Wait on Input)))
+== M66 Wait on Input
 
+(((M66 Wait on Input)))
 [source,{ngc}]
 ----
 M66 P- | E- <L->
@@ -420,8 +436,9 @@ net signal-name motion.digital-in-00 <= parport.0.pin10-in
 ----
 
 [[mcode:m67]]
-== M67 Analog Output, Synchronized(((M67 Analog Output, Synchronized)))
+== M67 Analog Output, Synchronized
 
+(((M67 Analog Output, Synchronized)))
 [source,{ngc}]
 ----
 M67 E- Q-
@@ -446,8 +463,9 @@ M67 will not function unless the appropriate motion.analog-out-_nn_ pins are
 connected in your HAL file to outputs.
 
 [[mcode:m68]]
-== M68 Analog Output, Immediate(((M68 Analog Output)))
+== M68 Analog Output, Immediate
 
+(((M68 Analog Output)))
 [source,{ngc}]
 ----
 M68 E- Q-
@@ -470,8 +488,9 @@ M68 will not function unless the appropriate motion.analog-out-_nn_ pins are
 connected in your HAL file to outputs.
 
 [[mcode:m70]]
-== M70 Save Modal State(((M70 Save Modal State)))
+== M70 Save Modal State
 
+(((M70 Save Modal State)))
 To explicitly save the modal state at the current call level, program
 'M70'. Once modal state has been saved with 'M70', it can be restored
 to exactly that state by executing an 'M72'.
@@ -481,7 +500,9 @@ protect a program against inadvertent modal changes within
 subroutines.
 
 [[mcode:m70-saved-state]]
-.M70 Saved state(((M70 Saved state)))
+.M70 Saved state
+
+(((M70 Saved state)))
 The state saved consists of:
 
 * current G20/G21 settings (imperial/metric)
@@ -519,8 +540,9 @@ Note that in particular, the motion mode (G1 etc) is NOT restored.
 A recursive invocation of a subroutine introduces a new call level.
 
 [[mcode:m71]]
-== M71 Invalidate Stored Modal State(((M71 Invalidate Stored Modal State)))
+== M71 Invalidate Stored Modal State
 
+(((M71 Invalidate Stored Modal State)))
 Modal state saved with an 'M70' or by an 'M73' at the current call
 level is invalidated (cannot be restored from anymore).
 
@@ -533,8 +555,9 @@ The usefulness of this feature is dubious. It should not be relied upon as it mi
 go away.
 
 [[mcode:m72]]
-== M72 Restore Modal State(((M72 Restore Modal State)))
+== M72 Restore Modal State
 
+(((M72 Restore Modal State)))
 <<mcode:m70-saved-state,Modal state saved with an 'M70'>> code can be
 restored by executing an 'M72'.
 
@@ -586,8 +609,9 @@ m2
 ----
 
 [[mcode:m73]]
-== M73 Save and Autorestore Modal State(((M73 Save and Autorestore Modal State)))
+== M73 Save and Autorestore Modal State
 
+(((M73 Save and Autorestore Modal State)))
 To save modal state within a subroutine, and restore state on
 subroutine 'endsub' or any 'return' path, program 'M73'.
 
@@ -675,8 +699,9 @@ O<measure> endsub
 ----
 
 [[mcode:m100-m199]]
-== M100-M199 User Defined Commands(((M100-M199 User Defined Commands)))
+== M100-M199 User Defined Commands
 
+(((M100-M199 User Defined Commands)))
 [source,{ngc}]
 ----
 M1-- <P- Q->

--- a/docs/src/gcode/machining-center.adoc
+++ b/docs/src/gcode/machining-center.adoc
@@ -2,7 +2,7 @@
 :toc:
 
 [[cha:cnc-machine-overview]]
-= CNC Machine Overview(((Machine Overview)))
+= CNC Machine Overview
 
 // Custom lang highlight
 // must come after the doc title, to work around a bug in asciidoc 8.6.6
@@ -10,6 +10,7 @@
 :hal: {basebackend@docbook:'':hal}
 :ngc: {basebackend@docbook:'':ngc}
 
+(((Machine Overview)))
 This section gives a brief description of how a CNC machine is viewed
 from the input and output ends of the Interpreter.
 
@@ -22,8 +23,9 @@ Interpreter. Mechanical components that do not interact directly with
 the Interpreter, such as the jog buttons, are not described here, even
 if they affect control.
 
-=== Axes(((axes)))
+=== Axes
 
+(((axes)))
 Any CNC machine has one or more Axes. Different types of CNC machines
 have different combinations. For instance, a '4-axis milling machine'
 may have XYZA or XYZB axes. A lathe typically has XZ axes. A
@@ -48,22 +50,26 @@ motors for one axis is better handled by the kinematics than by an additional
 linear axis.
 ====
 
-.Primary Linear Axes(((axes, primary linear)))
+(((axes, primary linear)))
+.Primary Linear Axes
 The X, Y, and Z axes produce linear motion in three mutually
 orthogonal directions.
 
-.Secondary Linear Axes(((axes, secondary linear)))
+(((axes, secondary linear)))
+.Secondary Linear Axes
 The U, V, and W axes produce linear motion in three mutually
 orthogonal directions. Typically, X and U are parallel, Y and V are
 parallel, and Z and W are parallel.
 
-.Rotational Axes(((axes, rotational)))
+(((axes, rotational)))
+.Rotational Axes
 The A, B and C axes produce angular motion (rotation). Typically, A
 rotates around a line parallel to X, B rotates around a line parallel
 to Y, and C rotates around a line parallel to Z.
 
-=== Spindle(((spindle)))
+=== Spindle
 
+(((spindle)))
 A CNC machine typically has a spindle which holds one cutting tool,
 probe, or the material in the case of a lathe. The spindle may or may
 not be controlled by the CNC software.
@@ -71,14 +77,16 @@ LinuxCNC offers support for up to 8 spindles, which can be individually
 controlled and can run simultaneously at different speeds and in different
 directions.
 
-=== Coolant(((coolant)))
+=== Coolant
 
+(((coolant)))
 Flood coolant and mist coolant may each be turned on independently.
 The RS274/NGC language turns them off together see section
 <<mcode:m7-m8-m9,M7 M8 M9>>.
 
-=== Feed and Speed Override(((feed override)))(((spindle override)))
+=== Feed and Speed Override
 
+(((feed override)))(((spindle override)))
 A CNC machine can have separate feed and speed override controls,
 which let the operator specify that the actual feed rate or spindle
 speed used in machining at some percentage of the programmed rate.
@@ -127,8 +135,9 @@ parallelism requirement is violated, the system builder will
 have to say how to distinguish clockwise from counterclockwise.]
 
 [[sec:controlled-point]]
-=== Controlled Point(((Controlled Point)))
+=== Controlled Point
 
+(((Controlled Point)))
 The controlled point is the point whose position and rate of motion
 are controlled. When the tool length offset is zero (the default
 value), this is a point on the spindle axis (often called the gauge
@@ -166,8 +175,9 @@ spindle rotation. If physical limits on axis speed make the desired
 rate unobtainable, all axes are slowed to maintain the desired path.
 
 [[sub:feed-rate]]
-=== Feed Rate(((Feed Rate)))
+=== Feed Rate
 
+(((Feed Rate)))
 The rate at which the controlled point moves is nominally a steady
 rate which may be set by the user. In the Interpreter, the feed
 rate is interpreted as follows (unless 'inverse time feed' or 'feed
@@ -183,14 +193,16 @@ per revolution' modes are being used, in which case see section
 . Otherwise, the move is pure rotary motion and the F word is in rotary
   units in the ABC 'pseudo-cartesian' system.
 
-=== Cooling(((Cooling)))
+=== Cooling
 
+(((Cooling)))
 Flood or droplets cooling can be enabled separately.
 RS274/NGC language stops them together.
 See section about <<mcode:m7-m8-m9,cooling control>>.
 
-=== Dwell(((dwell)))
+=== Dwell
 
+(((dwell)))
 A machining center may be commanded to dwell (i.e., keep all axes
 unmoving) for a specific amount of time. The most common use of dwell
 is to break and clear chips, so the spindle is usually turning during a
@@ -198,8 +210,9 @@ dwell. Regardless of the Path Control Mode (see section
 <<sec:path-control-mode,Path Control>>) the machine will stop exactly at the end of
 the previous programmed move, as though it was in exact path mode.
 
-=== Units(((units)))
+=== Units
 
+(((units)))
 Units used for distances along the X, Y, and Z axes may be measured in
 millimeters or inches. Units for all other quantities involved in
 machine control cannot be changed. Different quantities use different
@@ -249,8 +262,9 @@ See inhibition and activation <<mcode:m48-m49, speed correctors>>.
 See also <<sec:speed-interaction,here for further details>>.
 
 [[sec:path-control-mode]]
-=== Path Control Mode(((Path Control Mode)))
+=== Path Control Mode
 
+(((Path Control Mode)))
 The machining center may be put into any one of three path control
 modes:
 
@@ -276,8 +290,9 @@ describes the interactions in more detail. In no case does the
 Interpreter know what the setting of any of these switches is.
 
 [[sec:speed-interaction]]
-=== Feed and Speed Override Switches(((Feed and Speed Interaction)))
+=== Feed and Speed Override Switches
 
+(((Feed and Speed Interaction)))
 The Interpreter will interpret RS274/NGC commands which enable 'M48'
 or disable 'M49' the feed and speed override switches. For certain
 moves, such as the traverse out of the end of a thread during a threading cycle, the
@@ -302,8 +317,9 @@ switch should be set before starting the NGC program.
 If this switch is on and an M1 code is encountered, program execution
 is paused.
 
-== Tool Table(((Tool Table)))
+== Tool Table
 
+(((Tool Table)))
 A tool table is required to use the Interpreter. The file tells which
 tools are in which tool changer slots and what the size and type of
 each tool is. The name of the tool table is defined in the INI file:
@@ -336,8 +352,9 @@ For more information on the specifics of the tool table format, see the
 <<sec:tool-table,Tool Table Format>> section.
 
 [[sec:machine-center-parameters]]
-== Parameters(((Parameters)))
+== Parameters
 
+(((Parameters)))
 In the RS274/NGC language view, a machining center maintains an array
 of numerical parameters defined by a system definition
 (RS274NGC_MAX_PARAMETERS). Many of them have specific uses especially

--- a/docs/src/gcode/o-code.adoc
+++ b/docs/src/gcode/o-code.adoc
@@ -2,7 +2,7 @@
 :toc:
 
 [[cha:o-codes]]
-= O Codes(((O Codes)))
+= O Codes
 
 // Custom lang highlight
 // must come after the doc title, to work around a bug in asciidoc 8.6.6
@@ -38,8 +38,9 @@ o100 endsub
 ----
 
 [[ocode:comments]]
-== Comments(((Comments)))
+== Comments
 
+(((Comments)))
 Comments on the same line as the O word should not be used as the behavior can
 change in the future.
 
@@ -55,8 +56,9 @@ that might have been mistyped. For example 'o100' is easier to
 see than 'O100' that it is not a '0'.
 
 [[ocode:subroutines]]
-== Subroutines(((Subroutines)))
+== Subroutines
 
+(((Subroutines)))
 Subroutines starts at 'Onnn sub' and ends at 'Onnn endsub'. The lines between
 'Onnn sub' and 'Onnn endsub' are not executed until the subroutine is called
 with 'Onnn call'. Each subroutine must use a unique number.
@@ -133,8 +135,9 @@ Subroutines can change the value of parameters above #30 and those changes will 
 Subroutines may also change the value of <<gcode:named-parameters,global named parameters>> (i.e. parameters whose names begin with the underscore character "`_`").
 
 [[ocode:fanuc-style-programs]]
-=== Fanuc-Style Numbered Programs(((Subroutines,M98,M99)))
+=== Fanuc-Style Numbered Programs
 
+(((Subroutines, M98-M99)))
 Numbered programs (both main and subprograms), the 'M98' call and
 'M99' return M-codes, and their respective semantic differences are an
 alternative to the rs274ngc subroutines described above, provided for
@@ -242,8 +245,9 @@ Note that parameter `#1` is global.  At the end of the main program,
 after updates within `O100` and `O200`, its value will equal `5.25`.
 
 [[ocode:looping]]
-== Looping(((Subroutines,Looping)))
+== Looping
 
+(((Subroutines, Looping)))
 The 'while loop' has two structures: 'while/endwhile', and 'do/while'. In
 each case, the loop is exited when the 'while' condition evaluates to
 false. The difference is when the test condition is done. The 'do/while'
@@ -289,8 +293,9 @@ condition. If it is still true, the loop begins again at the top. If
 it is false, it exits the loop.
 
 [[ocode:conditional]]
-== Conditional(((Subroutines,Conditional Loops)))
+== Conditional
 
+(((Subroutines, Conditional loops)))
 The 'if' conditional consists of a group of statements with the same 'o' number
 that start with 'if' and end with 'endif'. Optional 'elseif' and 'else' conditions
 may be between the starting 'if' and the ending 'endif'.
@@ -348,8 +353,9 @@ O102 endif
 ----
 
 [[ocode:repeat]]
-== Repeat(((Subroutines,Repeat Loop)))
+== Repeat
 
+(((Subroutines, Repeat loop)))
 The 'repeat' will execute the statements inside of the
 repeat/endrepeat the specified number of times. The example shows how
 you might mill a diagonal series of shapes starting at the present
@@ -368,8 +374,9 @@ G90 (Absolute mode)
 ----
 
 [[ocode:indirection]]
-== Indirection(((Indirection)))
+== Indirection
 
+(((Indirection)))
 The O-number may be given by a parameter and/or calculation.
 
 .Indirection Example
@@ -387,8 +394,9 @@ For more information on computing values see the following sections:
 * <<gcode:functions,Functions>>
 
 [[ocode:calling-files]]
-== Calling Files(((Calling Files)))
+== Calling Files
 
+(((Calling Files)))
 To call a separate file with a subroutine name the file the same as
 your call and include a sub and endsub in the file. The file must be in the
 directory pointed to by 'PROGRAM_PREFIX' or 'SUBROUTINE_PATH' in the INI file.
@@ -425,8 +433,9 @@ The file names are lowercase letters only so 'o<MyFile>' is converted to 'o<myfi
 by the interpreter. More information about the search path and options for the
 search path are in the INI configuration section.
 
-== Subroutine return values(((Return Values)))
+== Subroutine return values
 
+(((Return Values)))
 Subroutines may optionally return a value by an optional expression at
 an 'endsub' or 'return' statement.
 
@@ -445,8 +454,9 @@ a value was returned. Both parameters are global, and are cleared just
 before the next subroutine call.
 
 [[ocode:errors]]
-== Errors(((O-Code Errors)))
+== Errors
 
+(((O-Code Errors)))
 The following statements  cause an error message and  abort the
 interpreter:
 

--- a/docs/src/gcode/other-code.adoc
+++ b/docs/src/gcode/other-code.adoc
@@ -2,11 +2,14 @@
 :toc:
 
 [[cha:other-codes]]
-= Other Codes(((Other Codes)))
+= Other Codes
+
+(((Other Codes)))
 
 [[sec:set-feed-rate]]
-== F: Set Feed Rate(((F: Set Feed Rate)))
+== F: Set Feed Rate
 
+(((F: Set Feed Rate)))
 'Fx' - set the feed rate to 'x'.  'x' is usually in machine units
 (inches or millimeters) per minute.
 
@@ -16,8 +19,9 @@ or 'feed per revolution mode' are in effect, in which case the feed rate
 is as described in the <<gcode:g93-g94-g95,G93 G94 G95>> section.
 
 [[sec:set-spindle-speed]]
-== S: Set Spindle Speed(((S: Set Spindle Speed)))
+== S: Set Spindle Speed
 
+(((S: Set Spindle Speed)))
 'Sx [$n]' - set the speed of the spindle to 'x' revolutions per minute (RPM)
 with the optional $ set the spindle speed for a specific spindle. Without the $
 the command will default to spindle.0.
@@ -41,8 +45,9 @@ speed may differ from the one programmed, even if the speed correction potentiom
 is set to 100%.
 
 [[sec:select-tool]]
-== T: Select Tool(((T: Select Tool)))
+== T: Select Tool
 
+(((T: Select Tool)))
 'Tx' - prepare to change to tool 'x'.
 
 The tool is not changed until an 'M6' is programmed (see Section

--- a/docs/src/gcode/overview.adoc
+++ b/docs/src/gcode/overview.adoc
@@ -75,8 +75,9 @@ outside a comment may be in upper or lower case without changing the
 meaning of a line.
 
 [[sub:block-delete]]
-=== '/': Block Delete((('/' Block Delete)))
+=== '/': Block Delete
 
+((('/' Block Delete)))
 The optional block delete character the slash '/' when placed first on a line
 can be used by some user interfaces to skip lines of code when needed. In Axis
 the key combination Alt-m-/ toggles block delete on and off. When block delete
@@ -87,8 +88,9 @@ In AXIS, it is also possible to enable block delete with the following icon:
 .AXIS Block Delete Icon
 image:../gui/images/tool_blockdelete.png[]
 
-=== Line Number(((Line Number)))
+=== Line Number
 
+(((Line number)))
 A line number is the letter N followed by an unsigned integer,
 optionally followed by a period and another unsigned integer. For
 example, 'N1234' and 'N56.78' are valid line numbers. They may be
@@ -97,8 +99,9 @@ such usage. Line numbers may also be skipped, and that is normal
 practice. A line number is not required to be used, but must be in the
 proper place if used.
 
-=== Word(((Words)))
+=== Word
 
+(((Words)))
 A word is a letter other than N followed by a real value.
 
 Words may begin with any of the letters shown in the following Table.
@@ -140,28 +143,33 @@ not have the corresponding axis.
 |Z | Z axis of machine
 |===
 
-==== Parameters(((Parameters)))
+==== Parameters
 
+(((Parameters)))
 Parameters are identified with a "#" symbol in front of them. See <<sec:overview-parameters,Parameters Section>> below. 
 
-==== Subroutine Codes(((Subroutine Codes)))
+==== Subroutine Codes
 
+(((Subroutine Codes)))
 Also called 'o-codes' these provide program flow control (such as if-else logic and callable subroutines) and are covered fully at the page on <<cha:o-codes,o-Codes>> and also below in <<sub:subroutine-parameters,Subroutine Codes and Parameters>>.
 
 NOTE: o-codes are sometimes also called o-words. 
 
-==== Comments(((Comments)))
+==== Comments
 
+(((Comments)))
 Comments can be embedded in a line using parentheses () or for the remainder of a line using a semi-colon. There are also 'active' comments like MSG, DEBUG, etc. See the <<gcode:comments,section on comments>>.
 
-=== End of Line Marker(((End of Line Marker)))
+=== End of Line Marker
 
+(((End of Line Marker)))
 This is any combination of carriage return or line feed. 
 
 
 [[gcode:numbers]]
-=== Numbers(((Numbers)))
+=== Numbers
 
+(((Numbers)))
 The following rules are used for (explicit) numbers. In these rules a
 digit is a single character between 0 and 9.
 
@@ -195,8 +203,9 @@ which is intended to represent an integer is considered close enough if
 it is within 0.0001 of an integer value.
 
 [[sec:overview-parameters]]
-== Parameters(((Parameters)))
+== Parameters
 
+(((Parameters)))
 The RS274/NGC language supports 'parameters' - what in other
 programming languages would be called 'variables'. There are several
 types of parameter of different purpose and appearance, each described
@@ -259,8 +268,9 @@ Intended Use::
   running version. They are read-only.
 
 [[sub:numbered-parameters]]
-=== Numbered Parameters(((Numbered Parameters)))
+=== Numbered Parameters
 
+(((Parameters,numbered)))
 A numbered parameter is the pound character '#' followed by an
 integer between 1 and (currently) 5602 footnote:[The RS274/NGC interpreter
 maintains an array of numbered parameters. Its size is defined by the
@@ -388,15 +398,17 @@ is written.
 |===
 
 [[sub:subroutine-parameters]]
-=== Subroutine Parameters(((Subroutine Parameters)))
+=== Subroutine Parameters
 
+(((Subroutine Parameters)))
 * '1-30' Subroutine local parameters of call arguments. These parameters are
   local to the subroutine. Volatile. See also the chapter on
   <<cha:o-codes,O-Codes>>.
 
 [[gcode:named-parameters]]
-=== Named Parameters(((Named Parameters)))
+=== Named Parameters
 
+(((Parameters, named)))
 Named parameters work like numbered parameters but are easier to read.
 All parameter names are converted to lower case and have spaces and
 tabs removed, so '#<param>' and '#<P a R am >' refer to the same
@@ -447,8 +459,9 @@ ends, and have these  values when the program is run again.
 The <<gcode:functions,'EXISTS' function>> tests whether a given named parameter exists.
 
 [[gcode:predefined-named-parameters]]
-=== Predefined Named Parameters(((Predefined Named Parameters)))
+=== Predefined Named Parameters
 
+(((Parameters, named, predefined)))
 The following global read only named parameters are available to
 access internal state of the interpreter and machine state. They can
 be used in arbitrary expressions, for instance to control flow of the
@@ -543,8 +556,9 @@ can be added easily without changes to the source code.
 * '#<_retract_old_z>' - Return 1 if G99 is on, else 0.
 
 [[sub:system-parameters]]
-=== System Parameters(((System Parameters)))
+=== System Parameters
 
+(((System Parameters)))
 * '#<_spindle_rpm_mode>' - Return 1 if spindle rpm mode (G97) is on, else 0.
 * '#<_spindle_css_mode>' - Return 1 if constant surface speed mode (G96) is on, else 0.
 * '#<_ijk_absolute_mode>' - Return 1 if Absolute Arc distance mode (G90.1) is on, else 0.
@@ -596,8 +610,9 @@ can be added easily without changes to the source code.
   to the remap level. For debugging.
 
 [[gcode:ini-hal-params]]
-== HAL pins and INI values(((HAL pins and INI values)))
+== HAL pins and INI values
 
+(((HAL pins and INI values)))
 If enabled in the <<sub:ini:sec:rs274ngc, INI file>> G-code has access
 to the values of INI file entries and HAL pins.
 
@@ -672,8 +687,9 @@ non-mnemonic namespace and is unnecessarily cumbersome just as a
 UI/Interpreter communications mechanism.
 
 [[gcode:expressions]]
-== Expressions(((Expressions)))
+== Expressions
 
+(((Expressions)))
 An expression is a set of characters starting with a left bracket '['
 and ending with a balancing right bracket ']' . In between the brackets
 are numbers, parameter values, mathematical
@@ -683,8 +699,9 @@ is read, before anything on the line is executed. An example of an
 expression is '[1 + acos[0] - [#3 ** [4.0/2]]]'.
 
 [[gcode:binary-operators]]
-== Binary Operators(((Binary Operators)))
+== Binary Operators
 
+(((Binary Operators)))
 Binary operators only appear inside expressions. There are four basic
 mathematical operations: addition ('+'), subtraction ('-'),
 multiplication ('\*'), and division ('/'). There are three logical
@@ -710,8 +727,9 @@ The logical operations and modulus are to be performed on any real
 numbers, not just on integers. The number zero is equivalent to logical
 false, and any non-zero number is equivalent to logical true.
 
+(((Operators Precedence)))
 [[gcode:operators-precedence]]
-.Operators Precedence(((Operators Precedence)))
+.Operators Precedence
 [width="60%",options="header",cols="2*^"]
 |===
 |Operators         | Precedence
@@ -731,8 +749,9 @@ their absolute difference is less than 1e-6 (this value is defined as
 'TOLERANCE_EQUAL' in src/emc/rs274ngc/interp_internal.hh).
 
 [[gcode:functions]]
-== Functions(((Functions)))(((Unary operations)))
+== Functions
 
+(((Functions)))(((Unary operations)))
 The available functions are shown in following table. Arguments to unary
 operations which take angle measures ('COS', 'SIN', and 'TAN' ) are in
 degrees. Values returned by unary operations which return angle measures
@@ -852,8 +871,9 @@ axis words or canceling motion.
 For example, G4 (dwell) is non-modal.
 
 [[gcode:polar-coordinates]]
-== Polar Coordinates(((Polar Coordinates)))
+== Polar Coordinates
 
+(((Polar Coordinates)))
 Polar Coordinates can be used to specify the XY coordinate of a move.
 The @n is the distance and ^n is the angle. The advantage of this is
 for things like bolt hole circles which can be done very simply by
@@ -917,8 +937,9 @@ It is an error if:
 * A mix of Polar and X or Y words are used
 
 [[gcode:modal-groups]]
-== Modal Groups(((Modal Groups)))
+== Modal Groups
 
+(((Modal Groups)))
 Modal commands are arranged in sets called 'modal groups', and only
 one member of a modal group may be in force at any given time. In
 general, a modal group contains commands for which it is logically
@@ -927,8 +948,9 @@ measure in inches vs. measure in millimeters. A machining center may be
 in many modes at the same time, with one mode from each modal group
 being in effect. The modal groups are shown in the following Table.
 
+(((Modal Groups: G-codes)))
 [[cap:modal-groups]]
-.G-code Modal Groups(((Modal Groups: G-codes)))
+.G-code Modal Groups
 [width="80%",cols="4,6",options="header"]
 |===
 |Modal Group Meaning                    | Member Words
@@ -949,8 +971,9 @@ being in effect. The modal groups are shown in the following Table.
 |Lathe Diameter Mode (Group 15)         | G7, G8
 |===
 
+(((Modal Groups: M-codes)))
 [[tbl:mcodes-modal-groups]]
-.M-code Modal Groups(((Modal Groups: M-codes)))
+.M-code Modal Groups
 [width="80%",cols="4,6",options="header"]
 |===
 |Modal Group Meaning         | Member Words
@@ -986,8 +1009,9 @@ It is an error to include any unrelated words on a line with 'O-' flow
 control.
 
 [[gcode:comments]]
-== Comments(((Comments)))
+== Comments
 
+(((Comments)))
 Comments are purely informative and have no influence on machine behaviour.
 
 Comments can be added to lines of G-code to help clear up the
@@ -1024,8 +1048,9 @@ NOTE: Inline comments on O-words should not be used see the O-code
 <<ocode:comments,comments>> section for more information.
 
 [[gcode:messages]]
-== Messages(((Messages)))
+== Messages
 
+(((Messages)))
 * '(MSG,)' - displays message if 'MSG' appears after the left parenthesis
   and before any other printing characters. Variants of 'MSG' which include
   white space and lower case characters are allowed. The rest of the
@@ -1039,8 +1064,9 @@ NOTE: Inline comments on O-words should not be used see the O-code
 ----
 
 [[gcode:probe-logging]]
-== Probe Logging(((Probe Logging)))
+== Probe Logging
 
+(((Probe Logging)))
 * '(PROBEOPEN filename.txt)' - will open filename.txt and store the 9-number
   coordinate consisting of XYZABCUVW of each successful straight probe in it.
 * '(PROBECLOSE)' - will close the open probelog file.
@@ -1048,8 +1074,9 @@ NOTE: Inline comments on O-words should not be used see the O-code
 For more information on probing see the <<gcode:g38,G38>> section.
 
 [[gcode:logging]]
-== Logging(((Logging)))
+== Logging
 
+(((Logging)))
 * '(LOGOPEN,filename.txt)' - opens the named log file. If the file already
   exists, it is truncated.
 * '(LOGAPPEND,filename)' - opens the named log file. If the file already
@@ -1062,20 +1089,23 @@ Examples of logging are in 'nc_files/examples/smartprobe.ngc' and in
 'nc_files/ngcgui_lib/rectange_probe.ngc' sample G-code files.
 
 [[gcode:debug]]
-== Debug Messages(((Debug Messages)))
+== Debug Messages
 
+(((Debug Messages)))
 * '(DEBUG,)' - displays a message like '(MSG,)' with the addition of special
   handling for comment parameters as described below.
 
 [[gcode:print]]
-== Print Messages(((Print Messages)))
+== Print Messages
 
+(((Print Messages)))
 * '(PRINT,)' - messages are output to 'stderr' with special handling for
   comment parameters as described below.
 
 [[gcode:comment-parameters]]
-== Comment Parameters(((Comment Parameters)))
+== Comment Parameters
 
+(((Comment Parameters)))
 In the DEBUG, PRINT and LOG comments, the values of parameters in the
 message are expanded.
 
@@ -1115,8 +1145,9 @@ If the formatting string is created with the wrong pattern it will be
 printed as characters.
 
 [[gcode:file-requirements]]
-== File Requirements(((File Requirements)))
+== File Requirements
 
+(((File Requirements)))
 A G-code file must contain one or more lines of G-code and be terminated
 with a <<mcode:m2-m30,Program End>>. Any G-code past the program end
 is not evaluated.
@@ -1138,8 +1169,9 @@ The file must be created with a text editor like Gedit and not a word
 processor like Open Office Word Processor.
 
 [[gcode:file-size]]
-== File Size(((File Size)))
+== File Size
 
+(((File Size)))
 The interpreter and task are carefully written so that the only limit
 on part program size is disk capacity. The TkLinuxCNC and Axis interface
 both load the program text to display it to the user, though, so RAM
@@ -1150,8 +1182,9 @@ part programs. In Axis sections of the preview can be turned off using
 <<axis:preview-control,preview control>> comments.
 
 [[gcode:order-of-execution]]
-== G-code Order of Execution(((G-code Order of Execution)))
+== G-code Order of Execution
 
+(((G-code Order of Execution)))
 The order of execution of items on a line is defined not by the
 position of each item on the line, but by the following list:
 
@@ -1185,8 +1218,9 @@ position of each item on the line, but by the following list:
 * Stop (M0, M1, M2, M30, M60).
 
 [[gcode:best-practices]]
-== G-code Best Practices(((G-code Best Practices)))
+== G-code Best Practices
 
+(((G-code Best Practices)))
 .Use an appropriate decimal precision
 Use at least 3 digits after the decimal when milling in millimeters,
 and at least 4 digits after the decimal when milling in inches.

--- a/docs/src/gcode/tool-compensation.adoc
+++ b/docs/src/gcode/tool-compensation.adoc
@@ -2,7 +2,7 @@
 :toc:
 
 [[cha:tool-compensation]]
-= Tool Compensation(((Tool Compensation)))
+= Tool Compensation
 
 // Custom lang highlight
 // must come after the doc title, to work around a bug in asciidoc 8.6.6
@@ -10,9 +10,12 @@
 :hal: {basebackend@docbook:'':hal}
 :ngc: {basebackend@docbook:'':ngc}
 
-[[sec:touch-off]]
-== Touch Off(((Touch Off)))
+(((Tool Compensation)))
 
+[[sec:touch-off]]
+== Touch Off
+
+(((Touch Off)))
 Using the Touch Off Screen in the AXIS interface you can update the tool table automatically.
 
 Typical steps for updating the tool table:
@@ -42,8 +45,9 @@ The G10 L1/L10/L11 commands can be used to set tool table offsets:
 This is only a brief presentation, refer to the reference guide of the G-code for more detailed explanations.
 
 [[sec:tool-table]]
-== Tool Table(((Tool Table)))
+== Tool Table
 
+(((Tool Table)))
 The 'Tool Table' is a text file that contains information about each tool.
 The file is located in the same directory as your configuration and is called 'tool.tbl' by default.
 A file name may be specified with the INI file [EMCIO]TOOL_TABLE setting.
@@ -56,7 +60,9 @@ The <<cha:tooledit-gui,Tool Editor>> or a text editor can be used to edit the to
 If you use a text editor make sure you reload the tool table in the GUI.
 
 [[sub:tool-table-format]]
-=== Tool Table Format(((Tool Table Format)))
+=== Tool Table Format
+
+(((Tool Table Format)))
 
 .Tool Table Format
 [width="100%",options="header"]
@@ -139,8 +145,9 @@ This column is for the benefit of human readers only. The comment must be preced
 Earlier versions of LinuxCNC had two different tool table formats for mills and lathes, but since the 2.4.x release, one tool table format is used for all machines.
 
 [[sub:tool-io]]
-=== Tool IO(((Tool IO)))
+=== Tool IO
 
+(((Tool IO)))
 The non-realtime program specified by `[EMCIO]EMCIO = io` is conventionally used for tool changer management
 (and other io functions for enabling LinuxCNC and the control of coolant/lube hardware).
 The HAL pins used for tool management are prefixed with `iocontrol.0.`.
@@ -196,8 +203,9 @@ An M61Q__n__ (_n_!=0) command does not change the *iocontrol.0.tool-from-pocket*
 An M61Q0 (_n_==0) command sets *iocontrol.0.tool-from-pocket* to 0.
 
 [[sub:tool-changers]]
-=== Tool Changers(((Tool Changers)))
+=== Tool Changers
 
+(((Tool Changers)))
 LinuxCNC supports three types of tool changers: 'manual', 'random location' and 'non-random or fixed location'.
 Information about configuring a LinuxCNC tool changer is in the <<sub:ini:sec:emcio,EMCIO Section>> of the INI chapter.
 
@@ -231,7 +239,9 @@ When a tool is changed LinuxCNC rewrites the pocket number to keep track of wher
 T can be any number but P must be a number that makes sense for the machine.
 
 
-== Tool Length Compensation(((Tool Length Compensation)))
+== Tool Length Compensation
+
+(((Tool Length Compensation)))
 The tool length compensations are given as positive numbers in the tool table.
 A tool compensation is programmed using G43 H_n_, where _n_ is the index number of the desired tool in the tool table.
 It is intended that all entries in the tool table are positive.
@@ -264,8 +274,9 @@ image:images/length1.png[]
 With this program, in most cases, the machine will apply the offset in the form of a ramp during the movement in xyz following the word G43.
 
 [[sec:cutter-radius-compensation]]
-== Cutter Radius Compensation(((Cutter Radius Compensation)))
+== Cutter Radius Compensation
 
+(((Cutter Radius Compensation)))
 Cutter Compensation allows the programmer to program the tool path without knowing the exact tool diameter.
 The only caveat is the programmer must program the lead in move to be at least as long as the largest tool radius that might be used.
 
@@ -279,8 +290,9 @@ If the next move creates an outside corner the move will be to the end point of 
 If the next move creates in an inside corner the move will stop short so to not gouge the part.
 The following figure shows how the compensated move will stop at different points depending on the next move.
 
+(((Compensation End Point)))
 [[cap:compensation-end-point]]
-.Compensation End Point(((Compensation End Point)))
+.Compensation End Point
 image::images/comp-path_en.svg["Compensation End Point",align="center"]
 
 === Overview

--- a/docs/src/getting-started/about-linuxcnc.adoc
+++ b/docs/src/getting-started/about-linuxcnc.adoc
@@ -2,10 +2,11 @@
 :toc:
 
 [[cha:about-linuxcnc]]
-= About LinuxCNC(((About LinuxCNC)))
+= About LinuxCNC
 
 == The Software
 
+(((About LinuxCNC)))
 * LinuxCNC (the Enhanced Machine Control) is a software system for computer
   control of machine tools such as milling machines and lathes, robots
   such as puma and scara and other computer controlled machines up to 9 axes.
@@ -48,10 +49,11 @@ LinuxCNC is available as ready-to-use packages for the Ubuntu and Debian
 distributions.
 
 [[sec:getting-help]]
-== Getting Help(((Getting Help)))
+== Getting Help
 
 === IRC
 
+(((Getting Help)))
 IRC stands for Internet Relay Chat.
 It is a live connection to other LinuxCNC users.
 The LinuxCNC IRC channel is #linuxcnc on libera.chat.

--- a/docs/src/getting-started/getting-linuxcnc.adoc
+++ b/docs/src/getting-started/getting-linuxcnc.adoc
@@ -39,7 +39,7 @@ This section describes some methods for downloading the Live/Install image.
 Software for LinuxCNC to download is presented on the project's
 https://linuxcnc.org/downloads/[Downloads page].
 Most users will aim for the disk image for Intel/AMD PCs, the URL
-will resemble https://www.linuxcnc.org/iso/linuxcnc_2.9.4-amd64.hybrid.iso.
+will resemble https://www.linuxcnc.org/iso/linuxcnc_2.9.7-amd64.hybrid.iso.
 
 For the Raspberry Pi, multiple images are provided to address
 differences between the RPi4 and RPi5.
@@ -82,13 +82,13 @@ https://www.assembla.com/spaces/zsync-windows/documents .
 . After downloading, verify the checksum of the image to ensure integrity.
 
 ----
-md5sum linuxcnc-2.9.4-amd64.iso
+md5sum linuxcnc-2.9.7-amd64.iso
 ----
 
 or
 
 ----
-sha256sum linuxcnc-2.9.4-amd64.iso
+sha256sum linuxcnc-2.9.7-amd64.iso
 ----
 . Then compare to these checksums
 
@@ -131,14 +131,14 @@ It looks more complicated but seems to be more compatible with various BIOSes.
 . Connect a USB storage device (for example a flash drive or thumb
   drive type device).
 . Determine the device file corresponding to the USB flash drive.
-  This information can be found in the output of `dmesg` after
-  connecting the device.  `/proc/partitions` may also be helpful.
+  This information can be found in the output of `sudo dmesg` after
+  connecting the device.  `cat /proc/partitions` may also be helpful.
 . Use the `dd` command to write the image to your USB storage device.
   For example, if your storage device showed up as `/dev/sde`,
   then use this command:
 +
 -----
-dd if=linuxcnc_2.9.4-amd64.hybrid.iso of=/dev/sde
+dd if=linuxcnc_2.9.7-amd64.hybrid.iso of=/dev/sde bs=4k status=progress
 -----
 
 === Command line - MacOS
@@ -160,7 +160,7 @@ diskutil unmountDisk /dev/diskN
   has an added "r" at the begining
 +
 -----
-sudo dd if=linuxcnc_2.9.4-amd64.hybrid.iso of=/dev/rdiskN bs=1m
+sudo dd if=linuxcnc_2.9.7-amd64.hybrid.iso of=/dev/rdiskN bs=1m
 -----
 . Note that this may take a long time to complete and there will be no
   feedback during the process.
@@ -223,8 +223,9 @@ using the RTAI realtime kernel which will often give better latency.
 
 To install LinuxCNC from the Live CD select 'Install (Graphical)' at bootup.
 
-== Updates to LinuxCNC (((Updates to LinuxCNC)))
+== Updates to LinuxCNC
 
+(((Updates to LinuxCNC)))
 With the normal install the Update Manager will notify you of updates
 to LinuxCNC when you go on line and allow you to easily upgrade with no
 Linux knowledge needed.

--- a/docs/src/getting-started/running-linuxcnc.adoc
+++ b/docs/src/getting-started/running-linuxcnc.adoc
@@ -2,17 +2,19 @@
 :toc:
 
 [[cha:running-emc]]
-= Running LinuxCNC(((Running LinuxCNC)))
+= Running LinuxCNC
 
 == Invoking LinuxCNC
 
+(((Running LinuxCNC)))
 After installation, LinuxCNC starts just like any other Linux program:
 run it from the <<faq:terminal,terminal>> by issuing the command 'linuxcnc',
 or select it in the 'Applications -> CNC' menu.
 
 [[sec:config-launcher]]
-== Configuration Launcher(((Configuration Launcher)))
+== Configuration Launcher
 
+(((Configuration Launcher)))
 When starting LinuxCNC (from the CNC menu or from the command line without
 specifying an INI file) the Configuration Selector dialog starts.
 

--- a/docs/src/getting-started/system-requirements.adoc
+++ b/docs/src/getting-started/system-requirements.adoc
@@ -2,10 +2,11 @@
 :toc:
 
 [[cha:system-requirements]]
-= System Requirements(((System Requirements)))
+= System Requirements
 
 == Minimum Requirements
 
+(((System Requirements)))
 The minimum system to run LinuxCNC and Debian / Ubuntu may vary depending
 on the exact usage. Stepper systems in general require faster threads to
 generate step pulses than servo systems. You can use the Live CD to test

--- a/docs/src/getting-started/updating-linuxcnc.adoc
+++ b/docs/src/getting-started/updating-linuxcnc.adoc
@@ -2,7 +2,7 @@
 :toc:
 
 [[cha:updating-linuxcnc]]
-= Updating LinuxCNC(((Updating LinuxCNC)))
+= Updating LinuxCNC
 
 // Custom lang highlight
 // must come after the doc title, to work around a bug in asciidoc 8.6.6

--- a/docs/src/gui/axis.adoc
+++ b/docs/src/gui/axis.adoc
@@ -2,7 +2,7 @@
 :toc:
 
 [[cha:axis-gui]]
-= AXIS GUI(((AXIS GUI)))
+= AXIS GUI
 
 // Custom lang highlight
 // must come after the doc title, to work around a bug in asciidoc 8.6.6
@@ -10,8 +10,7 @@
 :hal: {basebackend@docbook:'':hal}
 :ngc: {basebackend@docbook:'':ngc}
 
-== Introduction
-
+(((AXIS GUI)))
 AXIS is a graphical front-end for LinuxCNC which features a live
 preview and backplot. It is written in Python and uses
 Tk and OpenGL to display its user interface.
@@ -182,7 +181,7 @@ Do not use 'Run From Selected Line' if your G-code program contains subroutines.
 * 'Unhoming' - Unhome one or all axes.
 * 'Zero Coordinate System' - Set all offsets to zero in the coordinate system chosen.
 //[[sub:axis:tool-touch-off]]
-* Tool Touch Off(((AXIS, Tool Touch Off)))
+* Tool Touch Off(((AXIS GUI, Tool Touch Off)))
 ** 'Tool touch off to workpiece' - When performing Touch Off, the value
    entered is relative to the current workpiece ('G5x') coordinate system,
    as modified by the axis offset ('G92').  When the Touch Off is complete,
@@ -359,8 +358,9 @@ and the program requires 3.83 inches of X travel.
 To move the program so it's within the machine's travel in this case,
 jog to the left and Touch Off X again.
 
+(((AXIS GUI, Soft Limits)))(((Soft Limits)))
 [[fig:soft-limits]]
-.Soft Limits(((Soft Limits)))
+.Soft Limits
 image::images/axis-outofrange.png["Soft Limits",align="center"]
 
 .Tool Cone
@@ -616,8 +616,9 @@ to 0% - 100%.
 
 The most frequently used keyboard shortcuts are shown in the following table:
 
+(((AXIS GUI,Keyboard Shortcuts)))
 [[tab:common-keyboard-shortcuts]]
-.Most Common Keyboard Shortcuts(((AXIS,Keyboard Shortcuts)))
+.Most Common Keyboard Shortcuts
 [width="80%",options="header",cols="^,<,^"]
 |===
 |Keystroke        |Action Taken                              |Mode
@@ -700,8 +701,9 @@ commands to a running AXIS. The available commands are shown by running
 file ('--reload'), and making AXIS exit ('--quit').
 
 [[sec:manual-tool-change]]
-== Manual Tool Change(((AXIS:Manual Tool Change)))
+== Manual Tool Change
 
+(((AXIS GUI, Manual Tool Change)))(((Manual Tool Change)))
 LinuxCNC includes a non-realtime HAL component called 'hal_manualtoolchange',
 which shows a window prompt telling you what tool is expected when a
 'M6' command is issued. After the OK button is pressed, execution of
@@ -725,13 +727,15 @@ This can be very confusing to most users.
 To turn this feature off for the current tool change
 program a G1 with no move after the T<n>.
 
+(((AXIS GUI, Manual Toolchange Window)))
 [[fig:manual-toolchange-window]]
-.Manual Toolchange Window(((AXIS:Manual Toolchange Window)))
+.Manual Toolchange Window
 image::images/manual-tool-change.png["Manual Toolchange Window",align="center"]
 
 [[sec:axis-python-modules]]
-== Python modules(((AXIS:Python Modules)))
+== Python modules
 
+(((AXIS GUI,Python Modules)))
 AXIS includes several Python modules which may be useful to others. For more
 information on one of these modules, use 'pydoc <module name>' or read the
 source code. These modules include:
@@ -749,8 +753,9 @@ installed version of LinuxCNC, this should happen automatically. When
 running 'in-place', this can be done by using 'scripts/rip-environment'.
 
 [[sec:axis-lathe-mode]]
-== Using AXIS in Lathe Mode(((AXIS:Lathe Mode)))
+== Using AXIS in Lathe Mode
 
+(((AXIS GUI, Lathe Mode)))
 By including the line 'LATHE = 1'
 in the [DISPLAY] section of the INI file, AXIS selects lathe mode. The
 'Y' axis is not shown in coordinate readouts, the view is changed to
@@ -888,8 +893,9 @@ this causes the built-in options to be created at the option level
 can override them.
 
 [[sub:axis-jogwheel]]
-=== Jogwheel(((AXIS:Jogwheel)))
+=== Jogwheel
 
+(((AXIS GUI, Jogwheel)))
 To improve the interaction of AXIS with a physical jogwheel, the current
 active axis selected in the GUI is also reported on a 'HAL pin' with a
 name like 'axisui.jog.x'.
@@ -901,8 +907,9 @@ declared with: [HAL]POSTGUI_HALFILE. What differs from [HAL]HALFILE,
 which can only be used once.
 
 [[sub:axis-axisrc]]
-=== ~/.axisrc(((AXIS:.axisrc)))
+=== ~/.axisrc
 
+(((AXIS GUI, .axisrc)))
 If it exists, the contents of `~/.axisrc`  are executed as Python
 source code just before the AXIS GUI is
 displayed. The details of what may be written in the `~/.axisrc` are subject
@@ -960,8 +967,9 @@ Useful values include EDITOR=gedit and EDITOR=gnome-terminal -e vim.
 For more information, see the <<sub:ini:sec:display,Display Section>>
 of the INI Configuration Chapter.
 
-=== Virtual Control Panel(((AXIS: Virtual Control Panel)))
+=== Virtual Control Panel
 
+(((AXIS GUI, Virtual Control Panel)))
 AXIS can display a custom virtual control panel in either the right
 side column or the bottom row.
 Additionally one or more panels may be displayed as embedded tabs.
@@ -969,8 +977,9 @@ You can program buttons, indicators, data displays and more. For
 more information, see the <<cha:pyvcp,PyVCP>> and the <<cha:glade-vcp,GladeVCP>> chapters.
 
 [[axis:preview-control]]
-=== Preview Control(((AXIS: Preview Control)))
+=== Preview Control
 
+(((AXIS GUI, Preview Control)))
 Special comments can be inserted into the G-code file to control how
 the preview of AXIS behaves. In the case where you want to limit the
 drawing of the preview use these special comments. Anything between the
@@ -991,8 +1000,9 @@ preview on certain parts that are already working OK).
 This display can be useful in the AXIS preview when (debug,message) comments are not displayed.
 
 [[sec:axis-axisui-pins]]
-== Axisui(((AXIS: axisui pins)))
+== Axisui
 
+(((AXIS GUI, axisui pins)))
 To improve the interaction of AXIS with physical jog wheels, the axis
 currently selected in the GUI is also reported on a pin with a name
 like 'axisui.jog.x'. One of these pins is 'TRUE' at one time, and the rest are

--- a/docs/src/gui/gladevcp.adoc
+++ b/docs/src/gui/gladevcp.adoc
@@ -2,7 +2,7 @@
 :toc:
 
 [[cha:glade-vcp]]
-= GladeVCP: Glade Virtual Control Panel(((GladeVCP: Glade Virtual Control Panel)))
+= GladeVCP: Glade Virtual Control Panel
 
 // TODO:
 // - manual-example.ui layout - really bad
@@ -20,6 +20,7 @@
 
 == What is GladeVCP?
 
+(((GladeVCP: Glade Virtual Control Panel)))
 GladeVCP is a LinuxCNC component which adds the ability to add a new user interface panel to LinuxCNC user interfaces like:
 
 * AXIS

--- a/docs/src/gui/mdro.adoc
+++ b/docs/src/gui/mdro.adoc
@@ -2,7 +2,7 @@
 :toc:
 
 [[cha:mdro-gui]]
-= MDRO GUI(((mdro GUI)))
+= MDRO GUI
 
 // Custom lang highlight
 // must come after the doc title, to work around a bug in asciidoc 8.6.6
@@ -12,6 +12,7 @@
 
 == Introduction
 
+(((mdro GUI)))
 MDRO is a simple graphical front-end for LinuxCNC providing a display of data
 from Digital Read Out (DRO) scales. It provides functionality similar to
 a normal machinist's DRO display, allowing the user to use the DRO scales

--- a/docs/src/gui/ngcgui.adoc
+++ b/docs/src/gui/ngcgui.adoc
@@ -2,7 +2,7 @@
 :toc:
 
 [[cha:ngcgui]]
-= NGCGUI(((NGCGUI)))
+= NGCGUI
 
 // Custom lang highlight
 // must come after the doc title, to work around a bug in asciidoc 8.6.6
@@ -15,6 +15,7 @@ image::images/ngcgui.png[align="center"]
 
 == Overview
 
+(((NGCGUI)))
 * 'NGCGUI' is a Tcl application to work with subroutines. It allows you to
   have a conversational interface with LinuxCNC. You can organize the
   subroutines in the order you need them to run and concatenate the

--- a/docs/src/gui/panelui.adoc
+++ b/docs/src/gui/panelui.adoc
@@ -2,7 +2,7 @@
 :toc:
 
 [[cha:Panelui]]
-= Panelui(((Panelui)))
+= Panelui
 
 :ini: {basebackend@docbook:'':ini}
 :hal: {basebackend@docbook:'':hal}
@@ -10,6 +10,7 @@
 
 == Introduction
 
+(((Panelui)))
 Panelui is a non-realtime component to interface buttons to LinuxCNC or HAL:
 
 * It decodes MESA 7I73 style key-scan codes and calls the appropriate routine.

--- a/docs/src/gui/pyvcp.adoc
+++ b/docs/src/gui/pyvcp.adoc
@@ -80,8 +80,9 @@ Parts of PyVCP files are evaluated as Python code, and can take any action avail
 Only use PyVCP XML files from a source that you trust.
 
 [[sec:pyvcp-with-axis]]
-== AXIS(((PyVCP with AXIS)))
+== AXIS
 
+(((PyVCP with AXIS)))
 Since AXIS uses the same GUI toolkit (Tkinter) as PyVCP,
 it is possible to include a PyVCP panel at either the right side or the bottom of the AXIS user interface.
 It is not possible to display a panel in both of these positions simultaneously.
@@ -236,8 +237,9 @@ This tells HAL to wait for component 'panelname' to close before continuing HAL 
 This is usually set as the last command so that HAL shuts down when the panel is closed.
 
 [[sec:pyvcp:widgets]]
-== Widgets(((PyVCP Widgets Reference)))
+== Widgets
 
+(((PyVCP Widgets Reference)))
 HAL signals come in two variants, bits and numbers.
 Bits are off/on signals. Numbers can be 'float', 's32' or 'u32'.
 For more information on HAL data types see the <<sec:hal-data,HAL Data>> section.

--- a/docs/src/gui/qtdragon.adoc
+++ b/docs/src/gui/qtdragon.adoc
@@ -2,7 +2,7 @@
 :toc:
 
 [[cha:qtdragon-gui]]
-= QtDragon GUI(((QtDragon)))
+= QtDragon GUI
 
 :ini: {basebackend@docbook:'':ini}
 :hal: {basebackend@docbook:'':hal}
@@ -10,6 +10,7 @@
 
 == Introduction
 
+(((QtDragon)))
 QtDragon and QtDragon_hd are built with the QtVCP framework.
 It is the creative vision of forum personality Persei8.
 Much of it is based on the excellent work of others in the LinuxCNC community.

--- a/docs/src/gui/qtvcp.adoc
+++ b/docs/src/gui/qtvcp.adoc
@@ -46,8 +46,9 @@ image::images/qtvcp-cam-align.png["Qtscreen x1mill",align="center"]
 image::images/test_panel.png["Test Panel",align="center"]
 
 [[sec:qtvcp-overview]]
-== Overview(((QtVCP Overview)))
+== Overview
 
+(((QtVCP Overview)))
 _Two files are used, individually or in combination_, to add customizations:
 
 * A *UI file* that is a _XML_ file made with _Qt Designer_ graphical editor.

--- a/docs/src/gui/tklinuxcnc.adoc
+++ b/docs/src/gui/tklinuxcnc.adoc
@@ -129,7 +129,9 @@ When the machine moves, it leaves a trail called the backplot. You can
 start the backplot window by selecting View→Backplot.
 
 [[cap:tklinuxcnc-interpreter]]
-=== TkLinuxCNC Interpreter / Automatic Program Control(((TkLinuxCNC Interpreter)))
+=== TkLinuxCNC Interpreter / Automatic Program Control
+
+(((TkLinuxCNC Interpreter)))
 
 image::images/tkemc-interp.png["TkLinuxCNC Interpreter / program control",align="center"]
 

--- a/docs/src/gui/touchy.adoc
+++ b/docs/src/gui/touchy.adoc
@@ -2,12 +2,13 @@
 :toc:
 
 [[cha:touchy-gui]]
-= The Touchy Graphical User Interface(((touchygui)))
+= The Touchy Graphical User Interface
 
 :ini: {basebackend@docbook:'':ini}
 :hal: {basebackend@docbook:'':hal}
 :ngc: {basebackend@docbook:'':ngc}
 
+(((touchygui)))
 Touchy is a user interface for LinuxCNC meant for use on machine control panels,
 and therefore does not require keyboard or mouse.
 

--- a/docs/src/hal/basic-hal.adoc
+++ b/docs/src/hal/basic-hal.adoc
@@ -2,7 +2,7 @@
 :toc:
 
 [[cha:basic-hal-reference]]
-= HAL Basics(((HAL Basics)))
+= HAL Basics
 
 // Custom lang highlight
 // must come after the doc title, to work around a bug in asciidoc 8.6.6
@@ -10,11 +10,13 @@
 :hal: {basebackend@docbook:'':hal}
 :ngc: {basebackend@docbook:'':ngc}
 
+(((HAL,Basics)))
 This document provides a reference to the basics of HAL.
 
 [[sec:hal-commands]]
-== HAL Commands(((HAL Commands)))
+== HAL Commands
 
+(((HAL,Commands)))
 More detailed information can be found in the man page for halcmd: run 'man halcmd' in a terminal window.
 
 To see the HAL configuration and check the status of pins and parameters use the HAL Configuration window on the Machine menu in AXIS.
@@ -24,8 +26,9 @@ To watch a pin status open the Watch tab and click on each pin you wish to watch
 image::images/HAL_Configuration.png["The HAL Configuration Window",align="center"]
 
 [[sub:hal-loart]]
-=== loadrt(((HAL loadrt,loadrt)))
+=== loadrt
 
+(((HAL,Commands,loadrt)))(((loadrt)))
 The command `loadrt` loads a real time HAL component.
 Real time component functions need to be added to a thread to be updated at the rate of the thread.
 You cannot load a non-realtime component into the realtime space.
@@ -38,8 +41,9 @@ loadrt mux4 count=1
 ----
 
 [[sub:hal-addf]]
-=== addf(((HAL addf,addf)))
+=== addf
 
+(((HAL,Commands,addf)))(((addf)))
 The `addf` command adds a function to a real-time thread.
 If the StepConf wizard was used to create the configuration, two threads have been created (``base-thread`` and ``servo-thread``).
 
@@ -94,8 +98,9 @@ addf mux4.0 servo-thread
 If the component requires a floating point thread that is usually the slower servo-thread.
 
 [[sub:hal-loadusr]]
-=== loadusr(((HAL loadusr,loadusr)))
+=== loadusr
 
+(((HAL,Commands,loadusr)))(((loadusr)))
 The command `loadusr` loads a non-realtime HAL component.
 Non-realtime programs are their own separate processes, which optionally talk to other HAL components via pins and parameters.
 You cannot load realtime components into non-realtime space.
@@ -124,8 +129,9 @@ loadusr -Wn spindle gs2_vfd -n spindle
 In English it means 'loadusr wait for name spindle component gs2_vfd name spindle'.
 
 [[sub:hal-net]]
-=== net(((HAL net,net)))
+=== net
 
+(((HAL,Commands,net)))(((net)))
 The command `net` creates a 'connection' between a signal and one or more pins.
 If the signal does not exist net creates the new signal.
 This replaces the need to use the command newsig.
@@ -176,8 +182,9 @@ net xStep => parport.0.pin-06-out
 An I/O pin like encoder._N_.index-enable can be read or set as allowed by the component.
 
 [[sub:hal-setp]]
-=== setp(((HAL setp,setp)))
+=== setp
 
+(((HAL,Commands,setp)))(((setp)))
 The command `setp` sets the value of a pin or parameter.
 The valid values will depend on the type of the pin or parameter.
 It is an error if the data types do not match.
@@ -194,8 +201,9 @@ setp parport.0.pin-08-out TRUE
 ----
 
 [[sub:hal-sets]]
-=== sets(((HAL sets,sets)))
+=== sets
 
+(((HAL,Commands,sets)))(((sets)))
 The command `sets` sets the value of a signal.
 
 .Syntax and Examples of `sets`
@@ -213,8 +221,9 @@ It is an error if:
 * If value is not the correct type for the signal
 
 [[sub:hal-inlinkp]]
-=== unlinkp(((HAL unlinkp,unlinkp)))
+=== unlinkp
 
+(((HAL,Commands,unlinkp)))(((unlinkp)))
 The command `unlinkp` unlinks a pin from the connected signal.
 If no signal was connected to the pin prior running the command, nothing happens.
 The `unlinkp` command is useful for trouble shooting.
@@ -274,18 +283,22 @@ newsig Xstep bit
 More information can be found in the HAL manual or the man pages for `halrun`.
 
 [[sec:hal-data]]
-== HAL Data(((HAL Data)))
+== HAL Data
+
+(((HAL,Data)))
 
 [[sub:hal-bit]]
-=== Bit(((HAL Bit,bit)))
+=== Bit
 
+(((HAL,Data,bit)))(((bit)))
 A bit value is an on or off.
 
 - bit values = true or 1 and false or 0 (True, TRUE, true are all valid)
 
 [[sub:hal-float]]
-=== Float(((HAL Float,float)))
+=== Float
 
+(((HAL,Data,float)))(((float)))
 A 'float' is a floating point number.
 In other words the decimal point can move as needed.
 
@@ -296,22 +309,25 @@ For more information on floating point numbers see:
 https://en.wikipedia.org/wiki/Floating_point[https://en.wikipedia.org/wiki/Floating_point]
 
 [[sub:hal-s32]]
-=== s32(((HAL s32,s32)))
+=== s32
 
+(((HAL,Data,s32)))(((s32)))
 An 's32' number is a whole number that can have a negative or positive value.
 
 - s32 values = integer numbers from -2147483648 to 2147483647
 
 [[sub:hal-u32]]
-=== u32(((HAL u32,u32)))
+=== u32
 
+(((HAL,Data,u32)))(((u32)))
 A 'u32' number is a whole number that is positive only.
 
 - u32 values = integer numbers from 0 to 4294967295
 
 [[sec:hal-files]]
-== HAL Files(((HAL Files)))
+== HAL Files
 
+(((HAL,Data,Files)))
 If you used the Stepper Config Wizard to generate your config you will have up to three HAL files in your config directory.
 
 - 'my-mill.hal' (if your config is named 'my-mill') This file is loaded first and should not be changed if you used the Stepper Config Wizard.
@@ -322,8 +338,9 @@ If you used the Stepper Config Wizard to generate your config you will have up t
   Any HAL commands that use PyVCP widgets need to be placed here.
 
 [[sec:hal-parameters]]
-== HAL Parameter(((HAL Parameters)))
+== HAL Parameter
 
+(((HAL,Parameters)))
 Two parameters are automatically added to each HAL component when it is created.
 These parameters allow you to scope the execution time of a component.
 
@@ -334,8 +351,9 @@ These parameters allow you to scope the execution time of a component.
 `tmax` is a read/write parameter so the user can set it to 0 to get rid of the first time initialization on the function's execution time.
 
 [[sec:hal-logic-components]]
-== Basic Logic Components(((HAL Logic Components)))
+== Basic Logic Components
 
+(((HAL,Logic Components)))
 HAL contains several real time logic components.
 Logic components follow a 'Truth Table' that states what the output is for any given input.
 Typically these are bit manipulators and follow electrical logic gate truth tables.
@@ -343,8 +361,9 @@ Typically these are bit manipulators and follow electrical logic gate truth tabl
 For further components see <<sec:hal-components,HAL Components List>> or the man pages.
 
 [[sub:hal-and2]]
-=== and2(((HAL and2,and2)))
+=== and2
 
+(((HAL,Logic Components,and2)))(((and2)))
 The `and2` component is a two input and-gate.
 The truth table below shows the output based on each combination of input.
 
@@ -376,8 +395,9 @@ and2.N.out (bit, out)
 |===
 
 [[sub:hal-not]]
-=== not(((HAL not,not)))
+=== not
 
+(((HAL,Logic Components,not)))(((not)))
 The `not` component is a bit inverter.
 
 .Syntax
@@ -406,8 +426,9 @@ not.n.out (bit, out)
 |===
 
 [[sub:hal-or2]]
-=== or2(((HAL or2,or2)))
+=== or2
 
+(((HAL,Logic Components,or2)))(((or2)))
 The `or2` component is a two input or-gate.
 
 .Syntax
@@ -438,8 +459,9 @@ or2.n.out (bit, out)
 |===
 
 [[sub:hal-xor2]]
-=== xor2(((HAL xor2,xor2)))
+=== xor2
 
+(((HAL,Logic Components,xor2)))(((xor2)))
 The `xor2` component is a two input xor (exclusive or)-gate.
 
 .Syntax
@@ -470,8 +492,9 @@ xor2.n.out (bit, out)
 |===
 
 [[sec:hal-logic-examples]]
-== Logic Examples(((HAL Logic Examples)))
+== Logic Examples
 
+(((HAL,Logic Components,Examples)))
 .Example using `and2`
 [source,{hal}]
 ----
@@ -489,11 +512,14 @@ Last we connect the `and2` out bit to the parallel port `pin-14`.
 So following the truth table for `and2` if pin 11 and pin 12 are on then the output pin 14 will be on.
 
 [[sec:hal-conversion-components]]
-== Conversion Components(((HAL Conversion Components)))
+== Conversion Components
+
+(((HAL,Conversion Components)))
 
 [[sub:hal-weighted-sum]]
-=== weighted_sum(((HAL weighted_sum,weighted_sum)))
+=== weighted_sum
 
+(((HAL,Conversion Components,weighted_sum)))(((weighted_sum)))
 The weighted sum converts a group of bits into an integer.
 The conversion is the sum of the 'weights' of the bits present plus any offset.
 It's similar to 'binary coded decimal' but with more options.

--- a/docs/src/hal/canonical-devices.adoc
+++ b/docs/src/hal/canonical-devices.adoc
@@ -2,10 +2,9 @@
 :toc:
 
 [[cha:hal-canonical-device-interfaces]]
-= Canonical Device Interfaces(((HAL Canonical Device Interfaces)))
+= Canonical Device Interfaces
 
-== Introduction
-
+(((HAL, Canonical Device Interfaces)))
 The following sections show the pins, parameters, and functions that are supplied by "canonical devices".
 All HAL device drivers should supply the same pins and parameters, and implement the same behavior.
 
@@ -13,87 +12,103 @@ Note that only the `_<io-type>_` and `_<specific-name>_` fields are defined for 
 The `_<device-name>`, `_<device-num>_`, and `_<chan-num>_` fields are set based on the characteristics of the real device.
 
 [[sec:hal-cdi:digital-in]]
-== Digital Input(((HAL Digital Input)))
+== Digital Input
 
+(((HAL, Digital Input)))
 The canonical digital input (I/O type field: `digin`) is quite simple.
 
 [[sub:hal-cdi:di:pins]]
-=== Pins(((HAL Digital Input Pins)))
+=== Pins
+
+(((HAL, Digital Input Pins)))
 
 (bit) *in*:: State of the hardware input.
 (bit) *in-not*:: Inverted state of the input.
 
 [[sub:hal-cdi:di:parameters]]
-=== Parameters(((HAL Digital Input Parameters)))
+=== Parameters
 
+(((HAL, Digital Input Parameters)))
 None
 
 [[sub:hal-cdi:di:functions]]
-=== Functions(((HAL Digital Input Functions)))
+=== Functions
 
+(((HAL, Digital Input Functions)))
 (funct) *read*:: Read hardware and set `in` and `in-not` HAL pins.
 
 [[sec:hal-cdi:digital-out]]
-== Digital Output(((HAL Digital Output)))
+== Digital Output
 
+(((HAL, Digital Output)))
 The canonical digital output (I/O type field: `digout`) is also very simple.
 
 [[sub:hal-cdi:do:pins]]
-=== Pins(((HAL Digital Output Pins)))
+=== Pins
 
+(((HAL, Digital Output Pins)))
 (bit) *out*:: Value to be written (possibly inverted) to the hardware output.
 
 [[sub:hal-cdi:do:parameters]]
-=== Parameters(((HAL Digital Output Parameters)))
+=== Parameters
 
+(((HAL, Digital Output Parameters)))
 (bit) *invert*:: If TRUE, *out* is inverted before writing to the hardware.
 
 [[sub:hal-cdi:do:functions]]
-=== Functions(((HAL Digital Output Functions)))
+=== Functions
 
+(((HAL, Digital Output Functions)))
 (funct) *write*:: Read *out* and *invert*, and set hardware output accordingly.
 
 [[sec:hal-cdi:analog-in]]
-== Analog Input(((HAL Analog Input)))
+== Analog Input
 
+(((HAL, Analog Input)))
 The canonical analog input (I/O type: `adcin`).
 This is expected to be used for analog to digital converters, which convert e.g. voltage to a continuous range of values.
 
 [[sub:hal-cdi:ai:pins]]
-=== Pins(((HAL Analog Input Pins)))
+=== Pins
 
+(((HAL, Analog Input Pins)))
 (float) *value*:: The hardware reading, scaled according to the *scale* and *offset* parameters. +
   *value* = ((input reading, in hardware-dependent units) * *scale*) - *offset*
 
 [[sub:hal-cdi:ai:parameters]]
-=== Parameters(((HAL Analog Input Parameters)))
+=== Parameters
 
+(((HAL, Analog Input Parameters)))
 (float) *scale*:: The input voltage (or current) will be multiplied by *scale* before being output to *value*.
 (float) *offset*:: This will be subtracted from the hardware input voltage (or current) after the scale multiplier has been applied.
 (float) *bit_weight*:: The value of one least significant bit (LSB). This is effectively the granularity of the input reading.
 (float) *hw_offset*:: The value present on the input when 0 Volts is applied to the input pin(s).
 
 [[sub:hal-cdi:ai:functions]]
-=== Functions(((HAL Analog Input Functions)))
+=== Functions
 
+(((HAL, Analog Input Functions)))
 (funct) *read*:: Read the values of this analog input channel.  This may be used for individual channel reads, or it may cause all channels to be read.
 
 [[sec:hal-cdi:analog-out]]
-== Analog Output(((HAL Analog Output)))
+== Analog Output
 
+(((HAL, Analog Output)))
 The canonical analog output (I/O Type: *adcout*).
 This is intended for any kind of hardware that can output a more-or-less continuous range of values.
 Examples are digital to analog converters or PWM generators.
 
 [[sub:hal-cdi:ao:pins]]
-=== Pins(((HAL Analog Output Pins)))
+=== Pins
 
+(((HAL, Analog Output, Pins)))
 (float) *value*:: The value to be written. The actual value output to the hardware will depend on the scale and offset parameters.
 (bit) *enable*:: If false, then output 0 to the hardware, regardless of the *value* pin.
 
 [[sub:hal-cdi:ao:parameters]]
-=== Parameters(((HAL Analog Output Parameters)))
+=== Parameters
 
+(((HAL, Analog Output, Parameters)))
 (float) *offset*:: This will be added to the *value* before the hardware is updated.
 (float) *scale*:: This should be set so that an input of 1 on the *value* pin will cause the analog output pin to read 1 volt.
 (float) *high_limit* (optional):: When calculating the value to output to the hardware,
@@ -104,8 +119,9 @@ Examples are digital to analog converters or PWM generators.
 (float) *hw_offset*  (optional):: The actual voltage (or current) that will be output if 0 is written to the hardware.
 
 [[sub:hal-cdi:ao:functions]]
-=== Functions(((HAL Analog Output Functions)))
+=== Functions
 
+(((HAL, Analog Output, Functions)))
 (funct) *write*::
   This causes the calculated value to be output to the hardware.
   If enable is false, then the output will be 0, regardless of *value*, *scale*, and *offset*.

--- a/docs/src/hal/comp.adoc
+++ b/docs/src/hal/comp.adoc
@@ -2,7 +2,7 @@
 :toc:
 
 [[cha:hal-component-generator]]
-= HAL Component Generator(((HAL Component Generator)))
+= HAL Component Generator
 
 // Custom lang highlight
 // must come after the doc title, to work around a bug in asciidoc 8.6.6
@@ -10,8 +10,7 @@
 :hal: {basebackend@docbook:'':hal}
 :ngc: {basebackend@docbook:'':ngc}
 
-== Introduction
-
+(((HAL,Component Generator)))
 This section introduces to the compilation HAL components, i.e. the addition of some machinists' knowledge on how to deal with the machine.
 It should be noted that such components do not necessarily deal with the hardware directly.
 They often do, but not necessarily, e.g. there could be a component to convert between imperial and metric scales,

--- a/docs/src/hal/components.adoc
+++ b/docs/src/hal/components.adoc
@@ -2,12 +2,13 @@
 :tab_options: cols="15s,85,0,0", frame="none", grid="none"
 
 [[cha:hal-components]]
-= HAL Component List((("HAL Component List")))
+= HAL Component List
 
 == Components
 
 // < explanation of the difference between a realtime and a non-realtime component >
 
+((("HAL,Component List")))
 Most of the commands in the following list have their own dedicated man pages.
 Some will have expanded descriptions, some will have limited descriptions.
 From this list you know what components exist, and you can use `man` _name_ on your UNIX command line to get additional information.

--- a/docs/src/hal/general-ref.adoc
+++ b/docs/src/hal/general-ref.adoc
@@ -2,11 +2,14 @@
 :toc:
 
 [[cha:hal-general-reference]]
-= HAL General Reference(((HAL General Reference)))
+= HAL General Reference
+
+(((HAL,General Reference)))
 
 [[sec:hal-gr:names]]
-== HAL Entity Names(((HAL Entity Names)))
+== HAL Entity Names
 
+(((HAL,Entity names)))
 All HAL entities are accessible and manipulable by their names, so documenting the names of pins, signals, parameters, etc., is very important.
 Names in HAL have a maximum length of 41 characters (as defined by HAL_NAME_LEN in hal.h).
 Many names will be presented in the general form, with formatted text _<like-this>_ representing fields of various values.
@@ -21,8 +24,9 @@ Typical pins definitions look like these examples:
 Occasionally, an abbreviated version of the name may be used, for example the second pin above could be simply called with _.output_ when it can be done without causing confusion.
 
 [[sec:hal-gr:naming-conventions]]
-== HAL General Naming Conventions(((HAL General Naming Conventions)))
+== HAL General Naming Conventions
 
+(((HAL,General Naming Conventions)))
 Consistent naming conventions would make HAL much easier to use.
 For example, if every encoder driver provided the same set of pins and named them the same way, then it would be easy to change from one type of encoder driver to another.
 Unfortunately, like many open-source projects, HAL is a combination of things that were designed, and things that simply evolved.
@@ -44,7 +48,9 @@ To do that, all HAL components should follow these rules:
 - Use only lowercase letters and numbers in names.
 
 [[sec:hal-gr:hardware-drivers-naming]]
-== Hardware Driver Naming Conventions(((HAL Hardware Driver Naming Conventions)))
+== Hardware Driver Naming Conventions
+
+(((HAL,Hardware Driver Naming Conventions)))
 
 [NOTE]
 ====
@@ -53,8 +59,9 @@ This chapter is really a guide for future developments.
 ====
 
 [[sub:hal-gr:hw-drv:pin-parameter-names]]
-=== Pins/Parameters names(((HAL Hardware Driver Pins/Parameters Names)))
+=== Pins/Parameters names
 
+(((HAL,Hardware Driver Pins/Parameters Names)))
 Hardware drivers should use five fields (on three levels) to make up a pin or parameter name, as follows:
 
 ----
@@ -118,8 +125,9 @@ stg.0.din.03.in:: The state of the fourth digital input on the first Servo-to-Go
 ppmc.0.pwm.00-03.frequency:: The carrier frequency used for PWM channels 0 through 3 on the first Pico Systems ppmc board.
 
 [[sub:hal-gr:hw-drv:functions-names]]
-=== Function Names(((HAL Hardware Driver Function Names)))
+=== Function Names
 
+(((HAL,Hardware Driver Function Names)))
 Hardware drivers usually only have two kinds of HAL functions, ones that read the hardware and update HAL pins, and ones that write to the hardware using data from HAL pins.
 They should be named as follows:
 

--- a/docs/src/hal/hal-examples.adoc
+++ b/docs/src/hal/hal-examples.adoc
@@ -2,7 +2,7 @@
 :toc:
 
 [[cha:hal-examples]]
-= HAL Examples(((HAL Examples)))
+= HAL Examples
 
 // Custom lang highlight
 // must come after the doc title, to work around a bug in asciidoc 8.6.6
@@ -10,6 +10,7 @@
 :hal: {basebackend@docbook:'':hal}
 :ngc: {basebackend@docbook:'':ngc}
 
+(((HAL Examples)))
 All of these examples assume you are starting with a StepConf-based configuration and have two threads 'base-thread' and 'servo-thread'.
 The StepConf wizard will create an empty custom.hal and a custom_postgui.hal file.
 The custom.hal file will be loaded after the configuration HAL file and the custom_postgui.hal file is loaded after the GUI has been loaded.

--- a/docs/src/hal/halmodule.adoc
+++ b/docs/src/hal/halmodule.adoc
@@ -2,8 +2,9 @@
 :toc:
 
 [[cha:halmodule]]
-= Creating Non-realtime Python Components(((Creating Non-realtime Python Components)))
+= Creating Non-realtime Python Components
 
+(((Creating Non-realtime Python Components)))
 This section explains principles behind the implementation of HAL components with the Python programming language.
 
 == Basic usage example

--- a/docs/src/hal/halshow.adoc
+++ b/docs/src/hal/halshow.adoc
@@ -2,7 +2,7 @@
 :toc:
 
 [[cha:halshow]]
-= Halshow(((Halshow)))
+= Halshow
 
 // Custom lang highlight
 // must come after the doc title, to work around a bug in asciidoc 8.6.6
@@ -10,6 +10,7 @@
 :hal: {basebackend@docbook:'':hal}
 :ngc: {basebackend@docbook:'':ngc}
 
+(((Halshow)))
 The script `halshow` can help you find your way around a running HAL.
 It displays chosen HAL values and updates them continuously.
 

--- a/docs/src/hal/halui-examples.adoc
+++ b/docs/src/hal/halui-examples.adoc
@@ -2,7 +2,7 @@
 :toc:
 
 [[cha:halui-examples]]
-= Halui Examples(((Halui Examples)))
+= Halui Examples
 
 // Custom lang highlight
 // must come after the doc title, to work around a bug in asciidoc 8.6.6
@@ -10,6 +10,7 @@
 :hal: {basebackend@docbook:'':hal}
 :ngc: {basebackend@docbook:'':ngc}
 
+(((Halui Examples)))
 For any Halui examples to work you need to add the following line to the [HAL]
 section of the ini file.
 

--- a/docs/src/hal/intro.adoc
+++ b/docs/src/hal/intro.adoc
@@ -3,7 +3,7 @@
 
 [[cha:hal-introduction]]
 
-= HAL Introduction(((HAL Introduction)))
+= HAL Introduction
 
 // Custom lang highlight
 // must come after the doc title, to work around a bug in asciidoc 8.6.6
@@ -11,6 +11,7 @@
 :hal: {basebackend@docbook:'':hal}
 :ngc: {basebackend@docbook:'':ngc}
 
+(((HAL Introduction)))
 LinuxCNC is about interacting with hardware. But few users have the same exact hardware specifications - similar, but not the same.
 And even for the exact same hardware, there may be different ways to use it, say for different materials or with different mills, which would require adaptations to the control of an already running system.
 An abstraction was needed to make it easier to configure LinuxCNC for a wide variety of hardware devices.
@@ -20,8 +21,9 @@ This chapter introduces to that Hardware Abstraction Layer.
 You will see that many of the building blocks are indeed, drivers for hardware devices.
 However, HAL can do more than just configure hardware drivers.
 
-== HAL Overview(((HAL)))
+== HAL Overview
 
+(((HAL)))
 The Hardware Abstraction Layer (or with a reference to the link:https://en.wikipedia.org/wiki/2001:_A_Space_Odyssey_(film)[2001 Space Odyssey movie] just "HAL") is a software to
 
 * provide the infrastructure for the communication with and between the many software and hardware components of the system.
@@ -167,8 +169,9 @@ The remainder of this introduction presents
   - developing over time.
 
 [[sec:hal-system-design]]
-== HAL System Design(((HAL System Design)))
+== HAL System Design
 
+(((HAL System Design)))
 .HAL is based on traditional system design techniques.
 
 HAL is based on the same principles that are used to design hardware circuits and systems, so it is useful to examine those principles first.
@@ -188,8 +191,9 @@ net signal-red     component.0.pin3-out     component.1.pin3-in     component.1.
 ----
 
 [[sub:hal-part-selection]]
-=== Part Selection(((HAL Part selection)))
+=== Part Selection
 
+(((HAL Part selection)))
 The machine builder does not need to worry about how each individual part works.
 He treats them as black boxes. During the design stage,
 he decides which parts he is going to use - steppers or servos, which brand of servo amp, what kind of limit switches and how many, etc.
@@ -202,8 +206,9 @@ Usually every interface card will require a driver.
 Additional components may be needed for software generation of step pulses, PLC functionality, and a wide variety of other tasks.
 
 [[sub:hal-interconnections-design]]
-=== Interconnection Design(((HAL: Interconnections Design)))
+=== Interconnection Design
 
+(((HAL: Interconnections Design)))
 The designer of a hardware system not only selects the parts, he also decides how those parts will be interconnected.
 Each black box has terminals, perhaps only two for a simple switch, or dozens for a servo drive or PLC.  They need to be wired together.
 The motors connect to the servo amps, the limit switches connect to the controller, and so on.
@@ -213,8 +218,9 @@ When using HAL, components are interconnected by signals.
 The designer must decide which signals are needed, and what they should connect.
 
 [[sub:hal-implementation]]
-=== Implementation(((HAL: Implementation)))
+=== Implementation
 
+(((HAL: Implementation)))
 Once the wiring diagram is complete it is time to build the machine.
 The pieces need to be acquired and mounted, and then they are interconnected according to the wiring diagram.
 In a physical system, each interconnection is a piece of wire that needs to be cut and connected to the appropriate terminals.
@@ -224,8 +230,9 @@ Some of the tools allow you to 'connect' (or disconnect) a single 'wire'.
 Other tools allow you to save a complete list of all the parts, wires, and other information about the system, so that it can be 'rebuilt' with a single command.
 
 [[sub:hal-testing]]
-=== Testing(((HAL: Testing)))
+=== Testing
 
+(((HAL: Testing)))
 Very few machines work right the first time.
 While testing, the builder may use a meter to see whether a limit switch is working or to measure the DC voltage going to a servo motor.
 He may hook up an oscilloscope to check the tuning of a drive, or to look for electrical noise.
@@ -235,8 +242,9 @@ HAL provides the software equivalents of a voltmeter, oscilloscope, signal gener
 The same commands used to build the system can be used to make changes as needed.
 
 [[sub:hal-basics]]
-=== Summary(((HAL Basics Summary)))
+=== Summary
 
+(((HAL Basics Summary)))
 This document is aimed at people who already know how to do this kind of hardware system integration, but who do not know how to connect the hardware to LinuxCNC.
 See the <<sec:halui-remote-start,Remote Start Example>> section in the HAL UI Examples documentation.
 
@@ -262,8 +270,9 @@ This idea of extending the wiring diagram to the inside of the controller is wha
 If you are comfortable with the idea of interconnecting hardware black boxes, you will probably have little trouble using HAL to interconnect software black boxes.
 
 [[sec:hal-concepts]]
-== HAL Concepts(((HAL Concepts)))
+== HAL Concepts
 
+(((HAL Concepts)))
 This section is a glossary that defines key HAL terms but it is a bit different than a traditional glossary because these terms are not arranged in alphabetical order.
 They are arranged by their relationship or flow in the HAL way of things.
 
@@ -356,14 +365,16 @@ One to read the physical input pins and update the HAL pins, the other to take d
 Both of these functions are part of the parport driver.
 
 [[sec:hal-components]]
-== HAL components(((HAL Components)))
+== HAL components
 
+(((HAL Components)))
 Each HAL component is a piece of software with well-defined inputs, outputs, and behavior, that can be installed and interconnected as needed.
 The section <<sec:hal-components,HAL Components List>> lists all available components and a brief description of what each does.
 
 [[sec:hal-timing-issues]]
-== Timing Issues In HAL(((HAL Timing Issues)))
+== Timing Issues In HAL
 
+(((HAL Timing Issues)))
 Unlike the physical wiring models between black boxes that we have said that HAL is based upon,
 simply connecting two pins with a HAL-signal falls far short of the action of the physical case.
 

--- a/docs/src/hal/rtcomps.adoc
+++ b/docs/src/hal/rtcomps.adoc
@@ -10,8 +10,9 @@ This chapter provides details on core functionalities of LinuxCNC that demand ex
 * for the interpretation of signals sent by the hardware (like encoders).
 
 [[sec:stepgen]]
-== StepGen(((stepgen)))
+== StepGen
 
+(((stepgen)))
 This component provides software based generation of step pulses in response to position or velocity commands.
 In position mode, it has a built in pre-tuned position loop, so PID tuning is not required.
 In velocity mode, it drives a motor at the commanded speed, while obeying velocity and acceleration limits.
@@ -22,8 +23,9 @@ The second is for step type '1' (up/down, or pseudo-PWM), and the third is for s
 The first two diagrams show position mode control, and the third one shows velocity mode.
 Control mode and step type are set independently, and any combination can be selected.
 
+(((Stepgen Block Diagram)))
 [[fig:stepgen-block-diagram]]
-.Step Pulse Generator Block Diagram position mode(((Stepgen Block Diagram)))
+.Step Pulse Generator Block Diagram position mode
 image::images/stepgen-block-diag.png[align="center"]
 
 .Loading `stepgen` component
@@ -55,8 +57,9 @@ halcmd: unloadrt stepgen
 ----
 
 [[sub:stepgen-pins]]
-=== Pins(((HAL stepgen pins)))
+=== Pins
 
+(((HAL stepgen pins)))
 On the step type and control type selected.
 
 * (float) `stepgen.`__<chan>__`.position-cmd` - Desired motor position, in position units (position mode only).
@@ -75,8 +78,9 @@ On the step type and control type selected.
 * (bit) `stepgen.`__<chan>__`.phase-E` - Phase E output (step types 11-14 only).
 
 [[sec:stepgen-parameters]]
-=== Parameters(((HAL stepgen parameters)))
+=== Parameters
 
+(((HAL stepgen parameters)))
 * (float) `stepgen.`__<chan>__`.position-scale` - Steps per position unit. This parameter is used for both output and feedback.
 * (float) `stepgen.`__<chan>__`.maxvel` - Maximum velocity, in position units per second. If 0.0, has no effect.
 * (float) `stepgen.`__<chan>__`.maxaccel` - Maximum accel/decel rate, in positions units per second squared.
@@ -99,8 +103,9 @@ In velocity mode, maxvel is a simple limit that is applied to the commanded velo
 As in position mode, proper values for these parameters ensure that the motor can follow the generated pulse train.
 
 [[sub:stepgen-step-types]]
-=== Step Types(((HAL stepgen Step Types)))
+=== Step Types
 
+(((HAL stepgen Step Types)))
 Step generator supports 15 different _step sequences_:
 
 .Step Type 0
@@ -138,18 +143,22 @@ On each step, a state counter is incremented or decremented.
 The Two-and-Three-Phase, Four-Phase, and Five-Phase show the output patterns as a function of the state counter.
 The maximum frequency is 1,000,000,000 divided by _steplen_, and as in the other modes, _maxfreq_ will be lowered if it is above the limit.
 
-.Two-and-Three-Phase Step Types(((Two and Three Phase)))
+(((Two and Three Phase)))
+.Two-and-Three-Phase Step Types
 image::images/stepgen-type2-4.png["Step Types: Two-and-Three-Phase",align="center"]
 
-.Four-Phase Step Types(((Four Phase)))
+(((Four Phase)))
+.Four-Phase Step Types
 image::images/stepgen-type5-10.png["Step Types: Four-Phase",align="center"]
 
-.Five-Phase Step Types(((Five Phase)))
+(((Five Phase)))
+.Five-Phase Step Types
 image::images/stepgen-type11-14.png["Step Types: Five-Phase",align="center"]
 
 [[sub:stepgen-functions]]
-=== Functions(((Hal stepgen Functions)))
+=== Functions
 
+(((Hal stepgen Functions)))
 The component exports three functions.
 Each function acts on all of the step pulse generators - running different generators in different threads is not supported.
 
@@ -162,8 +171,9 @@ That thread's period determines the maximum step frequency, since 'steplen', 'st
 The other two functions can be called at a much lower rate.
 
 [[sec:pwmgen]]
-== PWMgen(((PWMgen)))
+== PWMgen
 
+(((PWMgen)))
 This component provides software based generation of PWM (Pulse Width Modulation) and PDM (Pulse Density Modulation) waveforms.
 It is a realtime component only, and depending on CPU speed, etc., is capable of PWM frequencies from a few hundred Hertz at pretty good resolution,
 to perhaps 10 kHz with limited resolution.
@@ -258,8 +268,9 @@ The component exports two functions. Each function acts on all of the PWM genera
   This is the function of the module that does the more complicated mathematics to work out how many base-periods the output should be high for, and how many it should be low for.
 
 [[sec:encoder]]
-== Encoder(((encoder)))
+== Encoder
 
+(((Encoder)))
 This component provides software based counting of signals from quadrature (or single-pulse) encoders.
 It is a realtime component only, and depending on CPU speed, latency, etc., is capable of maximum count rates of 10&#8239;kHz to perhaps up to 50&#8239;kHz.
 
@@ -270,8 +281,9 @@ The spindle speed of 3000&#8239;RPM = 50&#8239;RPS (revolutions per second). 400
 
 The Encoder Counter Block Diagram is a block diagram of one channel of an encoder counter.
 
+(((Encoder Block Diagram)))
 [[fig:encoder-block-diagram]]
-.Encoder Counter Block Diagram(((Encoder Block Diagram)))
+.Encoder Counter Block Diagram
 image::images/encoder-block-diag.png[align="center"]
 
 .Loading Encoder
@@ -353,15 +365,17 @@ Each function acts on all of the encoder counters - running different counters i
 * (funct) `encoder.capture-position` - Low speed function to update latches and scale position.
 
 [[sec:pid]]
-== PID(((PID)))
+== PID
 
+(((PID)))
 This component provides Proportional/Integral/Derivative control loops.
 It is a realtime component only. For simplicity, this discussion assumes that we are talking about position loops,
 however this component can be used to implement other feedback loops such as speed, torch height, temperature, etc.
 The PID Loop Block Diagram is a block diagram of a single PID loop.
 
+(((PID Block Diagram)))
 [[fig:pid-block-diag]]
-.PID Loop Block Diagram(((PID Block Diagram)))
+.PID Loop Block Diagram
 image::images/pid-block-diag.png[align="center"]
 
 .Loading PID
@@ -454,8 +468,9 @@ If you want to understand the exact algorithm used to compute the output of the 
 The loop calculations are in the C function 'calc_pid()'.
 
 [[sec:simulated-encoder]]
-== Simulated Encoder(((Simulated Encoder)))
+== Simulated Encoder
 
+(((Simulated Encoder)))
 The simulated encoder is exactly that.
 It produces quadrature pulses with an index pulse, at a speed controlled by a HAL pin.
 Mostly useful for testing.
@@ -502,8 +517,9 @@ The component exports two functions. Each function affects all simulated encoder
 * (funct) `sim-encoder.update-speed` - Low speed function to read `.speed`, do scaling, and set up `.make-pulses`.
 
 [[sec:debounce]]
-== Debounce(((debounce)))
+== Debounce
 
+(((debounce)))
 Debounce is a realtime component that can filter the glitches created by mechanical switch contacts.
 It may also be useful in other applications where short pulses are to be rejected.
 
@@ -562,8 +578,9 @@ Different groups of filters can be updated from different threads at different p
 * (funct) `debounce.`__<G>__ - Updates all filters in group _<G>_.
 
 [[sec:siggen]]
-== SigGen(((SigGen)))
+== SigGen
 
+(((SigGen)))
 SigGen is a realtime component that generates square, triangle, and sine waves. It is primarily used for testing.
 
 .Loading siggen
@@ -614,8 +631,9 @@ They were changed to pins to allow control by other components.]
 * (funct) `siggen.`__<chan>__`.update` - Calculates new values for all five outputs.
 
 [[sec:lut5]]
-== `lut5`(((lut5)))
+== `lut5`
 
+(((lut5)))
 The `lut5` component is a 5 input logic component based on a look up table.
 
 * `lut5` does not require a floating point thread.

--- a/docs/src/hal/tools.adoc
+++ b/docs/src/hal/tools.adoc
@@ -2,7 +2,7 @@
 :toc:
 
 [[cha:hal-tools]]
-= HAL Tools(((HAL Tools)))
+= HAL Tools
 
 // Custom lang highlight
 // must come after the doc title, to work around a bug in asciidoc 8.6.6
@@ -13,6 +13,7 @@
 [[sec:halcmd]]
 == Halcmd
 
+(((HAL Tools)))
 `halcmd` is a command line tool for manipulating the HAL.
 There is a rather complete man page for link:../man/man1/halcmd.1.html[`halcmd`], which will be installed if you have installed LinuxCNC from either source or a package.
 The manpage provides usage info:
@@ -34,8 +35,9 @@ The <<cha:hal-tutorial,HAL Tutorial>> has a number of examples of halcmd
 usage, and is a good tutorial for `halcmd`.
 
 [[sec:halmeter]]
-== Halmeter(((Halmeter)))
+== Halmeter
 
+(((Halmeter)))
 Halmeter is a 'voltmeter' for the HAL.
 It lets you look at a pin, signal, or parameter, and displays the current value of that item.
 It is pretty simple to use.

--- a/docs/src/hal/tutorial.adoc
+++ b/docs/src/hal/tutorial.adoc
@@ -2,10 +2,11 @@
 :toc:
 
 [[cha:hal-tutorial]]
-= HAL Tutorial(((HAL Tutorial)))
+= HAL Tutorial
 
 == Introduction
 
+(((HAL Tutorial)))
 Configuration moves from theory to device -- HAL device that is.
 For those who have had just a bit of computer programming,
 this section is the 'Hello World' of the HAL.
@@ -15,8 +16,9 @@ It is a command line or text file tool for configuration and tuning.
 The following examples illustrate its setup and operation.
 
 [[haltut-halcmd]]
-== Halcmd(((Halcmd Tutorial)))
+== Halcmd
 
+(((Halcmd Tutorial)))
 `halcmd` is a command line tool for manipulating HAL. A more complete man
 page exists for halcmd and installed together with LinuxCNC, from source
 or from a package. If LinuxCNC has been compiled as _run-in-place_, the
@@ -419,8 +421,9 @@ halrun -U
 ----
 
 [[sec:tutorial-halmeter]]
-== Halmeter(((Halmeter,Tutorial Halmeter)))
+== Halmeter
 
+(((Halmeter,Tutorial Halmeter)))
 You can build very complex HAL systems without ever using a graphical
 interface. However there is something satisfying about seeing the
 result of your work. The first and simplest GUI tool for the HAL is
@@ -522,8 +525,9 @@ time, you can just start more halmeters. The halmeter window was
 intentionally made very small so you could have a lot of them on the
 screen at once.
 
-== Stepgen Example(((stepgen Example)))
+== Stepgen Example
 
+(((stepgen Example)))
 Up till now we have only loaded one HAL component. But the whole idea
 behind the HAL is to allow you to load and connect a number of simple
 components to make up a complex system. The next example will use two
@@ -831,8 +835,9 @@ see how to bring those internal signals out to run motors in the real
 world, but first we want to look at them and see what is happening.
 
 [[sec:tutorial-halscope]]
-== Halscope(((Tutorial Halscope)))
+== Halscope
 
+(((Tutorial Halscope)))
 The previous example generates some very interesting signals. But much
 of what happens is far too fast to see with halmeter. To take a closer
 look at what is going on inside the HAL, we want an oscilloscope.

--- a/docs/src/install/latency-test.adoc
+++ b/docs/src/install/latency-test.adoc
@@ -2,8 +2,9 @@
 :toc:
 
 [[cha:latency-testing]]
-= Latency Testing(((Latency Testing)))
+= Latency Testing
 
+(((Latency Testing)))
 
 [[sec:what-is-latency]]
 == What is latency?
@@ -31,12 +32,10 @@ However, software step pulses also have some disadvantages:
 - jitter in the generated pulses
 - loads the CPU
 
-
-
-
 [[sec:latency-tests]]
-== Latency Tests(((Latency Tests)))
+== Latency Tests
 
+(((Latency Tests)))
 LinuxCNC includes several latency tests.  They all produce equivalent information.
 Running these tests will help determine if a computers is suitable for driving a CNC machine.
 
@@ -45,8 +44,9 @@ Do not run LinuxCNC or StepConf while the latency test is running.
 
 
 [[sec:latency-test]]
-=== Latency Test(((Latency Test)))
+=== Latency Test
 
+(((Latency Test)))
 To run the test, open a terminal window
 (in Ubuntu, from Applications → Accessories → Terminal)
 and run the following command:

--- a/docs/src/ladder/classic-ladder.adoc
+++ b/docs/src/ladder/classic-ladder.adoc
@@ -2,7 +2,7 @@
 :toc:
 
 [[cha:cl-programming]]
-= ClassicLadder Programming(((ClassicLadder Programming,CL Programming)))
+= ClassicLadder Programming
 
 // Custom lang highlight
 // must come after the doc title, to work around a bug in asciidoc 8.6.6
@@ -12,6 +12,7 @@
 
 == Ladder Concepts
 
+(((ClassicLadder Programming,CL Programming)))
 ClassicLadder is a type of programming language originally implemented on industrial PLCs (it's called Ladder Programming).
 It is based on the concept of relay contacts and coils, and can be used to construct logic checks and functions in a manner that is familiar to many systems integrators.
 Ladder consists of rungs that may have branches and resembles an electrical circuit.

--- a/docs/src/lathe/lathe-user.adoc
+++ b/docs/src/lathe/lathe-user.adoc
@@ -2,7 +2,7 @@
 :toc:
 
 [[cha:lathe-user-information]]
-= Lathe User Information(((Lathe User Information)))
+= Lathe User Information
 
 // Custom lang highlight
 // must come after the doc title, to work around a bug in asciidoc 8.6.6
@@ -10,6 +10,7 @@
 :hal: {basebackend@docbook:'':hal}
 :ngc: {basebackend@docbook:'':ngc}
 
+(((Lathe User Information)))
 This chapter will provide information specific to lathes.
 
 == Lathe Mode
@@ -44,8 +45,9 @@ RS274NGC_STARTUP_CODE = G18 G20 G90
 If your using GMOCCAPY then see the <<gmoccapy:lathe-section,the GMOCCAPY Lathe>> section.
 
 [[sec:lathe-tool-table]]
-== Lathe Tool Table(((Lathe Tool Table)))
+== Lathe Tool Table
 
+(((Lathe Tool Table)))
 The "Tool Table" is a text file that contains information about each tool.
 The file is located in the same directory as your configuration and is called "tool.tbl" by default.
 The tools might be in a tool changer or just changed manually.
@@ -59,8 +61,9 @@ Just ignore the parts of the tool table that don't pertain to your machine, or w
 For more information on the specifics of the tool table format, see the <<sec:tool-table,Tool Table>> Section.
 
 [[sec:lathe-tool-orientation]]
-== Lathe Tool Orientation(((Lathe Tool Orientation)))
+== Lathe Tool Orientation
 
+(((Lathe Tool Orientation)))
 The following figure shows the lathe tool orientations with the center line angle of each orientation and info on FRONTANGLE and BACKANGLE.
 
 The FRONTANGLE and BACKANGLE are clockwise starting at a line parallel to Z+.
@@ -70,15 +73,17 @@ image::images/tool-positions_en.svg["Lathe Tool Orientations",align="center"]
 
 In AXIS the following figures show what the Tool Positions look like, as entered in the tool table.
 
+(((Tool Positions 1, 2, 3 & 4)))
 [[fig:Outil-Positions-1-2-3-4]]
-.Tool Positions 1, 2, 3 & 4(((Tool Positions 1, 2, 3 & 4)))
+.Tool Positions 1, 2, 3 & 4
 image:images/tool-pos-1_en.svg["Tool Position 1"]
 image:images/tool-pos-2_en.svg["Tool Position 2"]
 image:images/tool-pos-3_en.svg["Tool Position 3"]
 image:images/tool-pos-4_en.svg["Tool Position 4"]
 
+(((Tool Positions 5, 6, 7 & 8)))
 [[fig:Outil-Positions-5-6-7-8]]
-.Tool Positions 5, 6, 7 & 8(((Tool Positions 5, 6, 7 & 8)))
+.Tool Positions 5, 6, 7 & 8
 image:images/tool-pos-5_en.svg["Tool Position 5"]
 image:images/tool-pos-6_en.svg["Tool Position 6"]
 image:images/tool-pos-7_en.svg["Tool Position 7"]

--- a/docs/src/motion/5-axis-kinematics.adoc
+++ b/docs/src/motion/5-axis-kinematics.adoc
@@ -6,7 +6,7 @@ use image:: for equation png files -- no latexmath
 ////////////////////////////////////////////////
 
 [[cha:5-axis-kinematics]]
-= 5-Axis Kinematics(((5-Axis Kinematics)))
+= 5-Axis Kinematics
 
 // Custom lang highlight
 // must come after the doc title, to work around a bug in asciidoc 8.6.6
@@ -16,6 +16,7 @@ use image:: for equation png files -- no latexmath
 
 == Introduction
 
+(((5-Axis Kinematics)))
 Coordinated multi-axis CNC machine tools controlled with LinuxCNC, require a special kinematics component for each type of machine. This chapter describes some of the most popular 5-axis machine configurations and then develops the forward (from work to joint coordinates) and inverse (from joint to work) transformations in a general mathematical process for two types of machine.
 
 The kinematics components are given as well as vismach simulation models to demonstrate their behaviour on a computer screen. Examples of HAL file data are also given.

--- a/docs/src/motion/dh-parameters.adoc
+++ b/docs/src/motion/dh-parameters.adoc
@@ -2,10 +2,11 @@
 :toc:
 
 [[cha:dh-parameters]]
-= Setting up "modified" Denavit-Hartenberg (DH) parameters for 'genserkins'(((DH parameters Examples)))
+= Setting up "modified" Denavit-Hartenberg (DH) parameters for 'genserkins'
 
 == Prelude
 
+(((DH parameters Examples)))
 LinuxCNC supports a number of kinematics modules including one that
 supports a generalized set of serial kinematics commonly specified via
 Denavit-Hartenberg parameters.

--- a/docs/src/motion/external-offsets.adoc
+++ b/docs/src/motion/external-offsets.adoc
@@ -2,7 +2,7 @@
 :toc:
 
 [[cha:external-offsets]]
-= External Axis Offsets(((externaloffsets)))
+= External Axis Offsets
 
 // Custom lang highlight
 // must come after the doc title, to work around a bug in asciidoc 8.6.6
@@ -10,6 +10,7 @@
 :hal: {basebackend@docbook:'':hal}
 :ngc: {basebackend@docbook:'':ngc}
 
+(((Offsets,external)))
 External axis offsets are supported during teleop (world) jogs
 and coordinated (G-code) motion.  External axis offsets are
 enabled on a per-axis basis by INI file settings and controlled

--- a/docs/src/motion/kinematics.adoc
+++ b/docs/src/motion/kinematics.adoc
@@ -2,10 +2,11 @@
 :toc:
 
 [[cha:kinematics]]
-= Kinematics(((kinematics)))
+= Kinematics
 
 == Introduction
 
+(((Kinematics)))
 When we talk about CNC machines, we usually think about machines that
 are commanded to move to certain locations and perform various tasks.
 In order to have an unified view of the machine space, and to make it
@@ -23,7 +24,7 @@ of commands (G0, G1, etc.) which have positions as parameters (X- Y-
 Z-). These positions refer exactly to Cartesian positions. Part of the
 LinuxCNC motion controller is responsible for translating those positions
 into positions which correspond to the machine
-(((kinematics)))kinematics footnote:[Kinematics: a two way function to
+kinematics footnote:[Kinematics: a two way function to
 transform from Cartesian space to joint space.].
 
 === Joints vs Axes

--- a/docs/src/motion/pid-theory.adoc
+++ b/docs/src/motion/pid-theory.adoc
@@ -2,7 +2,9 @@
 :toc:
 
 [[cha:pid-tuning]]
-= PID Tuning(((PID Tuning)))
+= PID Tuning
+
+(((PID Tuning)))
 
 == PID Controller
 

--- a/docs/src/plasma/plasma-cnc-primer.adoc
+++ b/docs/src/plasma/plasma-cnc-primer.adoc
@@ -2,7 +2,7 @@
 :toc:
 
 [[cha:plasma-primer]]
-= Plasma Cutting Primer for LinuxCNC Users(((Plasma Cutting Primer)))
+= Plasma Cutting Primer for LinuxCNC Users
 
 // Custom lang highlight
 // must come after the doc title, to work around a bug in asciidoc 8.6.6
@@ -12,6 +12,7 @@
 
 == What Is Plasma?
 
+(((Plasma Cutting Primer)))
 Plasma is a fourth state of matter, an ionised gas which has been heated to an extremely high temperature and ionised so that it becomes electrically conductive.
 The plasma arc cutting and gouging processes use this plasma to transfer an electrical arc to the workpiece.
 The metal to be cut or removed is melted by the heat of the arc and then blown away.

--- a/docs/src/user/starting-linuxcnc.adoc
+++ b/docs/src/user/starting-linuxcnc.adoc
@@ -2,7 +2,9 @@
 :toc:
 
 [[cha:starting-linuxcnc]]
-= Starting LinuxCNC(((Starting LinuxCNC)))
+= Starting LinuxCNC
+
+(((Starting LinuxCNC)))
 
 == Running LinuxCNC
 
@@ -59,8 +61,9 @@ connections to those pins. See the <<sub:ini:sec:hal,[HAL]>> section of the
 INI configuration for more information.
 
 [[sub:configuration-selector]]
-=== Configuration Selector(((Configuration Selection)))
+=== Configuration Selector
 
+(((Configuration Selection)))
 If no INI file is passed to the linuxcnc script it loads the configuration
 selector so you can choose and save a sample configuration. Once a sample
 configuration has been saved it can be modified to suit your application.

--- a/docs/src/user/user-concepts.adoc
+++ b/docs/src/user/user-concepts.adoc
@@ -2,7 +2,7 @@
 :toc:
 
 [[cha:important-user-concepts]]
-= Important User Concepts(((User Concepts)))
+= Important User Concepts
 
 // Custom lang highlight
 // must come after the doc title, to work around a bug in asciidoc 8.6.6
@@ -10,14 +10,18 @@
 :hal: {basebackend@docbook:'':hal}
 :ngc: {basebackend@docbook:'':ngc}
 
+(((User Concepts)))
 This chapter covers important user concepts that should be understood before attempting to run a CNC machine with G-code.
 
 [[sec:trajectory-control]]
-== Trajectory Control(((Trajectory Control)))
+== Trajectory Control
+
+(((Trajectory Control)))
 
 [[sub:trajectory-planning]]
-=== Trajectory Planning(((Trajectory Planning,TP)))
+=== Trajectory Planning
 
+(((Trajectory Planning,TP)))
 Trajectory planning, in general, is the means by which LinuxCNC follows the path specified by your G-code program, while still operating within the limits of your machinery.
 
 A G-code program can never be fully obeyed.
@@ -38,8 +42,9 @@ In the INI file the specified machine constraints, such as maximum axis velocity
 For more information on the Trajectory Planner INI options see the <<sub:ini:sec:traj,Trajectory Section>> in the INI chapter.
 
 [[sub:path-following]]
-=== Path Following(((Trajectory Planning:Path Following)))
+=== Path Following
 
+(((Trajectory Planning:Path Following)))
 A less straightforward problem is that of path following.
 When you program a corner in G-code, the trajectory planner can do several things,
 all of which are right in some cases:
@@ -55,8 +60,9 @@ Rapid moves also obey the current trajectory control.
 With moves long enough to reach maximum velocity on a machine with low acceleration and no path tolerance specified, you can get a fairly round corner.
 
 [[sub:programming-the-planner]]
-=== Programming the Planner(((Trajectory Planning:Programming the Planner)))
+=== Programming the Planner
 
+(((Trajectory Planning:Programming the Planner)))
 The trajectory control commands are as follows:
 
 `G61`:: (Exact Path Mode) `G61` visits the programmed point exactly,
@@ -114,8 +120,9 @@ The bottom plot shows the effect of the Naive Cam Detector to combine the moves 
 image::images/naive-cam.png["Naive CAM Detector",align="center"]
 
 [[sub:planning-moves]]
-=== Planning Moves(((Trajectory Planning:Planning Moves)))
+=== Planning Moves
 
+(((Trajectory Planning:Planning Moves)))
 Make sure moves are 'long enough' to suit your machine/material.
 Principally because of the rule that the machine will never move at such a speed that it cannot come to a complete stop at the end of the current movement,
 there is a minimum movement length that will allow the machine to keep up a requested feed rate with a given acceleration setting.
@@ -150,10 +157,11 @@ For a feed rate of 0.5 inch per second, the critical distance is latexmath:[$ \f
 ////
 
 [[sec:g-code]]
-== G-code(((G-code)))
+== G-code
 
 === Defaults
 
+(((G-code)))
 When LinuxCNC first starts up many G- and M-codes are loaded by default.
 The current active G- and M-codes can be viewed on the MDI tab in the 'Active G-codes:' window in the AXIS interface.
 These G- and M-codes define the behavior of LinuxCNC and

--- a/docs/src/user/user-foreword.adoc
+++ b/docs/src/user/user-foreword.adoc
@@ -2,8 +2,9 @@
 :toc:
 
 [[cha:user-foreword]]
-= User Foreword(((User Foreword)))
+= User Foreword
 
+(((User Foreword)))
 LinuxCNC is modular and flexible.
 These attributes lead many to see it as a confusing jumble of little things and wonder why it is the way it is.
 This page attempts to answer that question before you get into the thick of things.

--- a/docs/src/user/user-intro.adoc
+++ b/docs/src/user/user-intro.adoc
@@ -2,10 +2,11 @@
 :toc:
 
 [[cha:linuxcnc-user-introduction]]
-= LinuxCNC User Introduction(((LinuxCNC User Introduction,User Introduction)))
+= LinuxCNC User Introduction
 
 == Introduction
 
+(((LinuxCNC User Introduction,User Introduction)))
 This document is focused on the use of LinuxCNC, it is intended for readers who have already installed and configured it.
 Some information on installation is given in the following chapters.
 The complete documentation on installation and configuration can be found in the integrator's manual.
@@ -89,8 +90,9 @@ the folders created by the wizard would typically contain the following files:
   It also includes a number of subfolders with G-code examples.
 
 [[sec:graphical-user-interfaces]]
-== Graphical User Interfaces(((Graphical User Interfaces)))
+== Graphical User Interfaces
 
+(((Graphical User Interfaces)))
 A graphical user interface is the part of the LinuxCNC that the machine tool operator interacts with.
 LinuxCNC comes with several types of user interfaces
 which may be chosen from by editing certain fields contained in the <<cha:ini-configuration,INI file>>:


### PR DESCRIPTION
po4a has difficulties separating the header from the index when there is a ")" in the index and I see warnings in the asciidoc parsing that I accredit to the positioning of these index entries in the header.
Substituted some 2.9.4 occurrences with 2.9.7.