### PR TITLE
debian: Move python3-poppler-qt5 to Suggests

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -6,6 +6,9 @@ linuxcnc (1:2.10.0~pre1) UNRELEASED; urgency=medium
   [ andypugh ]
   * Add a finite-jerk trajectory planner
 
+  [ Bastian Germann ]
+  * Move python3-poppler-qt5 to Suggests (Closes: #1129683)
+
  -- andypugh <andy@bodgesoc.org>  Wed, 07 Jan 2026 22:15:18 +0000
 
 linuxcnc (1:2.9.8) UNRELEASED; urgency=medium

--- a/debian/configure
+++ b/debian/configure
@@ -134,7 +134,7 @@ PYTHON_GST=python3-gst-1.0,gstreamer1.0-plugins-base
 TCLTK_VERSION=8.6
 PYTHON_IMAGING=python3-pil
 PYTHON_IMAGING_TK=python3-pil.imagetk
-QTVCP_DEPENDS="python3-pyqt5,\n    python3-pyqt5.qsci,\n    python3-pyqt5.qtsvg,\n    python3-pyqt5.qtopengl,\n    python3-opencv,\n    python3-dbus,\n    python3-espeak,\n    python3-dbus.mainloop.pyqt5,\n    python3-pyqt5.qtwebengine,\n    espeak-ng,\n    pyqt5-dev-tools,\n    gstreamer1.0-tools,\n    espeak,\n    sound-theme-freedesktop,\n    python3-poppler-qt5"
+QTVCP_DEPENDS="python3-pyqt5,\n    python3-pyqt5.qsci,\n    python3-pyqt5.qtsvg,\n    python3-pyqt5.qtopengl,\n    python3-opencv,\n    python3-dbus,\n    python3-espeak,\n    python3-dbus.mainloop.pyqt5,\n    python3-pyqt5.qtwebengine,\n    espeak-ng,\n    pyqt5-dev-tools,\n    gstreamer1.0-tools,\n    espeak,\n    sound-theme-freedesktop"
 YAPPS_RUNTIME="python3-yapps"
 DEBHELPER="debhelper (>= 12)"
 COMPAT="12"

--- a/debian/control.main-pkg.in
+++ b/debian/control.main-pkg.in
@@ -40,6 +40,7 @@ Recommends:
     @PYTHON_IMAGING_TK@
 Suggests:
     mesaflash,
+    python3-poppler-qt5,
     onboard
 Description: motion controller for CNC machines and robots
  LinuxCNC is a fully-realised CNC machine controller that can interpret


### PR DESCRIPTION
The package is being removed from Debian. Having it in Suggests is a way to signal that you might need it for optional functions.
The code can already deal with the package not being installed.