### PR TITLE
debian: Depend on libedit instead of the libeditreadline compat layer

### DIFF
--- a/debian/configure
+++ b/debian/configure
@@ -72,7 +72,7 @@ fi
 
 EXTRA_BUILD=
 PYTHON_VERSION_NEXT=$(python3 -c 'import sys; print (sys.version[:2] + str(1+int(sys.version[2])))')
-LIBREADLINE_DEV="libeditreadline-dev"
+LIBREADLINE_DEV="libedit-dev"
 
 ENABLE_BUILD_DOCUMENTATION=--enable-build-documentation=pdf
 
@@ -141,7 +141,7 @@ COMPAT="12"
 
 case $DISTRIB_NAME in
     Ubuntu-25.*|Ubuntu-24.*|Ubuntu-21.*|Debian-11|Debian-11.*|Debian-12|Debian-12.*|Debian-13|Debian-13.*|Debian-testing|Debian-unstable)
-        LIBREADLINE_DEV=libeditreadline-dev
+        LIBREADLINE_DEV=libedit-dev
         COMPAT=""
         DEBHELPER="debhelper-compat (= 13)"
         ;;


### PR DESCRIPTION
With commit e4f906c56b ("Convert to libedit so everyone can redistribute"), the project does not depend on Debian's wrapper of libedit anymore but on libedit directly. So depend on the correct package in the linxcnc deb as well.