### PR TITLE
debian/tests: direct execution of rs274-test

### DIFF
--- a/debian/.gitignore
+++ b/debian/.gitignore
@@ -22,3 +22,5 @@ autoreconf.after
 autoreconf.before
 debhelper-build-stamp
 
+# from debian/tests
+*.out

--- a/debian/tests/rs274-test
+++ b/debian/tests/rs274-test
@@ -4,6 +4,9 @@ set -e
 
 cd "$(dirname "$0")"
 
+if [ -z "$AUTOPKGTEST_TMP" ]; then
+    AUTOPKGTEST_TMP="."
+fi
 log=$AUTOPKGTEST_TMP/rs274.out
 
 if ! rs274 -g rs274.ngc > "$log" 2>&1 ; then


### PR DESCRIPTION
The test could not be executed without that AUOPKGTEST_TMP variable predefined since output would otherwise be created in / directory.