### PR TITLE
Deprecate uses_fp: always enable FPU state save on all threads

### DIFF
--- a/docs/man/man3/hal_create_thread.3hal
+++ b/docs/man/man3/hal_create_thread.3hal
@@ -18,7 +18,8 @@ The name of the thread
 The interval, in nanoseconds, between iterations of the thread
 
 .IP \fIuses_fp\fR
-Must be nonzero if a function which uses floating-point will be attached to this thread.
+\fBDeprecated.\fR All threads now unconditionally save and restore
+floating-point state.  This parameter is accepted but ignored.
 
 .SH DESCRIPTION
 \fBhal_create_thread\fR establishes a realtime thread that will execute one or more HAL functions periodically.

--- a/docs/man/man3/hal_export_funct.3hal
+++ b/docs/man/man3/hal_export_funct.3hal
@@ -20,8 +20,8 @@ The pointer to the function
 The argument to be passed as the first parameter of \fIfunct\fR
 
 .IP \fIuses_fp\fR
-Nonzero if the function uses floating-point operations, including assignment
-of floating point values with "=".
+\fBDeprecated.\fR All threads now unconditionally save and restore
+floating-point state, so this flag has no effect.
 
 .IP \fIreentrant\fR
 If reentrant is non-zero, the function may be preempted and called again

--- a/docs/man/man3/rtapi_task_new.3rtapi
+++ b/docs/man/man3/rtapi_task_new.3rtapi
@@ -19,7 +19,8 @@ started
 .IP \fIprio\fR
 A task priority value returned by \fBrtapi_prio_xxxx\fR
 .IP \fIuses_fp\fR
-A flag that tells the OS whether the task uses floating point or not.
+\fBDeprecated.\fR All tasks now unconditionally save and restore
+floating-point state.  This parameter is accepted but ignored.
 .IP \fItask_id\fR
 A task ID returned by a previous call to \fBrtapi_task_new\fR
 .SH DESCRIPTION

--- a/docs/man/man9/motion.9
+++ b/docs/man/man9/motion.9
@@ -42,7 +42,8 @@ Optionally the number of Digital I/O is set with num_dio. The number of Analog I
 Pin names starting with "\fBjoint\fR"  or "\fBaxis\fR" are are read and updated by the motion-controller function.
 
 .SH DESCRIPTION
-By default, the base thread does not support floating point.  Software stepping, software encoder counting, and software pwm do not use floating point.  \fBbase_thread_fp\fR can be used to enable floating point in the base thread (for example for brushless DC motor control).
+\fBbase_thread_fp\fR is \fBdeprecated\fR and has no effect.  All threads now
+unconditionally save and restore floating-point state.
 
 .P
 These pins and parameters are created by the realtime \fBmotmod\fR module. This module provides a HAL interface for LinuxCNC's motion planner. Basically \fBmotmod\fR takes in a list of waypoints and generates a nice blended and constraint-limited stream of joint positions to be fed to the motor drives.

--- a/src/hal/components/abs_s32.comp
+++ b/src/hal/components/abs_s32.comp
@@ -21,7 +21,7 @@ pin out bit sign "Sign of input, false for positive, true for negative" ;
 pin out bit is_positive "TRUE if input is positive, FALSE if input is 0 or negative";
 pin out bit is_negative "TRUE if input is negative, FALSE if input is 0 or positive";
 
-function _ nofp;
+function _;
 license "GPL";
 author "Sebastian Kuzminsky";
 ;;

--- a/src/hal/components/and2.comp
+++ b/src/hal/components/and2.comp
@@ -14,7 +14,7 @@ Otherwise,
 \\fBout=FALSE\\fR
 .RE"""
 ;
-function _ nofp;
+function _;
 see_also """
 \\fBlogic\\fR(9),
 \\fBlut5\\fR(9),

--- a/src/hal/components/bin2gray.comp
+++ b/src/hal/components/bin2gray.comp
@@ -4,6 +4,6 @@ pin in unsigned in "binary code in";
 pin out unsigned out "gray code out";
 license "GPL";
 author "Andy Pugh";
-function _ nofp;
+function _;
 ;;
 out = (in >> 1) ^ in;

--- a/src/hal/components/bitslice.comp
+++ b/src/hal/components/bitslice.comp
@@ -7,7 +7,7 @@ pin in u32 in "The input value";
 pin out bit out-##[32:personality];
 author "Andy Pugh";
 license "GPL2+";
-function _ nofp;
+function _;
 option personality yes;
 ;;
 int i;

--- a/src/hal/components/bitwise.comp
+++ b/src/hal/components/bitwise.comp
@@ -10,7 +10,7 @@ pin out u32 out-xnor "The inverse of the bitwise XOR";
 
 author "Andy Pugh";
 license "GPL 2+";
-function _ nofp;
+function _;
 ;;
 
 out_and = (in0 & in1);

--- a/src/hal/components/charge_pump.comp
+++ b/src/hal/components/charge_pump.comp
@@ -21,7 +21,7 @@ pin out bit out "Square wave if 'enable' is TRUE or unconnected, low if 'enable'
 pin out bit out-2 "Square wave at half the frequency of 'out'";
 pin out bit out-4 "Square wave at a quarter of the frequency of 'out'";
 pin in bit enable = TRUE "If FALSE, forces all 'out' pins to be low";
-function _ nofp "Toggle the output bit (if enabled)";
+function _ "Toggle the output bit (if enabled)";
 description """
 The 'Charge Pump' should be added to the base thread function.
 When enabled the output is on for one period and off for one period. To calculate the

--- a/src/hal/components/comp.comp
+++ b/src/hal/components/comp.comp
@@ -12,7 +12,7 @@ separated by distance \\fBhyst\\fR around the point where \\fBin1\\fR = \\fBin0\
 Keep in mind that floating point calculations are never absolute
 and it is wise to always set \\fBhyst\\fR if you intend to use equal """;
 
-function _ fp "Update the comparator";
+function _ "Update the comparator";
 license "GPL";
 author "Jeff Epler";
 ;;

--- a/src/hal/components/conv.comp.in
+++ b/src/hal/components/conv.comp.in
@@ -3,7 +3,7 @@ pin in @IN@ in_;
 pin out @OUT@ out;
 @CC@ pin out bit out_of_range "TRUE when 'in' is not in the range of @OUT@";
 @CC@ param rw bit clamp """If TRUE, then clamp to the range of @OUT@.  If FALSE, then allow the value to "wrap around".""";
-function _ @FP@ "Update 'out' based on 'in'";
+function _ "Update 'out' based on 'in'";
 license "GPL";
 author "Jeff Epler";
 

--- a/src/hal/components/dbounce.comp
+++ b/src/hal/components/dbounce.comp
@@ -9,7 +9,7 @@ pin out bit out;
 pin in  u32 delay = 5;
 
 variable int state;
-function _ nofp;
+function _;
 license "GPL";
 author "Dewey Garrett";
 ;;

--- a/src/hal/components/edge.comp
+++ b/src/hal/components/edge.comp
@@ -28,7 +28,7 @@ param r signed time_left_ns "Time left in this output pulse";
 param r bit last_in "Previous input value";
 variable int first = 1;
 
-function _ nofp "Produce output pulses from input edges";
+function _ "Produce output pulses from input edges";
 license "GPL";
 author "Jeff Epler";
 ;;

--- a/src/hal/components/estop_latch.comp
+++ b/src/hal/components/estop_latch.comp
@@ -71,7 +71,7 @@ pin in bit reset;
 pin out bit ok_out = false;
 pin out bit fault_out = true;
 pin out bit watchdog;
-function _ nofp;
+function _;
 option data estop_data;
 license "GPL";
 author "John Kasunich";

--- a/src/hal/components/flipflop.comp
+++ b/src/hal/components/flipflop.comp
@@ -7,7 +7,7 @@ pin io bit out "output";
 pin io bit out-not "inverted output";
 option data flipflop_data;
 
-function _ nofp;
+function _;
 license "GPL";
 author "John Kasunich";
 ;;

--- a/src/hal/components/gantry.comp
+++ b/src/hal/components/gantry.comp
@@ -48,8 +48,8 @@ pin out float position-fb "Position feedback to motion";
 pin out bit   home "Combined home signal, true if all joint home inputs are true.";
 pin out bit   limit "Combined limit signal, true if any joint home input is true.";
 pin in  float search-vel "HOME_SEARCH_VEL from INI file";
-function read  fp "Update position-fb and home/limit outputs based on joint values.";
-function write fp "Update joint pos-cmd outputs based on position-cmd in.";
+function read "Update position-fb and home/limit outputs based on joint values.";
+function write "Update joint pos-cmd outputs based on position-cmd in.";
 description """
 --- Deprecation Notice 
 

--- a/src/hal/components/gray2bin.comp
+++ b/src/hal/components/gray2bin.comp
@@ -4,7 +4,7 @@ pin in unsigned in "gray code in";
 pin out unsigned out "binary code out";
 license "GPL";
 author "Andy Pugh";
-function _ nofp;
+function _;
 ;;
 unsigned int mask;
 out = in;

--- a/src/hal/components/histobins.comp
+++ b/src/hal/components/histobins.comp
@@ -66,7 +66,7 @@ pin out float  mean;
 // user may interrogate availablebins to determine this compiled-in limit
 pin out s32 availablebins = 200; //MAXBINNUMBER
 
-function _ fp;
+function _;
 
 variable int bin[200]; // MAXBINNUMBER
 variable int first = 1;

--- a/src/hal/components/latencybins.comp
+++ b/src/hal/components/latencybins.comp
@@ -47,7 +47,7 @@ pin out s32 variance;
 // user may interrogate available bins to determine this compiled-in limit
 pin out s32 availablebins = 1000; // MAXBINNUMBER
 
-function _ nofp;
+function _;
 variable rtapi_s64  last_timer = 0;
 variable int    last_binmax = 0;
 variable int    first = 1;

--- a/src/hal/components/logic.comp
+++ b/src/hal/components/logic.comp
@@ -20,7 +20,7 @@ pin out bit or if personality & 0x200;
 pin out bit xor if personality & 0x400;
 pin out bit nand if personality & 0x800;
 pin out bit nor if personality & 0x1000;
-function _ nofp "Read the inputs and toggle the output bit.";
+function _ "Read the inputs and toggle the output bit.";
 description """
 General `logic function' component.  Can perform `and', `or',
 `nand', `nor' and `xor' of up to 16 inputs.

--- a/src/hal/components/lut5.comp
+++ b/src/hal/components/lut5.comp
@@ -6,7 +6,7 @@ pin in bit in_3;
 pin in bit in_4;
 pin out bit out;
 param rw u32 function;
-function _ nofp;
+function _;
 description """
 .B lut5
 constructs a logic function with up to 5 inputs using a \\fBl\\fRook-\\fBu\\fRp \\fBt\\fRable.

--- a/src/hal/components/maj3.comp
+++ b/src/hal/components/maj3.comp
@@ -24,7 +24,7 @@ pin out bit out;
 
 param rw bit invert;
 
-function _ nofp;
+function _;
 
 license "GPL";
 author "Jeff Epler";

--- a/src/hal/components/match8.comp
+++ b/src/hal/components/match8.comp
@@ -17,7 +17,7 @@ pin in bit b5;
 pin in bit b6;
 pin in bit b7;
 pin out bit out "true only if in is true and a[m] matches b[m] for m = 0 thru 7";
-function _ nofp;
+function _;
 license "GPL";
 author "John Kasunich";
 ;;

--- a/src/hal/components/max31855.comp
+++ b/src/hal/components/max31855.comp
@@ -40,7 +40,7 @@ pin out unsigned fault_flags.# [15 : (personality & 0xf)]  "Fault flags: 0x1  = 
 variable unsigned data_frame [15];
 variable unsigned state = 1;
 
-function bitbang_spi fp;
+function bitbang_spi;
 license "GPL";
 author "Joseph Calderon";
 

--- a/src/hal/components/message.comp
+++ b/src/hal/components/message.comp
@@ -72,7 +72,7 @@ variable hal_bit_t prev_edge = TRUE;
  
 option extra_setup yes;
  
-function _ nofp "Display a message";
+function _ "Display a message";
 license "GPL v2";
 author "Les Newell";
 ;;

--- a/src/hal/components/mkconv.sh
+++ b/src/hal/components/mkconv.sh
@@ -1,3 +1,2 @@
 #!/bin/bash
-if [ "$1" = "float" -o "$2" = "float" ]; then F=""; else F="nofp"; fi
-sed -e "s,@IN@,$1,g; s,@OUT@,$2,g; s,@CC@,$3,g; s,@MIN@,${4-0},g; s,@MAX@,${5-0},g; s,@FP@,$F,g;"
+sed -e "s,@IN@,$1,g; s,@OUT@,$2,g; s,@CC@,$3,g; s,@MIN@,${4-0},g; s,@MAX@,${5-0},g;"

--- a/src/hal/components/multiclick.comp
+++ b/src/hal/components/multiclick.comp
@@ -138,7 +138,7 @@ the click separator space timeout has expired to show that no further
 click is coming.  This is useful for triggering halui MDI commands.""";
 
 
-function _ nofp "Detect single-, double-, triple-, and quadruple-clicks";
+function _ "Detect single-, double-, triple-, and quadruple-clicks";
 
 ;;
 

--- a/src/hal/components/not.comp
+++ b/src/hal/components/not.comp
@@ -1,7 +1,7 @@
 component not "Inverter";
 pin in bit in;
 pin out bit out;
-function _ nofp;
+function _;
 see_also """
 \\fBand2\\fR(9),
 \\fBlogic\\fR(9),

--- a/src/hal/components/or2.comp
+++ b/src/hal/components/or2.comp
@@ -13,7 +13,7 @@ Otherwise,
 \fBout=TRUE\fR
 .RE"""
 ;
-function _ nofp;
+function _;
 see_also """
 \\fBlogic\\fR(9)
 """;

--- a/src/hal/components/sample_hold.comp
+++ b/src/hal/components/sample_hold.comp
@@ -2,7 +2,7 @@ component sample_hold "Sample and Hold";
 pin in s32 in;
 pin in bit hold;
 pin out s32 out;
-function _ nofp;
+function _;
 see_also "\\fBtristate\\fR(9)";
 license "GPL";
 author "Stephen Wille Padnos";

--- a/src/hal/components/select8.comp
+++ b/src/hal/components/select8.comp
@@ -2,7 +2,7 @@ component select8 "8-bit binary match detector";
 pin in bit enable = TRUE "Set enable to FALSE to cause all outputs to be set FALSE.";
 pin in s32 sel "The number of the output to set TRUE.  All other outputs well be set FALSE.";
 pin out bit out#[8] "Output bits.  If enable is set and the sel input is between 0 and 7, then the corresponding output bit will be set true.";
-function _ nofp;
+function _;
 see_also "\\fBdemux\\fR(9)";
 license "GPL";
 author "Stephen Wille Padnos";

--- a/src/hal/components/sim_axis_hardware.comp
+++ b/src/hal/components/sim_axis_hardware.comp
@@ -158,7 +158,7 @@ pin out bit Vbothsw_homesw_out;
 
 pin in float limit_offset =.01 "how much the limit switches are offset from inputted position. added to max, subtracted from min";
 
-function update fp;
+function update;
 license "GPL";
 author "Chris S Morley";
 ;;

--- a/src/hal/components/sim_home_switch.comp
+++ b/src/hal/components/sim_home_switch.comp
@@ -19,7 +19,7 @@ pin in float index_delay_ms = 10 "delay in msec to reset index-enable";
 variable int    old_index_enable;
 variable double index_timer_ms;
 
-function _ fp;
+function _;
 license "GPL";
 author "Dewey Garrett";
 ;;

--- a/src/hal/components/sim_parport.comp
+++ b/src/hal/components/sim_parport.comp
@@ -124,9 +124,9 @@ pin out bit pin_15_in_not;
 
 pin in float reset_time;
 
-function read nofp;
-function write nofp;
-function reset nofp;
+function read;
+function write;
+function reset;
 license "GPL";
 author "Chris S Morley";
 ;;

--- a/src/hal/components/sphereprobe.comp
+++ b/src/hal/components/sphereprobe.comp
@@ -13,7 +13,7 @@ pin in signed r "Radius of hemisphere in counts";
 
 pin out bit probe-out;
 
-function _ nofp "update probe-out based on inputs";
+function _ "update probe-out based on inputs";
 ;;
 #undef abs
 int abs(int x) { if(x < 0) return -x; else return x; }

--- a/src/hal/components/spindle.comp
+++ b/src/hal/components/spindle.comp
@@ -132,7 +132,7 @@ If multiple select inputs are active then the highest is selected.
 variable float ngears;
 variable gear_t gears[16];
 
-function _ fp;
+function _;
 license "GPL";
 author "Les Newell";
 option extra_setup yes;

--- a/src/hal/components/threadtest.comp
+++ b/src/hal/components/threadtest.comp
@@ -1,7 +1,7 @@
 component threadtest "LinuxCNC HAL component for testing thread behavior";
 pin out unsigned count;
-function increment nofp;
-function reset nofp;
+function increment;
+function reset;
 license "GPL";
 author "Jeff Epler";
 

--- a/src/hal/components/timedelta.comp
+++ b/src/hal/components/timedelta.comp
@@ -19,7 +19,7 @@ pin out s32 err=0 "Cumulative time error (in ns).  Probably not useful.";
 pin out float avg_err=0 "The average scheduling error (in ns).";
 
 
-function _ nofp;
+function _;
 variable rtapi_s64 last=0;
 variable int first=1;
 license "GPL";

--- a/src/hal/components/tof.comp
+++ b/src/hal/components/tof.comp
@@ -24,7 +24,7 @@ pin out float et "Elapsed time since falling edge in seconds";
 
 param rw float pt "Delay time in seconds";
 
-function _ fp "Update the timer";
+function _ "Update the timer";
 license "GPL";
 author "Chad Woitas";
 ;;

--- a/src/hal/components/toggle.comp
+++ b/src/hal/components/toggle.comp
@@ -16,7 +16,7 @@ pin io bit out "on/off output";
 param rw u32 debounce = 2 "debounce delay in periods";
 option data toggle_data;
 
-function _ nofp;
+function _;
 license "GPL";
 author "John Kasunich";
 ;;

--- a/src/hal/components/toggle2nist.comp
+++ b/src/hal/components/toggle2nist.comp
@@ -35,7 +35,7 @@ pin out bit on;
 pin out bit off;
 variable int old_in;
 variable int to_state=0;
-function _ nofp;
+function _;
 license "GPL";
 author "Anders Wallin";
 ;;

--- a/src/hal/components/ton.comp
+++ b/src/hal/components/ton.comp
@@ -24,7 +24,7 @@ pin out float et "Elapsed time since rising edge in seconds";
 
 param rw float pt "Delay time in seconds";
 
-function _ fp "Update the timer";
+function _ "Update the timer";
 license "GPL";
 author "Chad Woitas";
 ;;

--- a/src/hal/components/tp.comp
+++ b/src/hal/components/tp.comp
@@ -26,7 +26,7 @@ param rw float pt "Pulse time in seconds";
 
 variable int in_old; // Value of in on last cycle, for rising edge detection
 
-function _ fp "Update the timer";
+function _ "Update the timer";
 license "GPL";
 author "Chad Woitas";
 ;;

--- a/src/hal/components/tristate_bit.comp
+++ b/src/hal/components/tristate_bit.comp
@@ -4,7 +4,7 @@ pin in bit in_ "Input value";
 pin io bit out "Output value";
 pin in bit enable "When TRUE, copy in to out";
 
-function _ nofp "If \\fBenable\\fR is TRUE, copy \\fBin\\fR to \\fBout\\fR.";
+function _ "If \\fBenable\\fR is TRUE, copy \\fBin\\fR to \\fBout\\fR.";
 license "GPL";
 author "Jeff Epler";
 ;;

--- a/src/hal/components/updown.comp
+++ b/src/hal/components/updown.comp
@@ -10,7 +10,7 @@ param rw s32 min "If clamp or wrap is set, count will never be less than this nu
 variable int oldup;
 variable int olddown;
 variable int first = 1;
-function _ nofp "Process inputs and update count if necessary";
+function _ "Process inputs and update count if necessary";
 license "GPL";
 author "Stephen Wille Padnos";
 

--- a/src/hal/components/xor2.comp
+++ b/src/hal/components/xor2.comp
@@ -13,7 +13,7 @@ to the following rule:
 .TP
 Otherwise,
 \\fBout=FALSE\\fR""";
-function _ nofp;
+function _;
 see_also """
 \\fBand2\\fR(9),
 \\fBlogic\\fR(9),

--- a/src/hal/drivers/pcl720.comp
+++ b/src/hal/drivers/pcl720.comp
@@ -15,9 +15,9 @@ param rw bit pin-##-out-invert[32] "Set to true to invert the sense of the outpu
 
 pin out  unsigned wait_clocks;
 
-function read nofp "Reads each of the digital inputs and updates the HAL pins";
-function write nofp "Writes the values of the output HAL pins to the digital IO";
-function reset nofp """Waits for the length of time specified by the
+function read "Reads each of the digital inputs and updates the HAL pins";
+function write "Writes the values of the output HAL pins to the digital IO";
+function reset """Waits for the length of time specified by the
 \\fBreset-time\\fP parameter and resets any pins for which the \\fBreset\\fP
 parameter has been set. This can be used to allow step generators to make a step
 every thread rather than every other thread. This function must be added to the

--- a/src/hal/drivers/serport.comp
+++ b/src/hal/drivers/serport.comp
@@ -40,8 +40,8 @@ option extra_setup;
 option extra_cleanup;
 option constructable no;
 
-function read nofp;
-function write nofp;
+function read;
+function write;
 
 license "GPL";
 ;;

--- a/src/hal/hal_lib.c
+++ b/src/hal/hal_lib.c
@@ -1917,6 +1917,12 @@ int hal_create_thread(const char *name, unsigned long period_nsec, int uses_fp)
     long prev_period, curr_period;
     char buf[HAL_NAME_LEN + 1];
 
+    if (!uses_fp) {
+	rtapi_print_msg(RTAPI_MSG_WARN,
+	    "HAL: WARNING: thread '%s' created with uses_fp=0, "
+	    "overriding to uses_fp=1 (uses_fp is deprecated).\n", name);
+	uses_fp = 1;
+    }
     rtapi_print_msg(RTAPI_MSG_DBG,
 	"HAL: creating thread %s, %ld nsec\n", name, period_nsec);
     if (hal_data == 0) {
@@ -2202,13 +2208,8 @@ int hal_add_funct_to_thread(const char *funct_name, const char *thread_name, int
 	    "HAL: ERROR: thread '%s' not found\n", thread_name);
 	return -EINVAL;
     }
-    /* ok, we have thread and function, are they compatible? */
-    if ((funct->uses_fp) && (!thread->uses_fp)) {
-	rtapi_mutex_give(&(hal_data->mutex));
-	rtapi_print_msg(RTAPI_MSG_ERR,
-	    "HAL: ERROR: function '%s' needs FP\n", funct_name);
-	return -EINVAL;
-    }
+    /* All threads now save FPU state (uses_fp is deprecated),
+       so the FP compatibility check is no longer needed. */
     /* find insertion point */
     list_root = &(thread->funct_list);
     list_entry = list_root;

--- a/src/hal/utils/halcompile.g
+++ b/src/hal/utils/halcompile.g
@@ -76,7 +76,7 @@ parser Hal:
                 | {{ return None }}
     rule OptSAssign: "=" SValue {{ return SValue; }}
                 | {{ return None }}
-    rule OptFP: "fp" {{ return 1 }} | "nofp" {{ return 0 }} | {{ return 1 }}
+    rule OptFP: "fp" {{ return optfp_warn(1) }} | "nofp" {{ return optfp_warn(0) }} | {{ return 1 }}
     rule Value: "yes" {{ return 1 }} | "no" {{ return 0 }}  
                 | "true" {{ return 1 }} | "false" {{ return 0 }}  
                 | "TRUE" {{ return 1 }} | "FALSE" {{ return 0 }}  
@@ -168,6 +168,9 @@ def Error(msg, *args):
     if args:
         msg = msg % args
     raise runtime.SyntaxError(S.get_pos(), msg, None)
+
+def optfp_warn(state):
+    return 1
 
 def comp(name, doc):
     docs.append(('component', name, doc))

--- a/src/rtapi/rtai_rtapi.c
+++ b/src/rtapi/rtai_rtapi.c
@@ -685,9 +685,18 @@ int rtapi_task_new(void (*taskcode) (void *), void *arg,
     }
     task->taskcode = taskcode;
     task->arg = arg;
-    /* call OS to initialize the task - use predetermined CPU */
+    if (!uses_fp) {
+	rtapi_print_msg(RTAPI_MSG_WARN,
+	    "RTAPI: WARNING: task created with uses_fp=0, "
+	    "overriding to uses_fp=1. All threads now save FPU state "
+	    "(uses_fp is deprecated).\n");
+    }
+    /* call OS to initialize the task - use predetermined CPU
+       Always enable FPU state save/restore: modern compilers may emit
+       SSE instructions even in code that doesn't explicitly use FP,
+       causing silent XMM register corruption without FPU save. */
     retval = rt_task_init_cpuid(ostask_array[task_id], wrapper, task_id,
-	 stacksize, prio, uses_fp, 0 /* signal */, rtapi_data->rt_cpu );
+	 stacksize, prio, 1 /* always save FPU */, 0 /* signal */, rtapi_data->rt_cpu );
     if (retval != 0) {
 	/* couldn't create task, free task data memory */
 	kfree(ostask_array[task_id]);


### PR DESCRIPTION
GCC on x86-64 may emit SSE instructions (e.g. for struct zeroing) even in functions that don't explicitly use floating point. On RTAI, threads created with uses_fp=0 skip FPU/SSE state save/restore, silently corrupting XMM registers of other Linux processes and causing heap corruption and system crashes.

Fix by always enabling FPU state save regardless of the uses_fp parameter:
- rtai_rtapi.c: always pass 1 to rt_task_init_cpuid
- hal_lib.c: override uses_fp=0 to 1 in hal_create_thread
- hal_lib.c: remove addf FP compatibility check (now meaningless)

Emit deprecation warnings when uses_fp=0 is requested.

Ref: linuxcnc/linuxcnc#3895