### PR TITLE
cppcheck: fix missing field initializers in constructor

### DIFF
--- a/src/emc/nml_intf/emc_nml.hh
+++ b/src/emc/nml_intf/emc_nml.hh
@@ -735,6 +735,7 @@ class EMC_TRAJ_LINEAR_MOVE:public EMC_TRAJ_CMD_MSG {
         vel(0.0),
         ini_maxvel(0.0),
         acc(0.0),
+        ini_maxjerk(0.0),
         feed_mode(0),
         indexer_jnum(0)
     {};
@@ -763,6 +764,7 @@ class EMC_TRAJ_CIRCULAR_MOVE:public EMC_TRAJ_CMD_MSG {
         vel(0.0),
         ini_maxvel(0.0),
         acc(0.0),
+        ini_maxjerk(0.0),
         feed_mode(0)
     {};
 
@@ -913,6 +915,7 @@ class EMC_TRAJ_PROBE:public EMC_TRAJ_CMD_MSG {
         vel(0.0),
         ini_maxvel(0.0),
         acc(0.0),
+        ini_maxjerk(0.0),
         probe_type(0)
     {};
 
@@ -935,7 +938,8 @@ class EMC_TRAJ_RIGID_TAP:public EMC_TRAJ_CMD_MSG {
         vel(0.0),
         ini_maxvel(0.0),
         acc(0.0),
-        scale(1.0)
+        scale(1.0),
+        ini_maxjerk(0.0)
     {};
 
     // For internal NML/CMS use only.

--- a/src/emc/nml_intf/emcops.cc
+++ b/src/emc/nml_intf/emcops.cc
@@ -70,6 +70,7 @@ EMC_TRAJ_STAT::EMC_TRAJ_STAT()
     queueFull(OFF),
     id(0),
     paused(OFF),
+    single_stepping(false),
     scale(0.0),
     rapid_scale(0.0),
 

--- a/src/emc/rs274ngc/interp_setup.cc
+++ b/src/emc/rs274ngc/interp_setup.cc
@@ -24,7 +24,6 @@
 #include "rs274ngc_interp.hh"
 #include <boost/python/object.hpp>
 
-#pragma GCC diagnostic error "-Wmissing-field-initializers"
 setup::setup() :
     AA_axis_offset(0.0),
     AA_current(0.0),
@@ -64,6 +63,8 @@ setup::setup() :
     control_mode(CANON_EXACT_STOP),
     tolerance(0.0),
     naivecam_tolerance(0.0),
+    tolerance_default(0.0),
+    naivecam_tolerance_default(0.0),
     current_pocket(0),
 
     current_x (0.0),


### PR DESCRIPTION
The new S-curve TP caused several missing constructor field init problems seen by cppcheck.
Also included is the removal of a #pragma to ignore missing initializers that was inappropriate.