### PR TITLE
configure: workaround "maybe uninitialized" warning

### DIFF
--- a/src/configure.ac
+++ b/src/configure.ac
@@ -987,6 +987,30 @@ if test "x" = "x$BOOST_PYTHON_LIB"; then
     DEPFOUND=false
 fi
 
+# Test for a "maybe uninitialized" in the python::boost library in
+# extract<std::string> when compiled with g++ 15.2.[01] and maybe others.
+# The test needs to have -O2 and -Wall enabled to expose the probem.
+AC_LANG_PUSH([C++])
+CPPFLAGS_SAVED="$CPPFLAGS"
+CPPFLAGS="$PYTHON_CPPFLAGS $BOOST_CPPFLAGS $CPPFLAGS -O2 -Wall -Werror"
+AC_CACHE_CHECK(whether $CXX has a "maybe uninitialized" false positive, ax_cv_cxx_boost_maybe_uninit,
+    [AC_COMPILE_IFELSE([AC_LANG_SOURCE([[
+#include <boost/python/extract.hpp>
+std::string func(boost::python::object& o) {
+	return boost::python::extract<std::string>(o);
+}
+int main() { return 0; }
+]])],
+        [ax_cv_cxx_boost_maybe_uninit=no],
+        [ax_cv_cxx_boost_maybe_uninit=yes])
+    ]
+)
+CPPFLAGS="$CPPFLAGS_SAVED"
+if test x$ax_cv_cxx_boost_maybe_uninit = xyes; then
+    CPPFLAGS="$CPPFLAGS -Wno-maybe-uninitialized"
+fi
+AC_LANG_POP([C++])
+
 AC_MSG_CHECKING([whether to build documentation])
 AC_ARG_ENABLE(build-documentation,
     AS_HELP_STRING(


### PR DESCRIPTION
At least g++ 15.2.0 and 15.2.1 generate warnings about "maybe uninitialized" in std::string/std::basic_string class as described in #3709. It is most probably a false positive as this warning has been seen before.

This PR "fixes" #3709 by detecting the warning in a configure test and adds "-Wno-maybe-uninitialized" to the compiler invocation if a warning was present. Older g++, like from debian 11, 12 and 13 as well as clang++, will not have this warning and no additional compiler flags are added.
The configure test will no longer flag a g++ when the distribution's compiler is updated with the issue fixed. That makes the configure test the better choice than to use complex #if constructs in the sources.

If it was only g++, then the test could have been slightly more tight by using "-Werror=maybe-uninitialized", but that does not work with clang++. Therefore, it is assumed that no other warnings will occur in the test and that should not be the case in the test program:
```c++
#include <boost/python/extract.hpp>
std::string func(boost::python::object& o) {
	return boost::python::extract<std::string>(o);
}
int main() { return 0; }
```