### PR TITLE
canterp presumed missinterpretation of scanf return value

### DIFF
--- a/src/emc/canterp/canterp.cc
+++ b/src/emc/canterp/canterp.cc
@@ -299,7 +299,7 @@ int Canterp::execute(const char *line) {
     }
 
     if (!strcmp(the_command_name, "STRAIGHT_PROBE")) {
-	if (6 != sscanf(the_command_args, "%lf %lf %lf %lf %lf %lf %lf %lf %lf",
+	if (9 != sscanf(the_command_args, "%lf %lf %lf %lf %lf %lf %lf %lf %lf",
 			&d1, &d2, &d3, &d4, &d5, &d6, &d7, &d8, &d9)) {
 	    return INTERP_ERROR;
 	}
@@ -325,7 +325,7 @@ int Canterp::execute(const char *line) {
 
 #if 0
     if (!strcmp(the_command_name, "SET_ORIGIN_OFFSETS")) {
-	if (6 != sscanf(the_command_args, "%lf %lf %lf %lf %lf %lf %lf %lf %lf",
+	if (9 != sscanf(the_command_args, "%lf %lf %lf %lf %lf %lf %lf %lf %lf",
 			&d1, &d2, &d3, &d4, &d5, &d6, &d7, &d8, &d9)) {
 	    return INTERP_ERROR;
 	}
@@ -389,7 +389,7 @@ int Canterp::execute(const char *line) {
 
 #if 0
     if (!strcmp(the_command_name, "USE_TOOL_LENGTH_OFFSET")) {
-	if (1 != sscanf(the_command_args, "%lf %lf %lf", &d1, &d2, &d3)) {
+	if (3 != sscanf(the_command_args, "%lf %lf %lf", &d1, &d2, &d3)) {
 	    return INTERP_ERROR;
 	}
 	USE_TOOL_LENGTH_OFFSET(d1, d2, d3);


### PR DESCRIPTION
A comment should be added if the comparison against 6 is correct - 6 <= scanf() if there are some values not expected to be set, or 9, since all values are used downstream.