### PR TITLE
libnml,emc: strtok -> strtok_r

### DIFF
--- a/src/emc/rs274ngc/interp_remap.cc
+++ b/src/emc/rs274ngc/interp_remap.cc
@@ -368,11 +368,12 @@ int Interp::parse_remap(const char *inistring, int lineno)
     if ((s = strchr(iniline, '#')) != NULL) {
 	*s = '\0';
     }
-    s = strtok((char *) iniline, " \t");
+    char* saveptr;
+    s = strtok_r((char *) iniline, " \t", &saveptr);
 
     while( s != NULL && argc < MAX_REMAPOPTS - 1) {
 	argv[argc++] = s;
-	s = strtok( NULL, " \t" );
+	s = strtok_r( NULL, " \t", &saveptr);
     }
     if (argc == MAX_REMAPOPTS) {
 	Error("parse_remap: too many arguments (max %d)", MAX_REMAPOPTS);

--- a/src/emc/rs274ngc/rs274ngc_pre.cc
+++ b/src/emc/rs274ngc/rs274ngc_pre.cc
@@ -975,7 +975,8 @@ int Interp::init()
             }
 
             rtapi_strxcpy(tmpdirs,inistring);
-            nextdir = strtok(tmpdirs,":");  // first token
+            char *saveptr;
+            nextdir = strtok_r(tmpdirs,":",&saveptr);  // first token
             dct = 0;
             while (1) {
                 char tmp_path[PATH_MAX];
@@ -996,7 +997,7 @@ int Interp::init()
                    logDebug("too many entries in SUBROUTINE_PATH, max=%d", MAX_SUB_DIRS);
                    break;
                 }
-                nextdir = strtok(NULL,":");
+                nextdir = strtok_r(NULL,":",&saveptr);
                 if (nextdir == NULL) break; // no more tokens
              }
           }

--- a/src/emc/task/emctask.cc
+++ b/src/emc/task/emctask.cc
@@ -147,7 +147,8 @@ int emcTaskInit()
         }
         strncpy(tmpdirs, inistring, sizeof(tmpdirs));
 
-        nextdir = strtok(tmpdirs,":");  // first token
+        char* saveptr;
+        nextdir = strtok_r(tmpdirs,":", &saveptr);  // first token
         dct = 1;
         while (dct < MAX_M_DIRS) {
             if (nextdir == NULL) break; // no more tokens
@@ -157,7 +158,7 @@ int emcTaskInit()
                 return -1;
             }
             strncpy(mdir[dct], nextdir, sizeof(mdir[dct]));
-            nextdir = strtok(NULL,":");
+            nextdir = strtok_r(NULL,":",&saveptr);
             dct++;
         }
         dmax=dct;

--- a/src/emc/tooldata/tooldata_common.cc
+++ b/src/emc/tooldata/tooldata_common.cc
@@ -93,14 +93,15 @@ int tooldata_read_entry(const char *input_line,
     orientation = empty.orientation;
     offset      = empty.offset;
 
-    buff = strtok(work_line, ";");
+    char* saveptr;
+    buff = strtok_r(work_line, ";", &saveptr);
     if (strlen(buff) <=1) {
         //fprintf(stderr,"skip blankline %s\n",__FILE__);
         return 0;
     }
-    comment = strtok(NULL, "\n");
+    comment = strtok_r(NULL, "\n", &saveptr);
 
-    token = strtok(buff, " ");
+    token = strtok_r(buff, " ", &saveptr);
     while (token != NULL) {
         switch (toupper(token[0])) {
         case 'T':
@@ -188,7 +189,7 @@ int tooldata_read_entry(const char *input_line,
                 valid = 0;
             break;
         }
-        token = strtok(NULL, " ");
+        token = strtok_r(NULL, " ", &saveptr);
     } // while token
 
     if (valid) {

--- a/src/emc/tooldata/tooldata_db.cc
+++ b/src/emc/tooldata/tooldata_db.cc
@@ -242,7 +242,8 @@ int tooldata_db_init(char progname_plus_args[],int random_toolchanger)
     if (getenv( (char*)"DB_SHOW") )  {db_show  = 1;}
     int   child_argc = 0;
     char* child_argv[MAX_DB_PROGRAM_ARGS] = {0};
-    char* token = strtok(progname_plus_args, " ");
+    char* saveptr;
+    char* token = strtok_r(progname_plus_args, " ", &saveptr);
     while (token != NULL) {
         child_argv[child_argc] = token;
         child_argc++;
@@ -251,7 +252,7 @@ int tooldata_db_init(char progname_plus_args[],int random_toolchanger)
                    ,MAX_DB_PROGRAM_ARGS);
             return -1;
         }
-        token = strtok(NULL, " ");
+        token = strtok_r(NULL, " ", &saveptr);
     }
     snprintf(db_childname,sizeof(db_childname),"%s",child_argv[0]);
     is_random_toolchanger = random_toolchanger;

--- a/src/libnml/rcs/rcs_print.cc
+++ b/src/libnml/rcs/rcs_print.cc
@@ -275,9 +275,10 @@ int separate_words(char **_dest, int _max, char *_src)
 	return -1;
     }
     rtapi_strxcpy(word_buffer, _src);
-    _dest[0] = strtok(word_buffer, " \n\r\t");
+    char* saveptr;
+    _dest[0] = strtok_r(word_buffer, " \n\r\t", &saveptr);
     for (i = 0; NULL != _dest[i] && i < _max - 1; i++) {
-	_dest[i + 1] = strtok(NULL, " \n\r\t");
+	_dest[i + 1] = strtok_r(NULL, " \n\r\t", &saveptr);
     }
     if (_dest[_max - 1] == NULL && i == _max - 1) {
 	i--;


### PR DESCRIPTION
The strtok function is not reentrant. It has an internal static char* memorizing where the function has last split the string when it is called again. As a consequence, its calls cannot be nested (as in an outer and inner loop) and also it cannot be used at the same time within two different threads.

The strtok_r function expects the programmer to take care of that internal variable, instead. This is what this patch is all about. The remnant strtok usage of LinuxCNC are for the binaries that implement remote access to LinuxCNC. Those would be more intrusive to transition to strtok_r and are not expected to be of immediate relevance, so this is not addressed in this stable branch.