### PR TITLE
fix: tooldata mutex init - give before try

### DIFF
--- a/docs/man/man3/rtapi_mutex.3rtapi
+++ b/docs/man/man3/rtapi_mutex.3rtapi
@@ -36,4 +36,4 @@ init/cleanup, and realtime code.
 \fBrtapi_mutex_try\fR returns 0 for if the mutex was claimed, and nonzero
 otherwise.
 
-\fBrtapi_mutex_get\fR and \fBrtapi_mutex_gif\fR have no return value.
+\fBrtapi_mutex_get\fR and \fBrtapi_mutex_give\fR have no return value.

--- a/src/emc/tooldata/tooldata_mmap.cc
+++ b/src/emc/tooldata/tooldata_mmap.cc
@@ -155,11 +155,12 @@ int tool_mmap_creator(EMC_TOOL_STAT const * ptr,int random_toolchanger)
     }
 
     tooldata_header_t *hptr = HPTR();
+    hptr->mutex = 0;
     hptr->is_random_toolchanger = random_toolchanger;
     hptr->last_index = 0;
 
     inited = 1;
-    tool_mmap_mutex_give(); return 0;
+    return 0;
 } // tool_mmap_creator();
 
 //typ: milltask, guis (emcmodule,emcsh,...), halui


### PR DESCRIPTION
explicitly initialize the mutex, instead of calling tool_mmap_mutex_give() without a prior lock.

Mutex is “given” without an initial successful “try/get” In src/emc/tooldata/tooldata_mmap.cc:163, tool_mmap_creator() calls tool_mmap_mutex_give() right after setup without any prior lock acquisition. According to the man page this is unusual and potentially undefined depending on rtapi_mutex semantics.

I am not sure about how much of a bug this is, but there should be an initial assignment of mutex, right?