### PR TITLE
hal: don't unnecessary include hal_priv.h header

### DIFF
--- a/src/hal/hal.hh
+++ b/src/hal/hal.hh
@@ -5,12 +5,18 @@
 #include <string>
 #include <variant>
 #include "hal.h"
-#include "hal_priv.h"
 
 enum class hal_dir{
     IN = HAL_IN,
     OUT = HAL_OUT,
 };
+
+#if 0
+// If this class is ever necessary, then it needs to be moved into a new
+// header 'hal_priv.hh' because it uses internal access methods from
+// 'hal_priv.h' that should not be available to the casual source file.
+
+#include "hal_priv.h"
 
 class hal{
     public:
@@ -34,6 +40,7 @@ class hal{
         return thecomp && (thecomp->ready != 0);
     }
 };
+#endif
 
 template<typename T>
 class hal_pin{

--- a/src/hal/utils/halcmd.c
+++ b/src/hal/utils/halcmd.c
@@ -66,7 +66,6 @@ FILE *halcmd_inifile = NULL;
 
 #include <rtapi.h>		/* RTAPI realtime OS API */
 #include <hal.h>		/* HAL public API decls */
-#include "../hal_priv.h"	/* private HAL decls */
 #include "halcmd_commands.h"
 
 /***********************************************************************


### PR DESCRIPTION
This PR removes the inclusion of `hal_priv.h` where it is not immediately required.

This is part of cleaning up in the headers and making better private/public, internal/external distinctions.