### PR TITLE
Fix tool mark disappearing with small tool diameter in g-code preview widget

### DIFF
--- a/configs/sim/axis/axis.ini
+++ b/configs/sim/axis/axis.ini
@@ -51,6 +51,9 @@ INTRO_TIME = 5
 #EDITOR = geany
 TOOL_EDITOR = tooledit
 
+#Prevent tool mark disappearing with small tool diameter in g-code preview widget
+GCODE_VIEW_TOOL_MIN_DIA = 0
+
 INCREMENTS = 1 in, 0.1 in, 10 mil, 1 mil, 1mm, .1mm, 1/8000 in
 
 [FILTER]

--- a/configs/sim/axis/axis.ini
+++ b/configs/sim/axis/axis.ini
@@ -52,7 +52,7 @@ INTRO_TIME = 5
 TOOL_EDITOR = tooledit
 
 #Prevent tool mark disappearing with small tool diameter in g-code preview widget
-GCODE_VIEW_TOOL_MIN_DIA = 0
+GCODE_VIEW_TOOL_MIN_DIA = 0.08
 
 INCREMENTS = 1 in, 0.1 in, 10 mil, 1 mil, 1mm, .1mm, 1/8000 in
 

--- a/configs/sim/axis/axis_mm.ini
+++ b/configs/sim/axis/axis_mm.ini
@@ -45,6 +45,9 @@ INTRO_TIME = 5
 
 #EDITOR = geany
 
+#Prevent tool mark disappearing with small tool diameter in g-code preview widget
+GCODE_VIEW_TOOL_MIN_DIA = 0.08
+
 INCREMENTS = 1 mm, .01 in, .1mm, 1 mil, .1 mil, 1/8000 in
 [FILTER]
 PROGRAM_EXTENSION = .png,.gif,.jpg Grayscale Depth Image

--- a/configs/sim/axis/axis_mm.ini
+++ b/configs/sim/axis/axis_mm.ini
@@ -46,7 +46,7 @@ INTRO_TIME = 5
 #EDITOR = geany
 
 #Prevent tool mark disappearing with small tool diameter in g-code preview widget
-GCODE_VIEW_TOOL_MIN_DIA = 0.08
+GCODE_VIEW_TOOL_MIN_DIA = 2.0
 
 INCREMENTS = 1 mm, .01 in, .1mm, 1 mil, .1 mil, 1/8000 in
 [FILTER]

--- a/configs/sim/gmoccapy/gmoccapy.ini
+++ b/configs/sim/gmoccapy/gmoccapy.ini
@@ -45,6 +45,9 @@ PROGRAM_PREFIX = ../../nc_files/
 INTRO_GRAPHIC = linuxcnc.gif
 INTRO_TIME = 5
 
+#Prevent tool mark disappearing with small tool diameter in g-code preview widget
+GCODE_VIEW_TOOL_MIN_DIA = 2.0
+
 # list of selectable jog increments
 INCREMENTS = 1.000 mm, 0.100 mm, 0.010 mm, 0.001 mm, 1.2345 inch
 

--- a/configs/sim/qtdragon_hd/qtdragon_hd_xyz/qtdragon_hd_vertical.ini
+++ b/configs/sim/qtdragon_hd/qtdragon_hd_xyz/qtdragon_hd_vertical.ini
@@ -40,6 +40,9 @@ MIN_LINEAR_VELOCITY     = 0
 MAX_LINEAR_VELOCITY     = 60.00
 DEFAULT_LINEAR_VELOCITY = 50.0
 
+#Prevent tool mark disappearing with small tool diameter in g-code preview widget
+GCODE_VIEW_TOOL_MIN_DIA = 2.0
+
 # incremental jog step length options
 INCREMENTS = 10 mm, 1.0 mm, 0.10 mm, 0.01 mm, 1.0 inch, 0.1 inch, 0.01 inch
 

--- a/configs/sim/qtdragon_hd/qtdragon_hd_xyz/qtdragon_hd_vertical_xyza.ini
+++ b/configs/sim/qtdragon_hd/qtdragon_hd_xyz/qtdragon_hd_vertical_xyza.ini
@@ -44,6 +44,9 @@ DEFAULT_ANGULAR_VELOCITY = 10
 MIN_ANGULAR_VELOCITY = 1
 MAX_ANGULAR_VELOCITY = 360
 
+#Prevent tool mark disappearing with small tool diameter in g-code preview widget
+GCODE_VIEW_TOOL_MIN_DIA = 2.0
+
 # incremental jog step length options
 INCREMENTS = 10 mm, 1.0 mm, 0.10 mm, 0.01 mm, 1.0 inch, 0.1 inch, 0.01 inch
 

--- a/configs/sim/qtdragon_hd/qtdragon_hd_xyz/qtdragon_hd_xyz.ini
+++ b/configs/sim/qtdragon_hd/qtdragon_hd_xyz/qtdragon_hd_xyz.ini
@@ -40,6 +40,9 @@ MIN_LINEAR_VELOCITY     = 0
 MAX_LINEAR_VELOCITY     = 60.00
 DEFAULT_LINEAR_VELOCITY = 50.0
 
+#Prevent tool mark disappearing with small tool diameter in g-code preview widget
+GCODE_VIEW_TOOL_MIN_DIA = 2.0
+
 # incremental jog step length options
 INCREMENTS = 10 mm, 1.0 mm, 0.10 mm, 0.01 mm, 1.0 inch, 0.1 inch, 0.01 inch
 

--- a/lib/python/rs274/glcanon.py
+++ b/lib/python/rs274/glcanon.py
@@ -518,6 +518,7 @@ class GlCanonDraw:
         self.foam_z_height = 0
         self.hide_icons = False
         self.disable_cone_scaling = False
+        self.view_tool_min_dia = 0.0
 
         try:
             system_memory_bytes = os.sysconf('SC_PAGE_SIZE') * os.sysconf('SC_PHYS_PAGES')
@@ -567,6 +568,9 @@ class GlCanonDraw:
                     self.max_file_size = int(temp) * 1024 * 1024
 
                 self.disable_cone_scaling = bool(self.inifile.find("DISPLAY", "DISABLE_CONE_SCALING"))
+                tool_min_dia = (self.inifile.find("DISPLAY", "GCODE_VIEW_TOOL_MIN_DIA") or None)
+                if tool_min_dia is not None:
+                    self.view_tool_min_dia = float(tool_min_dia)
 
         except:
             # Probably started in an editor so no INI
@@ -1496,7 +1500,7 @@ class GlCanonDraw:
                 glBlendFunc(GL_ONE, GL_CONSTANT_ALPHA)
 
                 current_tool = self.get_current_tool()
-                if current_tool is None or current_tool.diameter == 0:
+                if current_tool is None or current_tool.diameter < self.view_tool_min_dia:
                     if self.canon and not self.disable_cone_scaling:
                         g = self.canon
 


### PR DESCRIPTION
Tool marker disappears if its diameter less then some value but not equal zero (for example if diameter from tool table is used as wear corrector)