### PR TITLE
hal: fix bugs in the hal-streamer interface and implementation

### DIFF
--- a/docs/src/man/man3/hal_stream.3.adoc
+++ b/docs/src/man/man3/hal_stream.3.adoc
@@ -21,10 +21,10 @@ int hal_stream_maxdepth(hal_stream_t* stream);
 int hal_stream_num_underruns(hal_stream_t* stream);
 int hal_stream_num_overruns(hal_stream_t* stream);
 
-int hal_stream_read(hal_stream_t* stream, union hal_stream_data* buf, unsigned* sampleno);
+int hal_stream_read(hal_stream_t* stream, hal_stream_data_u *buf, unsigned* sampleno);
 bool hal_stream_readable(hal_stream_t* stream);
 
-int hal_stream_write(hal_stream_t* stream, union hal_stream_data* buf);
+int hal_stream_write(hal_stream_t* stream, hal_stream_data_u *buf);
 bool hal_stream_writable(hal_stream_t* stream);
 
 #ifdef ULAPI
@@ -115,16 +115,16 @@ depth::
   The number of samples that can be unread before any samples are lost
   (overrun)
 typestring::
-  A typestring is a case-insensitive string which consists of one or
-  more of the following type characters:
+  A typestring is limited to 20 characters. A typestring is a
+  case-insensitive string which consists of one or more of the
+  following type characters:
   +
-  [upperalpha, start=2]
-  . for bool / hal_bit_t
-  . for int32_t / hal_s32_t
-  . for uint32_t / hal_u32_t
-  . for real_t / hal_float_t
-  +
-  A typestring is limited to 16 characters.
+  * B for bool / hal_bit_t
+  * S for rtapi_s32 / hal_s32_t
+  * U for rtapi_u32 / hal_u32_t
+  * F for real_t / hal_float_t
+  * L for rtapi_s64 / hal_s64_t
+  * K for rtapi_u64 / hal_u64_t
 
 buf::
   A buffer big enough to hold all the data in one sample.

--- a/src/hal/hal.h
+++ b/src/hal/hal.h
@@ -927,29 +927,31 @@ extern void hal_port_wait_writable(hal_port_t** port, unsigned count, sig_atomic
 #endif
 
 
-
-
-
-
-union hal_stream_data {
-    real_t f;
-    bool b;
-    int32_t s;
-    uint32_t u;
-};
-
-struct hal_stream_shm; // Forward declaration. Only relevant in hal_lib.c.
-typedef struct {
-    int comp_id, shmem_id;
-    struct hal_stream_shm *fifo;
-} hal_stream_t;
-
 /**
  * HAL streams are modeled after sampler/stream and will hopefully replace
  * the independent implementations there.
  *
  * There may only be one reader and one writer but this is not enforced
  */
+
+typedef union hal_stream_data {
+    real_t f;
+    bool b;
+    rtapi_s32 s;
+    rtapi_u32 u;
+    rtapi_s64 l;
+    rtapi_u64 k;
+} hal_stream_data_u;
+typedef hal_stream_data_u *hal_stream_data_ptr_u;
+
+struct __hal_stream_shm_t;  // Forward declaration. Only relevant in hal_lib.c.
+
+typedef struct __hal_stream_t {
+    int comp_id;
+    int shmem_id;
+    struct __hal_stream_shm_t *fifo;
+} hal_stream_t;
+typedef hal_stream_t *hal_stream_ptr_t;
 
 #define HAL_STREAM_MAX_PINS (21)
 /** create and attach a stream */
@@ -967,7 +969,7 @@ extern int hal_stream_element_count(hal_stream_t *stream);
 extern hal_type_t hal_stream_element_type(hal_stream_t *stream, int idx);
 
 // only one reader and one writer is allowed.
-extern int hal_stream_read(hal_stream_t *stream, union hal_stream_data *buf, unsigned *sampleno);
+extern int hal_stream_read(hal_stream_t *stream, hal_stream_data_u *buf, unsigned *sampleno);
 extern bool hal_stream_readable(hal_stream_t *stream);
 extern int hal_stream_depth(hal_stream_t *stream);
 extern unsigned hal_stream_maxdepth(hal_stream_t *stream);
@@ -977,7 +979,7 @@ extern int hal_stream_num_overruns(hal_stream_t *stream);
 extern void hal_stream_wait_readable(hal_stream_t *stream, sig_atomic_t *stop);
 #endif
 
-extern int hal_stream_write(hal_stream_t *stream, union hal_stream_data *buf);
+extern int hal_stream_write(hal_stream_t *stream, hal_stream_data_u *buf);
 extern bool hal_stream_writable(hal_stream_t *stream);
 #ifdef ULAPI
 extern void hal_stream_wait_writable(hal_stream_t *stream, sig_atomic_t *stop);

--- a/src/hal/hal_lib.c
+++ b/src/hal/hal_lib.c
@@ -3741,22 +3741,6 @@ static void free_thread_struct(hal_thread_t * thread)
 }
 #endif /* RTAPI */
 
-static char *halpr_type_string(int type, char *buf, size_t nbuf) {
-    switch(type) {
-        case HAL_BIT: return "bit";
-        case HAL_FLOAT: return "float";
-        case HAL_S32: return "s32";
-        case HAL_U32: return "u32";
-        case HAL_S64: return "s64";
-        case HAL_U64: return "u64";
-        case HAL_PORT: return "port";
-        default:
-            rtapi_snprintf(buf, nbuf, "UNK#%d", type);
-            return buf;
-    }
-}
-
-
 
 /******************************************************************************
 HAL PORT functions
@@ -3771,20 +3755,20 @@ typedef struct __hal_port_shm_t {
     char buff[];
 } hal_port_shm_t;
 
-static void hal_port_atomic_load(hal_port_shm_t* port_shm, unsigned* read, unsigned* write)
+static inline void hal_port_atomic_load(hal_port_shm_t* port_shm, unsigned* read, unsigned* write)
 {
     *read = atomic_load_explicit(&port_shm->read, memory_order_acquire);
     *write = atomic_load_explicit(&port_shm->write, memory_order_acquire);
 }
 
 
-static void hal_port_atomic_store_read(hal_port_shm_t* port_shm, unsigned read)
+static inline void hal_port_atomic_store_read(hal_port_shm_t* port_shm, unsigned read)
 {
     atomic_store_explicit(&port_shm->read, read, memory_order_release);
 }
 
 
-static void hal_port_atomic_store_write(hal_port_shm_t* port_shm, unsigned write)
+static inline void hal_port_atomic_store_write(hal_port_shm_t* port_shm, unsigned write)
 {
     atomic_store_explicit(&port_shm->write, write, memory_order_release);
 }
@@ -3973,7 +3957,7 @@ bool hal_port_write(const hal_port_t *port, const char* src, unsigned count) {
              final_pos;
  
     if(!port || !*port || !count) {
-	    return false;
+        return false;
     } else {
        hal_port_shm_t* port_shm = SHMPTR(*port);
        hal_port_atomic_load(port_shm, &read, &write);
@@ -4072,14 +4056,16 @@ void hal_port_wait_writable(hal_port_t** port, unsigned count, sig_atomic_t* sto
 
 
 
+/*********************************************************************
+ * HAL stream implementation
+ *********************************************************************/
 
-/*
-hal stream implementation
-*/
+// Spells 'FIFO'
+#define HAL_STREAM_MAGIC_NUM		0x4649464F
 
 // This struct is purely local to this file to keep track of the stream
 // data in shmem.
-struct hal_stream_shm {
+typedef struct __hal_stream_shm_t {
     unsigned magic;
     atomic_uint in;
     atomic_uint out;
@@ -4089,62 +4075,72 @@ struct hal_stream_shm {
     atomic_uint num_overruns;
     atomic_uint num_underruns;
     hal_type_t type[HAL_STREAM_MAX_PINS];
-    union hal_stream_data data[];
-};
+    hal_stream_data_u data[];
+} hal_stream_shm_t;
 
-int halpr_parse_types(hal_type_t type[HAL_STREAM_MAX_PINS], const char *cfg)
+static char *hal_stream_type_string(int type, char *buf, size_t nbuf)
 {
-    const char *c;
+    const char *cptr;
+    switch(type) {
+    case HAL_BIT:   cptr = "bit";   break;
+    case HAL_FLOAT: cptr = "float"; break;
+    case HAL_S32:   cptr = "s32";   break;
+    case HAL_U32:   cptr = "u32";   break;
+    case HAL_S64:   cptr = "s64";   break;
+    case HAL_U64:   cptr = "u64";   break;
+    case HAL_PORT:  cptr = "port";  break;
+    default:
+        rtapi_snprintf(buf, nbuf, "UNK#%d", type);
+        return buf;
+    }
+    rtapi_snprintf(buf, nbuf, "%s", cptr);
+    return buf;
+}
+
+static int hal_stream_parse_types(hal_type_t type[HAL_STREAM_MAX_PINS], const char *cfg)
+{
     int n;
 
-    c = cfg;
-    n = 0;
-    while (( n < HAL_STREAM_MAX_PINS ) && ( *c != '\0' )) {
-	switch (*c) {
-	case 'f':
-	case 'F':
-	    type[n++] = HAL_FLOAT;
-	    c++;
-	    break;
-	case 'b':
-	case 'B':
-	    type[n++] = HAL_BIT;
-	    c++;
-	    break;
-	case 'u':
-	case 'U':
-	    type[n++] = HAL_U32;
-	    c++;
-	    break;
-	case 's':
-	case 'S':
-	    type[n++] = HAL_S32;
-	    c++;
-	    break;
-	default:
-	    rtapi_print_msg(RTAPI_MSG_ERR,
-		"stream: ERROR: unknown type '%c', must be F, B, U, or S\n", *c);
-	    return 0;
-	}
+    if(!cfg || !*cfg) {
+        rtapi_print_msg(RTAPI_MSG_ERR, "stream: ERROR: invalid null or empty type-string\n");
+        return 0;
     }
-    if ( *c != '\0' ) {
-	/* didn't reach end of cfg string */
-	rtapi_print_msg(RTAPI_MSG_ERR,
-	    "stream: ERROR: more than %d items\n", HAL_STREAM_MAX_PINS);
-	return 0;
+
+    for(n = 0; n < HAL_STREAM_MAX_PINS && *cfg != '\0'; n++) {
+        switch (*cfg) {
+        case 'f': case 'F': type[n] = HAL_FLOAT; break;
+        case 'b': case 'B': type[n] = HAL_BIT; break;
+        case 'u': case 'U': type[n] = HAL_U32; break;
+        case 's': case 'S': type[n] = HAL_S32; break;
+        case 'l': case 'L': type[n] = HAL_S64; break;
+        case 'k': case 'K': type[n] = HAL_U64; break;
+        default:
+            rtapi_print_msg(RTAPI_MSG_ERR, "stream: ERROR: unknown type '%c', must be F, B, U, S, L or K\n", *cfg);
+            return 0;
+        }
+        cfg++;
+    }
+    if ( *cfg != '\0' ) {
+        /* didn't reach end of cfg string */
+        rtapi_print_msg(RTAPI_MSG_ERR, "stream: ERROR: more than %d items\n", HAL_STREAM_MAX_PINS);
+        return 0;
     }
     return n;
 }
 
 int hal_stream_create(hal_stream_t *stream, int comp, int key, unsigned depth, const char *typestring)
 {
+    if(!stream) {
+        rtapi_print_msg(RTAPI_MSG_ERR, "hal_stream_create: Invalid stream\n");
+        return -EINVAL;
+    }
     int result = 0;
     hal_type_t type[HAL_STREAM_MAX_PINS];
-    result = halpr_parse_types(type, typestring);
+    result = hal_stream_parse_types(type, typestring);
     if(!result) return -EINVAL;
     int pin_count = result;
 
-    size_t size = sizeof(struct hal_stream_shm) + sizeof(union hal_stream_data) * depth * (1+pin_count);
+    size_t size = sizeof(hal_stream_shm_t) + sizeof(hal_stream_data_u) * depth * (1+pin_count);
     result = rtapi_shmem_new(key, comp, size);
     if(result < 0) return result;
     stream->shmem_id = result;
@@ -4154,60 +4150,99 @@ int hal_stream_create(hal_stream_t *stream, int comp, int key, unsigned depth, c
         rtapi_shmem_delete(key, comp);
         return result;
     }
-    memset(stream->fifo, 0, sizeof(*stream->fifo));
+    stream->comp_id = comp;
 
+    memset(stream->fifo, 0, sizeof(*stream->fifo));
+    memcpy(stream->fifo->type, type, sizeof(type));
     stream->fifo->depth = depth;
     stream->fifo->num_pins = pin_count;
-    memcpy(stream->fifo->type, type, sizeof(type));
-    stream->comp_id = comp;
     stream->fifo->magic = HAL_STREAM_MAGIC_NUM;
+    atomic_thread_fence(memory_order_release);
     return 0;
 }
 
-extern void hal_stream_destroy(hal_stream_t *stream)
+void hal_stream_destroy(hal_stream_t *stream)
 {
     hal_stream_detach(stream);
 }
 
-static unsigned hal_stream_advance(hal_stream_t *stream, unsigned n) {
-    n = n + 1;
-    if(n >= stream->fifo->depth) n = 0;
+static inline unsigned hal_stream_advance(hal_stream_t *stream, unsigned n)
+{
+    n += 1;
+    if(n >= stream->fifo->depth) return 0;
     return n;
 }
 
-static unsigned hal_stream_newin(hal_stream_t *stream) {
-    return hal_stream_advance(stream, stream->fifo->in);
+static inline unsigned hal_stream_atomic_load_in(hal_stream_t *stream)
+{
+    return atomic_load_explicit(&stream->fifo->in, memory_order_acquire);
 }
 
-bool hal_stream_writable(hal_stream_t *stream) {
-    return hal_stream_newin(stream) != stream->fifo->out;
+static inline unsigned hal_stream_atomic_load_out(hal_stream_t *stream)
+{
+    return atomic_load_explicit(&stream->fifo->out, memory_order_acquire);
 }
 
-bool hal_stream_readable(hal_stream_t *stream) {
-    return stream->fifo->in != stream->fifo->out;
+static inline void hal_stream_atomic_store_in(hal_stream_t *stream, unsigned newin)
+{
+    atomic_store_explicit(&stream->fifo->in, newin, memory_order_release);
 }
 
-int hal_stream_depth(hal_stream_t *stream) {
-    int out = stream->fifo->out;
-    int in = stream->fifo->in;
-    int result = in - out;
-    if(result < 0) result += stream->fifo->depth - 1;
-    return result;
+static inline void hal_stream_atomic_store_out(hal_stream_t *stream, unsigned newout)
+{
+    atomic_store_explicit(&stream->fifo->out, newout, memory_order_release);
 }
 
-unsigned hal_stream_maxdepth(hal_stream_t *stream) {
+static inline unsigned hal_stream_newin(hal_stream_t *stream)
+{
+    return hal_stream_advance(stream, hal_stream_atomic_load_in(stream));
+}
+
+bool hal_stream_writable(hal_stream_t *stream)
+{
+    if(!stream || !stream->fifo) {
+        rtapi_print_msg(RTAPI_MSG_ERR, "hal_stream_writable: Invalid stream\n");
+        return false;
+    }
+    return hal_stream_newin(stream) != hal_stream_atomic_load_out(stream);
+}
+
+bool hal_stream_readable(hal_stream_t *stream)
+{
+    if(!stream || !stream->fifo) {
+        rtapi_print_msg(RTAPI_MSG_ERR, "hal_stream_readable: Invalid stream\n");
+        return false;
+    }
+    return hal_stream_atomic_load_in(stream) != hal_stream_atomic_load_out(stream);
+}
+
+unsigned hal_stream_maxdepth(hal_stream_t *stream)
+{
+    if(!stream || !stream->fifo) {
+        rtapi_print_msg(RTAPI_MSG_ERR, "hal_stream_maxdepth: Invalid stream\n");
+        return 0;
+    }
     return stream->fifo->depth;
 }
 
 #ifdef ULAPI
 void hal_stream_wait_writable(hal_stream_t *stream, sig_atomic_t *stop) {
+    if(!stream || !stream->fifo) {
+        rtapi_print_msg(RTAPI_MSG_ERR, "hal_stream_wait_writable: Invalid stream\n");
+        return;
+    }
     while(!hal_stream_writable(stream) && (!stop || !*stop)) {
         /* fifo full, sleep for 10ms */
         rtapi_delay(10000000);
     }
 }
 
-void hal_stream_wait_readable(hal_stream_t *stream, sig_atomic_t *stop) {
+void hal_stream_wait_readable(hal_stream_t *stream, sig_atomic_t *stop)
+{
+    if(!stream || !stream->fifo) {
+        rtapi_print_msg(RTAPI_MSG_ERR, "hal_stream_wait_readable: Invalid stream\n");
+        return;
+    }
     while(!hal_stream_readable(stream) && (!stop || !*stop)) {
         /* fifo full, sleep for 10ms */
         rtapi_delay(10000000);
@@ -4215,104 +4250,108 @@ void hal_stream_wait_readable(hal_stream_t *stream, sig_atomic_t *stop) {
 }
 #endif
 
-static int hal_stream_atomic_load_in(hal_stream_t *stream)
+int hal_stream_depth(hal_stream_t *stream)
 {
-    return atomic_load_explicit(&stream->fifo->in, memory_order_acquire);
+    if(!stream || !stream->fifo) {
+        rtapi_print_msg(RTAPI_MSG_ERR, "hal_stream_depth: Invalid stream\n");
+        return 0;
+    }
+    unsigned out = hal_stream_atomic_load_out(stream);
+    unsigned in  = hal_stream_atomic_load_in(stream);
+    if(out > in)
+        return stream->fifo->depth + in - out;
+    return in - out;
 }
 
-static int hal_stream_atomic_load_out(hal_stream_t *stream)
+int hal_stream_write(hal_stream_t *stream, hal_stream_data_u *buf)
 {
-    return atomic_load_explicit(&stream->fifo->out, memory_order_acquire);
-}
-
-
-static void hal_stream_atomic_store_in(hal_stream_t *stream, int newin)
-{
-    atomic_store_explicit(&stream->fifo->in, newin, memory_order_release);
-}
-
-static void hal_stream_atomic_store_out(hal_stream_t *stream, int newout)
-{
-    atomic_store_explicit(&stream->fifo->out, newout, memory_order_release);
-}
-
-int hal_stream_write(hal_stream_t *stream, union hal_stream_data *buf) {
+    if(!stream || !stream->fifo) {
+        rtapi_print_msg(RTAPI_MSG_ERR, "hal_stream_write: Invalid stream\n");
+        return -EINVAL;
+    }
     if(!hal_stream_writable(stream)) {
         stream->fifo->num_overruns++;
         return -ENOSPC;
     }
-    int in = hal_stream_atomic_load_in(stream),
-        newin = hal_stream_advance(stream, in);
+    unsigned in = hal_stream_atomic_load_in(stream);
+    unsigned newin = hal_stream_advance(stream, in);
     int num_pins = stream->fifo->num_pins;
     int stride = num_pins + 1;
-    union hal_stream_data *dptr = &stream->fifo->data[in * stride];
-    memcpy(dptr, buf, sizeof(union hal_stream_data) * num_pins);
+    hal_stream_data_u *dptr = &stream->fifo->data[in * stride];
+    memcpy(dptr, buf, sizeof(hal_stream_data_u) * num_pins);
     dptr[num_pins].s = ++stream->fifo->this_sample;
     hal_stream_atomic_store_in(stream, newin);
     return 0;
 }
 
-int hal_stream_read(hal_stream_t *stream, union hal_stream_data *buf, unsigned *this_sample) {
+int hal_stream_read(hal_stream_t *stream, hal_stream_data_u *buf, unsigned *this_sample)
+{
+    if(!stream || !stream->fifo) {
+        rtapi_print_msg(RTAPI_MSG_ERR, "hal_stream_read: Invalid stream\n");
+        return -EINVAL;
+    }
     if(!hal_stream_readable(stream)) {
-        stream->fifo->num_underruns ++;
+        stream->fifo->num_underruns++;
         return -ENOSPC;
     }
-    int out = hal_stream_atomic_load_out(stream),
-        newout = hal_stream_advance(stream, out);
+    unsigned out = hal_stream_atomic_load_out(stream);
+    unsigned newout = hal_stream_advance(stream, out);
     int num_pins = stream->fifo->num_pins;
     int stride = num_pins + 1;
-    union hal_stream_data *dptr = &stream->fifo->data[out * stride];
-    memcpy(buf, dptr, sizeof(union hal_stream_data) * num_pins);
+    hal_stream_data_u *dptr = &stream->fifo->data[out * stride];
+    memcpy(buf, dptr, sizeof(hal_stream_data_u) * num_pins);
     if(this_sample) *this_sample = dptr[num_pins].s;
     hal_stream_atomic_store_out(stream, newout);
     return 0;
 }
 
-int hal_stream_attach(hal_stream_t *stream, int comp_id, int key, const char *typestring) {
-    int i;
-
+int hal_stream_attach(hal_stream_t *stream, int comp_id, int key, const char *typestring)
+{
+    if(!stream) {
+        rtapi_print_msg(RTAPI_MSG_ERR, "hal_stream_attach: Invalid stream\n");
+        return -EINVAL;
+    }
     stream->shmem_id = stream->comp_id = -1;
     stream->fifo = NULL;
-    memset(stream, 0, sizeof(*stream));
-    int result = rtapi_shmem_new(key, comp_id, sizeof(struct hal_stream_shm));
+    int result = rtapi_shmem_new(key, comp_id, sizeof(hal_stream_shm_t));
     int shmem_id = result;
     if ( result < 0 ) goto fail;
 
-    void *shmem_ptr;
-    result = rtapi_shmem_getptr(shmem_id, &shmem_ptr);
+    hal_stream_shm_t *fifo;
+    result = rtapi_shmem_getptr(shmem_id, (void **)&fifo);
     if ( result < 0 ) goto fail;
 
-    struct hal_stream_shm *fifo = shmem_ptr;
     if ( fifo->magic != HAL_STREAM_MAGIC_NUM ) {
         result = -EINVAL;
         goto fail;
     }
     if(typestring) {
         hal_type_t type[HAL_STREAM_MAX_PINS];
-        result = halpr_parse_types(type, typestring);
-        if(!result) { result = -EINVAL; goto fail; }
-        for(i=0; i<result; i++) {
-            if(type[i] != fifo->type[i]) {
-                char typename0[8], typename1[8];
-                rtapi_print_msg(RTAPI_MSG_ERR,
-                    "Type mismatch: types[%d] = %s vs %s\n", i,
-                        halpr_type_string(fifo->type[i],
-                            typename0, sizeof(typename0)),
-                        halpr_type_string(type[i],
-                            typename1, sizeof(typename1)));
-                result = -EINVAL; goto fail;
+        result = hal_stream_parse_types(type, typestring);
+        if(!result) {
+            result = -EINVAL;
+            goto fail;
+        }
+        for(int i = 0; i < result; i++) {
+            if(fifo->type[i] != type[i]) {
+                char tn0[32], tn1[32];
+                hal_stream_type_string(fifo->type[i], tn0, sizeof(tn0));
+                hal_stream_type_string(type[i], tn1, sizeof(tn1));
+                rtapi_print_msg(RTAPI_MSG_ERR, "hal_stream_attach: Type mismatch: types[%d]: '%s' != '%s'\n", i, tn0, tn1);
+                result = -EINVAL;
+                goto fail;
             }
         }
     }
     /* now use data in fifo structure to calculate proper shmem size */
     unsigned depth = fifo->depth;
     int pin_count = fifo->num_pins;
-    size_t size = sizeof(struct hal_stream_shm) + sizeof(union hal_stream_data) * depth * (1+pin_count);
+    size_t size = sizeof(hal_stream_shm_t) + sizeof(hal_stream_data_u) * depth * (1+pin_count);
     /* close shmem, re-open with proper size */
     rtapi_shmem_delete(shmem_id, comp_id);
     shmem_id = result = rtapi_shmem_new(key, comp_id, size);
     if ( result < 0 ) goto fail;
-    result = rtapi_shmem_getptr(shmem_id, &shmem_ptr);
+    result = rtapi_shmem_getptr(shmem_id, (void **)&fifo);
     if ( result < 0 ) goto fail;
 
     stream->shmem_id = shmem_id;
@@ -4327,6 +4366,10 @@ fail:
 }
 
 int hal_stream_detach(hal_stream_t *stream) {
+    if(!stream) {
+        rtapi_print_msg(RTAPI_MSG_ERR, "hal_stream_detach: Invalid stream\n");
+        return -EINVAL;
+    }
     if(stream->shmem_id >= 0) {
         int res = rtapi_shmem_delete(stream->shmem_id, stream->comp_id);
         if(res < 0)
@@ -4339,20 +4382,45 @@ int hal_stream_detach(hal_stream_t *stream) {
     return 0;
 }
 
-int hal_stream_element_count(hal_stream_t *stream) {
+int hal_stream_element_count(hal_stream_t *stream)
+{
+    if(!stream || !stream->fifo) {
+        rtapi_print_msg(RTAPI_MSG_ERR, "hal_stream_element_count: Invalid stream\n");
+        return 0;
+    }
     return stream->fifo->num_pins;
 }
 
-hal_type_t hal_stream_element_type(hal_stream_t *stream, int idx) {
+hal_type_t hal_stream_element_type(hal_stream_t *stream, int idx)
+{
+    if(!stream || !stream->fifo) {
+        rtapi_print_msg(RTAPI_MSG_ERR, "hal_stream_element_type: Invalid stream\n");
+        return HAL_TYPE_UNSPECIFIED;
+    }
+    if(idx < 0 || idx >= stream->fifo->num_pins) {
+        rtapi_print_msg(RTAPI_MSG_ERR, "hal_stream_element_type: Invalid type index %d (valid [0,%d])\n",
+                        idx, stream->fifo->num_pins - 1);
+        return HAL_TYPE_UNSPECIFIED;
+    }
     return stream->fifo->type[idx];
 }
 
-int hal_stream_num_overruns(hal_stream_t *stream) {
-    return stream->fifo->num_overruns;
+int hal_stream_num_overruns(hal_stream_t *stream)
+{
+    if(!stream || !stream->fifo) {
+        rtapi_print_msg(RTAPI_MSG_ERR, "hal_stream_num_overruns: Invalid stream\n");
+        return HAL_TYPE_UNSPECIFIED;
+    }
+    return atomic_load_explicit(&stream->fifo->num_overruns, memory_order_acquire);
 }
 
-int hal_stream_num_underruns(hal_stream_t *stream) {
-    return stream->fifo->num_underruns;
+int hal_stream_num_underruns(hal_stream_t *stream)
+{
+    if(!stream || !stream->fifo) {
+        rtapi_print_msg(RTAPI_MSG_ERR, "hal_stream_num_underruns: Invalid stream\n");
+        return 0;
+    }
+    return atomic_load_explicit(&stream->fifo->num_underruns, memory_order_acquire);
 }
 
 #ifdef RTAPI

--- a/src/hal/hal_priv.h
+++ b/src/hal/hal_priv.h
@@ -491,10 +491,5 @@ extern hal_pin_t *halpr_find_pin_by_sig(hal_sig_t * sig, hal_pin_t * start);
 */
 extern int hal_port_alloc(unsigned size, hal_port_t *port);
 
-
-
-#define HAL_STREAM_MAGIC_NUM		0x4649464F
-
-extern int halpr_parse_types(hal_type_t type[HAL_STREAM_MAX_PINS], const char *fcg);
 RTAPI_END_DECLS
 #endif /* HAL_PRIV_H */

--- a/src/hal/halmodule.cc
+++ b/src/hal/halmodule.cc
@@ -30,11 +30,18 @@ using namespace std;
 #include "hal_priv.h"
 
 #define EXCEPTION_IF_NOT_LIVE(retval) do { \
-    if(self->hal_id <= 0) { \
-        PyErr_SetString(PyExc_RuntimeError, "Invalid operation on closed HAL component"); \
-	return retval; \
-    } \
-} while(0)
+        if(self->hal_id <= 0) { \
+            PyErr_SetString(PyExc_RuntimeError, "Invalid operation on closed HAL component"); \
+            return retval; \
+        } \
+    } while(0)
+
+#define TEST_HAL_SHMEM_BASE(fname) do { \
+        if(!hal_shmem_base) { \
+            PyErr_Format(PyExc_RuntimeError, "%s: Cannot call before creating component", fname); \
+            return NULL; \
+        } \
+    } while(0)
 
 PyObject *to_python(bool b) {
     return PyBool_FromLong(b);
@@ -80,7 +87,7 @@ bool from_python(PyObject *o, double *d) {
     return true;
 }
 
-bool from_python(PyObject *o, hal_u32_t *u) {
+bool from_python(PyObject *o, rtapi_u32 *u) {
     PyObject *tmp = 0;
     long long l;
     tmp = PyLong_Check(o) ? o : PyNumber_Long(o);
@@ -101,7 +108,7 @@ fail:
     return false;
 }
 
-bool from_python(PyObject *o, hal_s32_t *i) {
+bool from_python(PyObject *o, rtapi_s32 *i) {
     PyObject *tmp = 0;
     long long l;
     tmp = PyLong_Check(o) ? o : PyNumber_Long(o);
@@ -122,7 +129,7 @@ fail:
     return false;
 }
 
-bool from_python(PyObject *o, hal_u64_t *u) {
+bool from_python(PyObject *o, rtapi_u64 *u) {
     PyObject *tmp = 0;
     long long l;
     tmp = PyLong_Check(o) ? o : PyNumber_Long(o);
@@ -143,7 +150,7 @@ fail:
     return false;
 }
 
-bool from_python(PyObject *o, hal_s64_t *i) {
+bool from_python(PyObject *o, rtapi_s64 *i) {
     PyObject *tmp = 0;
     long long l;
     tmp = PyLong_Check(o) ? o : PyNumber_Long(o);
@@ -296,25 +303,25 @@ static int pyhal_write_common(halitem *pin, PyObject *value) {
                 break;
             }
             case HAL_U32: {
-                hal_u32_t tmp;
+                rtapi_u32 tmp;
                 if(!from_python(value, &tmp)) return -1;
                 *pin->u->pin.u32 = tmp;
                 break;
             }
             case HAL_S32: {
-                hal_s32_t tmp;
+                rtapi_s32 tmp;
                 if(!from_python(value, &tmp)) return -1;
                 *pin->u->pin.s32 = tmp;
                 break;
             }
             case HAL_U64: {
-                hal_u64_t tmp;
+                rtapi_u64 tmp;
                 if(!from_python(value, &tmp)) return -1;
                 *pin->u->pin.u64 = tmp;
                 break;
             }
             case HAL_S64: {
-                hal_s64_t tmp;
+                rtapi_s64 tmp;
                 if(!from_python(value, &tmp)) return -1;
                 *pin->u->pin.s64 = tmp;
                 break;
@@ -334,30 +341,28 @@ static int pyhal_write_common(halitem *pin, PyObject *value) {
                 break;
             }
             case HAL_U32: {
-                hal_u32_t tmp;
+                rtapi_u32 tmp;
                 if(!from_python(value, &tmp)) return -1;
                 pin->u->param.u32 = tmp;
                 break;
             }
             case HAL_S32:
-                hal_s32_t tmp;
+                rtapi_s32 tmp;
                 if(!from_python(value, &tmp)) return -1;
                 pin->u->param.s32 = tmp;
                 break;
-            case HAL_U64:
-	        {
-		    hal_u64_t tmp;
-		    if(!from_python(value, &tmp)) return -1;
-		    pin->u->param.u64 = tmp;
-		}
+            case HAL_U64: {
+                rtapi_u64 tmp;
+                if(!from_python(value, &tmp)) return -1;
+                pin->u->param.u64 = tmp;
                 break;
-            case HAL_S64:
-	        {
-		    hal_s64_t tmp;
-		    if(!from_python(value, &tmp)) return -1;
-		    pin->u->param.s64 = tmp;
-		}
+            }
+            case HAL_S64: {
+                rtapi_s64 tmp;
+                if(!from_python(value, &tmp)) return -1;
+                pin->u->param.s64 = tmp;
                 break;
+            }
             default:
                 PyErr_Format(pyhal_error_type, "Invalid pin type %d", pin->type);
         }
@@ -761,8 +766,7 @@ static PyObject *pyhalpin_repr(PyObject *_self) {
 }
 
 static int pyhalpin_init(PyObject * /*_self*/, PyObject *, PyObject *) {
-    PyErr_Format(PyExc_RuntimeError,
-	    "Cannot be constructed directly");
+    PyErr_Format(PyExc_RuntimeError, "Cannot be constructed directly");
     return -1;
 }
 
@@ -901,11 +905,8 @@ static PyObject * pyhal_pin_new(halitem * pin, const char * name) {
 PyObject *pin_has_writer(PyObject * /*self*/, PyObject *args) {
     char *name;
     if(!PyArg_ParseTuple(args, "s", &name)) return NULL;
-    if(!hal_shmem_base) {
-	PyErr_Format(PyExc_RuntimeError,
-		"Cannot call before creating component");
-	return NULL;
-    }
+
+    TEST_HAL_SHMEM_BASE(__FUNCTION__);
 
     hal_pin_t *pin = halpr_find_pin_by_name(name);
     if(!pin) {
@@ -925,11 +926,8 @@ PyObject *pin_has_writer(PyObject * /*self*/, PyObject *args) {
 PyObject *component_exists(PyObject * /*self*/, PyObject *args) {
     char *name;
     if(!PyArg_ParseTuple(args, "s", &name)) return NULL;
-    if(!hal_shmem_base) {
-	PyErr_Format(PyExc_RuntimeError,
-		"Cannot call before creating component");
-	return NULL;
-    }
+
+    TEST_HAL_SHMEM_BASE(__FUNCTION__);
 
     return PyBool_FromLong(halpr_find_comp_by_name(name) != NULL);
 }
@@ -937,11 +935,8 @@ PyObject *component_exists(PyObject * /*self*/, PyObject *args) {
 PyObject *component_is_ready(PyObject * /*self*/, PyObject *args) {
     char *name;
     if(!PyArg_ParseTuple(args, "s", &name)) return NULL;
-    if(!hal_shmem_base) {
-	PyErr_Format(PyExc_RuntimeError,
-		"Cannot call before creating component");
-	return NULL;
-    }
+
+    TEST_HAL_SHMEM_BASE(__FUNCTION__);
 
     // Bad form to assume comp name exists - stop crashing!
     hal_comp_t *thecomp = halpr_find_comp_by_name(name);
@@ -952,34 +947,33 @@ PyObject *new_sig(PyObject * /*self*/, PyObject *args) {
     char *name;
     int type,retval;
     if(!PyArg_ParseTuple(args, "si", &name,&type)) return NULL;
-    if(!hal_shmem_base) {
-	PyErr_Format(PyExc_RuntimeError,
-		"Cannot call before creating component");
-	return NULL;
-    }
+
+    TEST_HAL_SHMEM_BASE(__FUNCTION__);
+
     //printf("INFO HALMODULE -- make signal -> %s type %d\n",name,(hal_type_t) type);
     switch (type) {
-	case HAL_BIT:
+    case HAL_BIT:
         retval = hal_signal_new(name, HAL_BIT);
         break;
-	case HAL_S32:
+    case HAL_S32:
         retval = hal_signal_new(name, HAL_S32);
         break;
-	case HAL_U32:
+    case HAL_U32:
         retval = hal_signal_new(name, HAL_U32);
         break;
-	case HAL_S64:
+    case HAL_S64:
         retval = hal_signal_new(name, HAL_S64);
         break;
-	case HAL_U64:
+    case HAL_U64:
         retval = hal_signal_new(name, HAL_U64);
         break;
-	case HAL_FLOAT:
+    case HAL_FLOAT:
         retval = hal_signal_new(name, HAL_FLOAT);
         break;
-	default: { PyErr_Format(PyExc_RuntimeError,
-		"not a valid HAL signal type");
-	return NULL;}
+    default: {
+        PyErr_Format(PyExc_RuntimeError, "not a valid HAL signal type");
+        return NULL;
+        }
     }
     return PyBool_FromLong(retval != 0);
 }
@@ -987,11 +981,9 @@ PyObject *new_sig(PyObject * /*self*/, PyObject *args) {
 PyObject *connect(PyObject * /*self*/, PyObject *args) {
     char *signame,*pinname;
     if(!PyArg_ParseTuple(args, "ss", &pinname,&signame)) return NULL;
-    if(!hal_shmem_base) {
-	PyErr_Format(PyExc_RuntimeError,
-		"Cannot call before creating component");
-	return NULL;
-    }
+
+    TEST_HAL_SHMEM_BASE(__FUNCTION__);
+
     //printf("INFO HALMODULE -- link sig %s to pin %s\n",signame,pinname);
     return PyBool_FromLong(hal_link(pinname, signame) != 0);
 }
@@ -999,16 +991,14 @@ PyObject *connect(PyObject * /*self*/, PyObject *args) {
 PyObject *disconnect(PyObject * /*self*/, PyObject *args) {
     char *pinname;
     if(!PyArg_ParseTuple(args, "s", &pinname)) return NULL;
-    if(!hal_shmem_base) {
-	PyErr_Format(PyExc_RuntimeError,
-		"Cannot call before creating component");
-	return NULL;
-    }
+
+    TEST_HAL_SHMEM_BASE(__FUNCTION__);
+
     //printf("INFO HALMODULE -- unlink pin %s\n",pinname);
     return PyBool_FromLong(hal_unlink(pinname) != 0);
 }
 
-static int set_common(hal_type_t type, void *d_ptr, char *value) {
+static int set_common(hal_type_t type, hal_data_u *d_ptr, const char *value) {
     // This function assumes that the mutex is held
     int retval = 0;
     double fval;
@@ -1016,7 +1006,7 @@ static int set_common(hal_type_t type, void *d_ptr, char *value) {
     unsigned long ulval;
     long long llval;
     unsigned long long ullval;
-    char *cp = value;
+    char *cp;
 
     // set locale category numeric to "C"
     // to assure proper parsing of floating point values
@@ -1031,12 +1021,11 @@ static int set_common(hal_type_t type, void *d_ptr, char *value) {
     switch (type) {
     case HAL_BIT:
 	if ((strcmp("1", value) == 0) || (strcasecmp("TRUE", value) == 0)) {
-	    *(hal_bit_t *) (d_ptr) = 1;
+	    d_ptr->b = 1;
 	} else if ((strcmp("0", value) == 0)
 	    || (strcasecmp("FALSE", value)) == 0) {
-	    *(hal_bit_t *) (d_ptr) = 0;
+	    d_ptr->b = 0;
 	} else {
-
 	    retval = -EINVAL;
 	}
 	break;
@@ -1044,74 +1033,66 @@ static int set_common(hal_type_t type, void *d_ptr, char *value) {
 	fval = strtod ( value, &cp );
 	if ((*cp != '\0') && (!isspace(*cp))) {
 	    // invalid character(s) in string
-
 	    retval = -EINVAL;
 	} else {
-	    *((hal_float_t *) (d_ptr)) = fval;
+	    d_ptr->f = fval;
 	}
 	break;
     case HAL_S32:
 	lval = strtol(value, &cp, 0);
 	if ((*cp != '\0') && (!isspace(*cp))) {
 	    // invalid chars in string
-
 	    retval = -EINVAL;
 	} else {
-	    *((hal_s32_t *) (d_ptr)) = lval;
+	    d_ptr->s = lval;
 	}
 	break;
     case HAL_U32:
 	ulval = strtoul(value, &cp, 0);
 	if ((*cp != '\0') && (!isspace(*cp))) {
 	    // invalid chars in string
-
 	    retval = -EINVAL;
 	} else {
-	    *((hal_u32_t *) (d_ptr)) = ulval;
+	    d_ptr->u = ulval;
 	}
 	break;
     case HAL_S64:
 	llval = strtoll(value, &cp, 0);
 	if ((*cp != '\0') && (!isspace(*cp))) {
 	    // invalid chars in string
-
 	    retval = -EINVAL;
 	} else {
-	    *((hal_s64_t *) (d_ptr)) = llval;
+	    d_ptr->ls = llval;
 	}
 	break;
     case HAL_U64:
 	ullval = strtoull(value, &cp, 0);
 	if ((*cp != '\0') && (!isspace(*cp))) {
 	    // invalid chars in string
-
 	    retval = -EINVAL;
 	} else {
-	    *((hal_u64_t *) (d_ptr)) = ullval;
+	    d_ptr->lu = ullval;
 	}
 	break;
     default:
 	// Shouldn't get here, but just in case...
-
 	retval = -EINVAL;
     }
     return retval;
 }
 
 PyObject *set_p(PyObject * /*self*/, PyObject *args) {
-    char *name,*value;
+    const char *name, *value;
     int retval;
     hal_param_t *param;
     hal_pin_t *pin;
     hal_type_t type;
-    void *d_ptr;
+    hal_data_u *d_ptr;
 
     if(!PyArg_ParseTuple(args, "ss", &name,&value)) return NULL;
-    if(!hal_shmem_base) {
-	PyErr_Format(PyExc_RuntimeError,
-		"Cannot call before creating component");
-	return NULL;
-    }
+
+    TEST_HAL_SHMEM_BASE(__FUNCTION__);
+
     //printf("INFO HALMODULE -- setting pin / param - name:%s value:%s\n",name,value);
     // get mutex before accessing shared data
     rtapi_mutex_get(&(hal_data->mutex));
@@ -1121,28 +1102,22 @@ PyObject *set_p(PyObject * /*self*/, PyObject *args) {
         pin = halpr_find_pin_by_name(name);
         if(pin == 0) {
             rtapi_mutex_give(&(hal_data->mutex));
-
-            PyErr_Format(PyExc_RuntimeError,
-		        "pin not found");
-	        return NULL;
+            PyErr_Format(PyExc_RuntimeError, "pin not found");
+            return NULL;
         } else {
             // found it
             type = pin->type;
             if(pin->dir == HAL_OUT) {
                 rtapi_mutex_give(&(hal_data->mutex));
-
-                PyErr_Format(PyExc_RuntimeError,
-		            "pin not writable");
-	            return NULL;
+                PyErr_Format(PyExc_RuntimeError, "pin not writable");
+                return NULL;
             }
             if(pin->signal != 0) {
                 rtapi_mutex_give(&(hal_data->mutex));
-
-                PyErr_Format(PyExc_RuntimeError,
-		            "pin connected to signal");
-	            return NULL;
+                PyErr_Format(PyExc_RuntimeError, "pin connected to signal");
+                return NULL;
             }
-            d_ptr = (void*)&pin->dummysig;
+            d_ptr = &pin->dummysig;
         }
     } else {
         // found it
@@ -1150,12 +1125,10 @@ PyObject *set_p(PyObject * /*self*/, PyObject *args) {
         /* is it read only? */
         if (param->dir == HAL_RO) {
             rtapi_mutex_give(&(hal_data->mutex));
-
-            PyErr_Format(PyExc_RuntimeError,
-		        "param not writable");
-	        return NULL;
+            PyErr_Format(PyExc_RuntimeError, "param not writable");
+            return NULL;
         }
-        d_ptr = SHMPTR(param->data_ptr);
+        d_ptr = reinterpret_cast<hal_data_u *>(SHMPTR(param->data_ptr));
     }
     retval = set_common(type, d_ptr, value);
     rtapi_mutex_give(&(hal_data->mutex));
@@ -1163,18 +1136,16 @@ PyObject *set_p(PyObject * /*self*/, PyObject *args) {
 }
 
 PyObject *set_s(PyObject * /*self*/, PyObject *args) {
-    char *name,*value;
+    const char *name, *value;
     int retval;
     hal_sig_t *sig;
     hal_type_t type;
-    void *d_ptr;
+    hal_data_u *d_ptr;
 
     if(!PyArg_ParseTuple(args, "ss", &name,&value)) return NULL;
-    if(!hal_shmem_base) {
-        PyErr_Format(PyExc_RuntimeError,
-            "Cannot call before creating component");
-        return NULL;
-    }
+
+    TEST_HAL_SHMEM_BASE(__FUNCTION__);
+
     // get mutex before accessing shared data
     rtapi_mutex_get(&(hal_data->mutex));
     sig = halpr_find_sig_by_name(name);
@@ -1192,7 +1163,7 @@ PyObject *set_s(PyObject * /*self*/, PyObject *args) {
         }
         /* no writer, so we can safely set it */
         type = sig->type;
-        d_ptr = SHMPTR(sig->data_ptr);
+        d_ptr = reinterpret_cast<hal_data_u *>(SHMPTR(sig->data_ptr));
         retval = set_common(type, d_ptr, value);
         rtapi_mutex_give(&(hal_data->mutex));
         return PyBool_FromLong(retval != 0);
@@ -1207,14 +1178,12 @@ PyObject *get_value(PyObject * /*self*/, PyObject *args) {
     hal_pin_t *pin;
     hal_sig_t *sig;
     hal_type_t type;
-    void *d_ptr;
+    hal_data_u *d_ptr;
 
     if(!PyArg_ParseTuple(args, "s", &name)) return NULL;
-    if(!hal_shmem_base) {
-	PyErr_Format(PyExc_RuntimeError,
-		"Cannot call before creating component");
-	return NULL;
-    }
+
+    TEST_HAL_SHMEM_BASE(__FUNCTION__);
+
     /* get mutex before accessing shared data */
     rtapi_mutex_get(&(hal_data->mutex));
     /* search param list for name */
@@ -1222,16 +1191,16 @@ PyObject *get_value(PyObject * /*self*/, PyObject *args) {
     if (param) {
         /* found it */
         type = param->type;
-        d_ptr = SHMPTR(param->data_ptr);
+        d_ptr = reinterpret_cast<hal_data_u *>(SHMPTR(param->data_ptr));
         rtapi_mutex_give(&(hal_data->mutex));
         /* convert to python value */
         switch(type) {
-            case HAL_BIT: return PyBool_FromLong((long)*(hal_bit_t *)d_ptr);
-            case HAL_U32: return Py_BuildValue("l",  (unsigned long)*(hal_u32_t *)d_ptr);
-            case HAL_S32: return Py_BuildValue("l",  (long)*(hal_s32_t *)d_ptr);
-            case HAL_U64: return Py_BuildValue("l",  (unsigned long long)*(hal_u64_t *)d_ptr);
-            case HAL_S64: return Py_BuildValue("l",  (long long)*(hal_s64_t *)d_ptr);
-            case HAL_FLOAT: return Py_BuildValue("f",  (double)*(hal_float_t *)d_ptr);
+            case HAL_BIT: return PyBool_FromLong((long)d_ptr->b);
+            case HAL_U32: return Py_BuildValue("k",   (unsigned long)d_ptr->u);
+            case HAL_S32: return Py_BuildValue("l",   (long)d_ptr->s);
+            case HAL_U64: return Py_BuildValue("K",   (unsigned long long)d_ptr->lu);
+            case HAL_S64: return Py_BuildValue("L",   (long long)d_ptr->ls);
+            case HAL_FLOAT: return Py_BuildValue("d", (double)d_ptr->f);
             case HAL_PORT: // HAL_PORT is currently not supported
             default:
                 break;
@@ -1244,7 +1213,7 @@ PyObject *get_value(PyObject * /*self*/, PyObject *args) {
         type = pin->type;
         if (pin->signal != 0) {
             sig = (hal_sig_t*)SHMPTR(pin->signal);
-            d_ptr = SHMPTR(sig->data_ptr);
+            d_ptr = reinterpret_cast<hal_data_u *>(SHMPTR(sig->data_ptr));
         } else {
             sig = 0;
             d_ptr = &(pin->dummysig);
@@ -1252,12 +1221,12 @@ PyObject *get_value(PyObject * /*self*/, PyObject *args) {
         rtapi_mutex_give(&(hal_data->mutex));
         /* convert to python value */
         switch(type) {
-            case HAL_BIT: return PyBool_FromLong((long)*(hal_bit_t *)d_ptr);
-            case HAL_U32: return Py_BuildValue("l",  (unsigned long)*(hal_u32_t *)d_ptr);
-            case HAL_S32: return Py_BuildValue("l",  (long)*(hal_s32_t *)d_ptr);
-            case HAL_U64: return Py_BuildValue("l",  (unsigned long long)*(hal_u64_t *)d_ptr);
-            case HAL_S64: return Py_BuildValue("l",  (long long)*(hal_s64_t *)d_ptr);
-            case HAL_FLOAT: return Py_BuildValue("f",  (double)*(hal_float_t *)d_ptr);
+            case HAL_BIT: return PyBool_FromLong((long)d_ptr->b);
+            case HAL_U32: return Py_BuildValue("k",   (unsigned long)d_ptr->u);
+            case HAL_S32: return Py_BuildValue("l",   (long)d_ptr->s);
+            case HAL_U64: return Py_BuildValue("K",   (unsigned long long)d_ptr->lu);
+            case HAL_S64: return Py_BuildValue("L",   (long long)d_ptr->ls);
+            case HAL_FLOAT: return Py_BuildValue("d", (double)d_ptr->f);
             case HAL_PORT: // HAL_PORT is currently not supported
             default:
                 break;
@@ -1267,16 +1236,16 @@ PyObject *get_value(PyObject * /*self*/, PyObject *args) {
     if (sig != 0) {
         /* found it */
         type = sig->type;
-        d_ptr = SHMPTR(sig->data_ptr);
+        d_ptr = reinterpret_cast<hal_data_u *>(SHMPTR(sig->data_ptr));
         rtapi_mutex_give(&(hal_data->mutex));
         /* convert to python value */
         switch(type) {
-            case HAL_BIT: return PyBool_FromLong((long)*(hal_bit_t *)d_ptr);
-            case HAL_U32: return Py_BuildValue("l",  (unsigned long)*(hal_u32_t *)d_ptr);
-            case HAL_S32: return Py_BuildValue("l",  (long)*(hal_s32_t *)d_ptr);
-            case HAL_U64: return Py_BuildValue("l",  (unsigned long long)*(hal_u64_t *)d_ptr);
-            case HAL_S64: return Py_BuildValue("l",  (long long)*(hal_s64_t *)d_ptr);
-            case HAL_FLOAT: return Py_BuildValue("f",  (double)*(hal_float_t *)d_ptr);
+            case HAL_BIT: return PyBool_FromLong((long)d_ptr->b);
+            case HAL_U32: return Py_BuildValue("k",   (unsigned long)d_ptr->u);
+            case HAL_S32: return Py_BuildValue("l",   (long)d_ptr->s);
+            case HAL_U64: return Py_BuildValue("K",   (unsigned long long)d_ptr->lu);
+            case HAL_S64: return Py_BuildValue("L",   (long long)d_ptr->ls);
+            case HAL_FLOAT: return Py_BuildValue("d", (double)d_ptr->f);
             case HAL_PORT: // HAL_PORT is currently not supported
             default:
                 break;
@@ -1284,9 +1253,8 @@ PyObject *get_value(PyObject * /*self*/, PyObject *args) {
     }
     /* error if here */
     rtapi_mutex_give(&(hal_data->mutex));
-    PyErr_Format(PyExc_RuntimeError,
-    "Can't set value: pin / param %s not found", name);
-	return NULL;
+    PyErr_Format(PyExc_RuntimeError, "Can't get value: pin / param %s not found", name);
+    return NULL;
 
 }
 
@@ -1299,7 +1267,7 @@ PyObject *get_info_pins(PyObject * /*self*/, PyObject * /*args*/) {
     char str_v[] = "VALUE";
     char str_t[] = "TYPE";
     char str_d[] = "DIRECTION";
-    void *d_ptr;
+    hal_data_u *d_ptr;
 
     hal_pin_t *pin;
     hal_sig_t *sig;
@@ -1307,21 +1275,17 @@ PyObject *get_info_pins(PyObject * /*self*/, PyObject * /*args*/) {
     PyObject* python_list = PyList_New(0);
     PyObject *obj;
 
-    if(!hal_shmem_base) {
-	PyErr_Format(PyExc_RuntimeError,
-		"Cannot call before creating component");
-	return NULL;
-    }
+    TEST_HAL_SHMEM_BASE(__FUNCTION__);
 
     /* get mutex before accessing shared data */
     rtapi_mutex_get(&(hal_data->mutex));
     next = hal_data->pin_list_ptr;
     while (next != 0) {
-	    pin = SHMPTR(next);
+        pin = SHMPTR(next);
         type = pin->type;
         if (pin->signal != 0) {
             sig = (hal_sig_t*)SHMPTR(pin->signal);
-            d_ptr = SHMPTR(sig->data_ptr);
+            d_ptr = reinterpret_cast<hal_data_u *>(SHMPTR(sig->data_ptr));
         } else {
             sig = 0;
             d_ptr = &(pin->dummysig);
@@ -1332,28 +1296,42 @@ PyObject *get_info_pins(PyObject * /*self*/, PyObject * /*args*/) {
             case HAL_BIT:
                 obj = Py_BuildValue("{s:s,s:N,s:N,s:N}",
                         str_n, pin->name,
-                        str_v, PyBool_FromLong((long)*(hal_bit_t *)d_ptr),
+                        str_v, PyBool_FromLong((long)d_ptr->b),
                         str_d, PyLong_FromLong(pin->dir),
                         str_t, PyLong_FromLong(HAL_BIT));
                 break;
             case HAL_U32:
-                obj = Py_BuildValue("{s:s,s:l,s:N,s:N}",
+                obj = Py_BuildValue("{s:s,s:k,s:N,s:N}",
                         str_n, pin->name,
-                        str_v, (unsigned long)*(hal_u32_t *)d_ptr,
+                        str_v, (unsigned long)d_ptr->u,
                         str_d, PyLong_FromLong(pin->dir),
                         str_t, PyLong_FromLong(HAL_U32));
                 break;
             case HAL_S32:
                 obj =  Py_BuildValue("{s:s,s:l,s:N,s:N}",
                         str_n, pin->name,
-                        str_v, (long)*(hal_s32_t *)d_ptr,
+                        str_v, (long)d_ptr->s,
                         str_d, PyLong_FromLong(pin->dir),
                         str_t, PyLong_FromLong(HAL_S32));
                 break;
-            case HAL_FLOAT:
-                obj = Py_BuildValue("{s:s,s:f,s:N,s:N}",
+            case HAL_U64:
+                obj =  Py_BuildValue("{s:s,s:K,s:N,s:N}",
                         str_n, pin->name,
-                        str_v, (double)*(hal_float_t *)d_ptr,
+                        str_v, (unsigned long long)d_ptr->lu,
+                        str_d, PyLong_FromLong(pin->dir),
+                        str_t, PyLong_FromLong(HAL_S64));
+                break;
+            case HAL_S64:
+                obj =  Py_BuildValue("{s:s,s:L,s:N,s:N}",
+                        str_n, pin->name,
+                        str_v, (long long)d_ptr->ls,
+                        str_d, PyLong_FromLong(pin->dir),
+                        str_t, PyLong_FromLong(HAL_S64));
+                break;
+            case HAL_FLOAT:
+                obj = Py_BuildValue("{s:s,s:d,s:N,s:N}",
+                        str_n, pin->name,
+                        str_v, (double)d_ptr->f,
                         str_d, PyLong_FromLong(pin->dir),
                         str_t, PyLong_FromLong(HAL_FLOAT));
                 break;
@@ -1371,7 +1349,7 @@ PyObject *get_info_pins(PyObject * /*self*/, PyObject * /*args*/) {
 
         // add to list
         PyList_Append( python_list, obj);
-	    next = pin->next_ptr;
+        next = pin->next_ptr;
     }
     // give back the mutex, so others can use data
     rtapi_mutex_give(&(hal_data->mutex));
@@ -1388,25 +1366,21 @@ PyObject *get_info_signals(PyObject * /*self*/, PyObject * /*args*/) {
     char str_v[] = "VALUE";
     char str_t[] = "TYPE";
     char str_d[] = "DRIVER";
-    void *d_ptr;
+    hal_data_u *d_ptr;
     hal_sig_t *sig;
     hal_pin_t *pin;
     PyObject* python_list = PyList_New(0);
     PyObject *obj;
 
-    if(!hal_shmem_base) {
-	PyErr_Format(PyExc_RuntimeError,
-		"Cannot call before creating component");
-	return NULL;
-    }
+    TEST_HAL_SHMEM_BASE(__FUNCTION__);
 
     /* get mutex before accessing shared data */
     rtapi_mutex_get(&(hal_data->mutex));
     next = hal_data->sig_list_ptr;
     while (next != 0) {
-	    sig = SHMPTR(next);
+        sig = SHMPTR(next);
         type = sig->type;
-        d_ptr = SHMPTR(sig->data_ptr);
+        d_ptr = reinterpret_cast<hal_data_u *>(SHMPTR(sig->data_ptr));
 
     /* it have a writer? */
         pin = halpr_find_pin_by_sig(sig, 0);
@@ -1419,28 +1393,42 @@ PyObject *get_info_signals(PyObject * /*self*/, PyObject * /*args*/) {
             case HAL_BIT:
                 obj = Py_BuildValue("{s:s,s:N,s:s,s:N}",
                         str_n, sig->name,
-                        str_v, PyBool_FromLong((long)*(hal_bit_t *)d_ptr),
+                        str_v, PyBool_FromLong((long)d_ptr->b),
                         str_d, (pin != 0) ? pin->name : NULL,
                         str_t, PyLong_FromLong(HAL_BIT));
                 break;
             case HAL_U32:
-                obj = Py_BuildValue("{s:s,s:l,s:s,s:N}",
+                obj = Py_BuildValue("{s:s,s:k,s:s,s:N}",
                         str_n, sig->name,
-                        str_v, (unsigned long)*(hal_u32_t *)d_ptr,
+                        str_v, (unsigned long)d_ptr->u,
                         str_d, (pin != 0) ? pin->name : NULL,
                         str_t, PyLong_FromLong(HAL_U32));
                 break;
             case HAL_S32:
                 obj =  Py_BuildValue("{s:s,s:l,s:s,s:N}",
                         str_n, sig->name,
-                        str_v, (long)*(hal_s32_t *)d_ptr,
+                        str_v, (long)d_ptr->s,
                         str_d, (pin != 0) ? pin->name : NULL,
                         str_t, PyLong_FromLong(HAL_S32));
                 break;
-            case HAL_FLOAT:
-                obj = Py_BuildValue("{s:s,s:f,s:s,s:N}",
+            case HAL_U64:
+                obj = Py_BuildValue("{s:s,s:K,s:s,s:N}",
                         str_n, sig->name,
-                        str_v, (double)*(hal_float_t *)d_ptr,
+                        str_v, (unsigned long long)d_ptr->lu,
+                        str_d, (pin != 0) ? pin->name : NULL,
+                        str_t, PyLong_FromLong(HAL_U64));
+                break;
+            case HAL_S64:
+                obj =  Py_BuildValue("{s:s,s:L,s:s,s:N}",
+                        str_n, sig->name,
+                        str_v, (long long)d_ptr->ls,
+                        str_d, (pin != 0) ? pin->name : NULL,
+                        str_t, PyLong_FromLong(HAL_S64));
+                break;
+            case HAL_FLOAT:
+                obj = Py_BuildValue("{s:s,s:d,s:s,s:N}",
+                        str_n, sig->name,
+                        str_v, (double)d_ptr->f,
                         str_d, (pin != 0) ? pin->name : NULL,
                         str_t, PyLong_FromLong(HAL_FLOAT));
                 break;
@@ -1457,7 +1445,7 @@ PyObject *get_info_signals(PyObject * /*self*/, PyObject * /*args*/) {
         }
 
         PyList_Append( python_list, obj);
-	    next = sig->next_ptr;
+        next = sig->next_ptr;
     }
     rtapi_mutex_give(&(hal_data->mutex));
 
@@ -1472,24 +1460,20 @@ PyObject *get_info_params(PyObject * /*self*/, PyObject * /*args*/) {
     char str_n[] = "NAME";
     char str_v[] = "VALUE";
     char str_d[] = "DIRECTION";
-    void *d_ptr;
+    hal_data_u *d_ptr;
     hal_param_t *param;
     PyObject* python_list = PyList_New(0);
     PyObject *obj;
 
-    if(!hal_shmem_base) {
-	PyErr_Format(PyExc_RuntimeError,
-		"Cannot call before creating component");
-	return NULL;
-    }
+    TEST_HAL_SHMEM_BASE(__FUNCTION__);
 
     /* get mutex before accessing shared data */
     rtapi_mutex_get(&(hal_data->mutex));
     next = hal_data->param_list_ptr;
     while (next != 0) {
-	    param = SHMPTR(next);
+        param = SHMPTR(next);
         type = param->type;
-        d_ptr = SHMPTR(param->data_ptr);
+        d_ptr = reinterpret_cast<hal_data_u *>(SHMPTR(param->data_ptr));
 
         /* convert to dict of python values */
         switch(type) {
@@ -1497,25 +1481,37 @@ PyObject *get_info_params(PyObject * /*self*/, PyObject * /*args*/) {
                 obj = Py_BuildValue("{s:s,s:N,s:N}",
                         str_n, param->name,
                         str_d, PyLong_FromLong(param->dir),
-                        str_v, PyBool_FromLong((long)*(hal_bit_t *)d_ptr));
+                        str_v, PyBool_FromLong((long)d_ptr->b));
                 break;
             case HAL_U32:
-                obj = Py_BuildValue("{s:s,s:N,s:l}",
+                obj = Py_BuildValue("{s:s,s:N,s:k}",
                         str_n, param->name,
                         str_d, PyLong_FromLong(param->dir),
-                        str_v, (unsigned long)*(hal_u32_t *)d_ptr);
+                        str_v, (unsigned long)d_ptr->u);
                 break;
             case HAL_S32:
                 obj =  Py_BuildValue("{s:s,s:N,s:l}",
                         str_n, param->name,
                         str_d, PyLong_FromLong(param->dir),
-                        str_v, (long)*(hal_s32_t *)d_ptr);
+                        str_v, (long)d_ptr->s);
                 break;
-            case HAL_FLOAT:
-                obj = Py_BuildValue("{s:s,s:N,s:f}",
+            case HAL_U64:
+                obj = Py_BuildValue("{s:s,s:N,s:K}",
                         str_n, param->name,
                         str_d, PyLong_FromLong(param->dir),
-                        str_v, (double)*(hal_float_t *)d_ptr);
+                        str_v, (unsigned long long)d_ptr->lu);
+                break;
+            case HAL_S64:
+                obj =  Py_BuildValue("{s:s,s:N,s:L}",
+                        str_n, param->name,
+                        str_d, PyLong_FromLong(param->dir),
+                        str_v, (long long)d_ptr->ls);
+                break;
+            case HAL_FLOAT:
+                obj = Py_BuildValue("{s:s,s:N,s:d}",
+                        str_n, param->name,
+                        str_d, PyLong_FromLong(param->dir),
+                        str_v, (double)d_ptr->f);
                 break;
             case HAL_PORT: // HAL_PORT is currently not supported
             case HAL_TYPE_UNSPECIFIED: /* fallthrough */ ;
@@ -1528,7 +1524,7 @@ PyObject *get_info_params(PyObject * /*self*/, PyObject * /*args*/) {
         }
 
         PyList_Append( python_list, obj);
-	    next = param->next_ptr;
+        next = param->next_ptr;
     }
     rtapi_mutex_give(&(hal_data->mutex));
 
@@ -1749,10 +1745,12 @@ static int pystream_init(PyObject *_self, PyObject *args, PyObject * /*kw*/) {
 
     for(int i=0; i<n; i++) {
         switch(hal_stream_element_type(&self->stream, i)) {
-        case HAL_BIT: tbuf[i] = 'b'; break;
-        case HAL_FLOAT: tbuf[i] = 'f'; break;
-        case HAL_S32: tbuf[i] = 's'; break;
-        case HAL_U32: tbuf[i] = 'u'; break;
+        case HAL_BIT: tbuf[i] = 'B'; break;
+        case HAL_FLOAT: tbuf[i] = 'F'; break;
+        case HAL_S32: tbuf[i] = 'S'; break;
+        case HAL_U32: tbuf[i] = 'U'; break;
+        case HAL_S64: tbuf[i] = 'L'; break;
+        case HAL_U64: tbuf[i] = 'K'; break;
         default: tbuf[i] = '?'; break;
         }
     }
@@ -1768,7 +1766,7 @@ PyObject *stream_read(PyObject *_self, PyObject * /*unused*/) {
         Py_INCREF(Py_None);
         return Py_None;
     }
-    vector<hal_stream_data> buf(n);
+    vector<hal_stream_data_u> buf(n);
     if(hal_stream_read(&self->stream, buf.data(), &self->sampleno) < 0) {
         Py_INCREF(Py_None);
         return Py_None;
@@ -1780,10 +1778,18 @@ PyObject *stream_read(PyObject *_self, PyObject * /*unused*/) {
     for(int i=0; i<n; i++) {
         PyObject *o;
         switch(PyBytes_AS_STRING(self->pyelt)[i]) {
+        case 'B':
         case 'b': o = to_python(buf[i].b); break;
+        case 'F':
         case 'f': o = to_python(buf[i].f); break;
+        case 'S':
         case 's': o = to_python(buf[i].s); break;
+        case 'U':
         case 'u': o = to_python(buf[i].u); break;
+        case 'L':
+        case 'l': o = to_python(buf[i].l); break;
+        case 'K':
+        case 'k': o = to_python(buf[i].k); break;
         default: Py_INCREF(Py_None); o = Py_None; break;
         }
         if(!o) {
@@ -1811,14 +1817,22 @@ PyObject *stream_write(PyObject *_self, PyObject *args) {
         return NULL;
     }
 
-    vector<hal_stream_data> buf(n);
+    vector<hal_stream_data_u> buf(n);
     for(int i=0; i<n; i++) {
         PyObject *o = PyTuple_GET_ITEM(data, i);
         switch(PyBytes_AS_STRING(self->pyelt)[i]) {
+        case 'B':
         case 'b': buf[i].b = PyObject_IsTrue(o); break;
+        case 'F':
         case 'f': if(!from_python(o, &buf[i].f)) return NULL; break;
+        case 'S':
         case 's': if(!from_python(o, &buf[i].s)) return NULL; break;
+        case 'U':
         case 'u': if(!from_python(o, &buf[i].u)) return NULL; break;
+        case 'L':
+        case 'l': if(!from_python(o, &buf[i].s)) return NULL; break;
+        case 'K':
+        case 'k': if(!from_python(o, &buf[i].u)) return NULL; break;
         default: memset(&buf[i], 0, sizeof(buf[i])); break;
         }
     }


### PR DESCRIPTION
This PR fixes the HAL stream interface and implementation. There were several issues. One error was that the buffer count would be off-by-one whenever the buffer content wrapped the buffer. There were several issues wit atomicity and the handling of different types was incomplete. The PR also removes private structural definitions from public headers and moves them to the only place they are used inside the source.

The halmodule python interface was cleaned up and, in addition to fixing the stream functionality. Unnecessary/invalid use and casting of `hal_*_t` types are removed and now use the proper hal union dereferences. Also, several python sized type conversions (in build value) were fixed where there were several copy-and-paste errors using the same signed 'l' conversion for both signed, unsigned and 32-bit and 64 bit conversions ('l', 'k', 'L' and 'K'). These now use the proper conversion type markers, including fixing 'f' (float) and 'd' (double) confusion.
