### PR TITLE
cppcheck: fix casts and copy constructors

### DIFF
--- a/src/emc/ini/emcIniFile.cc
+++ b/src/emc/ini/emcIniFile.cc
@@ -43,7 +43,7 @@ EmcIniFile::ErrorCode
 EmcIniFile::Find(EmcJointType *result,
                  const char *tag, const char *section, int num)
 {
-    return(IniFile::Find((int *)result, jointTypeMap, tag, section, num));
+    return(IniFile::Find(reinterpret_cast<int *>(result), jointTypeMap, tag, section, num));
 }
 
 

--- a/src/emc/nml_intf/emcops.cc
+++ b/src/emc/nml_intf/emcops.cc
@@ -111,7 +111,8 @@ EMC_MOTION_STAT::EMC_MOTION_STAT()
     external_offsets_applied(0),
     eoffset_pose{},
     numExtraJoints(0),
-    jogging_active(0)
+    jogging_active(0),
+    heartbeat(0)
 {
 }
 

--- a/src/emc/rs274ngc/interp_internal.hh
+++ b/src/emc/rs274ngc/interp_internal.hh
@@ -648,6 +648,10 @@ struct setup
   setup();
   ~setup();
 
+  // Not copyable
+  setup(const setup&) = delete;
+  setup& operator= (const setup&) = delete;
+
   double AA_axis_offset;        // A-axis g92 offset
   double AA_current;            // current A-axis position
   double AA_origin_offset;      // A-axis origin offset

--- a/src/emc/rs274ngc/interp_setup.cc
+++ b/src/emc/rs274ngc/interp_setup.cc
@@ -141,6 +141,7 @@ setup::setup() :
     tool_table{},
     traverse_rate (0.0),
     orient_offset (0.0),
+    g43_with_zero_offset(false),
 
     defining_sub(0),
     sub_name(NULL),

--- a/src/emc/task/taskclass.cc
+++ b/src/emc/task/taskclass.cc
@@ -127,6 +127,7 @@ struct _inittab builtin_modules[] = {
 
 Task::Task(EMC_IO_STAT & emcioStatus_in) :
     emcioStatus(emcioStatus_in),
+    iocontrol_data{},
     iocontrol("iocontrol.0"),
     ini_filename(emc_inifile),
     tool_status(0)

--- a/src/emc/tooldata/tooldata_nml.cc
+++ b/src/emc/tooldata/tooldata_nml.cc
@@ -85,7 +85,7 @@ toolidx_t tooldata_get(CANON_TOOL_TABLE* pdata,int idx)
         return IDX_FAIL;
     }
 
-    *pdata = *(struct CANON_TOOL_TABLE*)(the_table + idx);
+    *pdata = *reinterpret_cast<struct CANON_TOOL_TABLE*>(the_table + idx);
     return IDX_OK;
 } // tooldata_get()
 

--- a/src/hal/user_comps/xhc-whb04b-6/hal.h
+++ b/src/hal/user_comps/xhc-whb04b-6/hal.h
@@ -339,6 +339,11 @@ class Hal
 public:
     Hal(Profiles::HalRequestProfile halRequestProfile=Profiles::halRequestSlowProfile());
     ~Hal();
+
+    // Not copyable
+    Hal(const Hal&) = delete;
+    Hal& operator= (const Hal&) = delete;
+
     //! Initializes HAL memory and pins according to simulation mode. Must not be called more than once.
     //! If \ref mIsSimulationMode is true heap memory will be used, shared HAL memory otherwise.
     //! \ref setIsSimulationMode() must be set before accordingly

--- a/src/libnml/cms/cms_aup.cc
+++ b/src/libnml/cms/cms_aup.cc
@@ -224,7 +224,7 @@ int safe_strlen(char *string, int max)
 CMS_STATUS CMS_ASCII_UPDATER::update(bool &x)
 {
     /* Check to see if the pointers are in the proper range. */
-    if (-1 == check_pointer((char *) &x, sizeof(bool))) {
+    if (-1 == check_pointer(reinterpret_cast<char *>(&x), sizeof(bool))) {
 	return (CMS_UPDATE_ERROR);
     }
 
@@ -318,7 +318,7 @@ CMS_STATUS CMS_ASCII_UPDATER::update(uint8_t *x, unsigned int len)
 CMS_STATUS CMS_ASCII_UPDATER::update(int16_t &x)
 {
     /* Check to see if the pointers are in the proper range. */
-    if (-1 == check_pointer((char *) &x, sizeof(int16_t))) {
+    if (-1 == check_pointer(reinterpret_cast<char *>(&x), sizeof(int16_t))) {
 	return (status = CMS_UPDATE_ERROR);
     }
 
@@ -363,7 +363,7 @@ CMS_STATUS CMS_ASCII_UPDATER::update(int16_t &x)
 CMS_STATUS CMS_ASCII_UPDATER::update(int16_t *x, unsigned int len)
 {
     /* Check to see if the pointers are in the proper range. */
-    if (-1 == check_pointer((char *) x, sizeof(int16_t) * len)) {
+    if (-1 == check_pointer(reinterpret_cast<char *>(x), sizeof(int16_t) * len)) {
 	return (status = CMS_UPDATE_ERROR);
     }
 
@@ -378,7 +378,7 @@ CMS_STATUS CMS_ASCII_UPDATER::update(int16_t *x, unsigned int len)
 CMS_STATUS CMS_ASCII_UPDATER::update(uint16_t &x)
 {
     /* Check to see if the pointers are in the proper range. */
-    if (-1 == check_pointer((char *) &x, sizeof(uint16_t))) {
+    if (-1 == check_pointer(reinterpret_cast<char *>(&x), sizeof(uint16_t))) {
 	return (status = CMS_UPDATE_ERROR);
     }
 
@@ -423,7 +423,7 @@ CMS_STATUS CMS_ASCII_UPDATER::update(uint16_t &x)
 CMS_STATUS CMS_ASCII_UPDATER::update(uint16_t *x, unsigned int len)
 {
     /* Check to see if the pointers are in the proper range. */
-    if (-1 == check_pointer((char *) x, sizeof(uint16_t) * len)) {
+    if (-1 == check_pointer(reinterpret_cast<char *>(x), sizeof(uint16_t) * len)) {
 	return (status = CMS_UPDATE_ERROR);
     }
 
@@ -440,7 +440,7 @@ CMS_STATUS CMS_ASCII_UPDATER::update(uint16_t *x, unsigned int len)
 CMS_STATUS CMS_ASCII_UPDATER::update(int32_t &x)
 {
     /* Check to see if the pointers are in the proper range. */
-    if (-1 == check_pointer((char *) &x, sizeof(int32_t))) {
+    if (-1 == check_pointer(reinterpret_cast<char *>(&x), sizeof(int32_t))) {
 	return (status = CMS_UPDATE_ERROR);
     }
 
@@ -491,7 +491,7 @@ CMS_STATUS CMS_ASCII_UPDATER::update(int32_t &x)
 CMS_STATUS CMS_ASCII_UPDATER::update(int32_t *x, unsigned int len)
 {
     /* Check to see if the pointers are in the proper range. */
-    if (-1 == check_pointer((char *) x, sizeof(int32_t) * len)) {
+    if (-1 == check_pointer(reinterpret_cast<char *>(x), sizeof(int32_t) * len)) {
 	return (status = CMS_UPDATE_ERROR);
     }
 
@@ -506,7 +506,7 @@ CMS_STATUS CMS_ASCII_UPDATER::update(int32_t *x, unsigned int len)
 CMS_STATUS CMS_ASCII_UPDATER::update(uint32_t &x)
 {
     /* Check to see if the pointers are in the proper range. */
-    if (-1 == check_pointer((char *) &x, sizeof(uint32_t))) {
+    if (-1 == check_pointer(reinterpret_cast<char *>(&x), sizeof(uint32_t))) {
 	return (status = CMS_UPDATE_ERROR);
     }
 
@@ -557,7 +557,7 @@ CMS_STATUS CMS_ASCII_UPDATER::update(uint32_t &x)
 CMS_STATUS CMS_ASCII_UPDATER::update(uint32_t *x, unsigned int len)
 {
     /* Check to see if the pointers are in the proper range. */
-    if (-1 == check_pointer((char *) x, sizeof(uint32_t) * len)) {
+    if (-1 == check_pointer(reinterpret_cast<char *>(x), sizeof(uint32_t) * len)) {
 	return (status = CMS_UPDATE_ERROR);
     }
 
@@ -574,7 +574,7 @@ CMS_STATUS CMS_ASCII_UPDATER::update(uint32_t *x, unsigned int len)
 CMS_STATUS CMS_ASCII_UPDATER::update(int64_t &x)
 {
     /* Check to see if the pointers are in the proper range. */
-    if (-1 == check_pointer((char *) &x, sizeof(int64_t))) {
+    if (-1 == check_pointer(reinterpret_cast<char *>(&x), sizeof(int64_t))) {
 	return (status = CMS_UPDATE_ERROR);
     }
 
@@ -612,7 +612,7 @@ CMS_STATUS CMS_ASCII_UPDATER::update(int64_t &x)
 CMS_STATUS CMS_ASCII_UPDATER::update(int64_t *x, unsigned int len)
 {
     /* Check to see if the pointers are in the proper range. */
-    if (-1 == check_pointer((char *) x, sizeof(int64_t) * len)) {
+    if (-1 == check_pointer(reinterpret_cast<char *>(x), sizeof(int64_t) * len)) {
 	return (status = CMS_UPDATE_ERROR);
     }
 
@@ -627,7 +627,7 @@ CMS_STATUS CMS_ASCII_UPDATER::update(int64_t *x, unsigned int len)
 CMS_STATUS CMS_ASCII_UPDATER::update(uint64_t &x)
 {
     /* Check to see if the pointers are in the proper range. */
-    if (-1 == check_pointer((char *) &x, sizeof(uint64_t))) {
+    if (-1 == check_pointer(reinterpret_cast<char *>(&x), sizeof(uint64_t))) {
 	return (status = CMS_UPDATE_ERROR);
     }
 
@@ -666,7 +666,7 @@ CMS_STATUS CMS_ASCII_UPDATER::update(uint64_t &x)
 CMS_STATUS CMS_ASCII_UPDATER::update(uint64_t *x, unsigned int len)
 {
     /* Check to see if the pointers are in the proper range. */
-    if (-1 == check_pointer((char *) x, sizeof(uint64_t) * len)) {
+    if (-1 == check_pointer(reinterpret_cast<char *>(x), sizeof(uint64_t) * len)) {
 	return (status = CMS_UPDATE_ERROR);
     }
 
@@ -683,7 +683,7 @@ CMS_STATUS CMS_ASCII_UPDATER::update(uint64_t *x, unsigned int len)
 CMS_STATUS CMS_ASCII_UPDATER::update(float &x)
 {
     /* Check to see if the pointers are in the proper range. */
-    if (-1 == check_pointer((char *) &x, sizeof(float))) {
+    if (-1 == check_pointer(reinterpret_cast<char *>(&x), sizeof(float))) {
 	return (status = CMS_UPDATE_ERROR);
     }
 
@@ -728,7 +728,7 @@ CMS_STATUS CMS_ASCII_UPDATER::update(float &x)
 CMS_STATUS CMS_ASCII_UPDATER::update(float *x, unsigned int len)
 {
     /* Check to see if the pointers are in the proper range. */
-    if (-1 == check_pointer((char *) x, sizeof(float) * len)) {
+    if (-1 == check_pointer(reinterpret_cast<char *>(x), sizeof(float) * len)) {
 	return (status = CMS_UPDATE_ERROR);
     }
 
@@ -745,7 +745,7 @@ CMS_STATUS CMS_ASCII_UPDATER::update(float *x, unsigned int len)
 CMS_STATUS CMS_ASCII_UPDATER::update(double &x)
 {
     /* Check to see if the pointers are in the proper range. */
-    if (-1 == check_pointer((char *) &x, sizeof(double))) {
+    if (-1 == check_pointer(reinterpret_cast<char *>(&x), sizeof(double))) {
 	return (status = CMS_UPDATE_ERROR);
     }
 
@@ -783,7 +783,7 @@ CMS_STATUS CMS_ASCII_UPDATER::update(double &x)
 CMS_STATUS CMS_ASCII_UPDATER::update(double *x, unsigned int len)
 {
     /* Check to see if the pointers are in the proper range. */
-    if (-1 == check_pointer((char *) x, sizeof(double) * len)) {
+    if (-1 == check_pointer(reinterpret_cast<char *>(x), sizeof(double) * len)) {
 	return (status = CMS_UPDATE_ERROR);
     }
 
@@ -800,7 +800,7 @@ CMS_STATUS CMS_ASCII_UPDATER::update(double *x, unsigned int len)
 CMS_STATUS CMS_ASCII_UPDATER::update(long double &x)
 {
     /* Check to see if the pointers are in the proper range. */
-    if (-1 == check_pointer((char *) &x, sizeof(long double))) {
+    if (-1 == check_pointer(reinterpret_cast<char *>(&x), sizeof(long double))) {
 	return (status = CMS_UPDATE_ERROR);
     }
 
@@ -838,7 +838,7 @@ CMS_STATUS CMS_ASCII_UPDATER::update(long double &x)
 CMS_STATUS CMS_ASCII_UPDATER::update(long double *x, unsigned int len)
 {
     /* Check to see if the pointers are in the proper range. */
-    if (-1 == check_pointer((char *) x, sizeof(long double) * len)) {
+    if (-1 == check_pointer(reinterpret_cast<char *>(x), sizeof(long double) * len)) {
 	return (status = CMS_UPDATE_ERROR);
     }
 

--- a/src/libnml/cms/cms_cfg.cc
+++ b/src/libnml/cms/cms_cfg.cc
@@ -74,6 +74,10 @@ struct CONFIG_FILE_INFO {
 	}
     };
 
+    // Not copyable
+    CONFIG_FILE_INFO(const CONFIG_FILE_INFO&) = delete;
+    CONFIG_FILE_INFO& operator= (const CONFIG_FILE_INFO&) = delete;
+
     LinkedList *lines_list;
     char file_name[80];
 };

--- a/src/libnml/cms/cms_dup.cc
+++ b/src/libnml/cms/cms_dup.cc
@@ -274,7 +274,7 @@ CMS_STATUS CMS_DISPLAY_ASCII_UPDATER::update_char(char &x)
 CMS_STATUS CMS_DISPLAY_ASCII_UPDATER::update(bool &x)
 {
     /* Check to see if the pointers are in the proper range. */
-    if (-1 == check_pointer((char *) &x, sizeof(char))) {
+    if (-1 == check_pointer(reinterpret_cast<char *>(&x), sizeof(char))) {
 	return (CMS_UPDATE_ERROR);
     }
 
@@ -364,7 +364,7 @@ CMS_STATUS CMS_DISPLAY_ASCII_UPDATER::update(uint8_t *x, unsigned int len)
 CMS_STATUS CMS_DISPLAY_ASCII_UPDATER::update(int16_t &x)
 {
     /* Check to see if the pointers are in the proper range. */
-    if (-1 == check_pointer((char *) &x, sizeof(int16_t))) {
+    if (-1 == check_pointer(reinterpret_cast<char *>(&x), sizeof(int16_t))) {
 	return (CMS_UPDATE_ERROR);
     }
 
@@ -396,7 +396,7 @@ CMS_STATUS CMS_DISPLAY_ASCII_UPDATER::update(int16_t &x)
 CMS_STATUS CMS_DISPLAY_ASCII_UPDATER::update(int16_t *x, unsigned int len)
 {
     /* Check to see if the pointers are in the proper range. */
-    if (-1 == check_pointer((char *) x, sizeof(int16_t) * len)) {
+    if (-1 == check_pointer(reinterpret_cast<char *>(x), sizeof(int16_t) * len)) {
 	return (CMS_UPDATE_ERROR);
     }
 
@@ -411,7 +411,7 @@ CMS_STATUS CMS_DISPLAY_ASCII_UPDATER::update(int16_t *x, unsigned int len)
 CMS_STATUS CMS_DISPLAY_ASCII_UPDATER::update(uint16_t &x)
 {
     /* Check to see if the pointers are in the proper range. */
-    if (-1 == check_pointer((char *) &x, sizeof(uint16_t))) {
+    if (-1 == check_pointer(reinterpret_cast<char *>(&x), sizeof(uint16_t))) {
 	return (CMS_UPDATE_ERROR);
     }
 
@@ -447,7 +447,7 @@ CMS_STATUS CMS_DISPLAY_ASCII_UPDATER::update(uint16_t &x)
 CMS_STATUS CMS_DISPLAY_ASCII_UPDATER::update(uint16_t *x, unsigned int len)
 {
     /* Check to see if the pointers are in the proper range. */
-    if (-1 == check_pointer((char *) x, sizeof(uint16_t) * len)) {
+    if (-1 == check_pointer(reinterpret_cast<char *>(x), sizeof(uint16_t) * len)) {
 	return (CMS_UPDATE_ERROR);
     }
 
@@ -464,7 +464,7 @@ CMS_STATUS CMS_DISPLAY_ASCII_UPDATER::update(uint16_t *x, unsigned int len)
 CMS_STATUS CMS_DISPLAY_ASCII_UPDATER::update(int32_t &x)
 {
     /* Check to see if the pointers are in the proper range. */
-    if (-1 == check_pointer((char *) &x, sizeof(int32_t))) {
+    if (-1 == check_pointer(reinterpret_cast<char *>(&x), sizeof(int32_t))) {
 	return (CMS_UPDATE_ERROR);
     }
 
@@ -506,7 +506,7 @@ CMS_STATUS CMS_DISPLAY_ASCII_UPDATER::update(int32_t &x)
 CMS_STATUS CMS_DISPLAY_ASCII_UPDATER::update(int32_t *x, unsigned int len)
 {
     /* Check to see if the pointers are in the proper range. */
-    if (-1 == check_pointer((char *) x, sizeof(int32_t) * len)) {
+    if (-1 == check_pointer(reinterpret_cast<char *>(x), sizeof(int32_t) * len)) {
 	return (CMS_UPDATE_ERROR);
     }
 
@@ -521,7 +521,7 @@ CMS_STATUS CMS_DISPLAY_ASCII_UPDATER::update(int32_t *x, unsigned int len)
 CMS_STATUS CMS_DISPLAY_ASCII_UPDATER::update(uint32_t &x)
 {
     /* Check to see if the pointers are in the proper range. */
-    if (-1 == check_pointer((char *) &x, sizeof(uint32_t))) {
+    if (-1 == check_pointer(reinterpret_cast<char *>(&x), sizeof(uint32_t))) {
 	return (CMS_UPDATE_ERROR);
     }
 
@@ -563,7 +563,7 @@ CMS_STATUS CMS_DISPLAY_ASCII_UPDATER::update(uint32_t &x)
 CMS_STATUS CMS_DISPLAY_ASCII_UPDATER::update(uint32_t *x, unsigned int len)
 {
     /* Check to see if the pointers are in the proper range. */
-    if (-1 == check_pointer((char *) x, sizeof(uint32_t) * len)) {
+    if (-1 == check_pointer(reinterpret_cast<char *>(x), sizeof(uint32_t) * len)) {
 	return (CMS_UPDATE_ERROR);
     }
 
@@ -580,7 +580,7 @@ CMS_STATUS CMS_DISPLAY_ASCII_UPDATER::update(uint32_t *x, unsigned int len)
 CMS_STATUS CMS_DISPLAY_ASCII_UPDATER::update(int64_t &x)
 {
     /* Check to see if the pointers are in the proper range. */
-    if (-1 == check_pointer((char *) &x, sizeof(int64_t))) {
+    if (-1 == check_pointer(reinterpret_cast<char *>(&x), sizeof(int64_t))) {
 	return (CMS_UPDATE_ERROR);
     }
 
@@ -617,7 +617,7 @@ CMS_STATUS CMS_DISPLAY_ASCII_UPDATER::update(int64_t &x)
 CMS_STATUS CMS_DISPLAY_ASCII_UPDATER::update(int64_t *x, unsigned int len)
 {
     /* Check to see if the pointers are in the proper range. */
-    if (-1 == check_pointer((char *) x, sizeof(int64_t) * len)) {
+    if (-1 == check_pointer(reinterpret_cast<char *>(x), sizeof(int64_t) * len)) {
 	return (CMS_UPDATE_ERROR);
     }
 
@@ -632,7 +632,7 @@ CMS_STATUS CMS_DISPLAY_ASCII_UPDATER::update(int64_t *x, unsigned int len)
 CMS_STATUS CMS_DISPLAY_ASCII_UPDATER::update(uint64_t &x)
 {
     /* Check to see if the pointers are in the proper range. */
-    if (-1 == check_pointer((char *) &x, sizeof(uint64_t))) {
+    if (-1 == check_pointer(reinterpret_cast<char *>(&x), sizeof(uint64_t))) {
 	return (CMS_UPDATE_ERROR);
     }
 
@@ -664,7 +664,7 @@ CMS_STATUS CMS_DISPLAY_ASCII_UPDATER::update(uint64_t *x,
     unsigned int len)
 {
     /* Check to see if the pointers are in the proper range. */
-    if (-1 == check_pointer((char *) x, sizeof(uint64_t) * len)) {
+    if (-1 == check_pointer(reinterpret_cast<char *>(x), sizeof(uint64_t) * len)) {
 	return (CMS_UPDATE_ERROR);
     }
 
@@ -681,7 +681,7 @@ CMS_STATUS CMS_DISPLAY_ASCII_UPDATER::update(uint64_t *x,
 CMS_STATUS CMS_DISPLAY_ASCII_UPDATER::update(float &x)
 {
     /* Check to see if the pointers are in the proper range. */
-    if (-1 == check_pointer((char *) &x, sizeof(float))) {
+    if (-1 == check_pointer(reinterpret_cast<char *>(&x), sizeof(float))) {
 	return (CMS_UPDATE_ERROR);
     }
 
@@ -717,7 +717,7 @@ CMS_STATUS CMS_DISPLAY_ASCII_UPDATER::update(float &x)
 CMS_STATUS CMS_DISPLAY_ASCII_UPDATER::update(float *x, unsigned int len)
 {
     /* Check to see if the pointers are in the proper range. */
-    if (-1 == check_pointer((char *) x, sizeof(float) * len)) {
+    if (-1 == check_pointer(reinterpret_cast<char *>(x), sizeof(float) * len)) {
 	return (CMS_UPDATE_ERROR);
     }
 
@@ -734,7 +734,7 @@ CMS_STATUS CMS_DISPLAY_ASCII_UPDATER::update(float *x, unsigned int len)
 CMS_STATUS CMS_DISPLAY_ASCII_UPDATER::update(double &x)
 {
     /* Check to see if the pointers are in the proper range. */
-    if (-1 == check_pointer((char *) &x, sizeof(double))) {
+    if (-1 == check_pointer(reinterpret_cast<char *>(&x), sizeof(double))) {
 	return (CMS_UPDATE_ERROR);
     }
 
@@ -763,7 +763,7 @@ CMS_STATUS CMS_DISPLAY_ASCII_UPDATER::update(double &x)
 CMS_STATUS CMS_DISPLAY_ASCII_UPDATER::update(double *x, unsigned int len)
 {
     /* Check to see if the pointers are in the proper range. */
-    if (-1 == check_pointer((char *) x, sizeof(double) * len)) {
+    if (-1 == check_pointer(reinterpret_cast<char *>(x), sizeof(double) * len)) {
 	return (CMS_UPDATE_ERROR);
     }
 
@@ -780,7 +780,7 @@ CMS_STATUS CMS_DISPLAY_ASCII_UPDATER::update(double *x, unsigned int len)
 CMS_STATUS CMS_DISPLAY_ASCII_UPDATER::update(long double &x)
 {
     /* Check to see if the pointers are in the proper range. */
-    if (-1 == check_pointer((char *) &x, sizeof(long double))) {
+    if (-1 == check_pointer(reinterpret_cast<char *>(&x), sizeof(long double))) {
 	return (CMS_UPDATE_ERROR);
     }
 
@@ -810,7 +810,7 @@ CMS_STATUS CMS_DISPLAY_ASCII_UPDATER::update(long double &x)
 CMS_STATUS CMS_DISPLAY_ASCII_UPDATER::update(long double *x, unsigned int len)
 {
     /* Check to see if the pointers are in the proper range. */
-    if (-1 == check_pointer((char *) x, sizeof(long double) * len)) {
+    if (-1 == check_pointer(reinterpret_cast<char *>(x), sizeof(long double) * len)) {
 	return (CMS_UPDATE_ERROR);
     }
 

--- a/src/libnml/cms/cms_srv.hh
+++ b/src/libnml/cms/cms_srv.hh
@@ -64,6 +64,11 @@ class CMS_SERVER_LOCAL_PORT:public virtual CMS_USER {
   public:
       CMS_SERVER_LOCAL_PORT(CMS * _cms);
       virtual ~ CMS_SERVER_LOCAL_PORT();
+
+    // Not copyable
+    CMS_SERVER_LOCAL_PORT(const CMS_SERVER_LOCAL_PORT&) = delete;
+    CMS_SERVER_LOCAL_PORT& operator= (const CMS_SERVER_LOCAL_PORT&) = delete;
+
     int local_channel_reused;
 
 };
@@ -80,6 +85,10 @@ class CMS_SERVER_REMOTE_PORT {
   public:
     CMS_SERVER_REMOTE_PORT(CMS_SERVER *);
     virtual ~ CMS_SERVER_REMOTE_PORT();
+    // Not copyable
+    CMS_SERVER_REMOTE_PORT(const CMS_SERVER_REMOTE_PORT&) = delete;
+    CMS_SERVER_REMOTE_PORT& operator= (const CMS_SERVER_REMOTE_PORT&) = delete;
+
     virtual void run() = 0;
     virtual void register_port();
     virtual void unregister_port();

--- a/src/libnml/cms/cms_xup.cc
+++ b/src/libnml/cms/cms_xup.cc
@@ -69,7 +69,7 @@ CMS_XDR_UPDATER::CMS_XDR_UPDATER(CMS * _cms_parent):CMS_UPDATER(_cms_parent,
 	rcs_print_error("CMS:can't malloc encode_header_stream");
 	return;
     }
-    xdrmem_create((XDR *) encode_header_stream, (char *) encoded_header,
+    xdrmem_create(reinterpret_cast<XDR *>(encode_header_stream), (char *) encoded_header,
 	(int) neutral_size_factor * sizeof(CMS_HEADER), XDR_ENCODE);
 
     decode_header_stream = (XDR *) malloc(sizeof(XDR));
@@ -78,7 +78,7 @@ CMS_XDR_UPDATER::CMS_XDR_UPDATER(CMS * _cms_parent):CMS_UPDATER(_cms_parent,
 	status = CMS_CREATE_ERROR;
 	return;
     }
-    xdrmem_create((XDR *) decode_header_stream, (char *) encoded_header,
+    xdrmem_create(reinterpret_cast<XDR *>(decode_header_stream), (char *) encoded_header,
 	(int) neutral_size_factor * sizeof(CMS_HEADER), XDR_DECODE);
 
     /* If queuing is enabled, then initialize streams for */
@@ -99,7 +99,7 @@ CMS_XDR_UPDATER::CMS_XDR_UPDATER(CMS * _cms_parent):CMS_UPDATER(_cms_parent,
 	    rcs_print_error("CMS:can't malloc encode_queuing_header_stream");
 	    return;
 	}
-	xdrmem_create((XDR *) encode_queuing_header_stream,
+	xdrmem_create(reinterpret_cast<XDR *>(encode_queuing_header_stream),
 	    (char *) encoded_queuing_header,
 	    (int) neutral_size_factor * sizeof(CMS_QUEUING_HEADER),
 	    XDR_ENCODE);
@@ -110,7 +110,7 @@ CMS_XDR_UPDATER::CMS_XDR_UPDATER(CMS * _cms_parent):CMS_UPDATER(_cms_parent,
 	    status = CMS_CREATE_ERROR;
 	    return;
 	}
-	xdrmem_create((XDR *) decode_queuing_header_stream,
+	xdrmem_create(reinterpret_cast<XDR *>(decode_queuing_header_stream),
 	    (char *) encoded_queuing_header,
 	    (int) neutral_size_factor * sizeof(CMS_QUEUING_HEADER),
 	    XDR_DECODE);
@@ -143,22 +143,22 @@ CMS_XDR_UPDATER::~CMS_XDR_UPDATER()
 	decode_data_stream = (XDR *) NULL;
     }
     if (NULL != encode_header_stream) {
-	xdr_destroy(((XDR *) encode_header_stream));
+	xdr_destroy((reinterpret_cast<XDR *>(encode_header_stream)));
 	free(encode_header_stream);
 	encode_header_stream = (XDR *) NULL;
     }
     if (NULL != decode_header_stream) {
-	xdr_destroy(((XDR *) decode_header_stream));
+	xdr_destroy((reinterpret_cast<XDR *>(decode_header_stream)));
 	free(decode_header_stream);
 	decode_header_stream = (XDR *) NULL;
     }
     if (NULL != encode_queuing_header_stream) {
-	xdr_destroy(((XDR *) encode_queuing_header_stream));
+	xdr_destroy((reinterpret_cast<XDR *>(encode_queuing_header_stream)));
 	free(encode_queuing_header_stream);
 	encode_queuing_header_stream = (XDR *) NULL;
     }
     if (NULL != decode_queuing_header_stream) {
-	xdr_destroy(((XDR *) decode_queuing_header_stream));
+	xdr_destroy((reinterpret_cast<XDR *>(decode_queuing_header_stream)));
 	free(decode_queuing_header_stream);
 	decode_queuing_header_stream = (XDR *) NULL;
     }
@@ -322,10 +322,10 @@ int CMS_XDR_UPDATER::get_encoded_msg_size()
 CMS_STATUS CMS_XDR_UPDATER::update(bool &x)
 {
     /* Check to see if the pointers are in the proper range. */
-    if (-1 == check_pointer((char *) &x, sizeof(char))) {
+    if (-1 == check_pointer(reinterpret_cast<char *>(&x), sizeof(char))) {
 	return (CMS_UPDATE_ERROR);
     }
-    if (xdr_char(current_stream, (char *) &x) != TRUE) {
+    if (xdr_char(current_stream, reinterpret_cast<char *>(&x)) != TRUE) {
 	rcs_print_error("CMS_XDR_UPDATER: xdr_char failed.\n");
 	return (status = CMS_UPDATE_ERROR);
     }
@@ -393,7 +393,7 @@ CMS_STATUS CMS_XDR_UPDATER::update(uint8_t *x, unsigned int len)
 CMS_STATUS CMS_XDR_UPDATER::update(int16_t &x)
 {
     /* Check to see if the pointers are in the proper range. */
-    if (-1 == check_pointer((char *) &x, sizeof(int16_t))) {
+    if (-1 == check_pointer(reinterpret_cast<char *>(&x), sizeof(int16_t))) {
 	return (CMS_UPDATE_ERROR);
     }
 
@@ -407,11 +407,11 @@ CMS_STATUS CMS_XDR_UPDATER::update(int16_t &x)
 CMS_STATUS CMS_XDR_UPDATER::update(int16_t *x, unsigned int len)
 {
     /* Check to see if the pointers are in the proper range. */
-    if (-1 == check_pointer((char *) x, len * sizeof(int16_t))) {
+    if (-1 == check_pointer(reinterpret_cast<char *>(x), len * sizeof(int16_t))) {
 	return (CMS_UPDATE_ERROR);
     }
 
-    if (xdr_vector(current_stream, (char *) x, len, sizeof(int16_t),
+    if (xdr_vector(current_stream, reinterpret_cast<char *>(x), len, sizeof(int16_t),
 	    (xdrproc_t) xdr_int16_t) != TRUE) {
 	rcs_print_error
 	    ("CMS_XDR_UPDATER: xdr_vector(... xdr_int16_t) failed.\n");
@@ -422,7 +422,7 @@ CMS_STATUS CMS_XDR_UPDATER::update(int16_t *x, unsigned int len)
 
 CMS_STATUS CMS_XDR_UPDATER::update(uint16_t &x)
 {
-    if (-1 == check_pointer((char *) &x, sizeof(uint16_t))) {
+    if (-1 == check_pointer(reinterpret_cast<char *>(&x), sizeof(uint16_t))) {
 	return (CMS_UPDATE_ERROR);
     }
 
@@ -436,12 +436,12 @@ CMS_STATUS CMS_XDR_UPDATER::update(uint16_t &x)
 
 CMS_STATUS CMS_XDR_UPDATER::update(uint16_t *x, unsigned int len)
 {
-    if (-1 == check_pointer((char *) x, len * sizeof(uint16_t))) {
+    if (-1 == check_pointer(reinterpret_cast<char *>(x), len * sizeof(uint16_t))) {
 	return (CMS_UPDATE_ERROR);
     }
 
     if (xdr_vector(current_stream,
-	    (char *) x, len,
+	    reinterpret_cast<char *>(x), len,
 	    sizeof(uint16_t), (xdrproc_t) xdr_uint16_t) != TRUE) {
 	rcs_print_error
 	    ("CMS_XDR_UPDATER: xdr_vector(... xdr_uint16_t) failed.\n");
@@ -454,7 +454,7 @@ CMS_STATUS CMS_XDR_UPDATER::update(uint16_t *x, unsigned int len)
 
 CMS_STATUS CMS_XDR_UPDATER::update(int32_t &x)
 {
-    if (-1 == check_pointer((char *) &x, sizeof(int32_t))) {
+    if (-1 == check_pointer(reinterpret_cast<char *>(&x), sizeof(int32_t))) {
 	return (CMS_UPDATE_ERROR);
     }
 
@@ -467,10 +467,10 @@ CMS_STATUS CMS_XDR_UPDATER::update(int32_t &x)
 
 CMS_STATUS CMS_XDR_UPDATER::update(int32_t *x, unsigned int len)
 {
-    if (-1 == check_pointer((char *) x, len * sizeof(int32_t))) {
+    if (-1 == check_pointer(reinterpret_cast<char *>(x), len * sizeof(int32_t))) {
 	return (CMS_UPDATE_ERROR);
     }
-    if (xdr_vector(current_stream, (char *) x, len, sizeof(int32_t),
+    if (xdr_vector(current_stream, reinterpret_cast<char *>(x), len, sizeof(int32_t),
 	    (xdrproc_t) xdr_int32_t) != TRUE) {
 	rcs_print_error
 	    ("CMS_XDR_UPDATER: xdr_vector( ... xdr_int32_t) failed.\n");
@@ -481,7 +481,7 @@ CMS_STATUS CMS_XDR_UPDATER::update(int32_t *x, unsigned int len)
 
 CMS_STATUS CMS_XDR_UPDATER::update(uint32_t &x)
 {
-    if (-1 == check_pointer((char *) &x, sizeof(uint32_t))) {
+    if (-1 == check_pointer(reinterpret_cast<char *>(&x), sizeof(uint32_t))) {
 	return (CMS_UPDATE_ERROR);
     }
 
@@ -494,12 +494,12 @@ CMS_STATUS CMS_XDR_UPDATER::update(uint32_t &x)
 
 CMS_STATUS CMS_XDR_UPDATER::update(uint32_t *x, unsigned int len)
 {
-    if (-1 == check_pointer((char *) x, len * sizeof(uint32_t))) {
+    if (-1 == check_pointer(reinterpret_cast<char *>(x), len * sizeof(uint32_t))) {
 	return (CMS_UPDATE_ERROR);
     }
 
     if (xdr_vector(current_stream,
-	    (char *) x, len,
+	    reinterpret_cast<char *>(x), len,
 	    sizeof(uint32_t), (xdrproc_t) xdr_uint32_t) != TRUE) {
 	rcs_print_error
 	    ("CMS_XDR_UPDATER: xdr_vector(... xdr_uint32_t) failed.\n");
@@ -512,7 +512,7 @@ CMS_STATUS CMS_XDR_UPDATER::update(uint32_t *x, unsigned int len)
 
 CMS_STATUS CMS_XDR_UPDATER::update(int64_t &x)
 {
-    if (-1 == check_pointer((char *) &x, sizeof(int64_t))) {
+    if (-1 == check_pointer(reinterpret_cast<char *>(&x), sizeof(int64_t))) {
 	return (CMS_UPDATE_ERROR);
     }
 
@@ -525,11 +525,11 @@ CMS_STATUS CMS_XDR_UPDATER::update(int64_t &x)
 
 CMS_STATUS CMS_XDR_UPDATER::update(int64_t *x, unsigned int len)
 {
-    if (-1 == check_pointer((char *) x, len * sizeof(int64_t))) {
+    if (-1 == check_pointer(reinterpret_cast<char *>(x), len * sizeof(int64_t))) {
 	return (CMS_UPDATE_ERROR);
     }
 
-    if (xdr_vector(current_stream, (char *) x, len, sizeof(int64_t),
+    if (xdr_vector(current_stream, reinterpret_cast<char *>(x), len, sizeof(int64_t),
 	    (xdrproc_t) xdr_int64_t) != TRUE) {
 	rcs_print_error
 	    ("CMS_XDR_UPDATER: xdr_vector(... xdr_int64_t) failed.\n");
@@ -540,7 +540,7 @@ CMS_STATUS CMS_XDR_UPDATER::update(int64_t *x, unsigned int len)
 
 CMS_STATUS CMS_XDR_UPDATER::update(uint64_t &x)
 {
-    if (-1 == check_pointer((char *) &x, sizeof(uint64_t))) {
+    if (-1 == check_pointer(reinterpret_cast<char *>(&x), sizeof(uint64_t))) {
 	return (CMS_UPDATE_ERROR);
     }
 
@@ -554,12 +554,12 @@ CMS_STATUS CMS_XDR_UPDATER::update(uint64_t &x)
 
 CMS_STATUS CMS_XDR_UPDATER::update(uint64_t *x, unsigned int len)
 {
-    if (-1 == check_pointer((char *) x, len * sizeof(uint64_t))) {
+    if (-1 == check_pointer(reinterpret_cast<char *>(x), len * sizeof(uint64_t))) {
 	return (CMS_UPDATE_ERROR);
     }
 
     if (xdr_vector(current_stream,
-	    (char *) x, len, sizeof(uint64_t),
+	    reinterpret_cast<char *>(x), len, sizeof(uint64_t),
 	    (xdrproc_t) xdr_uint64_t) != TRUE) {
 	rcs_print_error
 	    ("CMS_XDR_UPDATER: xdr_vector(... xdr_uint64_t) failed.\n");
@@ -572,7 +572,7 @@ CMS_STATUS CMS_XDR_UPDATER::update(uint64_t *x, unsigned int len)
 
 CMS_STATUS CMS_XDR_UPDATER::update(float &x)
 {
-    if (-1 == check_pointer((char *) &x, sizeof(float))) {
+    if (-1 == check_pointer(reinterpret_cast<char *>(&x), sizeof(float))) {
 	return (CMS_UPDATE_ERROR);
     }
 
@@ -585,11 +585,11 @@ CMS_STATUS CMS_XDR_UPDATER::update(float &x)
 
 CMS_STATUS CMS_XDR_UPDATER::update(float *x, unsigned int len)
 {
-    if (-1 == check_pointer((char *) x, len * sizeof(float))) {
+    if (-1 == check_pointer(reinterpret_cast<char *>(x), len * sizeof(float))) {
 	return (CMS_UPDATE_ERROR);
     }
 
-    if (xdr_vector(current_stream, (char *) x, len, sizeof(float),
+    if (xdr_vector(current_stream, reinterpret_cast<char *>(x), len, sizeof(float),
 	    (xdrproc_t) xdr_float) != TRUE) {
 	rcs_print_error
 	    ("CMS_XDR_UPDATER: xdr_vector(... xdr_float) failed.\n");
@@ -600,7 +600,7 @@ CMS_STATUS CMS_XDR_UPDATER::update(float *x, unsigned int len)
 
 CMS_STATUS CMS_XDR_UPDATER::update(double &x)
 {
-    if (-1 == check_pointer((char *) &x, sizeof(double))) {
+    if (-1 == check_pointer(reinterpret_cast<char *>(&x), sizeof(double))) {
 	return (CMS_UPDATE_ERROR);
     }
 
@@ -613,11 +613,11 @@ CMS_STATUS CMS_XDR_UPDATER::update(double &x)
 
 CMS_STATUS CMS_XDR_UPDATER::update(double *x, unsigned int len)
 {
-    if (-1 == check_pointer((char *) x, len * sizeof(double))) {
+    if (-1 == check_pointer(reinterpret_cast<char *>(x), len * sizeof(double))) {
 	return (CMS_UPDATE_ERROR);
     }
 
-    if (xdr_vector(current_stream, (char *) x, len, sizeof(double),
+    if (xdr_vector(current_stream, reinterpret_cast<char *>(x), len, sizeof(double),
 	    (xdrproc_t) xdr_double) != TRUE) {
 	rcs_print_error
 	    ("CMS_XDR_UPDATER: xdr_vector(... xdr_double) failed.\n");
@@ -633,7 +633,7 @@ CMS_STATUS CMS_XDR_UPDATER::update(double *x, unsigned int len)
 /* Avoid using long doubles in NML messages. */
 CMS_STATUS CMS_XDR_UPDATER::update(long double &x)
 {
-    if (-1 == check_pointer((char *) &x, sizeof(long double))) {
+    if (-1 == check_pointer(reinterpret_cast<char *>(&x), sizeof(long double))) {
 	return (CMS_UPDATE_ERROR);
     }
 
@@ -651,7 +651,7 @@ CMS_STATUS CMS_XDR_UPDATER::update(long double &x)
 
 CMS_STATUS CMS_XDR_UPDATER::update(long double *x, unsigned int len)
 {
-    if (-1 == check_pointer((char *) x, len * sizeof(long double))) {
+    if (-1 == check_pointer(reinterpret_cast<char *>(x), len * sizeof(long double))) {
 	return (CMS_UPDATE_ERROR);
     }
 
@@ -660,7 +660,7 @@ CMS_STATUS CMS_XDR_UPDATER::update(long double *x, unsigned int len)
         y[i] = (double) x[i];
     }
 
-    if (xdr_vector(current_stream, (char *)y.data(), len, sizeof(double),
+    if (xdr_vector(current_stream, reinterpret_cast<char *>(y.data()), len, sizeof(double),
 	    (xdrproc_t) xdr_double) != TRUE) {
 	rcs_print_error
 	    ("CMS_XDR_UPDATER: xdr_vector(... xdr_double) failed.\n");

--- a/src/libnml/cms/cms_xup.hh
+++ b/src/libnml/cms/cms_xup.hh
@@ -53,6 +53,10 @@ class CMS_XDR_UPDATER:public CMS_UPDATER {
     int check_pointer(char *, long);
       CMS_XDR_UPDATER(CMS *);
       virtual ~ CMS_XDR_UPDATER();
+    // Not copyable
+    CMS_XDR_UPDATER(const CMS_XDR_UPDATER&) = delete;
+    CMS_XDR_UPDATER& operator= (const CMS_XDR_UPDATER&) = delete;
+
     friend class CMS;
     XDR *encode_data_stream;	/* XDR streams for data */
     XDR *decode_data_stream;

--- a/src/libnml/cms/cmsdiag.hh
+++ b/src/libnml/cms/cmsdiag.hh
@@ -82,6 +82,10 @@ class CMS_DIAGNOSTICS_INFO:public CMS_DIAG_HEADER {
   public:
     CMS_DIAGNOSTICS_INFO();
     virtual ~ CMS_DIAGNOSTICS_INFO();
+    // Not copyable
+    CMS_DIAGNOSTICS_INFO(const CMS_DIAGNOSTICS_INFO&) = delete;
+    CMS_DIAGNOSTICS_INFO& operator= (const CMS_DIAGNOSTICS_INFO&) = delete;
+
     CMS_DIAG_PROC_INFO *last_writer_dpi;
     CMS_DIAG_PROC_INFO *last_reader_dpi;
     LinkedList *dpis;

--- a/src/libnml/cms/tcp_srv.hh
+++ b/src/libnml/cms/tcp_srv.hh
@@ -78,6 +78,10 @@ class TCP_BUFFER_SUBSCRIPTION_INFO {
   public:
     TCP_BUFFER_SUBSCRIPTION_INFO();
     ~TCP_BUFFER_SUBSCRIPTION_INFO();
+    // Not copyable
+    TCP_BUFFER_SUBSCRIPTION_INFO(const TCP_BUFFER_SUBSCRIPTION_INFO&) = delete;
+    TCP_BUFFER_SUBSCRIPTION_INFO& operator= (const TCP_BUFFER_SUBSCRIPTION_INFO&) = delete;
+
     int buffer_number;
     int min_last_id;
     int list_id;
@@ -105,6 +109,10 @@ class CLIENT_TCP_PORT {
   public:
     CLIENT_TCP_PORT();
     ~CLIENT_TCP_PORT();
+    // Not copyable
+    CLIENT_TCP_PORT(const CLIENT_TCP_PORT&) = delete;
+    CLIENT_TCP_PORT& operator= (const CLIENT_TCP_PORT&) = delete;
+
     long serial_number;
     int errors, max_errors;
     struct sockaddr_in address;


### PR DESCRIPTION
This PR addresses most remaining warnings.
Missing class member initialization is fixed. All the "dangerous old" casts are now changed into `reinterpret_cast<>()`. Classes that use dynamic memory, as detected by cppcheck, have their copy constructors and copy assignment removed. These classes are not meant to be duplicated anyway.

The remaining cppcheck warnings deal with `emc/usr_intf/schedrmt.cc` stuff. However, the scheduler program needs a complete overhaul like linuxcncrsh recently had. That is on the todo list.