### PR TITLE
Add runtime dependency x11-xserver-utils providing xset (smoe:add-runtime-dependency-for-xset)

### DIFF
--- a/debian/control.main-pkg.in
+++ b/debian/control.main-pkg.in
@@ -34,10 +34,12 @@ Depends:
 Recommends:
     linuxcnc-doc-en | linuxcnc-doc,
     librsvg2-dev,
+    x11-xserver-utils,
     @EXTRA_RECOMMENDS@,
     @PYTHON_IMAGING@,
     @PYTHON_IMAGING_TK@
-Suggests: mesaflash,
+Suggests:
+    mesaflash,
     onboard
 Description: motion controller for CNC machines and robots
  LinuxCNC is a fully-realised CNC machine controller that can interpret

--- a/debian/control.top.in
+++ b/debian/control.top.in
@@ -63,13 +63,14 @@ Rules-Requires-Root: binary-targets
 Package: @MAIN_PACKAGE_NAME@-dev
 Architecture: any
 Conflicts: linuxcnc-sim-dev, @OTHER_MAIN_PACKAGE_NAME@-dev
-Depends: ${misc:Depends},
-         ${python3:Depends},
-         @KERNEL_HEADERS@,
-         python3-serial,
-         @MAIN_PACKAGE_NAME@ (= ${binary:Version}),
-         udev,
-         @YAPPS_RUNTIME@
+Depends:
+    ${misc:Depends},
+    ${python3:Depends},
+    @KERNEL_HEADERS@,
+    python3-serial,
+    @MAIN_PACKAGE_NAME@ (= ${binary:Version}),
+    udev,
+    @YAPPS_RUNTIME@
 Section: devel
 Description: PC based motion controller for real-time Linux
  LinuxCNC is a fully-realised CNC machine controller that can interpret


### PR DESCRIPTION
I yet fail to understand where exactly xset is invoked but have no difficulty to accept that one wants the tools shipping with  x11-xserver-utils:

```
/usr/bin/iceauth
/usr/bin/sessreg
/usr/bin/showrgb
/usr/bin/xcmsdb
/usr/bin/xgamma
/usr/bin/xhost
/usr/bin/xkeystone
/usr/bin/xmodmap
/usr/bin/xrandr
/usr/bin/xrdb
/usr/bin/xrefresh
/usr/bin/xset
/usr/bin/xsetmode
/usr/bin/xsetpointer
/usr/bin/xsetroot
/usr/bin/xstdcmap
/usr/bin/xvidtune
```
Addresses https://github.com/LinuxCNC/linuxcnc/issues/3391.

Took the freedom to also harmonize the number of blanks at the start of the lines in d/control files.