### PR TITLE
build: fix INCLUDE path for non-uspace builds (fixes #3873)

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -245,7 +245,7 @@ $(shell $(VECHO) 1>&2 Done reading dependencies)
 endif
 
 # Each directory in $(INCLUDES) is passed as a -I directory when compiling.
-INCLUDE := $(patsubst %,-I%, $(INCLUDES)) -I$(RTDIR)/../include
+INCLUDE := $(patsubst %,-I%, $(INCLUDES)) -I$(EMC2_HOME)/include
 INCLUDE += $(PYTHON_CPPFLAGS)
 INCLUDE += $(LIBTIRPC_CFLAGS)
 


### PR DESCRIPTION
RTDIR points to the realtime prefix (e.g. /usr/realtime-5.4.280-rtai-amd64 for RTAI), so -I$(RTDIR)/../include resolved to /usr/include instead of the project's include/ directory, breaking all <rtapi.h> and similar angle-bracket includes for userspace objects in RTAI builds.

Use $(EMC2_HOME)/include which always resolves to the project's include/ directory regardless of build system.