### PR TITLE
fix: Error detection after open(2)

### DIFF
--- a/src/emc/tooldata/tooldata_common.cc
+++ b/src/emc/tooldata/tooldata_common.cc
@@ -83,7 +83,8 @@ int tooldata_read_entry(const char *input_line,
         return -1;
     }
     if (input_line[0] == ';') {return 0;} //ignore leading ';'
-    strcpy(work_line, input_line);
+    strncpy(work_line, input_line, sizeof(work_line)-1);
+    work_line[sizeof(work_line)-1] = 0;
 
     CANON_TOOL_TABLE empty = tooldata_entry_init();
     toolno      = empty.toolno;

--- a/src/emc/tooldata/tooldata_mmap.cc
+++ b/src/emc/tooldata/tooldata_mmap.cc
@@ -16,10 +16,11 @@
 ** along with this program; if not, write to the Free Software
 ** Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
+
 #include <stdio.h>
 #include <sys/types.h>
-#include <unistd.h>
-#include <fcntl.h>
+#include <unistd.h> // write(2),lseek(2)
+#include <fcntl.h> // open(2)
 #include <sys/mman.h>
 #include <string.h>
 #include "rtapi_mutex.h"
@@ -132,7 +133,7 @@ int tool_mmap_creator(EMC_TOOL_STAT const * ptr,int random_toolchanger)
     toolstat = ptr; //note NULL for sai
     creator_fd = open(tool_mmap_fname(),
                      TOOL_MMAP_CREATOR_OPEN_FLAGS,TOOL_MMAP_MODE);
-    if (!creator_fd) {
+    if (creator_fd < 0) {
         perror("tool_mmap_creator(): file open fail");
         exit(EXIT_FAILURE);
     }


### PR DESCRIPTION
The patch speaks for itself. I guess there was some confusion between open and fopen.