### PR TITLE
WIP: Fix: Rtapi cleanup: Library not found after install

### DIFF
--- a/src/rtapi/uspace_rtapi_main.cc
+++ b/src/rtapi/uspace_rtapi_main.cc
@@ -769,17 +769,17 @@ static RtapiApp *makeDllApp(std::string dllName, int policy) {
 static RtapiApp *makeApp() {
     RtapiApp *app;
     if (euid != 0 || harden_rt() < 0) {
-        app = makeDllApp(EMC2_HOME "/lib/libuspace-posix.so.0", SCHED_OTHER);
+        app = makeDllApp("libuspace-posix.so.0", SCHED_OTHER);
     } else {
         WithRoot r;
         if (detect_xenomai_evl()) {
-            app = makeDllApp(EMC2_HOME "/lib/libuspace-xenomai-evl.so.0", SCHED_FIFO);
+            app = makeDllApp("libuspace-xenomai-evl.so.0", SCHED_FIFO);
         } else if (detect_xenomai()) {
-            app = makeDllApp(EMC2_HOME "/lib/libuspace-xenomai.so.0", SCHED_FIFO);
+            app = makeDllApp("libuspace-xenomai.so.0", SCHED_FIFO);
         } else if (detect_rtai()) {
-            app = makeDllApp(EMC2_HOME "/lib/libuspace-rtai.so.0", SCHED_FIFO);
+            app = makeDllApp("libuspace-rtai.so.0", SCHED_FIFO);
         } else {
-            app = makeDllApp(EMC2_HOME "/lib/libuspace-posix.so.0", SCHED_FIFO);
+            app = makeDllApp("libuspace-posix.so.0", SCHED_FIFO);
         }
     }
 


### PR DESCRIPTION
This might fix the bug https://github.com/LinuxCNC/linuxcnc/issues/3915 introduced in https://github.com/LinuxCNC/linuxcnc/pull/3908

According to the manual page of dlopen(), this variant should search the library using ld.so.

~Caviat: I was not able to reproduce the issue until now. I am working on it. For me, both variant's work but this one is nicer anyway.~

Also https://github.com/LinuxCNC/linuxcnc/pull/3908#issuecomment-4212735732 is still open. Depending on the urgency, you can merge this already if it solves the bug.

@NTULINUX: Can you check if this solves the issue for you?