### PR TITLE
Emc race and cppcheck warnings

### DIFF
--- a/src/emc/usr_intf/emcrsh.cc
+++ b/src/emc/usr_intf/emcrsh.cc
@@ -528,7 +528,7 @@ static int initSocket()
   server_address.sin_addr.s_addr = htonl(INADDR_ANY);
   server_address.sin_port = htons(port);
   server_len = sizeof(server_address);
-  err = bind(server_sockfd, (struct sockaddr *)&server_address, server_len);
+  err = bind(server_sockfd, reinterpret_cast<struct sockaddr*>(&server_address), server_len);
   if (err) {
       rcs_print_error("error initializing sockets: %s\n", strerror(errno));
       return err;

--- a/src/emc/usr_intf/schedrmt.cc
+++ b/src/emc/usr_intf/schedrmt.cc
@@ -328,7 +328,7 @@ static int initSockets()
   server_address.sin_addr.s_addr = htonl(INADDR_ANY);
   server_address.sin_port = htons(port);
   server_len = sizeof(server_address);
-  bind(server_sockfd, (struct sockaddr *)&server_address, server_len);
+  bind(server_sockfd, reinterpret_cast<struct sockaddr*>(&server_address), server_len);
   listen(server_sockfd, 5);
   signal(SIGCHLD, SIG_IGN);
   return 0;
@@ -1210,7 +1210,7 @@ void sockMain()
         int res = -1;
         struct sockaddr_in client_address;
         socklen_t client_len = sizeof(client_address);
-        int client_sockfd = accept(server_sockfd, (struct sockaddr *)&client_address, &client_len);
+        int client_sockfd = accept(server_sockfd, reinterpret_cast<struct sockaddr*>(&client_address), &client_len);
         if (client_sockfd < 0) {
             perror("sockMain: accept failed\n");
             exit(EXIT_FAILURE);


### PR DESCRIPTION
Took the patch proposed by @BsAtHome for https://github.com/LinuxCNC/linuxcnc/issues/3700 and prepared this PR for it. It looks fine to me but I also did not test it. Any takers?

The most important bits are
 * elimination of dynamic memory allocation
 * the declaration of the sessions variable as atomic. It is decreased when the client can no longer be read (within a thread), and increased in sockMain when a new thread is started (outside a thread) and also when the return value of the thread is != 0 (outside a thread).

There are some meta talking points:
 * There is no pthread_join or pthread_detach anywhere.
 * Is the exit(0) upon an acceptance failure (the immediate stop of the controller with no explanation whatsoever) what we truly want? 
