### PR TITLE
configure: Add Python 3.14 and remove unsupported older than 3.8

### DIFF
--- a/src/m4/ax_python.m4
+++ b/src/m4/ax_python.m4
@@ -55,7 +55,7 @@
 AC_DEFUN([AX_PYTHON],
 [AC_MSG_CHECKING(for python build information)
 AC_MSG_RESULT([])
-for python in python3.13 python3.12 python3.11 python3.10 python3.9 python3.8 python3.7 python3.6 python3.5 python3.4 python3.3 python3.2 python3.1 python3.0 python2.7 python2.6 python2.5 python2.4 python2.3 python2.2 python2.1 python; do
+for python in python3.14 python3.13 python3.12 python3.11 python3.10 python3.9 python3.8 python; do
 AC_CHECK_PROGS(PYTHON_BIN, [$python])
 ax_python_bin=$PYTHON_BIN
 if test x$ax_python_bin != x; then


### PR DESCRIPTION
Drop Python tests for unsupported versions 2 and anything older than 3.8. Add python 3.14 to the list of tests.