### PR TITLE
Interpreter: Fix Allow G43 for tools with zero offsets

### DIFF
--- a/src/emc/rs274ngc/interp_convert.cc
+++ b/src/emc/rs274ngc/interp_convert.cc
@@ -6239,9 +6239,9 @@ int Interp::convert_tool_length_offset(int g_code,       //!< g_code being execu
     tool_offset.v = USER_TO_PROGRAM_LEN(settings->tool_table[idx].offset.v);
     tool_offset.w = USER_TO_PROGRAM_LEN(settings->tool_table[idx].offset.w);
     settings->g43_with_zero_offset =
-      (settings->tool_offset.tran.x || settings->tool_offset.tran.y || settings->tool_offset.tran.z ||
-       settings->tool_offset.a || settings->tool_offset.b || settings->tool_offset.c ||
-       settings->tool_offset.u || settings->tool_offset.v || settings->tool_offset.w);
+      !(tool_offset.tran.x || tool_offset.tran.y || tool_offset.tran.z ||
+        tool_offset.a || tool_offset.b || tool_offset.c ||
+        tool_offset.u || tool_offset.v || tool_offset.w);
   } else if (g_code == G_43_1) {
     tool_offset = settings->tool_offset;
     idx = -1;

--- a/src/emc/rs274ngc/interp_setup.cc
+++ b/src/emc/rs274ngc/interp_setup.cc
@@ -140,6 +140,7 @@ setup::setup() :
     tool_table{},
     traverse_rate (0.0),
     orient_offset (0.0),
+    g43_with_zero_offset(false),
 
     defining_sub(0),
     sub_name(NULL),


### PR DESCRIPTION
Fixes errors that I seem to have inadvertently introduced while preparing the final PR for 0673e3f :

- Fix wrong logic (current version sets the flag when an offset value is unequal zero)
- Check tool table offsets not the currently active tool offsets

Also includes 
- Initialization for the flag in interp_setup as suggested by @BsAtHome 