### PR TITLE
Fix heartbeats from task and motion

### DIFF
--- a/src/emc/motion/motion.h
+++ b/src/emc/motion/motion.h
@@ -60,6 +60,8 @@ to another.
 #ifndef MOTION_H
 #define MOTION_H
 
+#include <stdint.h>
+
 #include "posemath.h"		/* PmCartesian, PmPose, pmCartMag() */
 #include "emcpos.h"		/* EmcPose */
 #include "cubic.h"		/* CUBIC_STRUCT, CUBIC_COEFF */
@@ -623,7 +625,7 @@ Suggestion: Split this in to an Error and a Status flag register..
 /*! \todo FIXME - all structure members beyond this point are in limbo */
 
 	/* dynamic status-- changes every cycle */
-	unsigned int heartbeat;
+	uint64_t heartbeat;     /* Incremented every time the motion controller is done. */
 	int config_num;		/* incremented whenever configuration
 				   changed. */
 	int id;			/* id for executing motion */

--- a/src/emc/motion/usrmotintf.cc
+++ b/src/emc/motion/usrmotintf.cc
@@ -370,7 +370,7 @@ void usrmotPrintEmcmotStatus(emcmot_status_t *s, int which)
 	    );
 	printf("cmd:          \t%d\n", s->commandEcho);
 	printf("cmd num:      \t%d\n", s->commandNumEcho);
-	printf("heartbeat:    \t%u\n", s->heartbeat);
+	printf("heartbeat:    \t%lu\n", s->heartbeat);
 /*! \todo Another #if 0 */
 #if 0				/*! \todo FIXME - change to work with joint
 				   structures */

--- a/src/emc/nml_intf/emc.cc
+++ b/src/emc/nml_intf/emc.cc
@@ -881,7 +881,7 @@ void EMC_AUX_STAT::update(CMS * cms)
 */
 void EMC_TASK_STAT_MSG::update(CMS * cms)
 {
-    cms->update(heartbeat);
+    cms->update(taskbeat);
 }
 
 /*
@@ -1847,6 +1847,7 @@ void EMC_MOTION_STAT::update(CMS * cms)
     EmcPose_update(cms, &eoffset_pose);
     cms->update(numExtraJoints);
     cms->update(jogging_active);
+    cms->update(heartbeat);
 }
 
 /*

--- a/src/emc/nml_intf/emc_nml.hh
+++ b/src/emc/nml_intf/emc_nml.hh
@@ -1157,6 +1157,7 @@ class EMC_MOTION_STAT:public EMC_MOTION_STAT_MSG {
     EmcPose eoffset_pose;
     int numExtraJoints;
     bool jogging_active;
+    uint64_t heartbeat;  // motion controller's heartbeat counter
 };
 
 // declarations for EMC_TASK classes
@@ -1422,13 +1423,13 @@ class EMC_TASK_STAT_MSG:public RCS_STAT_MSG {
   public:
     EMC_TASK_STAT_MSG(NMLTYPE t, size_t s)
       : RCS_STAT_MSG(t, s),
-	heartbeat(0)
+	taskbeat(0)
     {};
 
     // For internal NML/CMS use only.
     void update(CMS * cms);
 
-    uint32_t heartbeat;
+    uint64_t taskbeat;  // milltask's main loop heartbeat counter
 };
 
 class EMC_TASK_STAT:public EMC_TASK_STAT_MSG {

--- a/src/emc/task/emctask.cc
+++ b/src/emc/task/emctask.cc
@@ -734,6 +734,9 @@ int emcTaskUpdate(EMC_TASK_STAT * stat)
     //update state of block delete
     stat->block_delete_state = GET_BLOCK_DELETE();
 
+    extern uint64_t task_beat;  // Main loop heartbeat in emctaskmain.cc
+    stat->taskbeat = task_beat;
+
     return 0;
 }
 

--- a/src/emc/task/emctaskmain.cc
+++ b/src/emc/task/emctaskmain.cc
@@ -138,6 +138,7 @@ static int emctask_shutdown(void);
 extern void backtrace(int signo);
 int _task = 1; // control preview behaviour when remapping
 static int joints = 0;
+uint64_t task_beat = 0;  // Task's main loop heartbeat counter
 
 // for operator display on iocontrol signalling a toolchanger fault if io.fault is set
 // %d receives io.reason
@@ -3379,6 +3380,8 @@ int main(int argc, char *argv[])
     }
     while (!done) {
         static int gave_soft_limit_message = 0;
+        task_beat++;  // Task's heartbeat
+
         check_ini_hal_items(emcStatus->motion.traj.joints);
 	// read command
 	if (0 != emcCommandBuffer->read()) {
@@ -3585,11 +3588,11 @@ int main(int argc, char *argv[])
     // end of while (! done)
 
     rcs_print(
-        "task: %u cycles, min=%.6f, max=%.6f, avg=%.6f, %u latency excursions (> %dx expected cycle time of %.6fs)\n",
-        emcStatus->task.heartbeat,
+        "task: %lu cycles, min=%.6f, max=%.6f, avg=%.6f, %u latency excursions (> %dx expected cycle time of %.6fs)\n",
+        task_beat,
         minTime,
         maxTime,
-        (emcStatus->task.heartbeat != 0) ?  (endTime - first_start_time) / emcStatus->task.heartbeat : -1.0,
+        task_beat ? (endTime - first_start_time) / task_beat : -1.0,
         num_latency_warnings,
         latency_excursion_factor,
         emc_task_cycle_time

--- a/src/emc/task/taskintf.cc
+++ b/src/emc/task/taskintf.cc
@@ -2095,6 +2095,8 @@ int emcMotionUpdate(EMC_MOTION_STAT * stat)
     stat->echo_serial_number = localMotionEchoSerialNumber;
     stat->debug = emcmotConfig.debug;
 
+    stat->heartbeat = emcmotStatus.heartbeat; // Motion controller's heartbeat
+
     for (dio = 0; dio < EMCMOT_MAX_DIO; dio++) {
 	stat->synch_di[dio] = emcmotStatus.synch_di[dio];
 	stat->synch_do[dio] = emcmotStatus.synch_do[dio];


### PR DESCRIPTION
The motion controller has a heartbeat that was apparently addressed in task, but that heartbeat counter was never updated or propagated. Task's status line, when LCNC exists, always printed `task: 0 cycles, ...` because of this. Using motion controller's heartbeat in task was wrong anyway because it is supposed to track task's main loop.

This PR fixes this by adding a `taskbeat` to task's main loop and that is used to print the status line at the end at exit. Additionally, the taskbeat is exported in the NML shared emcStatus in the `task` structure.

Secondly, the motion controller's `heartbeat` is now correctly exported in the NML shared emcStatus in the `motion` structure. Motion controller's heartbeat is necessary to track the RT loop (servo-thread) because status changes can be delayed by one or more RT loops, causing potential for races between RT and non-RT. Non-RT needs to be able to track RT's progression. Example: setting TELEOP mode automatically happens after homing all joints, but that takes one extra loop of the motion controller for it to become set. Sending the next command can therefore fail if you do no wait appropriately.

Also, the heartbeats are now 64-bit (which became possible after the NML update() fixes). That should leave time for about half a billion years of uptime at 1 kHz rates.