### PR TITLE
Do not use xset when AXIS_NO_XSET is set

### DIFF
--- a/docs/src/gui/axis.adoc
+++ b/docs/src/gui/axis.adoc
@@ -611,6 +611,12 @@ full list of keyboard shortcuts can be found in the AXIS Quick
 Reference, which can be displayed by choosing Help > Quick Reference.
 Many of the shortcuts are unavailable when in MDI mode.
 
+The keyboard key repeat function is normally forcefully disabled in
+AXIS when LinuxCNC is started and forcefully re-enabled when you exit
+LinuxCNC. You can change this behavior by setting the environment
+variable 'AXIS_NO_XSET' to any value, causing AXIS to refrain from
+touching the key repeat settings.
+
 === Feed Override Keys
 
 [NOTE]

--- a/src/emc/usr_intf/axis/scripts/axis.py
+++ b/src/emc/usr_intf/axis/scripts/axis.py
@@ -120,7 +120,8 @@ inifile = linuxcnc.ini(sys.argv[2])
 ap = AxisPreferences()
 
 os.system("xhost -SI:localuser:gdm -SI:localuser:root > /dev/null 2>&1")
-os.system("xset r off")
+if None == os.getenv('AXIS_NO_XSET'):
+    os.system("xset r off")
 root_window = Tkinter.Tk(className="Axis")
 dpi_value = root_window.winfo_fpixels('1i')
 root_window.tk.call('tk', 'scaling', '-displayof', '.', dpi_value / 72.0)
@@ -154,7 +155,8 @@ except TclError:
 def General_Halt():
     text = _("Do you really want to close LinuxCNC?")
     if not root_window.tk.call("nf_dialog", ".error", _("Confirm Close"), text, "warning", 1, _("Yes"), _("No")):
-        os.system("xset r on")
+        if None == os.getenv('AXIS_NO_XSET'):
+            os.system("xset r on")
         root_window.destroy()
 
 root_window.protocol("WM_DELETE_WINDOW", General_Halt)


### PR DESCRIPTION
Having axis using `xset` to kill the key repeat wreaks havoc on the workflow when axis crashes or otherwise does not finish through the key repeat enable path.

This PR adds a simple environment variable `AXIS_NO_XSET` to disable messing with the key repeat. The default behaviour is not changed.