### PR TITLE
pwmgen: prevent GCC from emitting SSE in base-thread function

### DIFF
--- a/src/hal/components/pwmgen.c
+++ b/src/hal/components/pwmgen.c
@@ -135,7 +135,7 @@ static long periodns;		/* makepulses function period in nanosec */
 ************************************************************************/
 
 static int export_pwmgen(int num, pwmgen_t * addr, int output_type);
-static void make_pulses(void *arg, long period);
+static void __attribute__((target("general-regs-only"))) make_pulses(void *arg, long period);
 static void update(void *arg, long period);
 
 /***********************************************************************
@@ -231,7 +231,7 @@ void rtapi_app_exit(void)
     added and subtracted.
 */
 
-static void make_pulses(void *arg, long period)
+static void __attribute__((target("general-regs-only"))) make_pulses(void *arg, long period)
 {
     pwmgen_t *pwmgen;
     int n;


### PR DESCRIPTION
make_pulses() is exported with uses_fp=0 for the base-thread, but GCC optimizes struct zeroing into SSE instructions (pxor/movups on XMM registers). Since RTAI skips FPU/SSE save/restore for non-FP threads, this silently corrupts XMM state of whatever Linux process was running, causing heap corruption, segfaults, and hard crashes.

Add __attribute__((target("general-regs-only"))) to make_pulses() to force GCC to use only general-purpose registers.

Confirmed via objdump that the compiled function contains zero SSE instructions after this change. Tested on RTAI 5.4.280 with the etch-servo parport config which previously crashed reliably.

See: https://github.com/LinuxCNC/linuxcnc/issues/3895