### PR TITLE
Fix Bug in Limit Axis Hal Component

### DIFF
--- a/src/hal/components/limit_axis.comp
+++ b/src/hal/components/limit_axis.comp
@@ -65,11 +65,11 @@ FUNCTION(_){
 
   // Check all ranges
   for (i = 0; i < personality; i++){
-    if (max_range(i) < min_range(i)){
-      if(! enable(i)){
-        continue;
-      }
+    if(! enable(i)){
+      continue;
+    }
 
+    if (max_range(i) < min_range(i)){
       // Throw Error and skip this range
       if (! error_range(i) ){
         rtapi_print_msg(RTAPI_MSG_ERR,


### PR DESCRIPTION
Backport bugfix from master that prevents the enable pins on the axis ranges from being enabled/disabled. This results in the hal component defaulting to potentially disabled axis ranges and only checking the ranges rather than the enable statuses.

Replaced #3736 as my source branch was based off the wrong branch. 