### PR TITLE
homing.c: Fix accumulation of HOME_OFFSETs when re-homing absolute encoders.

### DIFF
--- a/src/emc/motion/homing.c
+++ b/src/emc/motion/homing.c
@@ -1128,6 +1128,10 @@ static int base_1joint_state_machine(int joint_num)
             /* set the current position to 'home_offset' */
             if (H[joint_num].home_flags & HOME_ABSOLUTE_ENCODER) {
                 offset = H[joint_num].home_offset;
+                joint->pos_cmd += joint->motor_offset;
+                joint->pos_fb += joint->motor_offset;
+                joint->free_tp.curr_pos += joint->motor_offset;
+                joint->motor_offset = 0;
             } else {
                 offset = H[joint_num].home_offset - joint->pos_fb;
             }


### PR DESCRIPTION
fix multiple homing of absolute encoders #3717