### PR TITLE
Fix priority check for LXRT

### DIFF
--- a/src/rtapi/rtapi_uspace.hh
+++ b/src/rtapi/rtapi_uspace.hh
@@ -75,6 +75,7 @@ struct RtapiApp
     virtual int prio_lowest() const;
     int prio_higher_delta() const;
     int prio_bound(int prio) const;
+    bool prio_check(int prio) const;
     int prio_next_higher(int prio) const;
     int prio_next_lower(int prio) const;
     long clock_set_period(long int period_nsec);

--- a/src/rtapi/uspace_rtapi_app.cc
+++ b/src/rtapi/uspace_rtapi_app.cc
@@ -869,6 +869,14 @@ int RtapiApp::prio_bound(int prio) const {
     return prio;
 }
 
+bool RtapiApp::prio_check(int prio) const {
+    if(rtapi_prio_highest() > rtapi_prio_lowest()) {
+        return (prio <= rtapi_prio_highest()) && (prio >= rtapi_prio_lowest());
+    } else {
+        return (prio <= rtapi_prio_lowest()) && (prio >= rtapi_prio_highest());
+    }
+}
+
 int RtapiApp::prio_next_higher(int prio) const
 {
     prio = prio_bound(prio);
@@ -899,8 +907,10 @@ int RtapiApp::allocate_task_id()
 int RtapiApp::task_new(void (*taskcode) (void*), void *arg,
         int prio, int owner, unsigned long int stacksize, int uses_fp) {
   /* check requested priority */
-  if ((prio > rtapi_prio_highest()) || (prio < rtapi_prio_lowest()))
+  if (!prio_check(prio))
   {
+    rtapi_print_msg(RTAPI_MSG_ERR,"rtapi:task_new prio is not in bound lowest %i prio %i highest %i\n",
+        rtapi_prio_lowest(), prio, rtapi_prio_highest());
     return -EINVAL;
   }
 


### PR DESCRIPTION
Based on this comment https://github.com/LinuxCNC/linuxcnc/issues/3878#issuecomment-4133280507, I track down the issue and fixed it.

It was introduced here:
https://github.com/LinuxCNC/linuxcnc/commit/233f3813a0f42b311f714c13eb5aff753b425b7c

git tag --contains 233f3813a0f42b311f714c13eb5aff753b425b7c
v2.10.0-pre0
v2.9.0
v2.9.0-pre1
v2.9.1
v2.9.2
v2.9.3
v2.9.4
v2.9.5
v2.9.6
v2.9.7
v2.9.8

That's why 2.9.0-pre0 in the picture was probably still working, however, I dont't have such an old VM to test this theory.

The issue is this check:
https://github.com/LinuxCNC/linuxcnc/blob/233f3813a0f42b311f714c13eb5aff753b425b7c/src/rtapi/uspace_rtapi_app.cc#L900

It fails when the lowest prio is bigger than the highest:
#define RT_SCHED_HIGHEST_PRIORITY  0
#define RT_SCHED_LOWEST_PRIORITY   0x3fffFfff
The above commit introduced a fix returning the correct prio for LXRT and broke the check with that.

Tested with:
POSIX non-realtime
POSIX realtime
XENOMAI (posix-skin) realtime
LXRT realtime

Just tell me if branch 2.9 is wrong for this fix and I will rebase to master.