### PR TITLE
Update Tcl code to work with both Tcl8 and Tcl9.

### DIFF
--- a/share/axis/tcl/axis.tcl
+++ b/share/axis/tcl/axis.tcl
@@ -1963,26 +1963,26 @@ set metric 0
 set max_speed 1
 set queued_mdi_commands 0
 set max_queued_mdi_commands 10
-trace variable taskfile w update_title
-trace variable machine w update_title
-trace variable taskfile w queue_update_state
-trace variable task_state w queue_update_state
-trace variable task_mode w queue_update_state
-trace variable task_paused w queue_update_state
-trace variable optional_stop w queue_update_state
-trace variable block_delete w queue_update_state
-trace variable interp_pause w queue_update_state
-trace variable interp_state w queue_update_state
-trace variable running_line w queue_update_state
-trace variable highlight_line w queue_update_state
-trace variable spindledir w queue_update_state
-trace variable coord_type w queue_update_state
-trace variable display_type w queue_update_state
-trace variable motion_mode w queue_update_state
-trace variable kinematics_type w queue_update_state
-trace variable on_any_limit w queue_update_state
-trace variable motion_mode w joint_mode_switch
-trace variable queued_mdi_commands  w queue_update_state
+trace add variable taskfile write update_title
+trace add variable machine write update_title
+trace add variable taskfile write queue_update_state
+trace add variable task_state write queue_update_state
+trace add variable task_mode write queue_update_state
+trace add variable task_paused write queue_update_state
+trace add variable optional_stop write queue_update_state
+trace add variable block_delete write queue_update_state
+trace add variable interp_pause write queue_update_state
+trace add variable interp_state write queue_update_state
+trace add variable running_line write queue_update_state
+trace add variable highlight_line write queue_update_state
+trace add variable spindledir write queue_update_state
+trace add variable coord_type write queue_update_state
+trace add variable display_type write queue_update_state
+trace add variable motion_mode write queue_update_state
+trace add variable kinematics_type write queue_update_state
+trace add variable on_any_limit write queue_update_state
+trace add variable motion_mode write joint_mode_switch
+trace add variable queued_mdi_commands write queue_update_state
 
 set editor_deleted 0
 

--- a/share/axis/tcl/combobox.tcl
+++ b/share/axis/tcl/combobox.tcl
@@ -27,7 +27,7 @@
 #
 # ... and many others over the years.
 
-package require Tk 8.0
+package require Tk
 package provide combobox 2.2
 
 namespace eval ::combobox {

--- a/tcl/bin/pickconfig.tcl
+++ b/tcl/bin/pickconfig.tcl
@@ -100,7 +100,7 @@ proc initialize_config {} {
         exit
         destroy .
     } else {
-        if {[catch {open ~/.linuxcncrc} programin]} {
+        if {[catch {open $::env(HOME)/.linuxcncrc} programin]} {
             return 
         } else {
             set rcstring [read $programin]
@@ -660,7 +660,7 @@ proc prompt_copy configname {
     set ncfiles [file normalize [file join $::myconfigs_node ../nc_files]]
     file mkdir [file join $::myconfigs_node]
 
-    set obsoletedir [file normalize [file join ~ emc2]]
+    set obsoletedir [file normalize [file join $::env(HOME) emc2]]
     if [file isdir $obsoletedir] {
       tk_messageBox -title "Copy Configuration Notice" \
         -message "A directory named:\n \
@@ -891,11 +891,11 @@ while {1} {
         # test for ~/.linuxcncrc file and modify if needed.
         # or make this file and add the var.
 
-        if {[file exists ~/.linuxcncrc]} {
+        if {[file exists $::env(HOME)/.linuxcncrc]} {
             if {$::inifile == $::last_ini} {
                 exit
             } else {
-                if {[catch {open ~/.linuxcncrc} programin]} {
+                if {[catch {open $::env(HOME)/.linuxcncrc} programin]} {
                     return 
                 } else {
                     set rcstring [read $programin]
@@ -903,8 +903,8 @@ while {1} {
                 }
                 set ret [setVal $rcstring PICKCONFIG LAST_CONFIG $::inifile ]
                 catch {file copy -force $name $name.bak}
-                if {[catch {open ~/.linuxcncrc w} fileout]} {
-                    puts stdout [msgcat::mc "can't save %s" ~/.linuxcncrc ]
+                if {[catch {open $::env(HOME)/.linuxcncrc w} fileout]} {
+                    puts stdout [msgcat::mc "can't save %s" $::env(HOME)/.linuxcncrc ]
                     exit
                 }
                 puts $fileout $ret
@@ -914,8 +914,8 @@ while {1} {
         }
         set newfilestring "# .linuxcncrc is a startup configuration file for LinuxCNC. \n# format is INI like. \n# \[SECTION_NAME\] \n# VARNAME = varvalue \n# where section name is the name of the system writing to this file \n\n# written by pickconfig.tcl \n\[PICKCONFIG\]\nLAST_CONFIG = $::inifile\n"
                 
-        if {[catch {open ~/.linuxcncrc w+} fileout]} {
-            puts stderr [msgcat::mc "can't save %s" ~/.linuxcncrc ]
+        if {[catch {open $::env(HOME)/.linuxcncrc w+} fileout]} {
+            puts stderr [msgcat::mc "can't save %s" $::env(HOME)/.linuxcncrc ]
             exit
         }
 

--- a/tcl/linuxcnc.tcl.in
+++ b/tcl/linuxcnc.tcl.in
@@ -32,6 +32,7 @@ namespace eval linuxcnc {
     variable REALTIME @REALTIME@
     variable RTS @RTS@
     variable CONFIG_DIR {}
+    variable _dir
     foreach _dir  [split {@LINUXCNC_CONFIG_PATH@} :] {
 	lappend CONFIG_DIR [file normalize $_dir]
     }
@@ -47,7 +48,7 @@ if {[string first $::linuxcnc::BIN_DIR: $env(PATH)] != 0} {
 }
 
 proc linuxcnc::image_search i {
-    set paths "$linuxcnc::IMAGEDIR $linuxcnc::HOME $linuxcnc::HOME/etc/linuxcnc /etc/linuxcnc ."
+    set paths "$::linuxcnc::IMAGEDIR $::linuxcnc::HOME $::linuxcnc::HOME/etc/linuxcnc /etc/linuxcnc ."
     foreach f $paths {
         if [file exists $f/$i] {
             return [image create photo -file $f/$i]

--- a/tcl/tooledit.tcl
+++ b/tcl/tooledit.tcl
@@ -62,9 +62,9 @@ if {"" == [info command "_"]} {
 
 
 proc ::tooledit::init { {columns ""} } {
-  if [file readable ~/.tooleditrc] {
-    if [catch {source ~/.tooleditrc} msg] {
-      puts stderr "[_ "Problem reading ~/.tooleditrc"]:\n$msg"
+  if [file readable $::env(HOME)/.tooleditrc] {
+    if [catch {source $::env(HOME)/.tooleditrc} msg] {
+      puts stderr "[_ "Problem reading $::env(HOME)/.tooleditrc"]:\n$msg"
     }
     if [info exists geometry] {
       set ::te(top,restore,geometry) $geometry
@@ -961,7 +961,7 @@ proc ::tooledit::bye {} {
 
   catch {after cancel $::te(afterid)}
 
-  if ![file exists ~/.tooleditrc] {
+  if ![file exists $::env(HOME)/.tooleditrc] {
     # first time use presumed, instruct for configuring columns
     set used ""
     foreach item $::te(items) {
@@ -1001,7 +1001,7 @@ proc ::tooledit::bye {} {
   }
 
   if [winfo exists $::te(top)] {
-    set fd [open ~/.tooleditrc w]
+    set fd [open $::env(HOME)/.tooleditrc w]
     set time [clock format [clock seconds] -format %Y%m%d.%H.%M.%S]
     puts $fd   "# $time [format [_ "Created by %s"] [file normalize $::argv0]]"
     puts $fd "\n# [_ "Saved geometry (updated on program termination)"]:"


### PR DESCRIPTION
This PR fixes small incompatibilities between Tcl8 and Tcl9 without changing any code behaviour. Changes cover:
* Tilde (`~`) expansion is no longer automatic in Tcl9. All instances are now expanded using the HOME environment variable using `$::env(HOME)`.
* Variable tracing with `trace` has had a new syntax already since Tcl 8.4. All supported Debians are on 8.6 or later. The `trace variable ...` syntax is updated to use `trace add variable ...`.
* Namespace resolution changed between Tcl8 and Tcl9 and few instances were updated to use explicit namespace resolution (`$linuxcnc::...` became `$::linuxcnc::...`).
* Explicit package versioning for Tk is not relevant, which will always follow Tcl version on distributions. Removed explicit binding to Tk 8.0+ only (preventing 9.0+ to be accepted).