### PR TITLE
CFLAGS: Replace instances of -Os with -O2

### DIFF
--- a/src/Makefile.inc.in
+++ b/src/Makefile.inc.in
@@ -77,7 +77,7 @@ RTAI = @RTAI@
 RTFLAGS = @RTFLAGS@ @EXT_RTFLAGS@
 KERNELDIR = @KERNELDIR@
 RTFLAGS := -I. -I@RTDIR@/include $(RTFLAGS) -DRTAPI -D_GNU_SOURCE -Drealtime
-ULFLAGS = -Wall -g -I. -I@RTDIR@/include -DULAPI -D_GNU_SOURCE -Os -DLOCALE_DIR=\"$(localedir)\" -DPACKAGE=\"$(package)\"
+ULFLAGS = -Wall -g -I. -I@RTDIR@/include -DULAPI -D_GNU_SOURCE -O2 -DLOCALE_DIR=\"$(localedir)\" -DPACKAGE=\"$(package)\"
 MODULE_EXT = @MODEXT@
 BUILD_SYS = @BUILD_SYS@
 CC = @CC@

--- a/src/hal/utils/halcompile.g
+++ b/src/hal/utils/halcompile.g
@@ -816,7 +816,7 @@ def build_usr(tempdir, filename, mode, origfilename):
     makefile = os.path.join(tempdir, "Makefile")
     f = open(makefile, "w")
     print("%s: %s" % (binname, filename), file=f)
-    print("\t$(CC) -I%s -I$(EMC2_HOME)/include -I/usr/include/linuxcnc -URTAPI -U__MODULE__ -DULAPI -Os %s -o $@ $< -Wl,-rpath,$(LIBDIR) -L$(LIBDIR) -llinuxcnchal %s" % (
+    print("\t$(CC) -I%s -I$(EMC2_HOME)/include -I/usr/include/linuxcnc -URTAPI -U__MODULE__ -DULAPI -O2 %s -o $@ $< -Wl,-rpath,$(LIBDIR) -L$(LIBDIR) -llinuxcnchal %s" % (
 
         os.path.abspath(os.path.dirname(origfilename)),
         options.get("extra_compile_args", ""),


### PR DESCRIPTION
-Os or -O2 should have no effect on doubles.