### PR TITLE
build: Need clang 21+ for nonstring attribute

### DIFF
--- a/src/hal/drivers/mesa-hostmot2/hostmot2.h
+++ b/src/hal/drivers/mesa-hostmot2/hostmot2.h
@@ -140,12 +140,18 @@
 // IDROM and MD structs
 //
 
+// Need clang 21+ for the nonstring attribute
+#if !defined(__clang__) || (defined(__clang_major__) && __clang_major__ >= 21)
+#define HM2_ATTRIBUTE_NONSTRING __attribute__((nonstring))
+#else
+#define HM2_ATTRIBUTE_NONSTRING
+#endif
 
 typedef struct {
     rtapi_u32 idrom_type;
     rtapi_u32 offset_to_modules;
     rtapi_u32 offset_to_pin_desc;
-    rtapi_u8 board_name[8] __attribute__ ((nonstring));  // ASCII string, but not NULL terminated!
+    rtapi_u8 board_name[8] HM2_ATTRIBUTE_NONSTRING;  // ASCII string, but not NULL terminated!
     rtapi_u32 fpga_size;
     rtapi_u32 fpga_pins;
     rtapi_u32 io_ports;

--- a/src/hal/drivers/mesa-hostmot2/llio_info.c
+++ b/src/hal/drivers/mesa-hostmot2/llio_info.c
@@ -26,7 +26,7 @@
 #include "llio_info.h"
 
 typedef struct __info_entry_t {
-	char board_name[8] __attribute__ ((nonstring));
+	char board_name[8] HM2_ATTRIBUTE_NONSTRING;
 	const char *base_name;
 	int num_ioport_connectors;
 	int pins_per_connector;


### PR DESCRIPTION
Building with clang on Debian 12 (bookworm; clang 14) and Debian 13 (trixie; clang 19) will result in a warning about the `nonstring` attribute not being valid. You need newer clang 21+ for this to work.
This PR adds a check to determine the version of clang and use/suppress the use of the attribute depending version found.