### PR TITLE
Fix halcmd debug (uspace only)

### DIFF
--- a/src/hal/utils/halcmd_commands.cc
+++ b/src/hal/utils/halcmd_commands.cc
@@ -241,12 +241,18 @@ int do_unlinkp_cmd(char *pin)
 }
 
 int do_set_debug_cmd(char* level){
-    int new_level = atoi(level);
-    if (new_level < 0 || new_level > 5){
-        halcmd_error("Debug level must be >=0 and <= 5\n");
-        return -EINVAL;
-    }
-    return rtapi_set_msg_level(atoi(level));
+    int m=0,retval=-EINVAL;
+    const char *argv[4];
+#if defined(RTAPI_USPACE)
+    argv[m++] = EMC2_BIN_DIR "/rtapi_app";
+    argv[m++] = "debug";
+    argv[m++] = level;
+    argv[m++] = NULL;
+    retval = hal_systemv(argv);
+#else
+    halcmd_error("debug: not implemented for anything else than uspace\n");
+#endif
+    return retval;
 }
 
 int do_source_cmd(char *hal_filename) {

--- a/src/rtapi/uspace_rtapi_app.cc
+++ b/src/rtapi/uspace_rtapi_app.cc
@@ -329,6 +329,21 @@ static int do_unload_cmd(const string& name) {
     return 0;
 }
 
+static int do_debug_cmd(const string& value) {
+    try{
+        int new_level = stoi(value);
+        if (new_level < 0 || new_level > 5){
+            rtapi_print_msg(RTAPI_MSG_ERR, "Debug level must be >=0 and <= 5\n");
+            return -EINVAL;
+        }
+        return rtapi_set_msg_level(new_level);
+    }catch(invalid_argument &e){
+        //stoi will throw an exception if parsing is not possible
+        rtapi_print_msg(RTAPI_MSG_ERR, "Debug level is not a number\n");
+        return -EINVAL;
+    }
+}
+
 struct ReadError : std::exception {};
 struct WriteError : std::exception {};
 
@@ -403,6 +418,8 @@ static int handle_command(vector<string> args) {
         return do_newinst_cmd(args[1], args[2], "");
     } else if(args.size() == 4 && args[0] == "newinst") {
         return do_newinst_cmd(args[1], args[2], args[3]);
+    } else if(args.size() == 2 && args[0] == "debug") {
+        return do_debug_cmd(args[1]);
     } else {
         rtapi_print_msg(RTAPI_MSG_ERR,
                 "Unrecognized command starting with %s\n",


### PR DESCRIPTION
As described in https://github.com/LinuxCNC/linuxcnc/pull/3866 the `hallcmd debug` was not working.

I fixed this by forwarding the command to `rtapi_app` and add the debug command also in there.

Caviat: This works only in uspace mode.

ToDo: Test with rtlinux. I tested only without so far.