### PR TITLE
Issue#3849 fix backported to 2.9

### DIFF
--- a/src/hal/drivers/mesa-hostmot2/hm2_modbus.c
+++ b/src/hal/drivers/mesa-hostmot2/hm2_modbus.c
@@ -387,7 +387,7 @@ static unsigned calc_ifdelay(hm2_modbus_inst_t *inst, unsigned baudrate, unsigne
 	}
 
 	// calculation works for baudrates less than ~24 Mbit/s
-	if(19200 < baudrate)
+	if(baudrate > 19200)
 		return (175u * baudrate + 99999u) / 100000u;
 	unsigned bits = 1 + 8 + (parity ? 1 : 0) + (stopbits > 1 ? 2 : 1);
 	return (bits * 35 + 9) / 10;	// Ceil of bits in 3.5 characters.
@@ -1049,7 +1049,7 @@ fetch_more_data:
 			break;
 		}
 		if(inst->maxicharbits && HM2_PKTUART_RCR_ICHARBITS_VAL(frsize) > inst->maxicharbits) {
-			MSG_WARN("%s: warning: reply to command %u had too long inter-character delay (%u > %u), dropping\n",
+			MSG_WARN("%s: warning: reply to command %u had too long inter-character delay (%u > %u), trying to interpret\n",
 					inst->name, inst->cmdidx,
 					HM2_PKTUART_RCR_ICHARBITS_VAL(frsize), inst->maxicharbits);
 			set_error(inst, ENOMSG);


### PR DESCRIPTION
Fixes calc_ifdelay() for baud > 19200 that was setting bit timing delays incorrectly leading to a variety of communication problems. Fixes ENOMSG error handling that was locking up modbus communication.