### PR TITLE
mesa_modbus.adoc - missing .00 in function name

### DIFF
--- a/docs/src/drivers/mesa_modbus.adoc
+++ b/docs/src/drivers/mesa_modbus.adoc
@@ -83,7 +83,7 @@ Load and activate the module with HAL commands such as
 
 ----
 loadrt my_file ports=hm2_7i69.0.pktuart.0
-addf my_file servo-thread
+addf my_file.00 servo-thread
 ----
 
 == Modbus ==


### PR DESCRIPTION
addf my_file servo-thread
is not working

but

addf my_file.00 servo-thread
works

I found it here:
<img width="1680" height="1050" alt="Mesa_modbus" src="https://github.com/user-attachments/assets/ffe61b93-e021-44f4-8283-8158fcc3f0cb" />
