### PR TITLE
hostmot2 - board_name: Explicitly indicate __atribute__(nonstring)

### DIFF
--- a/src/hal/drivers/mesa-hostmot2/hostmot2.h
+++ b/src/hal/drivers/mesa-hostmot2/hostmot2.h
@@ -145,7 +145,7 @@ typedef struct {
     rtapi_u32 idrom_type;
     rtapi_u32 offset_to_modules;
     rtapi_u32 offset_to_pin_desc;
-    rtapi_u8 board_name[8];  // ascii string, but not NULL terminated!
+    rtapi_u8 board_name[8] __attribute__ ((nonstring));  // ASCII string, but not NULL terminated!
     rtapi_u32 fpga_size;
     rtapi_u32 fpga_pins;
     rtapi_u32 io_ports;

--- a/src/hal/drivers/mesa-hostmot2/llio_info.c
+++ b/src/hal/drivers/mesa-hostmot2/llio_info.c
@@ -26,7 +26,7 @@
 #include "llio_info.h"
 
 typedef struct __info_entry_t {
-	char board_name[8];
+	char board_name[8] __attribute__ ((nonstring));
 	const char *base_name;
 	int num_ioport_connectors;
 	int pins_per_connector;


### PR DESCRIPTION
Addressing https://github.com/LinuxCNC/linuxcnc/issues/3698.