### PR TITLE
halrun: Fix missing variable initialization

### DIFF
--- a/scripts/halrun.in
+++ b/scripts/halrun.in
@@ -141,6 +141,7 @@ esac
 
 $REALTIME start || exit $?
 
+result=0
 if $HAVEFILE ; then
   if $IS_INI; then
     if ! inivar -ini "$filename" -sec HAL -var TWOPASS > /dev/null 2>&1 ; then


### PR DESCRIPTION
The halrun script would complain about `exit` at the end not having a value as argument. This patch fixes it by defaulting the return value to 0 (zero) as an initialization value earlier on in the script.