### PR TITLE
Gmoccapy: make Tool Table exit more verbose

### DIFF
--- a/src/emc/usr_intf/gmoccapy/gmoccapy.py
+++ b/src/emc/usr_intf/gmoccapy/gmoccapy.py
@@ -4744,11 +4744,20 @@ class gmoccapy(object):
             new_offset = (tt.xoffset, tt.yoffset, tt.zoffset,
                           tt.aoffset, tt.boffset, tt.coffset,
                           tt.uoffset, tt.voffset, tt.woffset)
+            message = None
+            new_offset_is_nonzero = any(v != 0.0 for v in new_offset)
+            old_offset_is_zero = all(v == 0.0 for v in self.stat.tool_offset)
             if (new_offset != self.stat.tool_offset) and ("G43" in self.active_gcodes):
                 message = _("Offset values for the tool in the spindle\n" \
                             "have been changed with tool compensation (G43) active.\n\n" \
                             "Do you want the new values to be applied as the currently\n" \
                             "active tool offset?")
+            elif new_offset_is_nonzero and old_offset_is_zero and ("G49" in self.active_gcodes):
+                message = _("Offset values for the tool in the spindle\n" \
+                            "have been changed from zero to non-zero.\n\n" \
+                            "Do you want to activate tool compensation (G43)\n" \
+                            "using the currently active tool offset?")
+            if message:
                 result = self.dialogs.yesno_dialog(self, message, _("Attention!"))
                 if result: # user says YES
                     self.command.mode(linuxcnc.MODE_MDI)


### PR DESCRIPTION
LinuxCNC core behavior:
Activating G43 with zero offsets deactivates tool compensation.
In this situation, G43 behaves like G49.
If the CNC operator is not aware of this, it can have dangerous consequences.

@hansu was not aware of this in the past. See:
https://github.com/LinuxCNC/linuxcnc/pull/3706#issuecomment-3777527229
I struggled with this as well.

Therefore, I made exiting the Tool Table in Gmoccapy more verbose and added the option to activate G43 when the active offset changes from zero to non-zero.

I would like to ask @Sigma1912 for their opinion on whether this is OK.
