### PR TITLE
Fix rtapi atomics

### DIFF
--- a/src/hal/hal.h
+++ b/src/hal/hal.h
@@ -339,13 +339,6 @@ typedef union {
     hal_u64_t lu;
 } hal_data_u;
 
-typedef struct {
-    volatile unsigned int read;  //offset into buff that outgoing data gets read from
-    volatile unsigned int write; //offset into buff that incoming data gets written to
-    unsigned int size;           //size of allocated buffer
-    char buff[];
-} hal_port_shm_t;
-
 /***********************************************************************
 *                      "LOCKING" FUNCTIONS                             *
 ************************************************************************/
@@ -945,6 +938,7 @@ union hal_stream_data {
     uint32_t u;
 };
 
+struct hal_stream_shm; // Forward declaration. Only relevant in hal_lib.c.
 typedef struct {
     int comp_id, shmem_id;
     struct hal_stream_shm *fifo;

--- a/src/hal/hal_lib.c
+++ b/src/hal/hal_lib.c
@@ -3762,6 +3762,15 @@ static char *halpr_type_string(int type, char *buf, size_t nbuf) {
 HAL PORT functions
 ******************************************************************************/
 
+// This struct is purely local to this file to keep track of the
+// port data in shmem.
+typedef struct __hal_port_shm_t {
+    atomic_uint read;  // offset into buff that outgoing data gets read from
+    atomic_uint write; // offset into buff that incoming data gets written to
+    unsigned int size; // size of allocated buffer
+    char buff[];
+} hal_port_shm_t;
+
 static void hal_port_atomic_load(hal_port_shm_t* port_shm, unsigned* read, unsigned* write)
 {
     *read = atomic_load_explicit(&port_shm->read, memory_order_acquire);
@@ -4067,6 +4076,22 @@ void hal_port_wait_writable(hal_port_t** port, unsigned count, sig_atomic_t* sto
 /*
 hal stream implementation
 */
+
+// This struct is purely local to this file to keep track of the stream
+// data in shmem.
+struct hal_stream_shm {
+    unsigned magic;
+    atomic_uint in;
+    atomic_uint out;
+    unsigned this_sample;
+    unsigned depth;
+    int num_pins;
+    atomic_uint num_overruns;
+    atomic_uint num_underruns;
+    hal_type_t type[HAL_STREAM_MAX_PINS];
+    union hal_stream_data data[];
+};
+
 int halpr_parse_types(hal_type_t type[HAL_STREAM_MAX_PINS], const char *cfg)
 {
     const char *c;

--- a/src/hal/hal_priv.h
+++ b/src/hal/hal_priv.h
@@ -494,17 +494,6 @@ extern int hal_port_alloc(unsigned size, hal_port_t *port);
 
 
 #define HAL_STREAM_MAGIC_NUM		0x4649464F
-struct hal_stream_shm {
-    unsigned magic;
-    volatile unsigned in;
-    volatile unsigned out;
-    unsigned this_sample;
-    unsigned depth;
-    int num_pins;
-    unsigned long num_overruns, num_underruns;
-    hal_type_t type[HAL_STREAM_MAX_PINS];
-    union hal_stream_data data[];
-};
 
 extern int halpr_parse_types(hal_type_t type[HAL_STREAM_MAX_PINS], const char *fcg);
 RTAPI_END_DECLS

--- a/src/rtapi/rtapi_atomic.h
+++ b/src/rtapi/rtapi_atomic.h
@@ -1,4 +1,5 @@
 //    Copyright 2015 Jeff Epler
+//    Copyright 2026 B.Stultiens
 //
 //    This program is free software; you can redistribute it and/or modify
 //    it under the terms of the GNU General Public License as published by
@@ -16,37 +17,33 @@
 #ifndef __LINUXCNC_RTAPI_ATOMIC_H
 #define __LINUXCNC_RTAPI_ATOMIC_H
 
-#if defined(__GNUC__) && ((__GNUC__ << 8) | __GNUC_MINOR__) >= 0x409
+#if defined(__cplusplus)
+
+// We use C++20 and that has all the atomics we need
+#include <atomic>
+
+#else // defined(__cplusplus)
+
+// Standard C, we require C11 or better
+#if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L
 #define RTAPI_USE_STDATOMIC
-#elif defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L
+#elif defined(__GNUC__) && ((__GNUC__ << 8) | __GNUC_MINOR__) >= 0x409
 #define RTAPI_USE_STDATOMIC
 #endif
 
-#ifdef RTAPI_USE_STDATOMIC
+#if defined(RTAPI_USE_STDATOMIC)
 #include <stdatomic.h>
-#else
 
-#warning "Old compiler has no C11 atomics. Please consider upgrading your compiler."
-
-enum memory_order {
-    memory_order_relaxed,
-    memory_order_consume,
-    memory_order_acquire,
-    memory_order_release,
-    memory_order_acq_rel,
-    memory_order_seq_cst
-};
-
-#define atomic_store(obj, desired) atomic_store_explicit((obj), (desired), memory_order_seq_cst)
-#define atomic_load(obj) atomic_load_explicit((obj), memory_order_seq_cst)
-
-// note that in this implementation, only one level of synchronization is supported, equivalent to memory_order_seq_cst
-#define atomic_store_explicit(obj, desired, order) \
-    ({ (void)order; __sync_synchronize(); *(obj) = (desired); (void)0; })
-
-#define atomic_load_explicit(obj, order) \
-    ({ (void)order; __typeof__(*(obj)) v = *(obj); __sync_synchronize(); v; })
-
+#if defined(__STDC_NO_ATOMICS__)
+#error "Your compiler/libc has set __STDC_NO_ATOMICS__ and atomics are required."
 #endif
+
+#else // defined(RTAPI_USE_STDATOMIC)
+
+#error "Old compiler has no C11 atomics. Please upgrade your compiler to support C11 or better."
+
+#endif // defined(RTAPI_USE_STDATOMIC)
+
+#endif // defined(__cplusplus)
 
 #endif

--- a/src/rtapi/rtapi_uspace.hh
+++ b/src/rtapi/rtapi_uspace.hh
@@ -22,7 +22,7 @@
 #endif
 #include <unistd.h>
 #include <pthread.h>
-#include <atomic>
+#include "rtapi_atomic.h"
 
 static inline void rtapi_timespec_add(timespec &result, const timespec &ta, const timespec &tb) {
     result.tv_sec = ta.tv_sec + tb.tv_sec;
@@ -45,7 +45,7 @@ struct WithRoot
 {
     WithRoot();
     ~WithRoot();
-    static std::atomic<int> level;
+    static std::atomic_int level;
 };
 
 struct rtapi_task {

--- a/src/rtapi/uspace_rtai.cc
+++ b/src/rtapi/uspace_rtai.cc
@@ -5,7 +5,6 @@
 #pragma GCC diagnostic ignored "-Wnarrowing"
 #include <rtai_lxrt.h>
 #pragma GCC diagnostic pop
-#include <atomic>
 #ifdef HAVE_SYS_IO_H
 #include <sys/io.h>
 #endif
@@ -16,7 +15,7 @@ RtapiApp *app;
 
 struct RtaiTask : rtapi_task {
     RtaiTask() : rtapi_task{}, cancel{}, rt_task{}, thr{} {}
-    std::atomic<int> cancel;
+    std::atomic_int cancel;
     RT_TASK *rt_task;
     pthread_t thr;
 };

--- a/src/rtapi/uspace_rtapi_app.cc
+++ b/src/rtapi/uspace_rtapi_app.cc
@@ -51,14 +51,14 @@
 #include <pthread_np.h>
 #endif
 
+#include <boost/lockfree/queue.hpp>
+
 #include "rtapi.h"
 #include <hal.h>
 #include "hal/hal_priv.h"
 #include "rtapi_uspace.hh"
 
-#include <boost/lockfree/queue.hpp>
-
-std::atomic<int> WithRoot::level;
+std::atomic_int WithRoot::level;
 static uid_t euid, ruid;
 
 #include "rtapi/uspace_common.h"

--- a/src/rtapi/uspace_xenomai.cc
+++ b/src/rtapi/uspace_xenomai.cc
@@ -5,7 +5,6 @@
 #include  <errno.h>
 #include <stdio.h>
 #include <cstring>
-#include <atomic>
 #ifdef HAVE_SYS_IO_H
 #include <sys/io.h>
 #endif
@@ -14,7 +13,7 @@ namespace
 {
 struct RtaiTask : rtapi_task {
     RtaiTask() : rtapi_task{}, cancel{}, thr{} {}
-    std::atomic<int> cancel;
+    std::atomic_int cancel;
     pthread_t thr;
 };
 


### PR DESCRIPTION
The atomics for C and C++ were not entirely functional when using clang. Partly functionality was provided by the `rtapi_atomc.h` header by (re-)defining some parts, but these should come from the compiler's headers (C:`<stdatomic.h>` and C++:`<atomic>`). As a consequence, only the copied explicit load/store operations were possible and non of the other atomic operations would be available or function with clang.

The main culprit was the misspelling of the `__STDC_VERSION__` macro in the rtapi header, missing the trailing underscores and a wrong comparison.
Atomics are provided in C11 and newer. This means that the minimum C-compiler support is C11. But this should not be any problem because we already require a very much newer C++20 on the other side.

Some further adjustments were required once the macro got fixed because using atomic operations with clang requires the variables to be marked as actually atomic variables. That meant moving some private internal structures out of public headers into private space, where these variables could be safely marked as being atomic. One boost header needed to be included before rtapi_atomic.h or the boost header would cause problems.