### PR TITLE
Don't crash milltask when no tool data file is specified

### DIFF
--- a/src/emc/tooldata/tooldata_common.cc
+++ b/src/emc/tooldata/tooldata_common.cc
@@ -388,6 +388,13 @@ int tooldata_save(const char *filename)
         if (!is_random_toolchanger) {return 0;}
         filename = DB_SPINDLE_SAVE; //one entry tbl (nonran only)
     } else {
+        // filename == NULL happens without ini entry [EMCIO]TOOL_TABLE
+        // and a Task::emcToolSetOffset is performed.
+        if (!filename) {
+            fprintf(stderr, "%s: No filename. Are you missing INI-entry [EMCIO]TOOL_TABLE?\n",
+                    __PRETTY_FUNCTION__);
+            return -1;
+        }
         if (filename[0] == 0) {
             UNEXPECTED_MSG;
         }


### PR DESCRIPTION
This PR addresses a crash in milltask that happens when the ini-file lacks an entry for [EMCIO]TOOL_TABLE and a request is made to set a tool offset. The filename argument to tooldata_save() would be NULL and was naively dereferenced.