### PR TITLE
d/control: Added build-dep x11-xserver-utils <!nocheck>

### DIFF
--- a/debian/control.top.in
+++ b/debian/control.top.in
@@ -50,6 +50,7 @@ Build-Depends:
     tcl@TCLTK_VERSION@-dev,
     tclx,
     tk@TCLTK_VERSION@-dev,
+    x11-xserver-utils <!nocheck>,
     xvfb,
     yapps2
 Build-Depends-Indep:


### PR DESCRIPTION
In continuation of https://github.com/LinuxCNC/linuxcnc/pull/3687, the extra dependency is also added as a build-dependency - with the "<!nocheck>" tag. Formally with respect to Debian's principles this is not fully correct as even when performing our tests, that package is not required. But for a manual execution it would be - so let's add it and at some point also add a test to our CI that would need it as apparently those tests are incomplete.