### PR TITLE
Interpreter: Allow active G43 for tools with all zero offsets

### DIFF
--- a/src/emc/rs274ngc/interp_convert.cc
+++ b/src/emc/rs274ngc/interp_convert.cc
@@ -6199,7 +6199,8 @@ int Interp::convert_tool_length_offset(int g_code,       //!< g_code being execu
   int idx;
   EmcPose tool_offset;
   ZERO_EMC_POSE(tool_offset);
-
+  settings->g43_with_zero_offset = 0;
+  
   CHKS((settings->cutter_comp_side != CUTTER_COMP::OFF),
        (_("Cannot change tool offset with cutter radius compensation on")));
   if (g_code == G_49) {
@@ -6237,6 +6238,10 @@ int Interp::convert_tool_length_offset(int g_code,       //!< g_code being execu
     tool_offset.u = USER_TO_PROGRAM_LEN(settings->tool_table[idx].offset.u);
     tool_offset.v = USER_TO_PROGRAM_LEN(settings->tool_table[idx].offset.v);
     tool_offset.w = USER_TO_PROGRAM_LEN(settings->tool_table[idx].offset.w);
+    settings->g43_with_zero_offset =
+      (settings->tool_offset.tran.x || settings->tool_offset.tran.y || settings->tool_offset.tran.z ||
+       settings->tool_offset.a || settings->tool_offset.b || settings->tool_offset.c ||
+       settings->tool_offset.u || settings->tool_offset.v || settings->tool_offset.w);
   } else if (g_code == G_43_1) {
     tool_offset = settings->tool_offset;
     idx = -1;

--- a/src/emc/rs274ngc/interp_internal.hh
+++ b/src/emc/rs274ngc/interp_internal.hh
@@ -759,6 +759,7 @@ struct setup
   CANON_TOOL_TABLE tool_table[CANON_POCKETS_MAX];      // index is pocket number
   double traverse_rate;         // rate for traverse motions
   double orient_offset;         // added to M19 R word, from [RS274NGC]ORIENT_OFFSET
+  bool g43_with_zero_offset;    // added to allow active G43 with tool offset values all zero
 
   /* stuff for subroutines and control structures */
   int defining_sub;                  // true if in a subroutine defn

--- a/src/emc/rs274ngc/interp_write.cc
+++ b/src/emc/rs274ngc/interp_write.cc
@@ -108,9 +108,10 @@ int Interp::write_g_codes(block_pointer block,   //!< pointer to a block of RS27
      7) ? (530 + (10 * settings->origin_index)) : (584 +
                                                    settings->origin_index);
   settings->active_g_codes[9] =
-    (settings->tool_offset.tran.x || settings->tool_offset.tran.y || settings->tool_offset.tran.z ||
-     settings->tool_offset.a || settings->tool_offset.b || settings->tool_offset.c ||
-     settings->tool_offset.u || settings->tool_offset.v || settings->tool_offset.w) ? G_43 : G_49;
+    (settings->g43_with_zero_offset ||
+     settings->tool_offset.tran.x || settings->tool_offset.tran.y || settings->tool_offset.tran.z ||
+	 settings->tool_offset.a || settings->tool_offset.b || settings->tool_offset.c ||
+	 settings->tool_offset.u || settings->tool_offset.v || settings->tool_offset.w) ? G_43 : G_49;
   settings->active_g_codes[10] = (settings->retract_mode == RETRACT_MODE::OLD_Z) ? G_98 : G_99;
   // Three modes:  G_64, G_61, G_61_1 or CANON_CONTINUOUS/EXACT_PATH/EXACT_STOP
   settings->active_g_codes[11] =
@@ -279,7 +280,8 @@ int Interp::write_state_tag(block_pointer block,
     state.flags[GM_FLAG_G92_IS_APPLIED] = settings->parameters[5210];
 
     state.flags[GM_FLAG_TOOL_OFFSETS_ON] =
-	(settings->tool_offset.tran.x ||
+    (settings->g43_with_zero_offset ||
+     settings->tool_offset.tran.x ||
 	 settings->tool_offset.tran.y ||
 	 settings->tool_offset.tran.z ||
 	 settings->tool_offset.a ||


### PR DESCRIPTION
Current behavior switches to G49 if G43 is commanded with loaded tool offset values all zero.

Behavior for G43.1 and G43.2 remains unchanged.

relates to discussion here https://github.com/LinuxCNC/linuxcnc/pull/3792