### PR TITLE
Fix memory leak in tcl/tk 9 update due to misspelled define

### DIFF
--- a/src/emc/usr_intf/axis/extensions/togl.c
+++ b/src/emc/usr_intf/axis/extensions/togl.c
@@ -1070,7 +1070,7 @@ int Togl_Configure(Tcl_Interp *interp, struct Togl *togl,
                           argc, (void *)optr, (char *)togl, flags) == TCL_ERROR) {
       return(TCL_ERROR);
    }
-#if TK_VERSION_MAJOR >= 9
+#if TK_MAJOR_VERSION >= 9
    for(int u = 0; u < argc; u++) {
       Tcl_DecrRefCount(optr[u]);
    }


### PR DESCRIPTION
The PR fixes a small static memory leak in Togl's widget configuration code. The problem, introduced in #3739, was simply a misspelled define in the code-path to free the memory.