### PR TITLE
Fix most of the "dangerousTypeCast" cppcheck warnings

### DIFF
--- a/src/emc/task/emctaskmain.cc
+++ b/src/emc/task/emctaskmain.cc
@@ -1586,14 +1586,14 @@ static EMC_TASK_EXEC emcTaskCheckPreconditions(NMLmsg * cmd)
 	break;
 
     case EMC_MOTION_SET_AOUT_TYPE:
-	if (((EMC_MOTION_SET_AOUT *) cmd)->now) {
+	if ((reinterpret_cast<EMC_MOTION_SET_AOUT *>(cmd))->now) {
     	    return EMC_TASK_EXEC::WAITING_FOR_MOTION;
 	}
 	return EMC_TASK_EXEC::DONE;
 	break;
 
     case EMC_MOTION_SET_DOUT_TYPE:
-	if (((EMC_MOTION_SET_DOUT *) cmd)->now) {
+	if ((reinterpret_cast<EMC_MOTION_SET_DOUT *>(cmd))->now) {
     	    return EMC_TASK_EXEC::WAITING_FOR_MOTION;
 	}
 	return EMC_TASK_EXEC::DONE;
@@ -1648,48 +1648,48 @@ static int emcTaskIssueCommand(NMLmsg * cmd)
 	// general commands
 
     case EMC_OPERATOR_ERROR_TYPE:
-	retval = emcOperatorError("%s", ((EMC_OPERATOR_ERROR *) cmd)->error);
+	retval = emcOperatorError("%s", (reinterpret_cast<EMC_OPERATOR_ERROR *>(cmd))->error);
 	break;
 
     case EMC_OPERATOR_TEXT_TYPE:
-	retval = emcOperatorText("%s", ((EMC_OPERATOR_TEXT *) cmd)->text);
+	retval = emcOperatorText("%s", (reinterpret_cast<EMC_OPERATOR_TEXT *>(cmd))->text);
 	break;
 
     case EMC_OPERATOR_DISPLAY_TYPE:
-	retval = emcOperatorDisplay("%s", ((EMC_OPERATOR_DISPLAY *) cmd)->display);
+	retval = emcOperatorDisplay("%s", (reinterpret_cast<EMC_OPERATOR_DISPLAY *>(cmd))->display);
 	break;
 
     case EMC_SYSTEM_CMD_TYPE:
-	retval = emcSystemCmd(((EMC_SYSTEM_CMD *) cmd)->string);
+	retval = emcSystemCmd((reinterpret_cast<EMC_SYSTEM_CMD *>(cmd))->string);
 	break;
 
 	// joint commands
 
     case EMC_JOINT_HOME_TYPE:
-	home_msg = (EMC_JOINT_HOME *) cmd;
+	home_msg = reinterpret_cast<EMC_JOINT_HOME *>(cmd);
 	retval = emcJointHome(home_msg->joint);
 	break;
 
     case EMC_JOINT_UNHOME_TYPE:
-	unhome_msg = (EMC_JOINT_UNHOME *) cmd;
+	unhome_msg = reinterpret_cast<EMC_JOINT_UNHOME *>(cmd);
 	retval = emcJointUnhome(unhome_msg->joint);
 	break;
 
     case EMC_JOG_CONT_TYPE:
-	jog_cont_msg = (EMC_JOG_CONT *) cmd;
+	jog_cont_msg = reinterpret_cast<EMC_JOG_CONT *>(cmd);
 	retval = emcJogCont(jog_cont_msg->joint_or_axis,
                             jog_cont_msg->vel,
                             jog_cont_msg->jjogmode);
 	break;
 
     case EMC_JOG_STOP_TYPE:
-	jog_stop_msg = (EMC_JOG_STOP *) cmd;
+	jog_stop_msg = reinterpret_cast<EMC_JOG_STOP *>(cmd);
 	retval = emcJogStop(jog_stop_msg->joint_or_axis,
                             jog_stop_msg->jjogmode);
 	break;
 
     case EMC_JOG_INCR_TYPE:
-	jog_incr_msg = (EMC_JOG_INCR *) cmd;
+	jog_incr_msg = reinterpret_cast<EMC_JOG_INCR *>(cmd);
 	retval = emcJogIncr(jog_incr_msg->joint_or_axis,
 			    jog_incr_msg->incr,
                             jog_incr_msg->vel,
@@ -1697,7 +1697,7 @@ static int emcTaskIssueCommand(NMLmsg * cmd)
 	break;
 
     case EMC_JOG_ABS_TYPE:
-	jog_abs_msg = (EMC_JOG_ABS *) cmd;
+	jog_abs_msg = reinterpret_cast<EMC_JOG_ABS *>(cmd);
 	retval = emcJogAbs(jog_abs_msg->joint_or_axis,
 	                   jog_abs_msg->pos,
                            jog_abs_msg->vel,
@@ -1705,14 +1705,14 @@ static int emcTaskIssueCommand(NMLmsg * cmd)
 	break;
 
     case EMC_JOINT_SET_BACKLASH_TYPE:
-	set_backlash_msg = (EMC_JOINT_SET_BACKLASH *) cmd;
+	set_backlash_msg = reinterpret_cast<EMC_JOINT_SET_BACKLASH *>(cmd);
 	retval =
 	    emcJointSetBacklash(set_backlash_msg->joint,
 			       set_backlash_msg->backlash);
 	break;
 
     case EMC_JOINT_SET_HOMING_PARAMS_TYPE:
-	set_homing_params_msg = (EMC_JOINT_SET_HOMING_PARAMS *) cmd;
+	set_homing_params_msg = reinterpret_cast<EMC_JOINT_SET_HOMING_PARAMS *>(cmd);
 	retval = emcJointSetHomingParams(set_homing_params_msg->joint,
 					set_homing_params_msg->home,
 					set_homing_params_msg->offset,
@@ -1730,41 +1730,41 @@ static int emcTaskIssueCommand(NMLmsg * cmd)
 	break;
 
     case EMC_JOINT_SET_FERROR_TYPE:
-	set_ferror_msg = (EMC_JOINT_SET_FERROR *) cmd;
+	set_ferror_msg = reinterpret_cast<EMC_JOINT_SET_FERROR *>(cmd);
 	retval = emcJointSetFerror(set_ferror_msg->joint,
 				  set_ferror_msg->ferror);
 	break;
 
     case EMC_JOINT_SET_MIN_FERROR_TYPE:
-	set_min_ferror_msg = (EMC_JOINT_SET_MIN_FERROR *) cmd;
+	set_min_ferror_msg = reinterpret_cast<EMC_JOINT_SET_MIN_FERROR *>(cmd);
 	retval = emcJointSetMinFerror(set_min_ferror_msg->joint,
 				     set_min_ferror_msg->ferror);
 	break;
 
     case EMC_JOINT_SET_MAX_POSITION_LIMIT_TYPE:
-	set_max_limit_msg = (EMC_JOINT_SET_MAX_POSITION_LIMIT *) cmd;
+	set_max_limit_msg = reinterpret_cast<EMC_JOINT_SET_MAX_POSITION_LIMIT *>(cmd);
 	retval = emcJointSetMaxPositionLimit(set_max_limit_msg->joint,
 					    set_max_limit_msg->limit);
 	break;
 
     case EMC_JOINT_SET_MIN_POSITION_LIMIT_TYPE:
-	set_min_limit_msg = (EMC_JOINT_SET_MIN_POSITION_LIMIT *) cmd;
+	set_min_limit_msg = reinterpret_cast<EMC_JOINT_SET_MIN_POSITION_LIMIT *>(cmd);
 	retval = emcJointSetMinPositionLimit(set_min_limit_msg->joint,
 					    set_min_limit_msg->limit);
 	break;
 
     case EMC_JOINT_HALT_TYPE:
-	joint_halt_msg = (EMC_JOINT_HALT *) cmd;
+	joint_halt_msg = reinterpret_cast<EMC_JOINT_HALT *>(cmd);
 	retval = emcJointHalt(joint_halt_msg->joint);
 	break;
 
     case EMC_JOINT_OVERRIDE_LIMITS_TYPE:
-	joint_lim_msg = (EMC_JOINT_OVERRIDE_LIMITS *) cmd;
+	joint_lim_msg = reinterpret_cast<EMC_JOINT_OVERRIDE_LIMITS *>(cmd);
 	retval = emcJointOverrideLimits(joint_lim_msg->joint);
 	break;
 
     case EMC_JOINT_LOAD_COMP_TYPE:
-	joint_load_comp_msg = (EMC_JOINT_LOAD_COMP *) cmd;
+	joint_load_comp_msg = reinterpret_cast<EMC_JOINT_LOAD_COMP *>(cmd);
 	retval = emcJointLoadComp(joint_load_comp_msg->joint,
 				 joint_load_comp_msg->file,
 				 joint_load_comp_msg->type);
@@ -1773,52 +1773,52 @@ static int emcTaskIssueCommand(NMLmsg * cmd)
 	// traj commands
 
     case EMC_TRAJ_SET_SCALE_TYPE:
-	emcTrajSetScaleMsg = (EMC_TRAJ_SET_SCALE *) cmd;
+	emcTrajSetScaleMsg = reinterpret_cast<EMC_TRAJ_SET_SCALE *>(cmd);
 	retval = emcTrajSetScale(emcTrajSetScaleMsg->scale);
 	break;
 
     case EMC_TRAJ_SET_RAPID_SCALE_TYPE:
-	emcTrajSetRapidScaleMsg = (EMC_TRAJ_SET_RAPID_SCALE *) cmd;
+	emcTrajSetRapidScaleMsg = reinterpret_cast<EMC_TRAJ_SET_RAPID_SCALE *>(cmd);
 	retval = emcTrajSetRapidScale(emcTrajSetRapidScaleMsg->scale);
 	break;
 
     case EMC_TRAJ_SET_MAX_VELOCITY_TYPE:
-	emcTrajSetMaxVelocityMsg = (EMC_TRAJ_SET_MAX_VELOCITY *) cmd;
+	emcTrajSetMaxVelocityMsg = reinterpret_cast<EMC_TRAJ_SET_MAX_VELOCITY *>(cmd);
 	retval = emcTrajSetMaxVelocity(emcTrajSetMaxVelocityMsg->velocity);
 	break;
 
     case EMC_TRAJ_SET_SPINDLE_SCALE_TYPE:
-	emcTrajSetSpindleScaleMsg = (EMC_TRAJ_SET_SPINDLE_SCALE *) cmd;
+	emcTrajSetSpindleScaleMsg = reinterpret_cast<EMC_TRAJ_SET_SPINDLE_SCALE *>(cmd);
 	retval = emcTrajSetSpindleScale(emcTrajSetSpindleScaleMsg->spindle,
                                     emcTrajSetSpindleScaleMsg->scale);
 	break;
 
     case EMC_TRAJ_SET_FO_ENABLE_TYPE:
-	retval = emcTrajSetFOEnable(((EMC_TRAJ_SET_FO_ENABLE *) cmd)->mode);  // feed override enable/disable
+	retval = emcTrajSetFOEnable((reinterpret_cast<EMC_TRAJ_SET_FO_ENABLE *>(cmd))->mode);  // feed override enable/disable
 	break;
 
     case EMC_TRAJ_SET_FH_ENABLE_TYPE:
-	retval = emcTrajSetFHEnable(((EMC_TRAJ_SET_FH_ENABLE *) cmd)->mode); //feed hold enable/disable
+	retval = emcTrajSetFHEnable((reinterpret_cast<EMC_TRAJ_SET_FH_ENABLE *>(cmd))->mode); //feed hold enable/disable
 	break;
 
     case EMC_TRAJ_SET_SO_ENABLE_TYPE:
-	retval = emcTrajSetSOEnable(((EMC_TRAJ_SET_SO_ENABLE *) cmd)->mode); //spindle speed override enable/disable
+	retval = emcTrajSetSOEnable((reinterpret_cast<EMC_TRAJ_SET_SO_ENABLE *>(cmd))->mode); //spindle speed override enable/disable
 	break;
 
     case EMC_TRAJ_SET_VELOCITY_TYPE:
-	emcTrajSetVelocityMsg = (EMC_TRAJ_SET_VELOCITY *) cmd;
+	emcTrajSetVelocityMsg = reinterpret_cast<EMC_TRAJ_SET_VELOCITY *>(cmd);
 	retval = emcTrajSetVelocity(emcTrajSetVelocityMsg->velocity,
 			emcTrajSetVelocityMsg->ini_maxvel);
 	break;
 
     case EMC_TRAJ_SET_ACCELERATION_TYPE:
-	emcTrajSetAccelerationMsg = (EMC_TRAJ_SET_ACCELERATION *) cmd;
+	emcTrajSetAccelerationMsg = reinterpret_cast<EMC_TRAJ_SET_ACCELERATION *>(cmd);
 	retval = emcTrajSetAcceleration(emcTrajSetAccelerationMsg->acceleration);
 	break;
 
     case EMC_TRAJ_LINEAR_MOVE_TYPE:
-	emcTrajUpdateTag(((EMC_TRAJ_LINEAR_MOVE *) cmd)->tag);
-	emcTrajLinearMoveMsg = (EMC_TRAJ_LINEAR_MOVE *) cmd;
+	emcTrajUpdateTag((reinterpret_cast<EMC_TRAJ_LINEAR_MOVE *>(cmd))->tag);
+	emcTrajLinearMoveMsg = reinterpret_cast<EMC_TRAJ_LINEAR_MOVE *>(cmd);
         retval = emcTrajLinearMove(emcTrajLinearMoveMsg->end,
                                    emcTrajLinearMoveMsg->type, emcTrajLinearMoveMsg->vel,
                                    emcTrajLinearMoveMsg->ini_maxvel, emcTrajLinearMoveMsg->acc, emcTrajLinearMoveMsg->ini_maxjerk,
@@ -1826,8 +1826,8 @@ static int emcTaskIssueCommand(NMLmsg * cmd)
 	break;
 
     case EMC_TRAJ_CIRCULAR_MOVE_TYPE:
-	emcTrajUpdateTag(((EMC_TRAJ_LINEAR_MOVE *) cmd)->tag);
-	emcTrajCircularMoveMsg = (EMC_TRAJ_CIRCULAR_MOVE *) cmd;
+	emcTrajUpdateTag((reinterpret_cast<EMC_TRAJ_LINEAR_MOVE *>(cmd))->tag);
+	emcTrajCircularMoveMsg = reinterpret_cast<EMC_TRAJ_CIRCULAR_MOVE *>(cmd);
         retval = emcTrajCircularMove(emcTrajCircularMoveMsg->end,
                 emcTrajCircularMoveMsg->center, emcTrajCircularMoveMsg->normal,
                 emcTrajCircularMoveMsg->turn, emcTrajCircularMoveMsg->type,
@@ -1851,42 +1851,42 @@ static int emcTaskIssueCommand(NMLmsg * cmd)
 	break;
 
     case EMC_TRAJ_DELAY_TYPE:
-	emcTrajDelayMsg = (EMC_TRAJ_DELAY *) cmd;
+	emcTrajDelayMsg = reinterpret_cast<EMC_TRAJ_DELAY *>(cmd);
 	// set the timeout clock to expire at 'now' + delay time
 	taskExecDelayTimeout = etime() + emcTrajDelayMsg->delay;
 	retval = 0;
 	break;
 
     case EMC_TRAJ_SET_TERM_COND_TYPE:
-	emcTrajSetTermCondMsg = (EMC_TRAJ_SET_TERM_COND *) cmd;
+	emcTrajSetTermCondMsg = reinterpret_cast<EMC_TRAJ_SET_TERM_COND *>(cmd);
 	retval = emcTrajSetTermCond(emcTrajSetTermCondMsg->cond, emcTrajSetTermCondMsg->tolerance);
 	break;
 
     case EMC_TRAJ_SET_SPINDLESYNC_TYPE:
-        emcTrajSetSpindlesyncMsg = (EMC_TRAJ_SET_SPINDLESYNC *) cmd;
+        emcTrajSetSpindlesyncMsg = reinterpret_cast<EMC_TRAJ_SET_SPINDLESYNC *>(cmd);
         retval = emcTrajSetSpindleSync(emcTrajSetSpindlesyncMsg->spindle, emcTrajSetSpindlesyncMsg->feed_per_revolution, emcTrajSetSpindlesyncMsg->velocity_mode);
         break;
 
     case EMC_TRAJ_SET_OFFSET_TYPE:
 	// update tool offset
-	emcStatus->task.toolOffset = ((EMC_TRAJ_SET_OFFSET *) cmd)->offset;
+	emcStatus->task.toolOffset = (reinterpret_cast<EMC_TRAJ_SET_OFFSET *>(cmd))->offset;
         retval = emcTrajSetOffset(emcStatus->task.toolOffset);
 	break;
 
     case EMC_TRAJ_SET_ROTATION_TYPE:
-        emcStatus->task.rotation_xy = ((EMC_TRAJ_SET_ROTATION *) cmd)->rotation;
+        emcStatus->task.rotation_xy = (reinterpret_cast<EMC_TRAJ_SET_ROTATION *>(cmd))->rotation;
         retval = 0;
         break;
 
     case EMC_TRAJ_SET_G5X_TYPE:
 	// struct-copy program origin
-	emcStatus->task.g5x_offset = ((EMC_TRAJ_SET_G5X *) cmd)->origin;
-        emcStatus->task.g5x_index = ((EMC_TRAJ_SET_G5X *) cmd)->g5x_index;
+	emcStatus->task.g5x_offset = (reinterpret_cast<EMC_TRAJ_SET_G5X *>(cmd))->origin;
+        emcStatus->task.g5x_index = (reinterpret_cast<EMC_TRAJ_SET_G5X *>(cmd))->g5x_index;
 	retval = 0;
 	break;
     case EMC_TRAJ_SET_G92_TYPE:
 	// struct-copy program origin
-	emcStatus->task.g92_offset = ((EMC_TRAJ_SET_G92 *) cmd)->origin;
+	emcStatus->task.g92_offset = (reinterpret_cast<EMC_TRAJ_SET_G92 *>(cmd))->origin;
 	retval = 0;
 	break;
     case EMC_TRAJ_CLEAR_PROBE_TRIPPED_FLAG_TYPE:
@@ -1895,17 +1895,17 @@ static int emcTaskIssueCommand(NMLmsg * cmd)
 
     case EMC_TRAJ_PROBE_TYPE:
 	retval = emcTrajProbe(
-	    ((EMC_TRAJ_PROBE *) cmd)->pos,
-	    ((EMC_TRAJ_PROBE *) cmd)->type,
-	    ((EMC_TRAJ_PROBE *) cmd)->vel,
-            ((EMC_TRAJ_PROBE *) cmd)->ini_maxvel,
-	    ((EMC_TRAJ_PROBE *) cmd)->acc,
-		((EMC_TRAJ_PROBE *) cmd)->ini_maxjerk,
-            ((EMC_TRAJ_PROBE *) cmd)->probe_type);
+	    (reinterpret_cast<EMC_TRAJ_PROBE *>(cmd))->pos,
+	    (reinterpret_cast<EMC_TRAJ_PROBE *>(cmd))->type,
+	    (reinterpret_cast<EMC_TRAJ_PROBE *>(cmd))->vel,
+            (reinterpret_cast<EMC_TRAJ_PROBE *>(cmd))->ini_maxvel,
+	    (reinterpret_cast<EMC_TRAJ_PROBE *>(cmd))->acc,
+	    (reinterpret_cast<EMC_TRAJ_PROBE *>(cmd))->ini_maxjerk,
+            (reinterpret_cast<EMC_TRAJ_PROBE *>(cmd))->probe_type);
 	break;
 
     case EMC_AUX_INPUT_WAIT_TYPE:
-	emcAuxInputWaitMsg = (EMC_AUX_INPUT_WAIT *) cmd;
+	emcAuxInputWaitMsg = reinterpret_cast<EMC_AUX_INPUT_WAIT *>(cmd);
 	if (emcAuxInputWaitMsg->timeout == WAIT_MODE_IMMEDIATE) { //nothing to do, CANON will get the needed value when asked by the interp
 	    emcStatus->task.input_timeout = 0; // no timeout can occur
 	    emcAuxInputWaitIndex = -1;
@@ -1920,22 +1920,22 @@ static int emcTaskIssueCommand(NMLmsg * cmd)
 	break;
 
     case EMC_SPINDLE_WAIT_ORIENT_COMPLETE_TYPE:
-	wait_spindle_orient_complete_msg = (EMC_SPINDLE_WAIT_ORIENT_COMPLETE *) cmd;
+	wait_spindle_orient_complete_msg = reinterpret_cast<EMC_SPINDLE_WAIT_ORIENT_COMPLETE *>(cmd);
 	taskExecDelayTimeout = etime() + wait_spindle_orient_complete_msg->timeout;
 	break;
 
     case EMC_TRAJ_RIGID_TAP_TYPE:
-	emcTrajUpdateTag(((EMC_TRAJ_LINEAR_MOVE *) cmd)->tag);
-	retval = emcTrajRigidTap(((EMC_TRAJ_RIGID_TAP *) cmd)->pos,
-	        ((EMC_TRAJ_RIGID_TAP *) cmd)->vel,
-        	((EMC_TRAJ_RIGID_TAP *) cmd)->ini_maxvel,
-		((EMC_TRAJ_RIGID_TAP *) cmd)->acc,
-		((EMC_TRAJ_RIGID_TAP *) cmd)->ini_maxjerk,
-		((EMC_TRAJ_RIGID_TAP *) cmd)->scale);
+	emcTrajUpdateTag((reinterpret_cast<EMC_TRAJ_LINEAR_MOVE *>(cmd))->tag);
+	retval = emcTrajRigidTap((reinterpret_cast<EMC_TRAJ_RIGID_TAP *>(cmd))->pos,
+	        (reinterpret_cast<EMC_TRAJ_RIGID_TAP *>(cmd))->vel,
+		(reinterpret_cast<EMC_TRAJ_RIGID_TAP *>(cmd))->ini_maxvel,
+		(reinterpret_cast<EMC_TRAJ_RIGID_TAP *>(cmd))->acc,
+		(reinterpret_cast<EMC_TRAJ_RIGID_TAP *>(cmd))->ini_maxjerk,
+		(reinterpret_cast<EMC_TRAJ_RIGID_TAP *>(cmd))->scale);
 	break;
 
     case EMC_TRAJ_SET_TELEOP_ENABLE_TYPE:
-	if (((EMC_TRAJ_SET_TELEOP_ENABLE *) cmd)->enable) {
+	if ((reinterpret_cast<EMC_TRAJ_SET_TELEOP_ENABLE *>(cmd))->enable) {
 	    retval = emcTrajSetMode(EMC_TRAJ_MODE::TELEOP);
 	} else {
 	    retval = emcTrajSetMode(EMC_TRAJ_MODE::FREE);
@@ -1943,26 +1943,26 @@ static int emcTaskIssueCommand(NMLmsg * cmd)
 	break;
 
     case EMC_MOTION_SET_AOUT_TYPE:
-	retval = emcMotionSetAout(((EMC_MOTION_SET_AOUT *) cmd)->index,
-				  ((EMC_MOTION_SET_AOUT *) cmd)->start,
-				  ((EMC_MOTION_SET_AOUT *) cmd)->end,
-				  ((EMC_MOTION_SET_AOUT *) cmd)->now);
+	retval = emcMotionSetAout((reinterpret_cast<EMC_MOTION_SET_AOUT *>(cmd))->index,
+				  (reinterpret_cast<EMC_MOTION_SET_AOUT *>(cmd))->start,
+				  (reinterpret_cast<EMC_MOTION_SET_AOUT *>(cmd))->end,
+				  (reinterpret_cast<EMC_MOTION_SET_AOUT *>(cmd))->now);
 	break;
 
     case EMC_MOTION_SET_DOUT_TYPE:
-	retval = emcMotionSetDout(((EMC_MOTION_SET_DOUT *) cmd)->index,
-				  ((EMC_MOTION_SET_DOUT *) cmd)->start,
-				  ((EMC_MOTION_SET_DOUT *) cmd)->end,
-				  ((EMC_MOTION_SET_DOUT *) cmd)->now);
+	retval = emcMotionSetDout((reinterpret_cast<EMC_MOTION_SET_DOUT *>(cmd))->index,
+				  (reinterpret_cast<EMC_MOTION_SET_DOUT *>(cmd))->start,
+				  (reinterpret_cast<EMC_MOTION_SET_DOUT *>(cmd))->end,
+				  (reinterpret_cast<EMC_MOTION_SET_DOUT *>(cmd))->now);
 	break;
 
     case EMC_MOTION_ADAPTIVE_TYPE:
-	retval = emcTrajSetAFEnable(((EMC_MOTION_ADAPTIVE *) cmd)->status);
+	retval = emcTrajSetAFEnable((reinterpret_cast<EMC_MOTION_ADAPTIVE *>(cmd))->status);
 	break;
 
     case EMC_SET_DEBUG_TYPE:
 	/* set the debug level here */
-	emc_debug = ((EMC_SET_DEBUG *) cmd)->debug;
+	emc_debug = (reinterpret_cast<EMC_SET_DEBUG *>(cmd))->debug;
 	/* and motion */
 	emcMotionSetDebug(emc_debug);
 	/* and reflect it in the status-- this isn't updated continually */
@@ -1974,50 +1974,50 @@ static int emcTaskIssueCommand(NMLmsg * cmd)
 	// IO commands
 
     case EMC_SPINDLE_SPEED_TYPE:
-	spindle_speed_msg = (EMC_SPINDLE_SPEED *) cmd;
+	spindle_speed_msg = reinterpret_cast<EMC_SPINDLE_SPEED *>(cmd);
 	retval = emcSpindleSpeed(spindle_speed_msg->spindle, spindle_speed_msg->speed,
 			spindle_speed_msg->factor, spindle_speed_msg->xoffset);
 	break;
 
     case EMC_SPINDLE_ORIENT_TYPE:
-	spindle_orient_msg = (EMC_SPINDLE_ORIENT *) cmd;
+	spindle_orient_msg = reinterpret_cast<EMC_SPINDLE_ORIENT *>(cmd);
 	retval = emcSpindleOrient(spindle_orient_msg->spindle, spindle_orient_msg->orientation,
 			spindle_orient_msg->mode);
 	break;
 
     case EMC_SPINDLE_ON_TYPE:
-	spindle_on_msg = (EMC_SPINDLE_ON *) cmd;
+	spindle_on_msg = reinterpret_cast<EMC_SPINDLE_ON *>(cmd);
 	retval = emcSpindleOn(spindle_on_msg->spindle, spindle_on_msg->speed,
 			spindle_on_msg->factor, spindle_on_msg->xoffset, spindle_on_msg->wait_for_spindle_at_speed);
 	break;
 
     case EMC_SPINDLE_OFF_TYPE:
-    spindle_off_msg = (EMC_SPINDLE_OFF *) cmd;
+    spindle_off_msg = reinterpret_cast<EMC_SPINDLE_OFF *>(cmd);
 	retval = emcSpindleOff(spindle_off_msg->spindle);
 	break;
 
     case EMC_SPINDLE_BRAKE_RELEASE_TYPE:
-    spindle_brake_release_msg = (EMC_SPINDLE_BRAKE_RELEASE *) cmd;
+    spindle_brake_release_msg = reinterpret_cast<EMC_SPINDLE_BRAKE_RELEASE *>(cmd);
 	retval = emcSpindleBrakeRelease(spindle_brake_release_msg->spindle);
 	break;
 
     case EMC_SPINDLE_INCREASE_TYPE:
-    spindle_increase_msg = (EMC_SPINDLE_INCREASE *) cmd;
+    spindle_increase_msg = reinterpret_cast<EMC_SPINDLE_INCREASE *>(cmd);
 	retval = emcSpindleIncrease(spindle_increase_msg->spindle);
 	break;
 
     case EMC_SPINDLE_DECREASE_TYPE:
-    spindle_decrease_msg = (EMC_SPINDLE_DECREASE *) cmd;
+    spindle_decrease_msg = reinterpret_cast<EMC_SPINDLE_DECREASE *>(cmd);
     retval = emcSpindleDecrease(spindle_decrease_msg->spindle);
 	break;
 
     case EMC_SPINDLE_CONSTANT_TYPE:
-    spindle_constant_msg = (EMC_SPINDLE_CONSTANT *) cmd;
+    spindle_constant_msg = reinterpret_cast<EMC_SPINDLE_CONSTANT *>(cmd);
     retval = emcSpindleConstant(spindle_constant_msg->spindle);
 	break;
 
     case EMC_SPINDLE_BRAKE_ENGAGE_TYPE:
-    spindle_brake_engage_msg = (EMC_SPINDLE_BRAKE_ENGAGE *) cmd;
+    spindle_brake_engage_msg = reinterpret_cast<EMC_SPINDLE_BRAKE_ENGAGE *>(cmd);
     retval = emcSpindleBrakeEngage(spindle_brake_engage_msg->spindle);
 	break;
 
@@ -2038,7 +2038,7 @@ static int emcTaskIssueCommand(NMLmsg * cmd)
 	break;
 
     case EMC_TOOL_PREPARE_TYPE:
-	tool_prepare_msg = (EMC_TOOL_PREPARE *) cmd;
+	tool_prepare_msg = reinterpret_cast<EMC_TOOL_PREPARE *>(cmd);
 	retval = emcToolPrepare(tool_prepare_msg->tool);
 	break;
 
@@ -2051,12 +2051,12 @@ static int emcTaskIssueCommand(NMLmsg * cmd)
 	break;
 
     case EMC_TOOL_LOAD_TOOL_TABLE_TYPE:
-	load_tool_table_msg = (EMC_TOOL_LOAD_TOOL_TABLE *) cmd;
+	load_tool_table_msg = reinterpret_cast<EMC_TOOL_LOAD_TOOL_TABLE *>(cmd);
 	retval = emcToolLoadToolTable(load_tool_table_msg->file);
 	break;
 
     case EMC_TOOL_SET_OFFSET_TYPE:
-	emc_tool_set_offset_msg = (EMC_TOOL_SET_OFFSET *) cmd;
+	emc_tool_set_offset_msg = reinterpret_cast<EMC_TOOL_SET_OFFSET *>(cmd);
 	retval = emcToolSetOffset(emc_tool_set_offset_msg->pocket,
                                   emc_tool_set_offset_msg->toolno,
                                   emc_tool_set_offset_msg->offset,
@@ -2067,7 +2067,7 @@ static int emcTaskIssueCommand(NMLmsg * cmd)
 	break;
 
     case EMC_TOOL_SET_NUMBER_TYPE:
-	emc_tool_set_number_msg = (EMC_TOOL_SET_NUMBER *) cmd;
+	emc_tool_set_number_msg = reinterpret_cast<EMC_TOOL_SET_NUMBER *>(cmd);
 	retval = emcToolSetNumber(emc_tool_set_number_msg->tool);
 	break;
 
@@ -2091,7 +2091,7 @@ static int emcTaskIssueCommand(NMLmsg * cmd)
 	// mode and state commands
 
     case EMC_TASK_SET_MODE_TYPE:
-	mode_msg = (EMC_TASK_SET_MODE *) cmd;
+	mode_msg = reinterpret_cast<EMC_TASK_SET_MODE *>(cmd);
 	if (emcStatus->task.mode == EMC_TASK_MODE::AUTO &&
 	    emcStatus->task.interpState != EMC_TASK_INTERP::IDLE &&
 	    mode_msg->mode != EMC_TASK_MODE::AUTO) {
@@ -2140,7 +2140,7 @@ static int emcTaskIssueCommand(NMLmsg * cmd)
 	break;
 
     case EMC_TASK_SET_STATE_TYPE:
-	state_msg = (EMC_TASK_SET_STATE *) cmd;
+	state_msg = reinterpret_cast<EMC_TASK_SET_STATE *>(cmd);
 	retval = emcTaskSetState(state_msg->state);
 	break;
 
@@ -2160,7 +2160,7 @@ static int emcTaskIssueCommand(NMLmsg * cmd)
         break;
 
     case EMC_TASK_PLAN_OPEN_TYPE:
-        open_msg = (EMC_TASK_PLAN_OPEN *) cmd;
+        open_msg = reinterpret_cast<EMC_TASK_PLAN_OPEN *>(cmd);
 
         /* receive file in chunks from remote process via open_msg->remote_buffer */
         if(open_msg->remote_filesize > 0) {
@@ -2226,7 +2226,7 @@ static int emcTaskIssueCommand(NMLmsg * cmd)
 	emcStatus->motion.traj.single_stepping = 0;
 	stepping = 0;
 	steppingWait = 0;
-	execute_msg = (EMC_TASK_PLAN_EXECUTE *) cmd;
+	execute_msg = reinterpret_cast<EMC_TASK_PLAN_EXECUTE *>(cmd);
         if (!all_homed() && !no_force_homing) { //!no_force_homing = force homing before MDI
             emcOperatorError(_("Can't issue MDI command when not homed"));
             retval = -1;
@@ -2325,7 +2325,7 @@ static int emcTaskIssueCommand(NMLmsg * cmd)
 	if (!taskplanopen && emcStatus->task.file[0] != 0) {
 	    emcTaskPlanOpen(emcStatus->task.file);
 	}
-	run_msg = (EMC_TASK_PLAN_RUN *) cmd;
+	run_msg = reinterpret_cast<EMC_TASK_PLAN_RUN *>(cmd);
 	programStartLine = run_msg->line;
 	emcStatus->task.interpState = EMC_TASK_INTERP::READING;
 	emcStatus->task.task_paused = 0;
@@ -2393,13 +2393,13 @@ static int emcTaskIssueCommand(NMLmsg * cmd)
 	break;
 
     case EMC_TASK_PLAN_SET_OPTIONAL_STOP_TYPE:
-	os_msg = (EMC_TASK_PLAN_SET_OPTIONAL_STOP *) cmd;
+	os_msg = reinterpret_cast<EMC_TASK_PLAN_SET_OPTIONAL_STOP *>(cmd);
 	emcTaskPlanSetOptionalStop(os_msg->state);
 	retval = 0;
 	break;
 
     case EMC_TASK_PLAN_SET_BLOCK_DELETE_TYPE:
-	bd_msg = (EMC_TASK_PLAN_SET_BLOCK_DELETE *) cmd;
+	bd_msg = reinterpret_cast<EMC_TASK_PLAN_SET_BLOCK_DELETE *>(cmd);
 	emcTaskPlanSetBlockDelete(bd_msg->state);
 	retval = 0;
 	break;

--- a/src/emc/tooldata/tooldata_mmap.cc
+++ b/src/emc/tooldata/tooldata_mmap.cc
@@ -58,10 +58,10 @@ typedef struct {
 
 #define TOOL_MMAP_STRIDE  sizeof(CANON_TOOL_TABLE)
 //---------------------------------------------------------------------
-#define HPTR()    (tooldata_header_t*)( tool_mmap_base \
+#define HPTR()    reinterpret_cast<tooldata_header_t*>( tool_mmap_base \
                                       + TOOL_MMAP_HEADER_OFFSET)
 
-#define TPTR(idx) (CANON_TOOL_TABLE*)( tool_mmap_base \
+#define TPTR(idx) reinterpret_cast<CANON_TOOL_TABLE*>( tool_mmap_base \
                                      + TOOL_MMAP_HEADER_OFFSET \
                                      + TOOL_MMAP_HEADER_SIZE \
                                      + idx * TOOL_MMAP_STRIDE)

--- a/src/emc/usr_intf/halui.cc
+++ b/src/emc/usr_intf/halui.cc
@@ -298,7 +298,7 @@ static int emcTaskNmlGet()
 	    emcStatus = 0;
 	    retval = -1;
 	} else {
-	    emcStatus = (EMC_STAT *) emcStatusBuffer->get_address();
+	    emcStatus = reinterpret_cast<EMC_STAT *>(emcStatusBuffer->get_address());
 	}
     }
 

--- a/src/hal/hal_priv.h
+++ b/src/hal/hal_priv.h
@@ -140,15 +140,15 @@ RTAPI_END_DECLS
 #ifdef __cplusplus
 template<class T>
 bool hal_shmchk(T *t) {
-    char *c = (char*)t;
+    char *c = reinterpret_cast<char*>(t);
     return c > hal_shmem_base && c < hal_shmem_base + HAL_SIZE;
 }
 
 template<class T>
-int hal_shmoff(T *t) { return t ? (char*)t - hal_shmem_base : 0; }
+int hal_shmoff(T *t) { return t ? reinterpret_cast<char*>(t) - hal_shmem_base : 0; }
 
 template<class T>
-T *hal_shmptr(int p) { return p ? (T*)(hal_shmem_base + p) : nullptr; }
+T *hal_shmptr(int p) { return p ? reinterpret_cast<T*>(hal_shmem_base + p) : nullptr; }
 
 template<class T>
 class hal_shmfield {

--- a/src/hal/halmodule.cc
+++ b/src/hal/halmodule.cc
@@ -234,7 +234,7 @@ static int pyhal_init(PyObject *_self, PyObject *args, PyObject *kw) {
     (void)kw;
     char *name;
     char *prefix = 0;
-    halobject *self = (halobject *)_self;
+    halobject *self = reinterpret_cast<halobject *>(_self);
 
     if(!PyArg_ParseTuple(args, "s|s:hal.component", &name, &prefix)) return -1;
 
@@ -276,7 +276,7 @@ static void pyhal_exit_impl(halobject *self) {
 }
 
 static void pyhal_delete(PyObject *_self) {
-    halobject *self = (halobject *)_self;
+    halobject *self = reinterpret_cast<halobject *>(_self);
     pyhal_exit_impl(self);
     Py_TYPE(self)->tp_free(self);
 }
@@ -477,7 +477,7 @@ static PyObject * pyhal_create_pin(halobject *self, char *name, hal_type_t type,
 static PyObject *pyhal_new_param(PyObject *_self, PyObject *o) {
     char *name;
     int type, dir;
-    halobject *self = (halobject *)_self;
+    halobject *self = reinterpret_cast<halobject *>(_self);
 
     if(!PyArg_ParseTuple(o, "sii", &name, &type, &dir))
         return NULL;
@@ -494,7 +494,7 @@ static PyObject *pyhal_new_param(PyObject *_self, PyObject *o) {
 static PyObject *pyhal_new_pin(PyObject *_self, PyObject *o) {
     char *name;
     int type, dir;
-    halobject *self = (halobject *)_self;
+    halobject *self = reinterpret_cast<halobject *>(_self);
 
     if(!PyArg_ParseTuple(o, "sii", &name, &type, &dir))
         return NULL;
@@ -509,7 +509,7 @@ static PyObject *pyhal_new_pin(PyObject *_self, PyObject *o) {
 
 static PyObject *pyhal_get_pin(PyObject *_self, PyObject *o) {
     char *name;
-    halobject *self = (halobject *)_self;
+    halobject *self = reinterpret_cast<halobject *>(_self);
 
     if(!PyArg_ParseTuple(o, "s", &name))
         return NULL;
@@ -524,7 +524,7 @@ static PyObject *pyhal_get_pin(PyObject *_self, PyObject *o) {
 
 static PyObject *pyhal_get_pins(PyObject *_self, PyObject * /*o*/) {
   char *name;
-  halobject *self = (halobject *)_self;
+  halobject *self = reinterpret_cast<halobject *>(_self);
 
   EXCEPTION_IF_NOT_LIVE(NULL);
 
@@ -540,7 +540,7 @@ static PyObject *pyhal_get_pins(PyObject *_self, PyObject * /*o*/) {
 
 static PyObject *pyhal_ready(PyObject *_self, PyObject * /*o*/) {
     // hal_ready did not exist in EMC 2.0.x, make it a no-op
-    halobject *self = (halobject *)_self;
+    halobject *self = reinterpret_cast<halobject *>(_self);
     EXCEPTION_IF_NOT_LIVE(NULL);
     int res = hal_ready(self->hal_id);
     if(res) return pyhal_error(res);
@@ -549,7 +549,7 @@ static PyObject *pyhal_ready(PyObject *_self, PyObject * /*o*/) {
 
 static PyObject *pyhal_unready(PyObject *_self, PyObject * /*o*/) {
     // hal_ready did not exist in EMC 2.0.x, make it a no-op
-    halobject *self = (halobject *)_self;
+    halobject *self = reinterpret_cast<halobject *>(_self);
     EXCEPTION_IF_NOT_LIVE(NULL);
     int res = hal_unready(self->hal_id);
     if(res) return pyhal_error(res);
@@ -557,23 +557,23 @@ static PyObject *pyhal_unready(PyObject *_self, PyObject * /*o*/) {
 }
 
 static PyObject *pyhal_exit(PyObject *_self, PyObject * /*o*/) {
-    halobject *self = (halobject *)_self;
+    halobject *self = reinterpret_cast<halobject *>(_self);
     pyhal_exit_impl(self);
     return Py_None;
 }
 
 static PyObject *pyhal_repr(PyObject *_self) {
-    halobject *self = (halobject *)_self;
+    halobject *self = reinterpret_cast<halobject *>(_self);
     return PyUnicode_FromFormat("<hal component %s(%d) with %d pins and params>",
             self->name, self->hal_id, (int)self->items->size());
 }
 
 static PyObject *pyhal_getattro(PyObject *_self, PyObject *attro)  {
     PyObject *result;
-    halobject *self = (halobject *)_self;
+    halobject *self = reinterpret_cast<halobject *>(_self);
     EXCEPTION_IF_NOT_LIVE(NULL);
 
-    result = PyObject_GenericGetAttr((PyObject*)self, attro);
+    result = PyObject_GenericGetAttr(reinterpret_cast<PyObject*>(self), attro);
     if(result) return result;
 
     PyErr_Clear();
@@ -581,19 +581,19 @@ static PyObject *pyhal_getattro(PyObject *_self, PyObject *attro)  {
 }
 
 static int pyhal_setattro(PyObject *_self, PyObject *attro, PyObject *v) {
-    halobject *self = (halobject *)_self;
+    halobject *self = reinterpret_cast<halobject *>(_self);
     EXCEPTION_IF_NOT_LIVE(-1);
     return pyhal_write_common(find_item(self, PyUnicode_AsUTF8(attro)), v);
 }
 
 static Py_ssize_t pyhal_len(PyObject *_self) {
-    halobject* self = (halobject*)_self;
+    halobject* self = reinterpret_cast<halobject*>(_self);
     EXCEPTION_IF_NOT_LIVE(-1);
     return self->items->size();
 }
 
 static PyObject *pyhal_get_prefix(PyObject *_self, PyObject *args) {
-    halobject* self = (halobject*)_self;
+    halobject* self = reinterpret_cast<halobject*>(_self);
     if(!PyArg_ParseTuple(args, "")) return NULL;
     EXCEPTION_IF_NOT_LIVE(NULL);
 
@@ -606,7 +606,7 @@ static PyObject *pyhal_get_prefix(PyObject *_self, PyObject *args) {
 
 static PyObject *pyhal_set_prefix(PyObject *_self, PyObject *args) {
     char *newprefix;
-    halobject* self = (halobject*)_self;
+    halobject* self = reinterpret_cast<halobject*>(_self);
     if(!PyArg_ParseTuple(args, "s", &newprefix)) return NULL;
     EXCEPTION_IF_NOT_LIVE(NULL);
 
@@ -741,7 +741,7 @@ static const char * param_dir2name(hal_param_dir_t type) {
 }
 
 static PyObject *pyhalpin_repr(PyObject *_self) {
-    pyhalitem *pyself = (pyhalitem *) _self;
+    pyhalitem *pyself = reinterpret_cast<pyhalitem *>(_self);
     halitem *self = &pyself->pin;
 
     const char * name = "(null)";
@@ -761,7 +761,7 @@ static int pyhalpin_init(PyObject * /*_self*/, PyObject *, PyObject *) {
 }
 
 static void pyhalpin_delete(PyObject *_self) {
-    pyhalitem *self = (pyhalitem *)_self;
+    pyhalitem *self = reinterpret_cast<pyhalitem *>(_self);
 
     if(self->name) free(self->name);
 
@@ -769,24 +769,24 @@ static void pyhalpin_delete(PyObject *_self) {
 }
 
 static PyObject * pyhal_pin_set(PyObject * _self, PyObject * value) {
-    pyhalitem * self = (pyhalitem *) _self;
+    pyhalitem * self = reinterpret_cast<pyhalitem *>(_self);
     if (pyhal_write_common(&self->pin, value) == -1)
 	return NULL;
     return Py_None;
 }
 
 static PyObject * pyhal_pin_get(PyObject * _self, PyObject *) {
-    pyhalitem * self = (pyhalitem *) _self;
+    pyhalitem * self = reinterpret_cast<pyhalitem *>(_self);
     return pyhal_read_common(&self->pin);
 }
 
 static PyObject * pyhal_pin_get_type(PyObject * _self, PyObject *) {
-    pyhalitem * self = (pyhalitem *) _self;
+    pyhalitem * self = reinterpret_cast<pyhalitem *>(_self);
     return PyLong_FromLong(self->pin.type);
 }
 
 static PyObject * pyhal_pin_get_dir(PyObject * _self, PyObject *) {
-    pyhalitem * self = (pyhalitem *) _self;
+    pyhalitem * self = reinterpret_cast<pyhalitem *>(_self);
     if (self->pin.is_pin)
 	return PyLong_FromLong(self->pin.dir.pindir);
     else
@@ -794,12 +794,12 @@ static PyObject * pyhal_pin_get_dir(PyObject * _self, PyObject *) {
 }
 
 static PyObject * pyhal_pin_is_pin(PyObject * _self, PyObject *) {
-    pyhalitem * self = (pyhalitem *) _self;
+    pyhalitem * self = reinterpret_cast<pyhalitem *>(_self);
     return PyBool_FromLong(self->pin.is_pin);
 }
 
 static PyObject * pyhal_pin_get_name(PyObject * _self, PyObject *) {
-    pyhalitem * self = (pyhalitem *) _self;
+    pyhalitem * self = reinterpret_cast<pyhalitem *>(_self);
     if (!self->name)
 	return Py_None;
     return PyUnicode_FromString(self->name);
@@ -886,7 +886,7 @@ static PyObject * pyhal_pin_new(halitem * pin, const char * name) {
     else
 	pypin->name = NULL;
 
-    return (PyObject *) pypin;
+    return reinterpret_cast<PyObject *>(pypin);
 }
 
 PyObject *pin_has_writer(PyObject * /*self*/, PyObject *args) {
@@ -1536,7 +1536,7 @@ struct shmobject {
 };
 
 static int pyshm_init(PyObject *_self, PyObject *args, PyObject * /*kw*/) {
-    shmobject *self = (shmobject *)_self;
+    shmobject *self = reinterpret_cast<shmobject *>(_self);
     self->comp = 0;
     self->shm_id = -1;
 
@@ -1559,7 +1559,7 @@ static int pyshm_init(PyObject *_self, PyObject *args, PyObject * /*kw*/) {
 }
 
 static void pyshm_delete(PyObject *_self) {
-    shmobject *self = (shmobject *)_self;
+    shmobject *self = reinterpret_cast<shmobject *>(_self);
     if(self->comp && self->shm_id > 0)
 	rtapi_shmem_delete(self->shm_id, self->comp->hal_id);
     Py_XDECREF(self->comp);
@@ -1570,8 +1570,8 @@ static int shm_buffer_getbuffer(PyObject *obj, Py_buffer *view, int /*flags*/) {
     PyErr_SetString(PyExc_ValueError, "NULL view in getbuffer");
     return -1;
   }
-  shmobject* self = (shmobject *)obj;
-  view->obj = (PyObject*)self;
+  shmobject* self = reinterpret_cast<shmobject *>(obj);
+  view->obj = reinterpret_cast<PyObject*>(self);
   view->buf = (void*)self->buf;
   view->len = self->size;
   view->readonly = 0;
@@ -1580,13 +1580,13 @@ static int shm_buffer_getbuffer(PyObject *obj, Py_buffer *view, int /*flags*/) {
 }
 
 static PyObject *pyshm_repr(PyObject *_self) {
-    shmobject *self = (shmobject *)_self;
+    shmobject *self = reinterpret_cast<shmobject *>(_self);
     return PyUnicode_FromFormat("<shared memory buffer key=%08x id=%d size=%ld>",
 	    self->key, self->shm_id, (unsigned long)self->size);
 }
 
 static PyObject *shm_setsize(PyObject *_self, PyObject *args) {
-    shmobject *self = (shmobject *)_self;
+    shmobject *self = reinterpret_cast<shmobject *>(_self);
     if(!PyArg_ParseTuple(args, "k", &self->size)) return NULL;
     return Py_None;
 }
@@ -1594,8 +1594,8 @@ static PyObject *shm_setsize(PyObject *_self, PyObject *args) {
 
 static PyObject *shm_getbuffer(PyObject *_self, PyObject * /*dummy*/) {
 
-    shmobject *self = (shmobject *)_self;
-    return (PyObject*)PyMemoryView_FromObject((PyObject*)self);
+    shmobject *self = reinterpret_cast<shmobject *>(_self);
+    return (PyObject*)PyMemoryView_FromObject(reinterpret_cast<PyObject*>(self));
 }
 
 static PyObject *set_msg_level(PyObject * /*_self*/, PyObject *args) {
@@ -1698,7 +1698,7 @@ static int pystream_init(PyObject *_self, PyObject *args, PyObject * /*kw*/) {
     int depth=0;
     char *typestring=NULL;
 
-    streamobj *self = (streamobj *)_self;
+    streamobj *self = reinterpret_cast<streamobj *>(_self);
     self->sampleno = 0;
 
     // creating a new stream
@@ -1751,7 +1751,7 @@ static int pystream_init(PyObject *_self, PyObject *args, PyObject * /*kw*/) {
 }
 
 PyObject *stream_read(PyObject *_self, PyObject * /*unused*/) {
-    streamobj *self = (streamobj *)_self;
+    streamobj *self = reinterpret_cast<streamobj *>(_self);
     int n = PyBytes_Size(self->pyelt);
     if(n <= 0)
         return Py_None;
@@ -1781,7 +1781,7 @@ PyObject *stream_read(PyObject *_self, PyObject * /*unused*/) {
 }
 
 PyObject *stream_write(PyObject *_self, PyObject *args) {
-    streamobj *self = (streamobj *)_self;
+    streamobj *self = reinterpret_cast<streamobj *>(_self);
     PyObject *data;
     if(!PyArg_ParseTuple(args, "O!:hal.stream.write", &PyTuple_Type, &data))
         return NULL;

--- a/src/hal/user_comps/xhc-hb04.cc
+++ b/src/hal/user_comps/xhc-hb04.cc
@@ -191,14 +191,14 @@ int xhc_encode_float(float v, unsigned char *buf)
 	unsigned short int_part = int_v / 10000;
 	unsigned short fract_part = int_v % 10000;
 	if (v < 0) fract_part = fract_part | 0x8000;
-	*(short *)buf = int_part;
-	*((short *)buf+1) = fract_part;
+	*reinterpret_cast<short *>(buf) = int_part;
+	*(reinterpret_cast<short *>(buf)+1) = fract_part;
 	return 4;
 }
 
 int xhc_encode_s16(int v, unsigned char *buf)
 {
-	*(short *)buf = v;
+	*reinterpret_cast<short *>(buf) = v;
 	return 2;
 }
 

--- a/src/hal/user_comps/xhc-whb04b-6/xhc-whb04b6.cc
+++ b/src/hal/user_comps/xhc-whb04b-6/xhc-whb04b6.cc
@@ -384,9 +384,9 @@ void XhcWhb04b6Component::printInputData(const UsbInPackage& inPackage, std::ost
     out << " | ";
     printPushButtonText(inPackage.buttonKeyCode2, inPackage.buttonKeyCode1, out);
     out << " | ";
-    printRotaryButtonText((KeyCode*)&mKeyCodes.Feed, inPackage.rotaryButtonFeedKeyCode, out);
+    printRotaryButtonText(reinterpret_cast<const KeyCode*>(&mKeyCodes.Feed), inPackage.rotaryButtonFeedKeyCode, out);
     out << " | ";
-    printRotaryButtonText((KeyCode*)&mKeyCodes.Axis, inPackage.rotaryButtonAxisKeyCode, out);
+    printRotaryButtonText(reinterpret_cast<const KeyCode*>(&mKeyCodes.Axis), inPackage.rotaryButtonAxisKeyCode, out);
     out << " | " << std::setfill(' ') << std::setw(3) << static_cast<short>(inPackage.stepCount) << " | " << std::hex
         << std::setfill('0')
         << std::setw(2) << static_cast<unsigned short>(inPackage.crc);

--- a/src/hal/utils/halcmd_commands.cc
+++ b/src/hal/utils/halcmd_commands.cc
@@ -2039,7 +2039,7 @@ static void print_thread_info(char **patterns)
 	    n = 1;
 	    while (list_entry != list_root) {
 		/* print the function info */
-		fentry = (hal_funct_entry_t *) list_entry;
+		fentry = reinterpret_cast<hal_funct_entry_t *>(list_entry);
 		funct = SHMPTR(fentry->funct_ptr);
 		/* scriptmode only uses one line per thread, which contains: 
 		   thread period, FP flag, name, then all functs separated by spaces  */
@@ -2842,7 +2842,7 @@ static void save_threads(FILE *dst)
 	list_entry = list_next(list_root);
 	while (list_entry != list_root) {
 	    /* print the function info */
-	    fentry = (hal_funct_entry_t *) list_entry;
+	    fentry = reinterpret_cast<hal_funct_entry_t *>(list_entry);
 	    funct = SHMPTR(fentry->funct_ptr);
 	    fprintf(dst, "addf %s %s\n", funct->name, tptr->name);
 	    list_entry = list_next(list_entry);

--- a/src/libnml/buffer/physmem.cc
+++ b/src/libnml/buffer/physmem.cc
@@ -103,7 +103,7 @@ int PHYSMEM_HANDLE::read(void *_to, long _read_size)
 	char *from;
 	from = ((char *) local_address) + offset;
 	if (_read_size == 2) {
-	    short *sfrom = (short *) from;
+	    short *sfrom = reinterpret_cast<short *>(from);
 	    short sval;
 	    sval = *sfrom;
 	    short *sto = (short *) _to;
@@ -153,7 +153,7 @@ int PHYSMEM_HANDLE::write(void *_from, long _write_size)
 	char *to;
 	to = ((char *) local_address) + offset;
 	if (_write_size == 2) {
-	    short *sto = (short *) to;
+	    short *sto = reinterpret_cast<short *>(to);
 	    short sval = *(short *) _from;
 	    *sto = sval;
 	} else {

--- a/src/libnml/buffer/tcpmem.cc
+++ b/src/libnml/buffer/tcpmem.cc
@@ -206,7 +206,7 @@ void
     rcs_print_debug(PRINT_ALL_SOCKET_REQUESTS,
 	"TCPMEM sending request: fd = %d, serial_number=%ld, request_type=%d, buffer_number=%ld\n",
 	socket_fd, serial_number,
-	ntohl(*((uint32_t *) diag_info_buf + 1)), buffer_number);
+	ntohl(*(reinterpret_cast<uint32_t *>(diag_info_buf) + 1)), buffer_number);
     reenable_sigpipe();
 
 }
@@ -234,7 +234,7 @@ void TCPMEM::verify_bufname()
     rcs_print_debug(PRINT_ALL_SOCKET_REQUESTS,
 	"TCPMEM sending request: fd = %d, serial_number=%ld, request_type=%d, buffer_number=%ld\n",
 	socket_fd, serial_number,
-	ntohl(*((uint32_t *) temp_buffer + 1)), buffer_number);
+	ntohl(*(reinterpret_cast<uint32_t *>(temp_buffer) + 1)), buffer_number);
     if (recvn(socket_fd, temp_buffer, 40, 0, timeout, &recvd_bytes) < 0) {
 	if (recvn_timedout) {
 	    bytes_to_throw_away = 40;
@@ -255,7 +255,7 @@ void TCPMEM::verify_bufname()
 	status = CMS_MISC_ERROR;
 	return;
     }
-    status = (CMS_STATUS) ntohl(*((uint32_t *) temp_buffer + 1));
+    status = (CMS_STATUS) ntohl(*(reinterpret_cast<uint32_t *>(temp_buffer) + 1));
     if (status < 0) {
 	return;
     }
@@ -302,7 +302,7 @@ CMS_DIAGNOSTICS_INFO *TCPMEM::get_diagnostics_info()
     rcs_print_debug(PRINT_ALL_SOCKET_REQUESTS,
 	"TCPMEM sending request: fd = %d, serial_number=%ld, request_type=%d, buffer_number=%ld\n",
 	socket_fd, serial_number,
-	ntohl(*((uint32_t *) temp_buffer + 1)), buffer_number);
+	ntohl(*(reinterpret_cast<uint32_t *>(temp_buffer) + 1)), buffer_number);
     if (recvn(socket_fd, temp_buffer, 32, 0, -1.0, &recvd_bytes) < 0) {
 	if (recvn_timedout) {
 	    bytes_to_throw_away = 32;
@@ -324,7 +324,7 @@ CMS_DIAGNOSTICS_INFO *TCPMEM::get_diagnostics_info()
 	status = CMS_MISC_ERROR;
 	return (NULL);
     }
-    status = (CMS_STATUS) ntohl(*((uint32_t *) temp_buffer + 1));
+    status = (CMS_STATUS) ntohl(*(reinterpret_cast<uint32_t *>(temp_buffer) + 1));
     if (status < 0) {
 	return (NULL);
     }
@@ -336,14 +336,14 @@ CMS_DIAGNOSTICS_INFO *TCPMEM::get_diagnostics_info()
     }
     di->last_writer_dpi = NULL;
     di->last_reader_dpi = NULL;
-    di->last_writer = ntohl(*((uint32_t *) temp_buffer + 2));
-    di->last_reader = ntohl(*((uint32_t *) temp_buffer + 3));
+    di->last_writer = ntohl(*(reinterpret_cast<uint32_t *>(temp_buffer) + 2));
+    di->last_reader = ntohl(*(reinterpret_cast<uint32_t *>(temp_buffer) + 3));
     double server_time;
     memcpy(&server_time, temp_buffer + 16, 8);
     double local_time = etime();
     double diff_time = local_time - server_time;
-    int dpi_count = ntohl(*((uint32_t *) temp_buffer + 6));
-    int dpi_max_size = ntohl(*((uint32_t *) temp_buffer + 7));
+    int dpi_count = ntohl(*(reinterpret_cast<uint32_t *>(temp_buffer) + 6));
+    int dpi_max_size = ntohl(*(reinterpret_cast<uint32_t *>(temp_buffer) + 7));
     if (dpi_max_size > 32 && dpi_max_size < 0x2000) {
 	if (recvn
 	    (socket_fd, temp_buffer + 32, dpi_max_size - 32, 0, -1.0,
@@ -364,27 +364,27 @@ CMS_DIAGNOSTICS_INFO *TCPMEM::get_diagnostics_info()
 	    memcpy(cms_dpi.host_sysinfo, temp_buffer + dpi_offset, 32);
 	    dpi_offset += 32;
 	    cms_dpi.pid =
-		ntohl(*((uint32_t *) ((char *) temp_buffer + dpi_offset)));
+		ntohl(*reinterpret_cast<uint32_t *>(reinterpret_cast<char *>(temp_buffer) + dpi_offset));
 	    dpi_offset += 4;
 	    memcpy(&(cms_dpi.rcslib_ver), temp_buffer + dpi_offset, 8);
 	    dpi_offset += 8;
 	    cms_dpi.access_type = (CMS_INTERNAL_ACCESS_TYPE)
-		ntohl(*((uint32_t *) ((char *) temp_buffer + dpi_offset)));
+		ntohl(*reinterpret_cast<uint32_t *>(reinterpret_cast<char *>(temp_buffer) + dpi_offset));
 	    dpi_offset += 4;
 	    cms_dpi.msg_id =
-		ntohl(*((uint32_t *) ((char *) temp_buffer + dpi_offset)));
+		ntohl(*reinterpret_cast<uint32_t *>(reinterpret_cast<char *>(temp_buffer) + dpi_offset));
 	    dpi_offset += 4;
 	    cms_dpi.msg_size =
-		ntohl(*((uint32_t *) ((char *) temp_buffer + dpi_offset)));
+		ntohl(*reinterpret_cast<uint32_t *>(reinterpret_cast<char *>(temp_buffer) + dpi_offset));
 	    dpi_offset += 4;
 	    cms_dpi.msg_type =
-		ntohl(*((uint32_t *) ((char *) temp_buffer + dpi_offset)));
+		ntohl(*reinterpret_cast<uint32_t *>(reinterpret_cast<char *>(temp_buffer) + dpi_offset));
 	    dpi_offset += 4;
 	    cms_dpi.number_of_accesses =
-		ntohl(*((uint32_t *) ((char *) temp_buffer + dpi_offset)));
+		ntohl(*reinterpret_cast<uint32_t *>(reinterpret_cast<char *>(temp_buffer) + dpi_offset));
 	    dpi_offset += 4;
 	    cms_dpi.number_of_new_messages =
-		ntohl(*((uint32_t *) ((char *) temp_buffer + dpi_offset)));
+		ntohl(*reinterpret_cast<uint32_t *>(reinterpret_cast<char *>(temp_buffer) + dpi_offset));
 	    dpi_offset += 4;
 	    memcpy(&(cms_dpi.bytes_moved), temp_buffer + dpi_offset, 8);
 	    dpi_offset += 8;
@@ -407,14 +407,14 @@ CMS_DIAGNOSTICS_INFO *TCPMEM::get_diagnostics_info()
 	    dpi_offset += 8;
 	    di->dpis->store_at_tail(&cms_dpi, sizeof(CMS_DIAG_PROC_INFO), 1);
 	    int is_last_writer =
-		ntohl(*((uint32_t *) ((char *) temp_buffer + dpi_offset)));
+		ntohl(*reinterpret_cast<uint32_t *>(reinterpret_cast<char *>(temp_buffer) + dpi_offset));
 	    dpi_offset += 4;
 	    if (is_last_writer) {
 		di->last_writer_dpi =
 		    (CMS_DIAG_PROC_INFO *) di->dpis->get_tail();
 	    }
 	    int is_last_reader =
-		ntohl(*((uint32_t *) ((char *) temp_buffer + dpi_offset)));
+		ntohl(*reinterpret_cast<uint32_t *>(reinterpret_cast<char *>(temp_buffer) + dpi_offset));
 	    dpi_offset += 4;
 	    if (is_last_reader) {
 		di->last_reader_dpi =
@@ -470,7 +470,7 @@ void TCPMEM::reconnect()
 	status = CMS_CREATE_ERROR;
     }
     rcs_print_debug(PRINT_CMS_CONFIG_INFO, "Connecting . . .\n");
-    if (connect(socket_fd, (struct sockaddr *) &server_socket_address,
+    if (connect(socket_fd, reinterpret_cast<struct sockaddr *>(&server_socket_address),
 	    sizeof(server_socket_address)) < 0) {
 	if (EINPROGRESS == errno) {
 
@@ -542,7 +542,7 @@ void TCPMEM::reconnect()
 	    rcs_print_debug(PRINT_ALL_SOCKET_REQUESTS,
 		"TCPMEM sending request: fd = %d, serial_number=%ld, request_type=%d, buffer_number=%ld\n",
 		socket_fd, serial_number,
-		ntohl(*((uint32_t *) temp_buffer + 1)), buffer_number);
+		ntohl(*(reinterpret_cast<uint32_t *>(temp_buffer) + 1)), buffer_number);
 	    memset(temp_buffer, 0, 20);
 	    recvd_bytes = 0;
 	    if (recvn(socket_fd, temp_buffer, 8, 0, 30, &recvd_bytes) < 0) {
@@ -590,7 +590,7 @@ void TCPMEM::reconnect()
 	}
 	rcs_print_debug(PRINT_CMS_CONFIG_INFO, "Connecting . . .\n");
 	if (connect
-	    (write_socket_fd, (struct sockaddr *) &server_socket_address,
+	    (write_socket_fd, reinterpret_cast<struct sockaddr *>(&server_socket_address),
 		sizeof(server_socket_address)) < 0) {
 	    if (EINPROGRESS == errno) {
 		FD_ZERO(&fds);
@@ -721,11 +721,11 @@ CMS_STATUS TCPMEM::handle_old_replies()
 		    serial_number = returned_serial_number;
 		}
 	    }
-	    message_size = ntohl(*((uint32_t *) temp_buffer + 2));
+	    message_size = ntohl(*(reinterpret_cast<uint32_t *>(temp_buffer) + 2));
 	    timedout_request_status =
-		(CMS_STATUS) ntohl(*((uint32_t *) temp_buffer + 1));
-	    timedout_request_writeid = ntohl(*((uint32_t *) temp_buffer + 3));
-	    header.was_read = ntohl(*((uint32_t *) temp_buffer + 4));
+		(CMS_STATUS) ntohl(*(reinterpret_cast<uint32_t *>(temp_buffer) + 1));
+	    timedout_request_writeid = ntohl(*(reinterpret_cast<uint32_t *>(temp_buffer) + 3));
+	    header.was_read = ntohl(*(reinterpret_cast<uint32_t *>(temp_buffer) + 4));
 	    if (message_size > max_encoded_message_size) {
 		rcs_print_error("Received message is too big. (%ld > %ld)\n",
 		    message_size, max_encoded_message_size);
@@ -970,7 +970,7 @@ CMS_STATUS TCPMEM::read()
 
     int send_header_size = 20;
     if (total_subdivisions > 1) {
-	*((uint32_t *) temp_buffer + 5) = htonl((uint32_t) current_subdivision);
+	*(reinterpret_cast<uint32_t *>(temp_buffer) + 5) = htonl((uint32_t) current_subdivision);
 	send_header_size = 24;
     }
     if (sendn(socket_fd, temp_buffer, send_header_size, 0, timeout) < 0) {
@@ -984,7 +984,7 @@ CMS_STATUS TCPMEM::read()
     rcs_print_debug(PRINT_ALL_SOCKET_REQUESTS,
 	"TCPMEM sending request: fd = %d, serial_number=%ld, request_type=%d, buffer_number=%ld\n",
 	socket_fd, serial_number,
-	ntohl(*((uint32_t *) temp_buffer + 1)), buffer_number);
+	ntohl(*(reinterpret_cast<uint32_t *>(temp_buffer) + 1)), buffer_number);
 
     if (recvn(socket_fd, temp_buffer, 20, 0, timeout, &recvd_bytes) < 20) {
 	if (recvn_timedout) {
@@ -1021,10 +1021,10 @@ CMS_STATUS TCPMEM::read()
 	    return (status = CMS_MISC_ERROR);
 	}
     }
-    status = (CMS_STATUS) ntohl(*((uint32_t *) temp_buffer + 1));
-    message_size = ntohl(*((uint32_t *) temp_buffer + 2));
-    id = ntohl(*((uint32_t *) temp_buffer + 3));
-    header.was_read = ntohl(*((uint32_t *) temp_buffer + 4));
+    status = (CMS_STATUS) ntohl(*(reinterpret_cast<uint32_t *>(temp_buffer) + 1));
+    message_size = ntohl(*(reinterpret_cast<uint32_t *>(temp_buffer) + 2));
+    id = ntohl(*(reinterpret_cast<uint32_t *>(temp_buffer) + 3));
+    header.was_read = ntohl(*(reinterpret_cast<uint32_t *>(temp_buffer) + 4));
     if (message_size > max_encoded_message_size) {
 	rcs_print_error("Received message is too big. (%ld > %ld)\n",
 	    message_size, max_encoded_message_size);
@@ -1185,7 +1185,7 @@ CMS_STATUS TCPMEM::blocking_read(double _blocking_timeout)
 	"TCPMEM sending request: fd = %d, serial_number=%ld, "
 	"request_type=%d, buffer_number=%ld\n",
 	socket_fd, serial_number,
-	ntohl(*((uint32_t *) temp_buffer + 1)), buffer_number);
+	ntohl(*(reinterpret_cast<uint32_t *>(temp_buffer) + 1)), buffer_number);
     if (recvn(socket_fd, temp_buffer, 20, 0, blocking_timeout, &recvd_bytes) <
 	0) {
 	print_recvn_timeout_errors = orig_print_recvn_timeout_errors;
@@ -1224,10 +1224,10 @@ CMS_STATUS TCPMEM::blocking_read(double _blocking_timeout)
 	    return (status = CMS_MISC_ERROR);
 	}
     }
-    status = (CMS_STATUS) ntohl(*((uint32_t *) temp_buffer + 1));
-    message_size = ntohl(*((uint32_t *) temp_buffer + 2));
-    id = ntohl(*((uint32_t *) temp_buffer + 3));
-    header.was_read = ntohl(*((uint32_t *) temp_buffer + 4));
+    status = (CMS_STATUS) ntohl(*(reinterpret_cast<uint32_t *>(temp_buffer) + 1));
+    message_size = ntohl(*(reinterpret_cast<uint32_t *>(temp_buffer) + 2));
+    id = ntohl(*(reinterpret_cast<uint32_t *>(temp_buffer) + 3));
+    header.was_read = ntohl(*(reinterpret_cast<uint32_t *>(temp_buffer) + 4));
     if (message_size > max_encoded_message_size) {
 	rcs_print_error("Received message is too big. (%ld > %ld)\n",
 	    message_size, max_encoded_message_size);
@@ -1365,7 +1365,7 @@ CMS_STATUS TCPMEM::peek()
     putbe32(temp_buffer + 16, (uint32_t) in_buffer_id);
     int send_header_size = 20;
     if (total_subdivisions > 1) {
-	*((uint32_t *) temp_buffer + 20) = htonl((uint32_t) current_subdivision);
+	*(reinterpret_cast<uint32_t *>(temp_buffer) + 20) = htonl((uint32_t) current_subdivision);
 	send_header_size = 24;
     }
     if (sendn(socket_fd, temp_buffer, send_header_size, 0, timeout) < 0) {
@@ -1410,10 +1410,10 @@ CMS_STATUS TCPMEM::peek()
 	    return (status = CMS_MISC_ERROR);
 	}
     }
-    status = (CMS_STATUS) ntohl(*((uint32_t *) temp_buffer + 1));
-    message_size = ntohl(*((uint32_t *) temp_buffer + 2));
-    id = ntohl(*((uint32_t *) temp_buffer + 3));
-    header.was_read = ntohl(*((uint32_t *) temp_buffer + 4));
+    status = (CMS_STATUS) ntohl(*(reinterpret_cast<uint32_t *>(temp_buffer) + 1));
+    message_size = ntohl(*(reinterpret_cast<uint32_t *>(temp_buffer) + 2));
+    id = ntohl(*(reinterpret_cast<uint32_t *>(temp_buffer) + 3));
+    header.was_read = ntohl(*(reinterpret_cast<uint32_t *>(temp_buffer) + 4));
     if (message_size > max_encoded_message_size) {
 	reconnect_needed = 1;
 	rcs_print_error("Received message is too big. (%ld > %ld)\n",
@@ -1560,8 +1560,8 @@ CMS_STATUS TCPMEM::write(void *user_data, int *serial_number_out)
 	    "TCPMEM received_reply: fd = %d, serial_number=%ld, buffer_number=%ld\n",
 	    socket_fd, returned_serial_number, buffer_number);
 
-	status = (CMS_STATUS) ntohl(*((uint32_t *) temp_buffer + 1));
-	header.was_read = ntohl(*((uint32_t *) temp_buffer + 2));
+	status = (CMS_STATUS) ntohl(*(reinterpret_cast<uint32_t *>(temp_buffer) + 1));
+	header.was_read = ntohl(*(reinterpret_cast<uint32_t *>(temp_buffer) + 2));
 	header.write_id = returned_serial_number;
     } else {
 	header.was_read = 0;
@@ -1671,8 +1671,8 @@ CMS_STATUS TCPMEM::write_if_read(void *user_data, int *serial_number_out)
 	rcs_print_debug(PRINT_ALL_SOCKET_REQUESTS,
 	    "TCPMEM received_reply: fd = %d, serial_number=%ld, buffer_number=%ld\n",
 	    socket_fd, returned_serial_number, buffer_number);
-	status = (CMS_STATUS) ntohl(*((uint32_t *) temp_buffer + 1));
-	header.was_read = ntohl(*((uint32_t *) temp_buffer + 2));
+	status = (CMS_STATUS) ntohl(*(reinterpret_cast<uint32_t *>(temp_buffer) + 1));
+	header.was_read = ntohl(*(reinterpret_cast<uint32_t *>(temp_buffer) + 2));
     } else {
 	header.was_read = 0;
 	status = CMS_WRITE_OK;
@@ -1756,8 +1756,8 @@ int TCPMEM::check_if_read()
 	reenable_sigpipe();
 	return (status = CMS_MISC_ERROR);
     }
-    status = (CMS_STATUS) ntohl(*((uint32_t *) temp_buffer + 1));
-    header.was_read = ntohl(*((uint32_t *) temp_buffer + 2));
+    status = (CMS_STATUS) ntohl(*(reinterpret_cast<uint32_t *>(temp_buffer) + 1));
+    header.was_read = ntohl(*(reinterpret_cast<uint32_t *>(temp_buffer) + 2));
     reenable_sigpipe();
     return (header.was_read);
 }
@@ -1836,8 +1836,8 @@ int TCPMEM::get_queue_length()
 	reenable_sigpipe();
 	return (status = CMS_MISC_ERROR);
     }
-    status = (CMS_STATUS) ntohl(*((uint32_t *) temp_buffer + 1));
-    queuing_header.queue_length = ntohl(*((uint32_t *) temp_buffer + 2));
+    status = (CMS_STATUS) ntohl(*(reinterpret_cast<uint32_t *>(temp_buffer) + 1));
+    queuing_header.queue_length = ntohl(*(reinterpret_cast<uint32_t *>(temp_buffer) + 2));
     reenable_sigpipe();
     return (queuing_header.queue_length);
 }
@@ -1916,8 +1916,8 @@ int TCPMEM::get_msg_count()
 	reenable_sigpipe();
 	return (status = CMS_MISC_ERROR);
     }
-    status = (CMS_STATUS) ntohl(*((uint32_t *) temp_buffer + 1));
-    header.write_id = ntohl(*((uint32_t *) temp_buffer + 2));
+    status = (CMS_STATUS) ntohl(*(reinterpret_cast<uint32_t *>(temp_buffer) + 1));
+    header.write_id = ntohl(*(reinterpret_cast<uint32_t *>(temp_buffer) + 2));
     reenable_sigpipe();
     return (header.write_id);
 }
@@ -1996,8 +1996,8 @@ int TCPMEM::get_space_available()
 	reenable_sigpipe();
 	return (status = CMS_MISC_ERROR);
     }
-    status = (CMS_STATUS) ntohl(*((uint32_t *) temp_buffer + 1));
-    free_space = ntohl(*((uint32_t *) temp_buffer + 2));
+    status = (CMS_STATUS) ntohl(*(reinterpret_cast<uint32_t *>(temp_buffer) + 1));
+    free_space = ntohl(*(reinterpret_cast<uint32_t *>(temp_buffer) + 2));
     reenable_sigpipe();
     return (free_space);
 }
@@ -2063,8 +2063,8 @@ CMS_STATUS TCPMEM::clear()
 	reconnect_needed = 1;
 	return (status = CMS_MISC_ERROR);
     }
-    status = (CMS_STATUS) ntohl(*((uint32_t *) temp_buffer + 1));
-    header.was_read = ntohl(*((uint32_t *) temp_buffer + 2));
+    status = (CMS_STATUS) ntohl(*(reinterpret_cast<uint32_t *>(temp_buffer) + 1));
+    header.was_read = ntohl(*(reinterpret_cast<uint32_t *>(temp_buffer) + 2));
     return (status);
 }
 /*! \todo Another #if 0 */

--- a/src/libnml/cms/cms.cc
+++ b/src/libnml/cms/cms.cc
@@ -1151,8 +1151,8 @@ int CMS::encode_header()
     }
     CMS_UPDATER_MODE original_mode;
     original_mode = updater->get_mode();
-    format_low_ptr = (char *) &header;
-    format_high_ptr = ((char *) &header) + sizeof(CMS_HEADER);
+    format_low_ptr = reinterpret_cast<char *>(&header);
+    format_high_ptr = reinterpret_cast<char *>(&header) + sizeof(CMS_HEADER);
     updater->set_mode(CMS_ENCODE_HEADER);
     updater->rewind();
     updater->update(header.was_read);
@@ -1180,8 +1180,8 @@ int CMS::decode_header()
 	return -1;
     }
     CMS_UPDATER_MODE original_mode = updater->get_mode();
-    format_low_ptr = (char *) &header;
-    format_high_ptr = ((char *) &header) + sizeof(CMS_HEADER);
+    format_low_ptr = reinterpret_cast<char *>(&header);
+    format_high_ptr = reinterpret_cast<char *>(&header) + sizeof(CMS_HEADER);
     updater->set_mode(CMS_DECODE_HEADER);
     updater->rewind();
     updater->update(header.was_read);
@@ -1201,8 +1201,8 @@ int CMS::encode_queuing_header()
 	return -1;
     }
     CMS_UPDATER_MODE original_mode = updater->get_mode();
-    format_low_ptr = (char *) &queuing_header;
-    format_high_ptr = ((char *) &queuing_header) + sizeof(CMS_QUEUING_HEADER);
+    format_low_ptr = reinterpret_cast<char *>(&queuing_header);
+    format_high_ptr = reinterpret_cast<char *>(&queuing_header) + sizeof(CMS_QUEUING_HEADER);
     updater->set_mode(CMS_ENCODE_QUEUING_HEADER);
     updater->rewind();
     updater->update(queuing_header.head);
@@ -1232,8 +1232,8 @@ int CMS::decode_queuing_header()
 	return -1;
     }
     CMS_UPDATER_MODE original_mode = updater->get_mode();
-    format_low_ptr = (char *) &queuing_header;
-    format_high_ptr = ((char *) &queuing_header) + sizeof(CMS_QUEUING_HEADER);
+    format_low_ptr = reinterpret_cast<char *>(&queuing_header);
+    format_high_ptr = reinterpret_cast<char *>(&queuing_header) + sizeof(CMS_QUEUING_HEADER);
     updater->set_mode(CMS_DECODE_QUEUING_HEADER);
     updater->rewind();
     updater->update(queuing_header.head);

--- a/src/libnml/cms/cms_srv.cc
+++ b/src/libnml/cms/cms_srv.cc
@@ -639,14 +639,14 @@ REMOTE_CMS_REPLY *CMS_SERVER::process_request(REMOTE_CMS_REQUEST * _request)
 	}
 
     case REMOTE_CMS_READ_REQUEST_TYPE:
-	return (local_port->reader((REMOTE_READ_REQUEST *) request));
+	return (local_port->reader(reinterpret_cast<REMOTE_READ_REQUEST *>(request)));
     case REMOTE_CMS_GET_DIAG_INFO_REQUEST_TYPE:
 	return (local_port->get_diag_info
-	    ((REMOTE_GET_DIAG_INFO_REQUEST *) request));
+	    (reinterpret_cast<REMOTE_GET_DIAG_INFO_REQUEST *>(request)));
     case REMOTE_CMS_BLOCKING_READ_REQUEST_TYPE:
-	return (local_port->blocking_read((REMOTE_READ_REQUEST *) request));
+	return (local_port->blocking_read(reinterpret_cast<REMOTE_READ_REQUEST *>(request)));
     case REMOTE_CMS_WRITE_REQUEST_TYPE:
-	return (local_port->writer((REMOTE_WRITE_REQUEST *) request));
+	return (local_port->writer(reinterpret_cast<REMOTE_WRITE_REQUEST *>(request)));
     case REMOTE_CMS_CHECK_IF_READ_REQUEST_TYPE:
 	if (NULL == local_port->cms) {
 	    rcs_print_error
@@ -713,8 +713,8 @@ REMOTE_CMS_REPLY *CMS_SERVER::process_request(REMOTE_CMS_REQUEST * _request)
 	}
 	remote_port->current_connected_user_struct->user_info =
 	    get_user_info(
-	    ((REMOTE_LOGIN_REQUEST *) request)->name,
-	    ((REMOTE_LOGIN_REQUEST *) request)->passwd);
+	    reinterpret_cast<REMOTE_LOGIN_REQUEST *>(request)->name,
+	    reinterpret_cast<REMOTE_LOGIN_REQUEST *>(request)->passwd);
 	login_reply->success =
 	    (NULL != remote_port->current_connected_user_struct->user_info);
 	if (login_reply->success) {

--- a/src/libnml/cms/tcp_opts.cc
+++ b/src/libnml/cms/tcp_opts.cc
@@ -32,7 +32,7 @@ int set_tcp_socket_options(int socket_fd)
     int optval = 1;
 #ifdef TCP_NODELAY
     if (setsockopt(socket_fd, IPPROTO_TCP, TCP_NODELAY,
-	    (char *) &optval, sizeof(optval)) < 0) {
+	    reinterpret_cast<char *>(&optval), sizeof(optval)) < 0) {
 	rcs_print_error(" Can`t set a socket option.\n");
 	rcs_print_error("errno = %d = %s\n", errno, strerror(errno));
 	return -1;
@@ -42,7 +42,7 @@ int set_tcp_socket_options(int socket_fd)
     optval = 1;
 
     if (setsockopt(socket_fd, SOL_SOCKET, SO_REUSEADDR,
-	    (char *) &optval, sizeof(optval)) < 0) {
+	    reinterpret_cast<char *>(&optval), sizeof(optval)) < 0) {
 	rcs_print_error(" Can`t set a socket option.\n");
 	rcs_print_error("errno = %d = %s\n", errno, strerror(errno));
 	return -1;
@@ -51,7 +51,7 @@ int set_tcp_socket_options(int socket_fd)
     linger_opt.l_onoff = 0;
     linger_opt.l_linger = 0;
     if (setsockopt(socket_fd, SOL_SOCKET, SO_LINGER,
-	    (char *) &linger_opt, sizeof(linger_opt)) < 0) {
+	    reinterpret_cast<char *>(&linger_opt), sizeof(linger_opt)) < 0) {
 	rcs_print_error(" Can`t set a socket option.\n");
 	rcs_print_error("errno = %d = %s\n", errno, strerror(errno));
 	return -1;

--- a/src/libnml/nml/cmd_msg.hh
+++ b/src/libnml/nml/cmd_msg.hh
@@ -33,7 +33,7 @@ class RCS_CMD_CHANNEL:public NML {
     // Sub-class calls base-class
     // cppcheck-suppress duplInheritedMember
     RCS_CMD_MSG *get_address() {
-	return ((RCS_CMD_MSG *) NML::get_address());
+	return static_cast<RCS_CMD_MSG *>(NML::get_address());
     };
 
     int write(RCS_CMD_MSG * cmd_msg);

--- a/src/libnml/nml/nml.cc
+++ b/src/libnml/nml/nml.cc
@@ -115,7 +115,7 @@ void *NML::operator new(size_t size)
 	cptr = ((char *) nml_space) + sizeof(NML);
 	// guarantee alignment
 	cptr += sizeof(int) - (((size_t) cptr) % sizeof(int));
-	*((int *) cptr) = dynamic_list_id;
+	*reinterpret_cast<int *>(cptr) = dynamic_list_id;
     }
     rcs_print_debug(PRINT_NML_CONSTRUCTORS, "%p = NML::operator new(%zd)\n",
 	nml_space, size);
@@ -137,7 +137,7 @@ void NML::operator delete(void *nml_space)
     if (NULL != Dynamically_Allocated_NML_Objects) {
 	cptr = ((char *) nml_space) + sizeof(NML);
 	cptr += sizeof(int) - (((size_t) cptr) % sizeof(int));
-	dynamic_list_id = *((int *) cptr);
+	dynamic_list_id = *reinterpret_cast<int *>(cptr);
 	Dynamically_Allocated_NML_Objects->delete_node(dynamic_list_id);
 	if (Dynamically_Allocated_NML_Objects->list_size == 0) {
 	    delete Dynamically_Allocated_NML_Objects;
@@ -1865,7 +1865,7 @@ int NML::format_input(NMLmsg * nml_msg)
 	    return (-1);
 	}
 
-	cms->format_low_ptr = (char *) nml_msg;
+	cms->format_low_ptr = reinterpret_cast<char *>(nml_msg);
 	cms->format_high_ptr = cms->format_low_ptr + nml_msg->size;
 	/* Handle the generic part of the message. */
 	cms->rewind();		/* Move to the start of the encoded buffer. */
@@ -2436,7 +2436,7 @@ NML_DIAGNOSTICS_INFO *NML::get_diagnostics_info()
     if (NULL == cms) {
 	return NULL;
     }
-    return (NML_DIAGNOSTICS_INFO *) cms->get_diagnostics_info();
+    return reinterpret_cast<NML_DIAGNOSTICS_INFO *>(cms->get_diagnostics_info());
 }
 
 void nmlSetHostAlias(const char * const hostName, const char * const hostAlias)

--- a/src/libnml/nml/nml_srv.cc
+++ b/src/libnml/nml/nml_srv.cc
@@ -191,7 +191,7 @@ REMOTE_READ_REPLY *NML_SERVER_LOCAL_PORT::blocking_read(REMOTE_READ_REQUEST *
     double orig_bytes_moved = 0.0;
 
     REMOTE_BLOCKING_READ_REQUEST *breq =
-	(REMOTE_BLOCKING_READ_REQUEST *) _req;
+	reinterpret_cast<REMOTE_BLOCKING_READ_REQUEST *>(_req);
     breq->_nml = new NML(nml, 1, -1);
 
     NML *nmlcopy = breq->_nml;
@@ -283,7 +283,7 @@ REMOTE_WRITE_REPLY *NML_SERVER_LOCAL_PORT::writer(REMOTE_WRITE_REQUEST * _req)
     cms->header.in_buffer_size = _req->size;
     temp->size = _req->size;
     int *serial_number = cms->serial
-	? &(((RCS_CMD_MSG*)temp)->serial_number)
+	? &(reinterpret_cast<RCS_CMD_MSG*>(temp)->serial_number)
 	: NULL;
 
     switch (_req->access_type) {

--- a/src/libnml/nml/stat_msg.hh
+++ b/src/libnml/nml/stat_msg.hh
@@ -52,7 +52,7 @@ class RCS_STAT_CHANNEL:public NML {
     // Sub-class calls base-class
     // cppcheck-suppress duplInheritedMember
     RCS_STAT_MSG *get_address() {
-	return ((RCS_STAT_MSG *) NML::get_address());
+	return static_cast<RCS_STAT_MSG *>(NML::get_address());
     };
 };
 


### PR DESCRIPTION
This PR addresses the cppcheck message: "warning: Potentially invalid type conversion in old-style C cast, clarify/fix with C++ cast [dangerousTypeCast]".

Most are fixed by converting to C++ typecasts. Some are still not fixed because those files could create conflicts and more changes are in the pipeline.