### PR TITLE
Fix warnings detected by clang

### DIFF
--- a/src/emc/kinematics/switchkins.c
+++ b/src/emc/kinematics/switchkins.c
@@ -100,7 +100,7 @@ static int gui_forward_kins(const double *joints)
     // genhexkins and identity kinematic types
     // (similar needs for many parallel kinemtic machines)
     int res;
-    KINEMATICS_FORWARD_FLAGS  fflags;
+    KINEMATICS_FORWARD_FLAGS  fflags = 0;
     KINEMATICS_INVERSE_FLAGS  iflags;
     switch (kp.gui_kinstype) {
         case 0: res = kfwd0(joints, &lastpose[0], &fflags, &iflags);break;

--- a/src/emc/tp/sp_scurve.c
+++ b/src/emc/tp/sp_scurve.c
@@ -53,14 +53,14 @@ num initial calculation value
 */
 double solute( double a, double b, double c, double d, double num){
   double x ,x0 ,f ,f1;
-  int cnt = 0;
+  //int cnt = 0;
   x = num;
   do{
     x0 = x;
     f = (( a*x0 + b )*x0 + c )*x0 + d;
     f1 = ( 3*a*x0 + 2*b )*x0 + c;
     x = x0 - f / f1;
-    cnt++;
+    //cnt++;
   } while ( fabs( x - x0 ) > 1e-6 );
 
   //printf( "the value is %.14f \r\n", x );

--- a/src/hal/drivers/mesa-hostmot2/hm2_modbus.c
+++ b/src/hal/drivers/mesa-hostmot2/hm2_modbus.c
@@ -108,7 +108,7 @@ static const char *error_codes[] = {
 #define MBT_X_MASK		0x0f
 #define MBT_T_MASK		0xf0
 
-static inline bool mtypeiscompound(unsigned mtype) { return mtype >= MBT_ABCD && mtype <= MBT_HGFEDCBA; }
+// static inline bool mtypeiscompound(unsigned mtype) { return mtype >= MBT_ABCD && mtype <= MBT_HGFEDCBA; }
 static inline unsigned mtypeformat(unsigned mtype) { return mtype & MBT_X_MASK; }
 static inline unsigned mtypetype(unsigned mtype)   { return mtype & MBT_T_MASK; }
 static inline bool mtypeisvalid(unsigned mtype) {
@@ -818,8 +818,9 @@ static void process(void *arg, long period)
 		// Are we handling init commands?
 		if(handling_inits(inst)) {
 			// Yes, prepare and send
+			hm2_modbus_cmd_t *cc;
 retry_next_init:
-			hm2_modbus_cmd_t *cc = current_cmd(inst);
+			cc = current_cmd(inst);
 			if(0 == cc->cmd.func) {
 				// Special meta command
 				if(0 == cc->cmd.imetacmd) {			// This is a delay command
@@ -2162,8 +2163,9 @@ static ssize_t read_mbccb(const hm2_modbus_inst_t *inst, const char *fname, hm2_
 	}
 
 	// Read the entire file
+	ssize_t err;
 retry_read:
-	ssize_t err = read(fd, *pmbccb, sb.st_size);
+	err = read(fd, *pmbccb, sb.st_size);
 	if(err < 0) {
 		ssize_t rv = -errno;
 		if(errno == EINTR)


### PR DESCRIPTION
This PR fixes a few warnings detected by clang 21. Nothing big, just details.