### PR TITLE
d/configure: Prepare for execution on other OS

### DIFF
--- a/debian/configure
+++ b/debian/configure
@@ -1,6 +1,7 @@
 #!/bin/bash
 # dpkg configuration script for linuxcnc
-# Copyright (C) 2006 Jeff Epler
+# Copyright (C) 2006      Jeff Epler
+#               2025-2026 Steffen Moeller
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -13,23 +14,29 @@
 set -e
 
 if [[ -z "$OSTYPE" ]]; then
-    echo "W: The 'OSTYPE' environment variable is not set."
+    echo "E: The 'OSTYPE' environment variable is not set."
     echo "   Failure to confirm Linux as the operating system cannot be determined."
-elif [[ "$OSTYPE" == "linux-gnu"* ]]; then
-    echo "I: Found operating system '$OSTYPE'."
+    exit 1
 else
-    echo "W: LinuxCNC is not (yet) prepared for the operating system '$OSTYPE'."
-    echo "   Instead of this Debian+derivative-tailored configuration please invoke the compilation directly."
-    if [[ "$OSTYPE" == "darwin"* ]]; then
-        echo
-        echo "   LinuxCNC is yet unlikely to be successfully built on MacOS because of missing dependencies."
-        if command -v brew &> /dev/null; then
-            echo "   With brew, we are aware of packages"
-            echo "     autoconf automake libusb libmodbus libtircp pkgconf"
-            echo "   but missing is, e.g., a package for libgpiod."
+    echo "D: Found operating system '$OSTYPE'."
+    if [[ ! "$OSTYPE" == "linux-gnu"* ]]; then
+        echo "W: LinuxCNC is not (yet) prepared for the operating system '$OSTYPE'."
+        if [[ "$OSTYPE" == "freebsd"* ]]; then
+            echo "   For FreeBSD there have been reports for LinuxCNC to compile and be executable."
+        else
+            if [[ "$OSTYPE" == "darwin"* ]]; then
+                echo
+                echo "   LinuxCNC is yet unlikely to be successfully built on MacOS because of missing dependencies."
+                if command -v brew &> /dev/null; then
+                    echo "   With brew, we are aware of packages"
+                    echo "     autoconf automake libusb libmodbus libtircp pkgconf"
+                    echo "   but missing is, e.g., a package for libgpiod."
+                fi
+            fi
         fi
+        echo "   Instead of this Debian+derivative-tailored configuration please invoke the compilation directly."
+        exit 1
     fi
-    exit 1;
 fi
 
 usage () {


### PR DESCRIPTION
Somehow I feel like it may possibly not be completely pointless to consider a compilation of LinuxCNC or parts of it on non-Linux Operating Systems. At least we should prepare debian/configure for the event that someone is trying it. Here is what I came up with. My personal immediate motivation is to support writers of the documentation who are likely to have a the source tree on whatever OS their machine may be.

My attempt on MacOS did not complete a configure run. But that is just because of missing packages in brew - nothing technical. Conda may also be worthwhile to have a look, but the libgpiod-dev equivalent for either I fail to find. It may be of interest to come up with a configure option that prepared for the documentation only.