### PR TITLE
tooldata_db: Fix signal handling - waiting for multiple processes

### DIFF
--- a/src/emc/tooldata/tooldata_db.cc
+++ b/src/emc/tooldata/tooldata_db.cc
@@ -64,29 +64,31 @@ static int pipes[NUM_PIPES][2];
 static bool is_random_toolchanger = 0;
 static char db_childname[PATH_MAX];
 
-static void handle_sigchild(int s)
+static void handle_sigchild(int /*s*/)
 {
     pid_t pid;
-    int status;
-    while((pid = waitpid(-1, &status, WUNTRACED | WCONTINUED | WNOHANG)) > 0) ;
-    if (WIFSIGNALED(status))  {
-        db_live = 0;
-        fprintf(stderr,"%5d !!!%s terminated by signal %d\n"
-               ,getpid(),db_childname,WTERMSIG(status));
-    }
-    if (WIFEXITED(status)) {
-        db_live = 0;
-        fprintf(stderr,"%5d ===%s normal exit status=%d\n"
+    int status = 0;
+    while((pid = waitpid(-1, &status, WUNTRACED | WCONTINUED | WNOHANG)) > 0) {
+
+        if (WIFSIGNALED(status))  {
+            db_live = 0;
+            fprintf(stderr,"%5d !!!%s terminated by signal %d\n"
+                   ,getpid(),db_childname,WTERMSIG(status));
+        }
+        if (WIFEXITED(status)) {
+            db_live = 0;
+            fprintf(stderr,"%5d ===%s normal exit status=%d\n"
                ,getpid(),db_childname,WEXITSTATUS(status));
-    }
+        }
 #if 0
-    if (WIFSTOPPED(status)) {
-        fprintf(stderr,"%5d ===%s stopped\n",getpid(),db_childname);
-    }
-    if (WIFCONTINUED(status)) {
-        fprintf(stderr,"%5d ===%s continued\n",getpid(),db_childname);
-    }
+        if (WIFSTOPPED(status)) {
+            fprintf(stderr,"%5d ===%s stopped\n",getpid(),db_childname);
+        }
+        if (WIFCONTINUED(status)) {
+            fprintf(stderr,"%5d ===%s continued\n",getpid(),db_childname);
+        }
 #endif
+    }
 }
 
 static int fork_create(int myargc,char *const myargv[])


### PR DESCRIPTION
I need some help with this one. It is all a bit confusing. Am I confused?

In tooldata_db.cc (line 67), the old code does:

1.  waitpid(..., WNOHANG) in a while (...) ; loop with an empty body.
2. Then evaluates WIFSIGNALED(status) and WIFEXITED(status) once, after the loop.

The problem is:

1. waitpid only writes status when it returns > 0.
2. With WNOHANG, it can return 0 immediately (no state change yet), or -1 on error.
3. In those cases, status is not guaranteed to be written, thus left undefined.
4. That can cause false logs and incorrectly set db_live = 0.

What the patch changes:

1. It moves WIFSIGNALED/WIFEXITED checks inside the while (waitpid(...) > 0) loop.
2. status is only inspected in iterations where waitpid definitely produced a valid child status.
3. If no child was ready, the loop does not run, and nothing is logged or toggled.
4. If multiple children changed state, each valid status is handled, instead of only the last one.

I patched this against 2.9. But if that is too risky then maybe 2.10 is preferable to give this some time to mature? But then again, we should somehow figure out if this change is correct or not. :-)