### PR TITLE
build: enable -Werror on rip-and-test and rip-and-test-clang CI builds.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
         sudo eatmydata apt --yes --quiet -o Acquire::Retries=5 upgrade
         cd src
         eatmydata ./autogen.sh
-        eatmydata ./configure --disable-check-runtime-deps
+        eatmydata ./configure --disable-check-runtime-deps --enable-werror
         eatmydata make -O -j$((1+$(nproc))) default pycheck V=1
         # Note that the package build covers html docs
         eatmydata ../scripts/rip-environment runtests -p
@@ -61,7 +61,7 @@ jobs:
         sudo eatmydata apt --yes --quiet -o Acquire::Retries=5 upgrade
         cd src
         eatmydata ./autogen.sh
-        CC=clang CXX=clang++ eatmydata ./configure --disable-check-runtime-deps
+        CC=clang CXX=clang++ eatmydata ./configure --disable-check-runtime-deps --enable-werror
         eatmydata make -O -j$((1+$(nproc))) default pycheck V=1
         # Note that the package build covers html docs
         eatmydata ../scripts/rip-environment runtests -p


### PR DESCRIPTION
This PR makes CI fail if there are any warnings in the standard gcc/g++ or clang/clang++ CI builds (`rip-and-test` and `rip-and-test-clang`). The reason for this move should be clear after the recent mishaps leaving warnings behind in code updates. The current state of the code should be good enough to make -Werror the new standard.

It is not (yet) enabled for the package builds because there is some caution required to iron out any potential version problems. Bookworm and Trixie should work, but Sid is a wildcard at this moment. Future evaluation (and possibly fixes) should enable us to add -Werror on all package CI builds too.