### PR TITLE
canterp: fix parsing of ORIENT_SPINDLE

### DIFF
--- a/src/emc/canterp/canterp.cc
+++ b/src/emc/canterp/canterp.cc
@@ -592,11 +592,11 @@ int Canterp::execute(const char *line) {
 	    return INTERP_ERROR;
 	}
 	if (!strcmp(s1, "CANON_CLOCKWISE")) {
-	    ORIENT_SPINDLE(i1, d2, CANON_CLOCKWISE);
+	    ORIENT_SPINDLE(i1, d1, CANON_CLOCKWISE);
 	    return 0;
 	}
 	if (!strcmp(s1, "CANON_COUNTERCLOCKWISE")) {
-	    ORIENT_SPINDLE(i1, d2, CANON_COUNTERCLOCKWISE);
+	    ORIENT_SPINDLE(i1, d1, CANON_COUNTERCLOCKWISE);
 	    return 0;
 	}
 	return INTERP_ERROR;


### PR DESCRIPTION
Did not feel like trusting my eyes, but while the parser is parsing into d1, the value passed is that of d2, with the value of d1 lost. This makes no sense, right?

Can anyone confirm that this patch is correct? I would then prepare the same against 2.9.