### PR TITLE
Fix cppcheck not finding cmdline files

### DIFF
--- a/scripts/cppcheck.sh
+++ b/scripts/cppcheck.sh
@@ -29,9 +29,6 @@ CXSTD=( --std=c++17 --language=c++ )
 CPPCHKCC=( "${CPPCHKOPT[@]}" "${CCSTD[@]}" )
 CPPCHKCX=( "${CPPCHKOPT[@]}" "${CXSTD[@]}" )
 
-# Do this from the source directory
-cd "$(dirname "$0")/../src" || { echo "Could not change directory to '$(dirname "$0")/../src'"; exit 1; }
-
 # Only process individual files if passed on the command line.
 if [ $# -gt 0 ]; then
     retval=0
@@ -52,6 +49,9 @@ if [ $# -gt 0 ]; then
     done
     exit $retval
 fi
+
+# Do the rest from the source directory
+cd "$(dirname "$0")/../src" || { echo "Could not change directory to '$(dirname "$0")/../src'"; exit 1; }
 
 docheck() {
     local rv


### PR DESCRIPTION
This PR fixes a problem where cppcheck.sh could not find command line provided files if it was not called from the src directory as current working directory.