### PR TITLE
Rtapi cleanup v2

### DIFF
--- a/src/rtapi/Submakefile
+++ b/src/rtapi/Submakefile
@@ -51,41 +51,41 @@ endif
 USPACE_POSIX_SRCS := rtapi/uspace_posix.cc
 USERSRCS += $(USPACE_POSIX_SRCS)
 $(call TOOBJSDEPS, $(USPACE_POSIX_SRCS)): EXTRAFLAGS += -pthread -fPIC
-../lib/libuspace-posix.so.0: $(call TOOBJS, $(USPACE_POSIX_SRCS))
+../lib/liblinuxcnc-uspace-posix.so.0: $(call TOOBJS, $(USPACE_POSIX_SRCS))
 	$(ECHO) Linking $(notdir $@)
 	$(Q)$(CXX) -shared $(LDFLAGS) -o $@ $^ -Wl,-soname,$(notdir $@)
-TARGETS += ../lib/libuspace-posix.so.0
-TARGETS += ../lib/libuspace-posix.so
+TARGETS += ../lib/liblinuxcnc-uspace-posix.so.0
+TARGETS += ../lib/liblinuxcnc-uspace-posix.so
 
 ifeq ($(CONFIG_USPACE_RTAI),y)
 USPACE_RTAI_SRCS := rtapi/uspace_rtai.cc
 USERSRCS += $(USPACE_RTAI_SRCS)
 $(call TOOBJSDEPS, $(USPACE_RTAI_SRCS)): EXTRAFLAGS += -pthread -fPIC $(filter-out -Wstrict-prototypes,$(RTAI_LXRT_CFLAGS))
-../lib/libuspace-rtai.so.0: $(call TOOBJS, $(USPACE_RTAI_SRCS))
+../lib/liblinuxcnc-uspace-rtai.so.0: $(call TOOBJS, $(USPACE_RTAI_SRCS))
 	$(ECHO) Linking $(notdir $@)
 	$(Q)$(CXX) -shared $(LDFLAGS) -o $@ $^ $(RTAI_LXRT_LDFLAGS) -Wl,-soname,$(notdir $@)
-TARGETS += ../lib/libuspace-rtai.so.0
-TARGETS += ../lib/libuspace-rtai.so
+TARGETS += ../lib/liblinuxcnc-uspace-rtai.so.0
+TARGETS += ../lib/liblinuxcnc-uspace-rtai.so
 endif
 
 ifeq ($(CONFIG_USPACE_XENOMAI),y)
 USPACE_XENOMAI_SRCS := rtapi/uspace_xenomai.cc
 USERSRCS += $(USPACE_XENOMAI_SRCS)
 $(call TOOBJSDEPS, $(USPACE_XENOMAI_SRCS)): EXTRAFLAGS += -fPIC $(XENOMAI_CFLAGS)
-../lib/libuspace-xenomai.so.0: $(call TOOBJS, $(USPACE_XENOMAI_SRCS))
+../lib/liblinuxcnc-uspace-xenomai.so.0: $(call TOOBJS, $(USPACE_XENOMAI_SRCS))
 	$(ECHO) Linking $(notdir $@)
 	$(Q)$(CXX) -shared $(LDFLAGS) -o $@ $^ $(XENOMAI_LDFLAGS) -Wl,-soname,$(notdir $@)
-TARGETS += ../lib/libuspace-xenomai.so.0
-TARGETS += ../lib/libuspace-xenomai.so
+TARGETS += ../lib/liblinuxcnc-uspace-xenomai.so.0
+TARGETS += ../lib/liblinuxcnc-uspace-xenomai.so
 endif
 
 ifeq ($(CONFIG_USPACE_XENOMAI_EVL),y)
 USPACE_XENOMAI_EVL_SRCS := rtapi/uspace_xenomai_evl.cc
 USERSRCS += $(USPACE_XENOMAI_EVL_SRCS)
 $(call TOOBJSDEPS, $(USPACE_XENOMAI_EVL_SRCS)): EXTRAFLAGS += -fPIC $(XENOMAI_EVL_CFLAGS)
-../lib/libuspace-xenomai-evl.so.0: $(call TOOBJS, $(USPACE_XENOMAI_EVL_SRCS))
+../lib/liblinuxcnc-uspace-xenomai-evl.so.0: $(call TOOBJS, $(USPACE_XENOMAI_EVL_SRCS))
 	$(ECHO) Linking $(notdir $@)
 	$(Q)$(CXX) -shared $(LDFLAGS) -o $@ $^ $(XENOMAI_EVL_LDFLAGS) -Wl,-soname,$(notdir $@)
-TARGETS += ../lib/libuspace-xenomai-evl.so.0
-TARGETS += ../lib/libuspace-xenomai-evl.so
+TARGETS += ../lib/liblinuxcnc-uspace-xenomai-evl.so.0
+TARGETS += ../lib/liblinuxcnc-uspace-xenomai-evl.so
 endif

--- a/src/rtapi/Submakefile
+++ b/src/rtapi/Submakefile
@@ -32,6 +32,7 @@ $(patsubst ./rtapi/%,../include/%,$(RTAPIINCS)): ../include/%.h: ./rtapi/%.h
 ifeq ($(BUILD_SYS),uspace)
 
 RTAPI_APP_SRCS := \
+	rtapi/uspace_rtapi_main.cc \
 	rtapi/uspace_rtapi_app.cc \
 	rtapi/uspace_rtapi_parport.cc \
 	rtapi/uspace_rtapi_string.c \
@@ -43,9 +44,18 @@ $(call TOOBJSDEPS, $(RTAPI_APP_SRCS)): EXTRAFLAGS += -DSIM \
 	-UULAPI -DRTAPI -pthread
 ../bin/rtapi_app: $(call TOOBJS, $(RTAPI_APP_SRCS))
 	$(ECHO) Linking $(notdir $@)
-	$(Q)$(CXX) -rdynamic -o $@ $^ $(LIBDL) -pthread -lrt $(LIBUDEV_LIBS) -ldl $(LDFLAGS)
+	$(Q)$(CXX) -rdynamic -o $@ $^ $(LIBDL) -pthread -lrt -lfmt $(LIBUDEV_LIBS) -ldl $(LDFLAGS)
 TARGETS += ../bin/rtapi_app
 endif
+
+USPACE_POSIX_SRCS := rtapi/uspace_posix.cc
+USERSRCS += $(USPACE_POSIX_SRCS)
+$(call TOOBJSDEPS, $(USPACE_POSIX_SRCS)): EXTRAFLAGS += -pthread -fPIC
+../lib/libuspace-posix.so.0: $(call TOOBJS, $(USPACE_POSIX_SRCS))
+	$(ECHO) Linking $(notdir $@)
+	$(Q)$(CXX) -shared $(LDFLAGS) -o $@ $^ -Wl,-soname,$(notdir $@)
+TARGETS += ../lib/libuspace-posix.so.0
+TARGETS += ../lib/libuspace-posix.so
 
 ifeq ($(CONFIG_USPACE_RTAI),y)
 USPACE_RTAI_SRCS := rtapi/uspace_rtai.cc

--- a/src/rtapi/Submakefile
+++ b/src/rtapi/Submakefile
@@ -46,7 +46,6 @@ $(call TOOBJSDEPS, $(RTAPI_APP_SRCS)): EXTRAFLAGS += -DSIM \
 	$(ECHO) Linking $(notdir $@)
 	$(Q)$(CXX) -rdynamic -o $@ $^ $(LIBDL) -pthread -lrt -lfmt $(LIBUDEV_LIBS) -ldl $(LDFLAGS)
 TARGETS += ../bin/rtapi_app
-endif
 
 USPACE_POSIX_SRCS := rtapi/uspace_posix.cc
 USERSRCS += $(USPACE_POSIX_SRCS)
@@ -56,6 +55,8 @@ $(call TOOBJSDEPS, $(USPACE_POSIX_SRCS)): EXTRAFLAGS += -pthread -fPIC
 	$(Q)$(CXX) -shared $(LDFLAGS) -o $@ $^ -Wl,-soname,$(notdir $@)
 TARGETS += ../lib/liblinuxcnc-uspace-posix.so.0
 TARGETS += ../lib/liblinuxcnc-uspace-posix.so
+
+endif
 
 ifeq ($(CONFIG_USPACE_RTAI),y)
 USPACE_RTAI_SRCS := rtapi/uspace_rtai.cc

--- a/src/rtapi/rtapi_pci.cc
+++ b/src/rtapi/rtapi_pci.cc
@@ -34,7 +34,7 @@
 #include <rtapi.h>
 #include <rtapi_pci.h>
 #include <rtapi_firmware.h>
-#include "rtapi_uspace.hh"
+#include "uspace_rtapi_app.hh"
 
 #include <dirent.h>
 #include <errno.h>

--- a/src/rtapi/uspace_common.h
+++ b/src/rtapi/uspace_common.h
@@ -116,7 +116,7 @@ shmget_again:
    */
   /* ensure the segment is owned by user, not root */
   if(geteuid() == 0) {
-    stat.shm_perm.uid = ruid;
+    stat.shm_perm.uid = WithRoot::getRuid();
     res = shmctl(shmem->id, IPC_SET, &stat);
     if(res < 0) perror("shmctl IPC_SET");
   }

--- a/src/rtapi/uspace_common.h
+++ b/src/rtapi/uspace_common.h
@@ -21,6 +21,7 @@
 #include <sys/time.h>
 #include <time.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <sys/utsname.h>
 #include <string.h>
 #include <unistd.h>
@@ -39,7 +40,7 @@ static msg_level_t msg_level = RTAPI_MSG_ERR;	/* message printing level */
 #include "config.h"
 
 #ifdef RTAPI
-#include "rtapi_uspace.hh"
+#include "uspace_rtapi_app.hh"
 #endif
 
 typedef struct {

--- a/src/rtapi/uspace_posix.cc
+++ b/src/rtapi/uspace_posix.cc
@@ -27,8 +27,8 @@
 #endif
 
 namespace {
-struct PosixTask : rtapi_task {
-    PosixTask() : rtapi_task{}, thr{} {
+struct PosixTask : RtapiTask {
+    PosixTask() : RtapiTask{}, thr{} {
     }
 
     pthread_t thr; /* thread's context */
@@ -42,7 +42,7 @@ struct PosixApp : RtapiApp {
         }
     }
 
-    struct rtapi_task *do_task_new() {
+    RtapiTask *do_task_new() {
         return new PosixTask;
     }
 
@@ -138,14 +138,14 @@ struct PosixApp : RtapiApp {
     }
 
     long long task_pll_get_reference(void) {
-        struct rtapi_task *task = reinterpret_cast<rtapi_task *>(pthread_getspecific(key));
+        RtapiTask *task = reinterpret_cast<RtapiTask *>(pthread_getspecific(key));
         if (!task)
             return 0;
         return task->nextstart.tv_sec * 1000000000LL + task->nextstart.tv_nsec;
     }
 
     int task_pll_set_correction(long value) {
-        struct rtapi_task *task = reinterpret_cast<rtapi_task *>(pthread_getspecific(key));
+        RtapiTask *task = reinterpret_cast<RtapiTask *>(pthread_getspecific(key));
         if (!task)
             return -EINVAL;
         if (value > task->pll_correction_limit)
@@ -160,7 +160,7 @@ struct PosixApp : RtapiApp {
         if (do_thread_lock)
             pthread_mutex_unlock(&thread_lock);
         pthread_testcancel();
-        struct rtapi_task *task = reinterpret_cast<rtapi_task *>(pthread_getspecific(key));
+        RtapiTask *task = reinterpret_cast<RtapiTask *>(pthread_getspecific(key));
         rtapi_timespec_advance(task->nextstart, task->nextstart, task->period + task->pll_correction);
         struct timespec now;
         clock_gettime(CLOCK_MONOTONIC, &now);
@@ -195,7 +195,7 @@ struct PosixApp : RtapiApp {
     }
 
     int task_self() {
-        struct rtapi_task *task = reinterpret_cast<rtapi_task *>(pthread_getspecific(key));
+        RtapiTask *task = reinterpret_cast<RtapiTask *>(pthread_getspecific(key));
         if (!task)
             return -EINVAL;
         return task->id;

--- a/src/rtapi/uspace_posix.cc
+++ b/src/rtapi/uspace_posix.cc
@@ -1,4 +1,4 @@
-/* Copyright (C) 2016 Jeff Epler <jepler@unpythonic.net>
+/* Copyright (C) 2006-2014 Jeff Epler <jepler@unpythonic.net>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -14,43 +14,45 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
+
 #include "config.h"
 #include "rtapi.h"
 #include "uspace_rtapi_app.hh"
-#include <pthread.h>
-#include <errno.h>
 #include <stdio.h>
-#include <cstring>
+#include <stdlib.h>
+#include <string.h>
 #include <stdexcept>
 #ifdef HAVE_SYS_IO_H
 #include <sys/io.h>
 #endif
 
 namespace {
-struct XenomaiTask : rtapi_task {
-    XenomaiTask() : rtapi_task{}, cancel{}, thr{} {
+struct PosixTask : rtapi_task {
+    PosixTask() : rtapi_task{}, thr{} {
     }
-    std::atomic_int cancel;
-    pthread_t thr;
+
+    pthread_t thr; /* thread's context */
 };
 
-
-struct XenomaiApp : RtapiApp {
-    XenomaiApp() : RtapiApp(SCHED_FIFO) {
+struct PosixApp : RtapiApp {
+    PosixApp(int policy = SCHED_FIFO) : RtapiApp(policy), do_thread_lock(policy != SCHED_FIFO) {
         pthread_once(&key_once, init_key);
+        if (do_thread_lock) {
+            pthread_once(&lock_once, init_lock);
+        }
     }
 
     struct rtapi_task *do_task_new() {
-        return new XenomaiTask;
+        return new PosixTask;
     }
 
     int task_delete(int id) {
-        auto task = ::rtapi_get_task<XenomaiTask>(id);
+        auto task = ::rtapi_get_task<PosixTask>(id);
         if (!task)
             return -EINVAL;
 
-        task->cancel = 1;
-        pthread_join(task->thr, nullptr);
+        pthread_cancel(task->thr);
+        pthread_join(task->thr, 0);
         task->magic = 0;
         task_array[id] = 0;
         delete task;
@@ -58,7 +60,7 @@ struct XenomaiApp : RtapiApp {
     }
 
     int task_start(int task_id, unsigned long period_nsec) {
-        auto task = ::rtapi_get_task<XenomaiTask>(task_id);
+        auto task = ::rtapi_get_task<PosixTask>(task_id);
         if (!task)
             return -EINVAL;
 
@@ -89,13 +91,19 @@ struct XenomaiApp : RtapiApp {
             const static int rt_cpu_number = find_rt_cpu_number();
             rtapi_print_msg(RTAPI_MSG_INFO, "rt_cpu_number = %i\n", rt_cpu_number);
             if (rt_cpu_number != -1) {
+#ifdef __FreeBSD__
+                cpuset_t cpuset;
+#else
                 cpu_set_t cpuset;
+#endif
                 CPU_ZERO(&cpuset);
                 CPU_SET(rt_cpu_number, &cpuset);
                 if ((ret = pthread_attr_setaffinity_np(&attr, sizeof(cpuset), &cpuset)) != 0)
                     return -ret;
             }
         }
+        if (do_thread_lock)
+            pthread_mutex_lock(&thread_lock);
         if ((ret = pthread_create(&task->thr, &attr, &wrapper, reinterpret_cast<void *>(task))) != 0)
             return -ret;
 
@@ -103,23 +111,20 @@ struct XenomaiApp : RtapiApp {
     }
 
     static void *wrapper(void *arg) {
-        auto task = reinterpret_cast<XenomaiTask *>(arg);
+        auto task = reinterpret_cast<PosixTask *>(arg);
+
         pthread_setspecific(key, arg);
+        set_namef("rtapi_app:T#%d", task->id);
 
         struct timespec now;
         clock_gettime(CLOCK_MONOTONIC, &now);
-
-        // originally, I used pthread_make_periodic_np here, and
-        // pthread_wait_np in wait(), but in about 1 run in 50 this led to
-        // "xenomai: watchdog triggered" and rtapi_app was killed.
-        //
-        // encountered on: 3.18.20-xenomai-2.6.5 with a 2-thread SMP system
         rtapi_timespec_advance(task->nextstart, now, task->period + task->pll_correction);
 
+        /* call the task function with the task argument */
         (task->taskcode)(task->arg);
 
         rtapi_print("ERROR: reached end of wrapper for task %d\n", task->id);
-        return nullptr;
+        return NULL;
     }
 
     int task_pause(int task_id) {
@@ -152,11 +157,10 @@ struct XenomaiApp : RtapiApp {
     }
 
     void wait() {
-        int task_id = task_self();
-        auto task = ::rtapi_get_task<XenomaiTask>(task_id);
-        if (task->cancel) {
-            pthread_exit(nullptr);
-        }
+        if (do_thread_lock)
+            pthread_mutex_unlock(&thread_lock);
+        pthread_testcancel();
+        struct rtapi_task *task = reinterpret_cast<rtapi_task *>(pthread_getspecific(key));
         rtapi_timespec_advance(task->nextstart, task->nextstart, task->period + task->pll_correction);
         struct timespec now;
         clock_gettime(CLOCK_MONOTONIC, &now);
@@ -168,6 +172,8 @@ struct XenomaiApp : RtapiApp {
             if (res < 0)
                 perror("clock_nanosleep");
         }
+        if (do_thread_lock)
+            pthread_mutex_lock(&thread_lock);
     }
 
     unsigned char do_inb(unsigned int port) {
@@ -202,10 +208,18 @@ struct XenomaiApp : RtapiApp {
         return task->id;
     }
 
+    bool do_thread_lock;
+
     static pthread_once_t key_once;
     static pthread_key_t key;
     static void init_key(void) {
         pthread_key_create(&key, NULL);
+    }
+
+    static pthread_once_t lock_once;
+    static pthread_mutex_t thread_lock;
+    static void init_lock(void) {
+        pthread_mutex_init(&thread_lock, NULL);
     }
 
     long long do_get_time() {
@@ -220,16 +234,20 @@ struct XenomaiApp : RtapiApp {
     }
 };
 
-pthread_once_t XenomaiApp::key_once;
-pthread_key_t XenomaiApp::key;
+pthread_once_t PosixApp::key_once = PTHREAD_ONCE_INIT;
+pthread_once_t PosixApp::lock_once = PTHREAD_ONCE_INIT;
+pthread_key_t PosixApp::key;
+pthread_mutex_t PosixApp::thread_lock;
+
 } // namespace
 
 extern "C" RtapiApp *make(int policy);
 
 RtapiApp *make(int policy) {
-    if (policy != SCHED_FIFO) {
-        throw std::invalid_argument("Only SCHED_FIFO allowed");
+    if (policy == SCHED_OTHER) {
+        rtapi_print_msg(RTAPI_MSG_ERR, "Note: Using POSIX non-realtime\n");
+    } else {
+        rtapi_print_msg(RTAPI_MSG_ERR, "Note: Using POSIX realtime\n");
     }
-    rtapi_print_msg(RTAPI_MSG_ERR, "Note: Using XENOMAI (posix-skin) realtime\n");
-    return new XenomaiApp();
+    return new PosixApp(policy);
 }

--- a/src/rtapi/uspace_posix.cc
+++ b/src/rtapi/uspace_posix.cc
@@ -194,13 +194,6 @@ struct PosixApp : RtapiApp {
 #endif
     }
 
-    int run_threads(int fd, int (*callback)(int fd)) {
-        while (callback(fd)) {
-            /* nothing */
-        }
-        return 0;
-    }
-
     int task_self() {
         struct rtapi_task *task = reinterpret_cast<rtapi_task *>(pthread_getspecific(key));
         if (!task)

--- a/src/rtapi/uspace_rtai.cc
+++ b/src/rtapi/uspace_rtai.cc
@@ -175,13 +175,6 @@ struct RtaiApp : RtapiApp {
 #endif
     }
 
-    int run_threads(int fd, int (*callback)(int fd)) {
-        while (callback(fd)) {
-            /* nothing */
-        }
-        return 0;
-    }
-
     int task_self() {
         struct rtapi_task *task = reinterpret_cast<rtapi_task *>(pthread_getspecific(key));
         if (!task)

--- a/src/rtapi/uspace_rtai.cc
+++ b/src/rtapi/uspace_rtai.cc
@@ -29,15 +29,15 @@
 namespace {
 RtapiApp *app;
 
-struct RtaiTask : rtapi_task {
-    RtaiTask() : rtapi_task{}, cancel{}, rt_task{}, thr{} {
+struct RtaiTask : RtapiTask {
+    RtaiTask() : RtapiTask{}, cancel{}, rt_task{}, thr{} {
     }
     std::atomic_int cancel;
     RT_TASK *rt_task;
     pthread_t thr;
 };
 
-template <class T = rtapi_task> T *get_task(int task_id) {
+template <class T = RtapiTask> T *get_task(int task_id) {
     return static_cast<T *>(RtapiApp::get_task(task_id));
 }
 
@@ -47,7 +47,7 @@ struct RtaiApp : RtapiApp {
         pthread_once(&key_once, init_key);
     }
 
-    struct rtapi_task *do_task_new() {
+    RtapiTask *do_task_new() {
         return new RtaiTask;
     }
 
@@ -176,7 +176,7 @@ struct RtaiApp : RtapiApp {
     }
 
     int task_self() {
-        struct rtapi_task *task = reinterpret_cast<rtapi_task *>(pthread_getspecific(key));
+        RtapiTask *task = reinterpret_cast<RtapiTask *>(pthread_getspecific(key));
         if (!task)
             return -EINVAL;
         return task->id;

--- a/src/rtapi/uspace_rtai.cc
+++ b/src/rtapi/uspace_rtai.cc
@@ -1,28 +1,44 @@
+/* Copyright (C) 2016 Jeff Epler <jepler@unpythonic.net>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
 #include "config.h"
 #include "rtapi.h"
-#include "rtapi_uspace.hh"
+#include "uspace_rtapi_app.hh"
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wnarrowing"
 #include <rtai_lxrt.h>
 #pragma GCC diagnostic pop
+#include <stdexcept>
 #ifdef HAVE_SYS_IO_H
 #include <sys/io.h>
 #endif
 
-namespace
-{
+namespace {
 RtapiApp *app;
 
 struct RtaiTask : rtapi_task {
-    RtaiTask() : rtapi_task{}, cancel{}, rt_task{}, thr{} {}
+    RtaiTask() : rtapi_task{}, cancel{}, rt_task{}, thr{} {
+    }
     std::atomic_int cancel;
     RT_TASK *rt_task;
     pthread_t thr;
 };
 
-template<class T=rtapi_task>
-T *get_task(int task_id) {
-    return static_cast<T*>(RtapiApp::get_task(task_id));
+template <class T = rtapi_task> T *get_task(int task_id) {
+    return static_cast<T *>(RtapiApp::get_task(task_id));
 }
 
 
@@ -31,13 +47,14 @@ struct RtaiApp : RtapiApp {
         pthread_once(&key_once, init_key);
     }
 
-    RtaiTask *do_task_new() {
+    struct rtapi_task *do_task_new() {
         return new RtaiTask;
     }
 
     int task_delete(int id) {
         auto task = ::get_task<RtaiTask>(id);
-        if(!task) return -EINVAL;
+        if (!task)
+            return -EINVAL;
 
         task->cancel = 1;
         pthread_join(task->thr, nullptr);
@@ -49,7 +66,8 @@ struct RtaiApp : RtapiApp {
 
     int task_start(int task_id, unsigned long period_nsec) {
         auto task = ::get_task<RtaiTask>(task_id);
-        if(!task) return -EINVAL;
+        if (!task)
+            return -EINVAL;
 
         task->period = period_nsec;
         struct sched_param param;
@@ -62,30 +80,30 @@ struct RtaiApp : RtapiApp {
 
         int ret;
         pthread_attr_t attr;
-        if((ret = pthread_attr_init(&attr)) != 0)
+        if ((ret = pthread_attr_init(&attr)) != 0)
             return -ret;
-        if((ret = pthread_attr_setstacksize(&attr, task->stacksize)) != 0)
+        if ((ret = pthread_attr_setstacksize(&attr, task->stacksize)) != 0)
             return -ret;
-        if((ret = pthread_attr_setschedpolicy(&attr, policy)) != 0)
+        if ((ret = pthread_attr_setschedpolicy(&attr, policy)) != 0)
             return -ret;
-        if((ret = pthread_attr_setschedparam(&attr, &param)) != 0)
+        if ((ret = pthread_attr_setschedparam(&attr, &param)) != 0)
             return -ret;
-        if((ret = pthread_attr_setinheritsched(&attr, PTHREAD_EXPLICIT_SCHED)) != 0)
+        if ((ret = pthread_attr_setinheritsched(&attr, PTHREAD_EXPLICIT_SCHED)) != 0)
             return -ret;
-        if((ret = pthread_create(&task->thr, &attr, &wrapper, reinterpret_cast<void*>(task))) != 0)
+        if ((ret = pthread_create(&task->thr, &attr, &wrapper, reinterpret_cast<void *>(task))) != 0)
             return -ret;
 
         return 0;
     }
 
     static void *wrapper(void *arg) {
-        auto task = reinterpret_cast<RtaiTask*>(arg);
+        auto task = reinterpret_cast<RtaiTask *>(arg);
         pthread_setspecific(key, arg);
-        
-        int nprocs = sysconf( _SC_NPROCESSORS_ONLN );
-        int cpus_allowed = 1 << (nprocs-1); //Use last CPU as default
+
+        int nprocs = sysconf(_SC_NPROCESSORS_ONLN);
+        int cpus_allowed = 1 << (nprocs - 1); //Use last CPU as default
         const static int rt_cpu_number = find_rt_cpu_number();
-        if(rt_cpu_number != -1) {
+        if (rt_cpu_number != -1) {
             rtapi_print_msg(RTAPI_MSG_INFO, "rt_cpu_number = %i\n", rt_cpu_number);
             cpus_allowed = 1 << rt_cpu_number;
         }
@@ -96,7 +114,7 @@ struct RtaiApp : RtapiApp {
         rt_task_use_fpu(task->rt_task, 1);
         rt_make_hard_real_time();
         rt_task_make_periodic_relative_ns(task->rt_task, task->period, task->period);
-        (task->taskcode) (task->arg);
+        (task->taskcode)(task->arg);
 
         rtapi_print("ERROR: reached end of wrapper for task %d\n", task->id);
         rt_make_soft_real_time();
@@ -105,13 +123,15 @@ struct RtaiApp : RtapiApp {
 
     int task_pause(int task_id) {
         auto task = ::get_task<RtaiTask>(task_id);
-        if(!task) return -EINVAL;
+        if (!task)
+            return -EINVAL;
         return rt_task_suspend(task->rt_task);
     }
 
     int task_resume(int task_id) {
         auto task = ::get_task<RtaiTask>(task_id);
-        if(!task) return -EINVAL;
+        if (!task)
+            return -EINVAL;
         return rt_task_resume(task->rt_task);
     }
 
@@ -129,11 +149,12 @@ struct RtaiApp : RtapiApp {
     void wait() {
         int task_id = task_self();
         auto task = ::get_task<RtaiTask>(task_id);
-        if(task->cancel) {
+        if (task->cancel) {
             rt_make_soft_real_time();
             pthread_exit(nullptr);
         }
-        if(rt_task_wait_period() < 0) unexpected_realtime_delay(task);
+        if (rt_task_wait_period() < 0)
+            unexpected_realtime_delay(task);
     }
 
     unsigned char do_inb(unsigned int port) {
@@ -149,19 +170,22 @@ struct RtaiApp : RtapiApp {
 #ifdef HAVE_SYS_IO_H
         return outb(val, port);
 #else
+        (void)val;
         (void)port;
-        return 0;
 #endif
     }
 
     int run_threads(int fd, int (*callback)(int fd)) {
-        while(callback(fd)) { /* nothing */ }
+        while (callback(fd)) {
+            /* nothing */
+        }
         return 0;
     }
 
     int task_self() {
-        struct rtapi_task *task = reinterpret_cast<rtapi_task*>(pthread_getspecific(key));
-        if(!task) return -EINVAL;
+        struct rtapi_task *task = reinterpret_cast<rtapi_task *>(pthread_getspecific(key));
+        if (!task)
+            return -EINVAL;
         return task->id;
     }
 
@@ -190,11 +214,14 @@ struct RtaiApp : RtapiApp {
 
 pthread_once_t RtaiApp::key_once;
 pthread_key_t RtaiApp::key;
-}
+} // namespace
 
-extern "C" RtapiApp *make();
+extern "C" RtapiApp *make(int policy);
 
-RtapiApp *make() {
+RtapiApp *make(int policy) {
+    if (policy != SCHED_FIFO) {
+        throw std::invalid_argument("Only SCHED_FIFO allowed");
+    }
     rtapi_print_msg(RTAPI_MSG_ERR, "Note: Using LXRT realtime\n");
-    return app = new RtaiApp;
+    return app = new RtaiApp();
 }

--- a/src/rtapi/uspace_rtapi_app.cc
+++ b/src/rtapi/uspace_rtapi_app.cc
@@ -48,6 +48,8 @@ rtapi_task::rtapi_task()
 {
 }
 
+struct rtapi_task *RtapiApp::task_array[MAX_TASKS];
+
 /* Priority functions.  Uspace uses POSIX task priorities. */
 
 int RtapiApp::prio_highest() const {

--- a/src/rtapi/uspace_rtapi_app.cc
+++ b/src/rtapi/uspace_rtapi_app.cc
@@ -23,7 +23,7 @@
 #include <string.h>
 
 std::atomic_int WithRoot::level;
-uid_t euid, ruid;
+uid_t WithRoot::ruid, WithRoot::euid;
 
 WithRoot::WithRoot() {
     if (!level++) {
@@ -39,6 +39,11 @@ WithRoot::~WithRoot() {
         setfsuid(ruid);
 #endif
     }
+}
+
+void WithRoot::init(uid_t ruid_ini, uid_t euid_ini){
+    ruid=ruid_ini;
+    euid=euid_ini;
 }
 
 rtapi_task::rtapi_task()

--- a/src/rtapi/uspace_rtapi_app.cc
+++ b/src/rtapi/uspace_rtapi_app.cc
@@ -41,9 +41,9 @@ WithRoot::~WithRoot() {
     }
 }
 
-void WithRoot::init(uid_t ruid_ini, uid_t euid_ini){
-    ruid=ruid_ini;
-    euid=euid_ini;
+void WithRoot::init(uid_t ruid_ini, uid_t euid_ini) {
+    ruid = ruid_ini;
+    euid = euid_ini;
 }
 
 rtapi_task::rtapi_task()

--- a/src/rtapi/uspace_rtapi_app.cc
+++ b/src/rtapi/uspace_rtapi_app.cc
@@ -234,7 +234,7 @@ out:
     fclose(fp);
 }
 
-int find_rt_cpu_number() {
+int RtapiApp::find_rt_cpu_number() {
     if (getenv("RTAPI_CPU_NUMBER"))
         return atoi(getenv("RTAPI_CPU_NUMBER"));
 
@@ -269,7 +269,7 @@ int find_rt_cpu_number() {
 #endif
 }
 
-void set_namef(const char *fmt, ...) {
+void RtapiApp::set_namef(const char *fmt, ...) {
     char *buf = NULL;
     va_list ap;
 

--- a/src/rtapi/uspace_rtapi_app.cc
+++ b/src/rtapi/uspace_rtapi_app.cc
@@ -15,56 +15,18 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-#include "config.h"
-#include <linuxcnc.h>
-
-#ifdef __linux__
-#include <sys/fsuid.h>
-#endif
-#include <sys/types.h>
-#include <sys/socket.h>
-#include <sys/un.h>
-#include <sys/stat.h>
-#include <fcntl.h>
-#include <unistd.h>
-#include <errno.h>
-#include <dlfcn.h>
-#include <signal.h>
-#include <vector>
-#include <string>
-#include <map>
-#include <algorithm>
-#include <sys/time.h>
-#include <time.h>
-#include <stdlib.h>
-#include <stdio.h>
-#ifdef HAVE_SYS_IO_H
-#include <sys/io.h>
-#endif
-#include <sys/resource.h>
-#include <sys/mman.h>
-#ifdef __linux__
-#include <malloc.h>
-#include <sys/prctl.h>
-#endif
-#ifdef __FreeBSD__
-#include <pthread_np.h>
-#endif
-
-#include <boost/lockfree/queue.hpp>
-
 #include "rtapi.h"
-#include <hal.h>
-#include "hal/hal_priv.h"
-#include "rtapi_uspace.hh"
+#include "uspace_rtapi_app.hh"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 
 std::atomic_int WithRoot::level;
-static uid_t euid, ruid;
-
-#include "rtapi/uspace_common.h"
+uid_t euid, ruid;
 
 WithRoot::WithRoot() {
-    if(!level++) {
+    if (!level++) {
 #ifdef __linux__
         setfsuid(euid);
 #endif
@@ -72,848 +34,39 @@ WithRoot::WithRoot() {
 }
 
 WithRoot::~WithRoot() {
-    if(!--level) {
+    if (!--level) {
 #ifdef __linux__
         setfsuid(ruid);
 #endif
     }
 }
 
-namespace
-{
-RtapiApp &App();
-
-struct message_t {
-    msg_level_t level;
-    char msg[1024-sizeof(level)];
-};
-
-boost::lockfree::queue<message_t, boost::lockfree::capacity<128>>
-rtapi_msg_queue;
-
-static void set_namef(const char *fmt, ...) {
-    char *buf = NULL;
-    va_list ap;
-
-    va_start(ap, fmt);
-    if (vasprintf(&buf, fmt, ap) < 0) {
-        va_end(ap);
-        return;
-    }
-    va_end(ap);
-
-    int res = pthread_setname_np(pthread_self(), buf);
-    if (res) {
-        fprintf(stderr, "pthread_setname_np() failed for %s: %d\n", buf, res);
-    }
-    free(buf);
-}
-
-pthread_t queue_thread;
-void *queue_function(void * /*arg*/) {
-    set_namef("rtapi_app:mesg");
-    // note: can't use anything in this function that requires App() to exist
-    // but it's OK to use functions that aren't safe for realtime (that's the
-    // point of running this in a thread)
-    while(1) {
-        pthread_testcancel();
-        pthread_setcancelstate(PTHREAD_CANCEL_DISABLE, nullptr);
-        rtapi_msg_queue.consume_all([](const message_t &m) {
-            fputs(m.msg, m.level == RTAPI_MSG_ALL ? stdout : stderr);
-        });
-        pthread_setcancelstate(PTHREAD_CANCEL_ENABLE, nullptr);
-        struct timespec ts = {0, 10000000};
-        rtapi_clock_nanosleep(CLOCK_MONOTONIC, 0, &ts, NULL, NULL);
-    }
-    return nullptr;
-}
-}
-
-static int sim_rtapi_run_threads(int fd, int (*callback)(int fd));
-
-using namespace std;
-
-template<class T> T DLSYM(void *handle, const string &name) {
-	return (T)(dlsym(handle, name.c_str()));
-}
-
-template<class T> T DLSYM(void *handle, const char *name) {
-	return (T)(dlsym(handle, name));
-}
-
-static std::map<string, void*> modules;
-
-static int instance_count = 0;
-static int force_exit = 0;
-
-static int do_newinst_cmd(const string& type, const string& name, const string& arg) {
-    void *module = modules["hal_lib"];
-    if(!module) {
-        rtapi_print_msg(RTAPI_MSG_ERR,
-                "newinst: hal_lib is required, but not loaded\n");
-        return -1;
-    }
-
-    hal_comp_t *(*find_comp_by_name)(char*) =
-        DLSYM<hal_comp_t*(*)(char *)>(module, "halpr_find_comp_by_name");
-    if(!find_comp_by_name) {
-        rtapi_print_msg(RTAPI_MSG_ERR,
-                "newinst: halpr_find_comp_by_name not found\n");
-        return -1;
-    }
-
-    hal_comp_t *comp = find_comp_by_name((char*)type.c_str());
-    if(!comp) {
-        rtapi_print_msg(RTAPI_MSG_ERR,
-                "newinst: component %s not found\n", type.c_str());
-        return -1;
-    }
-
-    return comp->make((char*)name.c_str(), (char*)arg.c_str());
-}
-
-static int do_one_item(char item_type_char, const string &param_name, const string &param_value, void *vitem, int idx=0) {
-    char *endp;
-    switch(item_type_char) {
-        case 'l': {
-            long *litem = *(long**) vitem;
-            litem[idx] = strtol(param_value.c_str(), &endp, 0);
-	    if(*endp) {
-                rtapi_print_msg(RTAPI_MSG_ERR,
-                        "`%s' invalid for parameter `%s'",
-                        param_value.c_str(), param_name.c_str());
-                return -1;
-            }
-            return 0;
-        }
-        case 'i': {
-            int *iitem = *(int**) vitem;
-            iitem[idx] = strtol(param_value.c_str(), &endp, 0);
-	    if(*endp) {
-                rtapi_print_msg(RTAPI_MSG_ERR,
-                        "`%s' invalid for parameter `%s'",
-                        param_value.c_str(), param_name.c_str());
-                return -1;
-            }
-            return 0;
-        }
-        case 's': {
-            char **sitem = *(char***) vitem;
-            sitem[idx] = strdup(param_value.c_str());
-            return 0;
-        }
-        default:
-            rtapi_print_msg(RTAPI_MSG_ERR,
-                    "%s: Invalid type character `%c'\n",
-                    param_name.c_str(), item_type_char);
-            return -1;
-        }
-    return 0;
-}
-
-void remove_quotes(string &s) {
-    s.erase(remove_copy(s.begin(), s.end(), s.begin(), '"'), s.end());
-}
-
-static int do_comp_args(void *module, vector<string> args) {
-    for(unsigned i=1; i < args.size(); i++) {
-        string &s = args[i];
-	remove_quotes(s);
-        size_t idx = s.find('=');
-        if(idx == string::npos) {
-            rtapi_print_msg(RTAPI_MSG_ERR, "Invalid parameter `%s'\n",
-                    s.c_str());
-            return -1;
-        }
-        string param_name(s, 0, idx);
-        string param_value(s, idx+1);
-        void *item=DLSYM<void*>(module, "rtapi_info_address_" + param_name);
-        if(!item) {
-	    rtapi_print_msg(RTAPI_MSG_ERR,
-                    "Unknown parameter `%s'\n", s.c_str());
-            return -1;
-        }
-        char **item_type=DLSYM<char**>(module, "rtapi_info_type_" + param_name);
-        if(!item_type || !*item_type) {
-	    rtapi_print_msg(RTAPI_MSG_ERR,
-                    "Unknown parameter `%s' (type information missing)\n",
-                    s.c_str());
-            return -1;
-        }
-
-        int*max_size_ptr=DLSYM<int*>(module, "rtapi_info_size_" + param_name);
-
-        char item_type_char = **item_type;
-        if(max_size_ptr) {
-            int max_size = *max_size_ptr;
-            size_t idx = 0;
-            int i = 0;
-            while(idx != string::npos) {
-                if(i == max_size) {
-                    rtapi_print_msg(RTAPI_MSG_ERR,
-                            "%s: can only take %d arguments\n",
-                            s.c_str(), max_size);
-                    return -1;
-                }
-                size_t idx1 = param_value.find(",", idx);
-                string substr(param_value, idx, idx1 - idx);
-                int result = do_one_item(item_type_char, s, substr, item, i);
-                if(result != 0) return result;
-                i++;
-                idx = idx1 == string::npos ? idx1 : idx1 + 1;
-            }
-        } else {
-            int result = do_one_item(item_type_char, s, param_value, item);
-            if(result != 0) return result;
-        }
-    }
-    return 0;
-}
-
-static int do_load_cmd(const string& name, const vector<string>& args) {
-    void *w = modules[name];
-    if(w == NULL) {
-        char what[LINELEN+1];
-        snprintf(what, LINELEN, "%s/%s.so", EMC2_RTLIB_DIR, name.c_str());
-        void *module = modules[name] = dlopen(what, RTLD_GLOBAL | RTLD_NOW);
-        if(!module) {
-            rtapi_print_msg(RTAPI_MSG_ERR, "%s: dlopen: %s\n", name.c_str(), dlerror());
-            modules.erase(name);
-            return -1;
-        }
-	/// XXX handle arguments
-        int (*start)(void) = DLSYM<int(*)(void)>(module, "rtapi_app_main");
-        if(!start) {
-            rtapi_print_msg(RTAPI_MSG_ERR, "%s: dlsym: %s\n", name.c_str(), dlerror());
-            dlclose(module);
-            modules.erase(name);
-            return -1;
-        }
-        if(!DLSYM<void(*)(void)>(module, "rtapi_app_exit")) {
-            rtapi_print_msg(RTAPI_MSG_ERR, "%s: component is missing rtapi_app_exit\n", name.c_str());
-            dlclose(module);
-            modules.erase(name);
-            return -1;
-        }
-        int result;
-
-        result = do_comp_args(module, args);
-        if(result < 0) {
-            dlclose(module);
-            modules.erase(name);
-            return -1;
-        }
-
-        if ((result=start()) < 0) {
-            rtapi_print_msg(RTAPI_MSG_ERR, "%s: rtapi_app_main: %s (%d)\n",
-                name.c_str(), strerror(-result), result);
-            dlclose(module);
-            modules.erase(name);
-	    return result;
-        } else {
-            instance_count ++;
-	    return 0;
-        }
-    } else {
-        rtapi_print_msg(RTAPI_MSG_ERR, "%s: already exists\n", name.c_str());
-        return -1;
-    }
-}
-
-static int do_unload_cmd(const string& name) {
-    void *w = modules[name];
-    if(w == NULL) {
-        rtapi_print_msg(RTAPI_MSG_ERR, "%s: not loaded\n", name.c_str());
-	return -1;
-    } else {
-        void (*stop)(void) = DLSYM<void(*)(void)>(w, "rtapi_app_exit");
-	if(stop) stop();
-	modules.erase(modules.find(name));
-        dlclose(w);
-        instance_count --;
-    }
-    return 0;
-}
-
-static int do_debug_cmd(const string& value) {
-    try{
-        int new_level = stoi(value);
-        if (new_level < 0 || new_level > 5){
-            rtapi_print_msg(RTAPI_MSG_ERR, "Debug level must be >=0 and <= 5\n");
-            return -EINVAL;
-        }
-        return rtapi_set_msg_level(new_level);
-    }catch(invalid_argument &e){
-        //stoi will throw an exception if parsing is not possible
-        rtapi_print_msg(RTAPI_MSG_ERR, "Debug level is not a number\n");
-        return -EINVAL;
-    }
-}
-
-struct ReadError : std::exception {};
-struct WriteError : std::exception {};
-
-static int read_number(int fd) {
-    int r = 0, neg=1;
-    char ch;
-
-    while(1) {
-        int res = read(fd, &ch, 1);
-        if(res != 1) return -1;
-        if(ch == '-') neg = -1;
-        else if(ch == ' ') return r * neg;
-        else r = 10 * r + ch - '0';
-    }
-}
-
-static string read_string(int fd) {
-    int len = read_number(fd);
-    if(len < 0)
-        throw ReadError();
-    if(!len)
-        return string();
-    string str(len, 0);
-    if(read(fd, str.data(), len) != len)
-        throw ReadError();
-    return str;
-}
-
-static vector<string> read_strings(int fd) {
-    vector<string> result;
-    int count = read_number(fd);
-    if(count < 0)
-        return result;
-    for(int i=0; i<count; i++) {
-        result.push_back(read_string(fd));
-    }
-    return result;
-}
-
-static void write_number(string &buf, int num) {
-    char numbuf[10];
-    snprintf(numbuf, sizeof(numbuf), "%d ", num);
-    buf = buf + numbuf;
-}
-
-static void write_string(string &buf, const string& s) {
-    write_number(buf, s.size());
-    buf += s;
-}
-
-static void write_strings(int fd, const vector<string>& strings) {
-    string buf;
-    write_number(buf, strings.size());
-    for(unsigned int i=0; i<strings.size(); i++) {
-        write_string(buf, strings[i]);
-    }
-    if(write(fd, buf.data(), buf.size()) != (ssize_t)buf.size()) throw WriteError();
-}
-
-static int handle_command(vector<string> args) {
-    if(args.size() == 0) { return 0; }
-    if(args.size() == 1 && args[0] == "exit") {
-        force_exit = 1;
-        return 0;
-    } else if(args.size() >= 2 && args[0] == "load") {
-        string name = args[1];
-        args.erase(args.begin());
-        return do_load_cmd(name, args);
-    } else if(args.size() == 2 && args[0] == "unload") {
-        return do_unload_cmd(args[1]);
-    } else if(args.size() == 3 && args[0] == "newinst") {
-        return do_newinst_cmd(args[1], args[2], "");
-    } else if(args.size() == 4 && args[0] == "newinst") {
-        return do_newinst_cmd(args[1], args[2], args[3]);
-    } else if(args.size() == 2 && args[0] == "debug") {
-        return do_debug_cmd(args[1]);
-    } else {
-        rtapi_print_msg(RTAPI_MSG_ERR,
-                "Unrecognized command starting with %s\n",
-                args[0].c_str());
-        return -1;
-    }
-}
-
-static int slave(int fd, const vector<string>& args) {
-    try {
-        write_strings(fd, args);
-    }
-    catch (WriteError &e) {
-        rtapi_print_msg(RTAPI_MSG_ERR,
-            "rtapi_app: failed to write to master: %s\n", strerror(errno));
-    }
-
-    int result = read_number(fd);
-    return result;
-}
-
-static int callback(int fd)
-{
-    struct sockaddr_un client_addr;
-    memset(&client_addr, 0, sizeof(client_addr));
-    socklen_t len = sizeof(client_addr);
-    int fd1 = accept(fd, (sockaddr*)&client_addr, &len);
-    if(fd1 < 0) {
-        rtapi_print_msg(RTAPI_MSG_ERR,
-            "rtapi_app: failed to accept connection from slave: %s\n", strerror(errno));
-        return -1;
-    } else {
-        int result;
-        try {
-            result = handle_command(read_strings(fd1));
-        } catch (ReadError &e) {
-            rtapi_print_msg(RTAPI_MSG_ERR,
-                "rtapi_app: failed to read from slave: %s\n", strerror(errno));
-            close(fd1);
-            return -1;
-        }
-        string buf;
-        write_number(buf, result);
-        if(write(fd1, buf.data(), buf.size()) != (ssize_t)buf.size()) {
-            rtapi_print_msg(RTAPI_MSG_ERR,
-                "rtapi_app: failed to write to slave: %s\n", strerror(errno));
-        };
-        close(fd1);
-    }
-    return !force_exit && instance_count > 0;
-}
-
-static pthread_t main_thread{};
-
-static int master(int fd, const vector<string>& args) {
-    main_thread = pthread_self();
-    int result;
-    if((result = pthread_create(&queue_thread, nullptr, &queue_function, nullptr)) != 0) {
-        errno = result;
-        perror("pthread_create (queue function)");
-        return -1;
-    }
-    do_load_cmd("hal_lib", vector<string>());
-    instance_count = 0;
-    App(); // force rtapi_app to be created
-    if(args.size()) {
-        result = handle_command(args);
-        if(result != 0) goto out;
-        if(force_exit || instance_count == 0) goto out;
-    }
-    sim_rtapi_run_threads(fd, callback);
-out:
-    pthread_cancel(queue_thread);
-    pthread_join(queue_thread, nullptr);
-    rtapi_msg_queue.consume_all([](const message_t &m) {
-        fputs(m.msg, m.level == RTAPI_MSG_ALL ? stdout : stderr);
-    });
-    return result;
-}
-
-static std::string
-_get_fifo_path() {
-    std::string s;
-    if(getenv("RTAPI_FIFO_PATH"))
-       s = getenv("RTAPI_FIFO_PATH");
-    else if(getenv("HOME"))
-       s = std::string(getenv("HOME")) + "/.rtapi_fifo";
-    else {
-       rtapi_print_msg(RTAPI_MSG_ERR,
-           "rtapi_app: RTAPI_FIFO_PATH and HOME are unset.  rtapi fifo creation is unsafe.");
-       return NULL;
-    }
-    if(s.size() + 1 > sizeof(sockaddr_un::sun_path)) {
-       rtapi_print_msg(RTAPI_MSG_ERR,
-           "rtapi_app: rtapi fifo path is too long (arch limit %zd): %s",
-               sizeof(sockaddr_un::sun_path), s.c_str());
-       return NULL;
-    }
-    return s;
-}
-
-static const char *
-get_fifo_path() {
-    static std::string path = _get_fifo_path();
-    return path.c_str();
-}
-
-static int
-get_fifo_path(char *buf, size_t bufsize) {
-	int len;
-    const char *s = get_fifo_path();
-    if(!s) return -1;
-    len=snprintf(buf+1, bufsize-1, "%s", s);
-    return len;
-}
-
-int main(int argc, char **argv) {
-    if(getuid() == 0) {
-        char *fallback_uid_str = getenv("RTAPI_UID");
-        int fallback_uid = fallback_uid_str ? atoi(fallback_uid_str) : 0;
-        if(fallback_uid == 0)
-        {
-	    // Cppcheck cannot see EMC2_BIN_DIR when RTAPI is defined, but that
-	    // doesn't happen in uspace.
-            fprintf(stderr,
-                "Refusing to run as root without fallback UID specified\n"
-                "To run under a debugger with I/O, use e.g.,\n"
-                // cppcheck-suppress unknownMacro
-                "    sudo env RTAPI_UID=`id -u` RTAPI_FIFO_PATH=$HOME/.rtapi_fifo gdb " EMC2_BIN_DIR "/rtapi_app\n");
-            exit(1);
-        }
-        if (setreuid(fallback_uid, 0) != 0) { perror("setreuid"); abort(); }
-        fprintf(stderr,
-            "Running with fallback_uid.  getuid()=%d geteuid()=%d\n",
-            getuid(), geteuid());
-    }
-    ruid = getuid();
-    euid = geteuid();
-    if (setresuid(euid, euid, ruid) != 0) { perror("setresuid"); abort(); }
-#ifdef __linux__
-    setfsuid(ruid);
-#endif
-    vector<string> args;
-    for(int i=1; i<argc; i++) { args.push_back(string(argv[i])); }
-
-become_master:
-    int len=0;
-    int fd = socket(PF_UNIX, SOCK_STREAM, 0);
-    if(fd == -1) { perror("socket"); exit(1); }
-
-    int enable = 1;
-    setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &enable, sizeof(enable));
-    struct sockaddr_un addr;
-	memset(&addr, 0x0, sizeof(addr));
-    addr.sun_family = AF_UNIX;
-    if((len=get_fifo_path(addr.sun_path, sizeof(addr.sun_path))) < 0)
-       exit(1);
-	
-	// plus one because we use the abstract namespace, it will show up in
-	// /proc/net/unix prefixed with an @
-    int result = ::bind(fd, (sockaddr*)&addr, len+sizeof(addr.sun_family)+1); 
-
-    if(result == 0) {
-        int result = listen(fd, 10);
-        if(result != 0) { perror("listen"); exit(1); }
-        setsid(); // create a new session if we can...
-        result = master(fd, args);
-        return result;
-    } else if(errno == EADDRINUSE) {
-        struct timeval t0, t1;
-        gettimeofday(&t0, NULL);
-        gettimeofday(&t1, NULL);
-        for(int i=0; i < 3 || (t1.tv_sec < 3 + t0.tv_sec) ; i++) {
-            result = connect(fd, (sockaddr*)&addr, len+sizeof(addr.sun_family)+1);
-            if(result == 0) break;
-            if(i==0) srand48(t0.tv_sec ^ t0.tv_usec);
-            usleep(lrand48() % 100000);
-            gettimeofday(&t1, NULL);
-        }
-        if(result < 0 && errno == ECONNREFUSED) {
-            fprintf(stderr, "Waited 3 seconds for master.  giving up.\n");
-            close(fd);
-            goto become_master;
-        }
-        if(result < 0) { fprintf(stderr, "connect %s: %s", addr.sun_path, strerror(errno)); exit(1); }
-        return slave(fd, args);
-    } else {
-        perror("bind"); exit(1);
-    }
-}
-
-
-/* These structs hold data associated with objects like tasks, etc. */
-/* Task handles are pointers to these structs.                      */
-
-struct rtapi_module {
-  int magic;
-};
-
-#define MODULE_MAGIC  30812
-#define SHMEM_MAGIC   25453
-
-#define MAX_MODULES  64
-#define MODULE_OFFSET 32768
-
 rtapi_task::rtapi_task()
-    : magic{}, id{}, owner{}, uses_fp{}, stacksize{}, prio{},
-      period{}, nextstart{},
-      ratio{}, pll_correction{}, pll_correction_limit{},
-      arg{}, taskcode{}
+    : magic{}, id{}, owner{}, uses_fp{}, stacksize{}, prio{}, period{}, nextstart{}, pll_correction{},
+      pll_correction_limit{}, arg{}, taskcode{}
 
-{}
-
-namespace
 {
-struct PosixTask : rtapi_task
-{
-    PosixTask() : rtapi_task{}, thr{}
-    {}
-
-    pthread_t thr;                /* thread's context */
-};
-
-struct Posix : RtapiApp
-{
-    Posix(int policy = SCHED_FIFO) : RtapiApp(policy), do_thread_lock(policy != SCHED_FIFO) {
-        pthread_once(&key_once, init_key);
-        if(do_thread_lock) {
-            pthread_once(&lock_once, init_lock);
-        }
-    }
-    int task_delete(int id);
-    int task_start(int task_id, unsigned long period_nsec);
-    int task_pause(int task_id);
-    int task_resume(int task_id);
-    int task_self();
-    long long task_pll_get_reference(void);
-    int task_pll_set_correction(long value);
-    void wait();
-    struct rtapi_task *do_task_new() {
-        return new PosixTask;
-    }
-    unsigned char do_inb(unsigned int port);
-    void do_outb(unsigned char value, unsigned int port);
-    int run_threads(int fd, int (*callback)(int fd));
-    static void *wrapper(void *arg);
-    bool do_thread_lock;
-
-    static pthread_once_t key_once;
-    static pthread_key_t key;
-    static void init_key(void) {
-        pthread_key_create(&key, NULL);
-    }
-
-    static pthread_once_t lock_once;
-    static pthread_mutex_t thread_lock;
-    static void init_lock(void) {
-        pthread_mutex_init(&thread_lock, NULL);
-    }
-
-    long long do_get_time(void) {
-        struct timespec ts;
-        clock_gettime(CLOCK_MONOTONIC, &ts);
-        return ts.tv_sec * 1000000000LL + ts.tv_nsec;
-    }
-
-    void do_delay(long ns);
-};
-
-static void signal_handler(int sig, siginfo_t * /*si*/, void * /*uctx*/)
-{
-    switch (sig) {
-    case SIGXCPU:
-        // should not happen - must be handled in RTAPI if enabled
-        rtapi_print_msg(RTAPI_MSG_ERR,
-                        "rtapi_app: BUG: SIGXCPU received - exiting\n");
-        exit(0);
-        break;
-
-    case SIGTERM:
-        rtapi_print_msg(RTAPI_MSG_ERR,
-                        "rtapi_app: SIGTERM - shutting down\n");
-        exit(0);
-        break;
-
-    default: // pretty bad
-        rtapi_print_msg(RTAPI_MSG_ERR,
-                        "rtapi_app: caught signal %d - dumping core\n", sig);
-        sleep(1); // let syslog drain
-        signal(sig, SIG_DFL);
-        // for reasons unknown raise(sig); doesn't lead to core dump file
-        // but this will
-        kill(getpid(), sig);
-        break;
-    }
-    exit(1);
 }
-
-const size_t PRE_ALLOC_SIZE = 1024*1024*32;
-const static struct rlimit unlimited = {RLIM_INFINITY, RLIM_INFINITY};
-static void configure_memory()
-{
-    int res = setrlimit(RLIMIT_MEMLOCK, &unlimited);
-    if(res < 0) perror("setrlimit");
-
-    res = mlockall(MCL_CURRENT | MCL_FUTURE);
-    if(res < 0) perror("mlockall");
-
-#ifdef __linux__
-    /* Turn off malloc trimming.*/
-    if (!mallopt(M_TRIM_THRESHOLD, -1)) {
-        rtapi_print_msg(RTAPI_MSG_WARN,
-                  "mallopt(M_TRIM_THRESHOLD, -1) failed\n");
-    }
-    /* Turn off mmap usage. */
-    if (!mallopt(M_MMAP_MAX, 0)) {
-        rtapi_print_msg(RTAPI_MSG_WARN,
-                  "mallopt(M_MMAP_MAX, -1) failed\n");
-    }
-#endif
-    /*
-     * The following code seems pointless, but there is a non-observable effect
-     * in the allocation and loop.
-     *
-     * The malloc() is forced to set brk() because mmap() allocation is
-     * disabled in a call to mallopt() above. All touched pages become resident
-     * and locked in the loop because of above mlockall() call (see notes in
-     * mlockall(2)). The mallopt() trim setting prevents the brk() from being
-     * reduced after free(), effectively creating an open space for future
-     * allocations that will not generate page faults.
-     *
-     * The qualifier 'volatile' on the buffer pointer is required because newer
-     * clang would remove the malloc(), for()-loop and free() completely.
-     * Marking 'buf' volatile ensures that the code will remain in place.
-     */
-    volatile char *buf = static_cast<volatile char *>(malloc(PRE_ALLOC_SIZE));
-    if (buf == NULL) {
-        rtapi_print_msg(RTAPI_MSG_WARN, "malloc(PRE_ALLOC_SIZE) failed\n");
-        return;
-    }
-    long pagesize = sysconf(_SC_PAGESIZE);
-    /* Touch each page in this piece of memory to get it mapped into RAM */
-    for (size_t i = 0; i < PRE_ALLOC_SIZE; i += pagesize) {
-            /* Each write to this buffer will generate a pagefault.
-             * Once the pagefault is handled a page will be locked in
-             * memory and never given back to the system. */
-            buf[i] = 0;
-    }
-    free((void *)buf);
-}
-
-static int harden_rt()
-{
-    if(!rtapi_is_realtime()) return -EINVAL;
-
-    WITH_ROOT;
-#if defined(__linux__) && (defined(__x86_64__) || defined(__i386__))
-    if (iopl(3) < 0) {
-        rtapi_print_msg(RTAPI_MSG_ERR,
-                        "iopl() failed: %s\n"
-                        "cannot gain I/O privileges - "
-                        "forgot 'sudo make setuid' or using secure boot? -"
-                        "parallel port access is not allowed\n",
-                        strerror(errno));
-    }
-#endif
-
-    struct sigaction sig_act = {};
-#ifdef __linux__
-    // enable realtime
-    if (setrlimit(RLIMIT_RTPRIO, &unlimited) < 0)
-    {
-	rtapi_print_msg(RTAPI_MSG_WARN,
-		  "setrlimit(RTLIMIT_RTPRIO): %s\n",
-		  strerror(errno));
-        return -errno;
-    }
-
-    // enable core dumps
-    if (setrlimit(RLIMIT_CORE, &unlimited) < 0)
-	rtapi_print_msg(RTAPI_MSG_WARN,
-		  "setrlimit: %s - core dumps may be truncated or non-existent\n",
-		  strerror(errno));
-
-    // even when setuid root
-    if (prctl(PR_SET_DUMPABLE, 1) < 0)
-	rtapi_print_msg(RTAPI_MSG_WARN,
-		  "prctl(PR_SET_DUMPABLE) failed: no core dumps will be created - %d - %s\n",
-		  errno, strerror(errno));
-#endif /* __linux__ */
-
-    configure_memory();
-
-    sigemptyset( &sig_act.sa_mask );
-    sig_act.sa_handler = SIG_IGN;
-    sig_act.sa_sigaction = NULL;
-
-    // prevent stopping of RT threads by ^Z
-    sigaction(SIGTSTP, &sig_act, (struct sigaction *) NULL);
-
-    sig_act.sa_sigaction = signal_handler;
-    sig_act.sa_flags   = SA_SIGINFO;
-
-    sigaction(SIGSEGV, &sig_act, (struct sigaction *) NULL);
-    sigaction(SIGILL,  &sig_act, (struct sigaction *) NULL);
-    sigaction(SIGFPE,  &sig_act, (struct sigaction *) NULL);
-    sigaction(SIGTERM, &sig_act, (struct sigaction *) NULL);
-    sigaction(SIGINT, &sig_act, (struct sigaction *) NULL);
-
-#ifdef __linux__
-    int fd = open("/dev/cpu_dma_latency", O_WRONLY | O_CLOEXEC);
-    if (fd < 0) {
-        rtapi_print_msg(RTAPI_MSG_WARN, "failed to open /dev/cpu_dma_latency: %s\n", strerror(errno));
-    } else {
-        int r;
-        r = write(fd, "\0\0\0\0", 4);
-        if (r != 4) {
-            rtapi_print_msg(RTAPI_MSG_WARN, "failed to write to /dev/cpu_dma_latency: %s\n", strerror(errno));
-        }
-        // deliberately leak fd until program exit
-    }
-#endif /* __linux__ */
-    return 0;
-}
-
-
-static RtapiApp *makeApp()
-{
-    if(euid != 0 || harden_rt() < 0)
-    {
-        rtapi_print_msg(RTAPI_MSG_ERR, "Note: Using POSIX non-realtime\n");
-        return new Posix(SCHED_OTHER);
-    }
-    WithRoot r;
-    void *dll = nullptr;
-    if(detect_xenomai_evl()) {
-        dll = dlopen(EMC2_HOME "/lib/libuspace-xenomai-evl.so.0", RTLD_NOW);
-        if(!dll) fprintf(stderr, "dlopen: %s\n", dlerror());
-    }else if(detect_xenomai()) {
-        dll = dlopen(EMC2_HOME "/lib/libuspace-xenomai.so.0", RTLD_NOW);
-        if(!dll) fprintf(stderr, "dlopen: %s\n", dlerror());
-    } else if(detect_rtai()) {
-        dll = dlopen(EMC2_HOME "/lib/libuspace-rtai.so.0", RTLD_NOW);
-        if(!dll) fprintf(stderr, "dlopen: %s\n", dlerror());
-    }
-    if(dll)
-    {
-        auto fn = reinterpret_cast<RtapiApp*(*)()>(dlsym(dll, "make"));
-        if(!fn) fprintf(stderr, "dlopen: %s\n", dlerror());
-        auto result = fn ? fn() : nullptr;
-        if(result) {
-            return result;
-        }
-    }
-    rtapi_print_msg(RTAPI_MSG_ERR, "Note: Using POSIX realtime\n");
-    return new Posix(SCHED_FIFO);
-}
-RtapiApp &App()
-{
-    static RtapiApp *app = makeApp();
-    return *app;
-}
-
-}
-/* data for all tasks */
-struct rtapi_task *task_array[MAX_TASKS];
 
 /* Priority functions.  Uspace uses POSIX task priorities. */
 
-int RtapiApp::prio_highest() const
-{
+int RtapiApp::prio_highest() const {
     return sched_get_priority_max(policy);
 }
 
-int RtapiApp::prio_lowest() const
-{
-  return sched_get_priority_min(policy);
+int RtapiApp::prio_lowest() const {
+    return sched_get_priority_min(policy);
 }
 
 int RtapiApp::prio_higher_delta() const {
-    if(rtapi_prio_highest() > rtapi_prio_lowest()) {
+    if (rtapi_prio_highest() > rtapi_prio_lowest()) {
         return 1;
     }
     return -1;
 }
 
 int RtapiApp::prio_bound(int prio) const {
-    if(rtapi_prio_highest() > rtapi_prio_lowest()) {
+    if (rtapi_prio_highest() > rtapi_prio_lowest()) {
         if (prio >= rtapi_prio_highest())
             return rtapi_prio_highest();
         if (prio < rtapi_prio_lowest())
@@ -928,77 +81,81 @@ int RtapiApp::prio_bound(int prio) const {
 }
 
 bool RtapiApp::prio_check(int prio) const {
-    if(rtapi_prio_highest() > rtapi_prio_lowest()) {
+    if (rtapi_prio_highest() > rtapi_prio_lowest()) {
         return (prio <= rtapi_prio_highest()) && (prio >= rtapi_prio_lowest());
     } else {
         return (prio <= rtapi_prio_lowest()) && (prio >= rtapi_prio_highest());
     }
 }
 
-int RtapiApp::prio_next_higher(int prio) const
-{
+int RtapiApp::prio_next_higher(int prio) const {
     prio = prio_bound(prio);
-    if(prio != rtapi_prio_highest())
+    if (prio != rtapi_prio_highest())
         return prio + prio_higher_delta();
     return prio;
 }
 
-int RtapiApp::prio_next_lower(int prio) const
-{
+int RtapiApp::prio_next_lower(int prio) const {
     prio = prio_bound(prio);
-    if(prio != rtapi_prio_lowest())
+    if (prio != rtapi_prio_lowest())
         return prio - prio_higher_delta();
     return prio;
 }
 
-int RtapiApp::allocate_task_id()
-{
-    for(int n=0; n<MAX_TASKS; n++)
-    {
+int RtapiApp::allocate_task_id() {
+    for (int n = 0; n < MAX_TASKS; n++) {
         rtapi_task **taskptr = &(task_array[n]);
-        if(__sync_bool_compare_and_swap(taskptr, (rtapi_task*)0, TASK_MAGIC_INIT))
+        if (__sync_bool_compare_and_swap(taskptr, (rtapi_task *)0, TASK_MAGIC_INIT))
             return n;
     }
     return -ENOSPC;
 }
 
-int RtapiApp::task_new(void (*taskcode) (void*), void *arg,
-        int prio, int owner, unsigned long int stacksize, int /*uses_fp*/) {
-  /* check requested priority */
-  if (!prio_check(prio))
-  {
-    rtapi_print_msg(RTAPI_MSG_ERR,"rtapi:task_new prio is not in bound lowest %i prio %i highest %i\n",
-        rtapi_prio_lowest(), prio, rtapi_prio_highest());
-    return -EINVAL;
-  }
+int RtapiApp::task_new(
+    void (*taskcode)(void *), void *arg, int prio, int owner, unsigned long int stacksize, int /*uses_fp*/
+) {
+    /* check requested priority */
+    if (!prio_check(prio)) {
+        rtapi_print_msg(
+            RTAPI_MSG_ERR,
+            "rtapi:task_new prio is not in bound lowest %i prio %i highest %i\n",
+            rtapi_prio_lowest(),
+            prio,
+            rtapi_prio_highest()
+        );
+        return -EINVAL;
+    }
 
-  /* label as a valid task structure */
-  int n = allocate_task_id();
-  if(n < 0) return n;
+    /* label as a valid task structure */
+    int n = allocate_task_id();
+    if (n < 0)
+        return n;
 
-  struct rtapi_task *task = do_task_new();
-  if(stacksize < (1024*1024)) stacksize = (1024*1024);
-  task->id = n;
-  task->owner = owner;
-  /* uses_fp is deprecated and ignored; always save FPU state */
-  task->uses_fp = 1;
-  task->arg = arg;
-  task->stacksize = stacksize;
-  task->taskcode = taskcode;
-  task->prio = prio;
-  task->magic = TASK_MAGIC;
-  task_array[n] = task;
+    struct rtapi_task *task = do_task_new();
+    if (stacksize < (1024 * 1024))
+        stacksize = (1024 * 1024);
+    task->id = n;
+    task->owner = owner;
+    /* uses_fp is deprecated and ignored; always save FPU state */
+    task->uses_fp = 1;
+    task->arg = arg;
+    task->stacksize = stacksize;
+    task->taskcode = taskcode;
+    task->prio = prio;
+    task->magic = TASK_MAGIC;
+    task_array[n] = task;
 
-  /* and return handle to the caller */
+    /* and return handle to the caller */
 
-  return n;
+    return n;
 }
 
 rtapi_task *RtapiApp::get_task(int task_id) {
-    if(task_id < 0 || task_id >= MAX_TASKS) return NULL;
+    if (task_id < 0 || task_id >= MAX_TASKS)
+        return NULL;
     /* validate task handle */
     rtapi_task *task = task_array[task_id];
-    if(!task || task == TASK_MAGIC_INIT || task->magic != TASK_MAGIC)
+    if (!task || task == TASK_MAGIC_INIT || task->magic != TASK_MAGIC)
         return NULL;
 
     return task;
@@ -1006,34 +163,33 @@ rtapi_task *RtapiApp::get_task(int task_id) {
 
 void RtapiApp::unexpected_realtime_delay(rtapi_task *task, int /*nperiod*/) {
     static int printed = 0;
-    if(!printed)
-    {
-        rtapi_print_msg(RTAPI_MSG_ERR,
-                "Unexpected realtime delay on task %d with period %ld\n"
-                "This Message will only display once per session.\n"
-                "Run the Latency Test and resolve before continuing.\n",
-                task->id, task->period);
+    if (!printed) {
+        rtapi_print_msg(
+            RTAPI_MSG_ERR,
+            "Unexpected realtime delay on task %d with period %ld\n"
+            "This Message will only display once per session.\n"
+            "Run the Latency Test and resolve before continuing.\n",
+            task->id,
+            task->period
+        );
         printed = 1;
     }
 }
 
-int Posix::task_delete(int id)
-{
-  auto task = ::rtapi_get_task<PosixTask>(id);
-  if(!task) return -EINVAL;
-
-  pthread_cancel(task->thr);
-  pthread_join(task->thr, 0);
-  task->magic = 0;
-  task_array[id] = 0;
-  delete task;
-  return 0;
+long RtapiApp::clock_set_period(long nsecs) {
+    if (nsecs == 0)
+        return period;
+    if (period != 0) {
+        rtapi_print_msg(RTAPI_MSG_ERR, "attempt to set period twice\n");
+        return -EINVAL;
+    }
+    period = nsecs;
+    return period;
 }
 
 //parse_cpu_list from https://gitlab.com/Xenomai/xenomai4/libevl/-/blob/11e6a1fb183a315ae861762e7650fd5e10d83ff5/tests/helpers.c
 //License: MIT
-static void parse_cpu_list(const char *path, cpu_set_t *cpuset)
-{
+static void parse_cpu_list(const char *path, cpu_set_t *cpuset) {
     char *p, *range, *range_p = NULL, *id, *id_r;
     int start, end, cpu;
     char buf[BUFSIZ];
@@ -1072,29 +228,33 @@ out:
 }
 
 int find_rt_cpu_number() {
-    if(getenv("RTAPI_CPU_NUMBER")) return atoi(getenv("RTAPI_CPU_NUMBER"));
+    if (getenv("RTAPI_CPU_NUMBER"))
+        return atoi(getenv("RTAPI_CPU_NUMBER"));
 
 #ifdef __linux__
-    const char* isolated_file="/sys/devices/system/cpu/isolated";
+    const char *isolated_file = "/sys/devices/system/cpu/isolated";
     cpu_set_t cpuset;
 
     parse_cpu_list(isolated_file, &cpuset);
 
     //Print list
     rtapi_print_msg(RTAPI_MSG_INFO, "cpuset isolated ");
-    for(int i=0; i<CPU_SETSIZE; i++) {
-        if(CPU_ISSET(i, &cpuset)){
+    for (int i = 0; i < CPU_SETSIZE; i++) {
+        if (CPU_ISSET(i, &cpuset)) {
             rtapi_print_msg(RTAPI_MSG_INFO, "%i ", i);
         }
     }
     rtapi_print_msg(RTAPI_MSG_INFO, "\n");
 
     int top = -1;
-    for(int i=0; i<CPU_SETSIZE; i++) {
-        if(CPU_ISSET(i, &cpuset)) top = i;
+    for (int i = 0; i < CPU_SETSIZE; i++) {
+        if (CPU_ISSET(i, &cpuset))
+            top = i;
     }
-    if(top == -1){
-        rtapi_print_msg(RTAPI_MSG_ERR, "No isolated CPU's found, expect some latency or set RTAPI_CPU_NUMBER to select CPU\n");
+    if (top == -1) {
+        rtapi_print_msg(
+            RTAPI_MSG_ERR, "No isolated CPU's found, expect some latency or set RTAPI_CPU_NUMBER to select CPU\n"
+        );
     }
     return top;
 #else
@@ -1102,340 +262,20 @@ int find_rt_cpu_number() {
 #endif
 }
 
-int Posix::task_start(int task_id, unsigned long int period_nsec)
-{
-  auto task = ::rtapi_get_task<PosixTask>(task_id);
-  if(!task) return -EINVAL;
+void set_namef(const char *fmt, ...) {
+    char *buf = NULL;
+    va_list ap;
 
-  if(period_nsec < (unsigned long)period) period_nsec = (unsigned long)period;
-  task->period = period_nsec;
-  task->ratio = period_nsec / period;
-
-  struct sched_param param;
-  memset(&param, 0, sizeof(param));
-  param.sched_priority = task->prio;
-
-  // limit PLL correction values to +/-1% of cycle time
-  task->pll_correction_limit = period_nsec / 100;
-  task->pll_correction = 0;
-
-  int nprocs = sysconf( _SC_NPROCESSORS_ONLN );
-
-  pthread_attr_t attr;
-  int ret;
-  if((ret = pthread_attr_init(&attr)) != 0)
-      return -ret;
-  if((ret = pthread_attr_setstacksize(&attr, task->stacksize)) != 0)
-      return -ret;
-  if((ret = pthread_attr_setschedpolicy(&attr, policy)) != 0)
-      return -ret;
-  if((ret = pthread_attr_setschedparam(&attr, &param)) != 0)
-      return -ret;
-  if((ret = pthread_attr_setinheritsched(&attr, PTHREAD_EXPLICIT_SCHED)) != 0)
-      return -ret;
-  if(nprocs > 1) {
-      const static int rt_cpu_number = find_rt_cpu_number();
-      rtapi_print_msg(RTAPI_MSG_INFO, "rt_cpu_number = %i\n", rt_cpu_number);
-      if(rt_cpu_number != -1) {
-#ifdef __FreeBSD__
-          cpuset_t cpuset;
-#else
-          cpu_set_t cpuset;
-#endif
-          CPU_ZERO(&cpuset);
-          CPU_SET(rt_cpu_number, &cpuset);
-          if((ret = pthread_attr_setaffinity_np(&attr, sizeof(cpuset), &cpuset)) != 0)
-               return -ret;
-      }
-  }
-  if((ret = pthread_create(&task->thr, &attr, &wrapper, reinterpret_cast<void*>(task))) != 0)
-      return -ret;
-
-  return 0;
-}
-
-#define RTAPI_CLOCK (CLOCK_MONOTONIC)
-
-pthread_once_t Posix::key_once = PTHREAD_ONCE_INIT;
-pthread_once_t Posix::lock_once = PTHREAD_ONCE_INIT;
-pthread_key_t Posix::key;
-pthread_mutex_t Posix::thread_lock;
-
-void *Posix::wrapper(void *arg)
-{
-  struct rtapi_task *task;
-
-  /* use the argument to point to the task data */
-  task = (struct rtapi_task*)arg;
-  long int period = App().period;
-  if(task->period < period) task->period = period;
-  task->ratio = task->period / period;
-  task->period = task->ratio * period;
-  rtapi_print_msg(RTAPI_MSG_INFO, "task %p period = %lu ratio=%u\n",
-	  task, task->period, task->ratio);
-
-  pthread_setspecific(key, arg);
-  set_namef("rtapi_app:T#%d", task->id);
-
-  Posix &papp = reinterpret_cast<Posix&>(App());
-  if(papp.do_thread_lock)
-      pthread_mutex_lock(&papp.thread_lock);
-
-  struct timespec now;
-  clock_gettime(RTAPI_CLOCK, &now);
-  rtapi_timespec_advance(task->nextstart, now, task->period + task->pll_correction);
-
-  /* call the task function with the task argument */
-  (task->taskcode) (task->arg);
-
-  rtapi_print("ERROR: reached end of wrapper for task %d\n", task->id);
-  return NULL;
-}
-
-long long Posix::task_pll_get_reference(void) {
-    struct rtapi_task *task = reinterpret_cast<rtapi_task*>(pthread_getspecific(key));
-    if(!task) return 0;
-    return task->nextstart.tv_sec * 1000000000LL + task->nextstart.tv_nsec;
-}
-
-int Posix::task_pll_set_correction(long value) {
-    struct rtapi_task *task = reinterpret_cast<rtapi_task*>(pthread_getspecific(key));
-    if(!task) return -EINVAL;
-    if (value > task->pll_correction_limit) value = task->pll_correction_limit;
-    if (value < -(task->pll_correction_limit)) value = -(task->pll_correction_limit);
-    task->pll_correction = value;
-    return 0;
-}
-
-int Posix::task_pause(int) {
-    return -ENOSYS;
-}
-
-int Posix::task_resume(int) {
-    return -ENOSYS;
-}
-
-int Posix::task_self() {
-    struct rtapi_task *task = reinterpret_cast<rtapi_task*>(pthread_getspecific(key));
-    if(!task) return -EINVAL;
-    return task->id;
-}
-
-void Posix::wait() {
-    if(do_thread_lock)
-        pthread_mutex_unlock(&thread_lock);
-    pthread_testcancel();
-    struct rtapi_task *task = reinterpret_cast<rtapi_task*>(pthread_getspecific(key));
-    rtapi_timespec_advance(task->nextstart, task->nextstart, task->period + task->pll_correction);
-    struct timespec now;
-    clock_gettime(RTAPI_CLOCK, &now);
-    if(rtapi_timespec_less(task->nextstart, now))
-    {
-        if(policy == SCHED_FIFO)
-            unexpected_realtime_delay(task);
+    va_start(ap, fmt);
+    if (vasprintf(&buf, fmt, ap) < 0) {
+        va_end(ap);
+        return;
     }
-    else
-    {
-        int res = rtapi_clock_nanosleep(RTAPI_CLOCK, TIMER_ABSTIME, &task->nextstart, nullptr, &now);
-        if(res < 0) perror("clock_nanosleep");
+    va_end(ap);
+
+    int res = pthread_setname_np(pthread_self(), buf);
+    if (res) {
+        fprintf(stderr, "pthread_setname_np() failed for %s: %d\n", buf, res);
     }
-    if(do_thread_lock)
-        pthread_mutex_lock(&thread_lock);
-}
-
-unsigned char Posix::do_inb(unsigned int port)
-{
-#ifdef HAVE_SYS_IO_H
-    return inb(port);
-#else
-    (void)port;
-    return 0;
-#endif
-}
-
-void Posix::do_outb(unsigned char val, unsigned int port)
-{
-#ifdef HAVE_SYS_IO_H
-    return outb(val, port);
-#else
-    (void)val;
-    (void)port;
-#endif
-}
-
-void Posix::do_delay(long ns) {
-    struct timespec ts = {0, ns};
-    rtapi_clock_nanosleep(CLOCK_MONOTONIC, 0, &ts, NULL, NULL);
-}
-int rtapi_prio_highest(void)
-{
-    return App().prio_highest();
-}
-
-int rtapi_prio_lowest(void)
-{
-    return App().prio_lowest();
-}
-
-int rtapi_prio_next_higher(int prio)
-{
-    return App().prio_next_higher(prio);
-}
-
-int rtapi_prio_next_lower(int prio)
-{
-    return App().prio_next_lower(prio);
-}
-
-long rtapi_clock_set_period(long nsecs)
-{
-    return App().clock_set_period(nsecs);
-}
-
-long RtapiApp::clock_set_period(long nsecs)
-{
-  if(nsecs == 0) return period;
-  if(period != 0) {
-      rtapi_print_msg(RTAPI_MSG_ERR, "attempt to set period twice\n");
-      return -EINVAL;
-  }
-  period = nsecs;
-  return period;
-}
-
-
-int rtapi_task_new(void (*taskcode) (void*), void *arg,
-        int prio, int owner, unsigned long int stacksize, int uses_fp) {
-    return App().task_new(taskcode, arg, prio, owner, stacksize, uses_fp);
-}
-
-int rtapi_task_delete(int id) {
-    return App().task_delete(id);
-}
-
-int rtapi_task_start(int task_id, unsigned long period_nsec)
-{
-    int ret = App().task_start(task_id, period_nsec);
-    if(ret != 0) {
-        errno = -ret;
-        perror("rtapi_task_start()");
-    }
-    return ret;
-}
-
-int rtapi_task_pause(int task_id)
-{
-    return App().task_pause(task_id);
-}
-
-int rtapi_task_resume(int task_id)
-{
-    return App().task_resume(task_id);
-}
-
-int rtapi_task_self()
-{
-    return App().task_self();
-}
-
-long long rtapi_task_pll_get_reference(void)
-{
-    return App().task_pll_get_reference();
-}
-
-int rtapi_task_pll_set_correction(long value)
-{
-    return App().task_pll_set_correction(value);
-}
-
-void rtapi_wait(void)
-{
-    App().wait();
-}
-
-void rtapi_outb(unsigned char byte, unsigned int port)
-{
-    App().do_outb(byte, port);
-}
-
-unsigned char rtapi_inb(unsigned int port)
-{
-    return App().do_inb(port);
-}
-
-long int simple_strtol(const char *nptr, char **endptr, int base) {
-  return strtol(nptr, endptr, base);
-}
-
-int Posix::run_threads(int fd, int(*callback)(int fd)) {
-    while(callback(fd)) { /* nothing */ }
-    return 0;
-}
-
-int sim_rtapi_run_threads(int fd, int (*callback)(int fd)) {
-    return App().run_threads(fd, callback);
-}
-
-long long rtapi_get_time() {
-    return App().do_get_time();
-}
-
-void default_rtapi_msg_handler(msg_level_t level, const char *fmt, va_list ap) {
-    if(main_thread && pthread_self() != main_thread) {
-        message_t m;
-        m.level = level;
-        vsnprintf(m.msg, sizeof(m.msg), fmt, ap);
-        rtapi_msg_queue.push(m);
-    } else {
-        vfprintf(level == RTAPI_MSG_ALL ? stdout : stderr, fmt, ap);
-    }
-}
-
-long int rtapi_delay_max() { return 10000; }
-
-void rtapi_delay(long ns) {
-    if(ns > rtapi_delay_max()) ns = rtapi_delay_max();
-    App().do_delay(ns);
-}
-
-const unsigned long ONE_SEC_IN_NS = 1000000000;
-void rtapi_timespec_advance(struct timespec &result, const struct timespec &src, unsigned long nsec)
-{
-    time_t sec = src.tv_sec;
-    while(nsec >= ONE_SEC_IN_NS)
-    {
-        ++sec;
-        nsec -= ONE_SEC_IN_NS;
-    }
-    nsec += src.tv_nsec;
-    if(nsec >= ONE_SEC_IN_NS)
-    {
-        ++sec;
-        nsec -= ONE_SEC_IN_NS;
-    }
-    result.tv_sec = sec;
-    result.tv_nsec = nsec;
-}
-
-int rtapi_open_as_root(const char *filename, int mode) {
-    WITH_ROOT;
-    int r = open(filename, mode);
-    if(r < 0) return -errno;
-    return r;
-}
-
-int rtapi_spawn_as_root(pid_t *pid, const char *path,
-    const posix_spawn_file_actions_t *file_actions,
-    const posix_spawnattr_t *attrp,
-    char *const argv[], char *const envp[])
-{
-    return posix_spawn(pid, path, file_actions, attrp, argv, envp);
-}
-
-int rtapi_spawnp_as_root(pid_t *pid, const char *path,
-    const posix_spawn_file_actions_t *file_actions,
-    const posix_spawnattr_t *attrp,
-    char *const argv[], char *const envp[])
-{
-    return posix_spawnp(pid, path, file_actions, attrp, argv, envp);
+    free(buf);
 }

--- a/src/rtapi/uspace_rtapi_app.cc
+++ b/src/rtapi/uspace_rtapi_app.cc
@@ -46,14 +46,14 @@ void WithRoot::init(uid_t ruid_ini, uid_t euid_ini) {
     euid = euid_ini;
 }
 
-rtapi_task::rtapi_task()
+RtapiTask::RtapiTask()
     : magic{}, id{}, owner{}, uses_fp{}, stacksize{}, prio{}, period{}, nextstart{}, pll_correction{},
       pll_correction_limit{}, arg{}, taskcode{}
 
 {
 }
 
-struct rtapi_task *RtapiApp::task_array[MAX_TASKS];
+RtapiTask *RtapiApp::task_array[MAX_TASKS];
 
 /* Priority functions.  Uspace uses POSIX task priorities. */
 
@@ -111,8 +111,8 @@ int RtapiApp::prio_next_lower(int prio) const {
 
 int RtapiApp::allocate_task_id() {
     for (int n = 0; n < MAX_TASKS; n++) {
-        rtapi_task **taskptr = &(task_array[n]);
-        if (__sync_bool_compare_and_swap(taskptr, (rtapi_task *)0, TASK_MAGIC_INIT))
+        RtapiTask **taskptr = &(task_array[n]);
+        if (__sync_bool_compare_and_swap(taskptr, (RtapiTask *)0, TASK_MAGIC_INIT))
             return n;
     }
     return -ENOSPC;
@@ -138,7 +138,7 @@ int RtapiApp::task_new(
     if (n < 0)
         return n;
 
-    struct rtapi_task *task = do_task_new();
+    RtapiTask *task = do_task_new();
     if (stacksize < (1024 * 1024))
         stacksize = (1024 * 1024);
     task->id = n;
@@ -157,18 +157,18 @@ int RtapiApp::task_new(
     return n;
 }
 
-rtapi_task *RtapiApp::get_task(int task_id) {
+RtapiTask *RtapiApp::get_task(int task_id) {
     if (task_id < 0 || task_id >= MAX_TASKS)
         return NULL;
     /* validate task handle */
-    rtapi_task *task = task_array[task_id];
+    RtapiTask *task = task_array[task_id];
     if (!task || task == TASK_MAGIC_INIT || task->magic != TASK_MAGIC)
         return NULL;
 
     return task;
 }
 
-void RtapiApp::unexpected_realtime_delay(rtapi_task *task, int /*nperiod*/) {
+void RtapiApp::unexpected_realtime_delay(RtapiTask *task, int /*nperiod*/) {
     static int printed = 0;
     if (!printed) {
         rtapi_print_msg(

--- a/src/rtapi/uspace_rtapi_app.hh
+++ b/src/rtapi/uspace_rtapi_app.hh
@@ -110,6 +110,8 @@ struct RtapiApp {
     virtual int run_threads(int fd, int (*callback)(int fd)) = 0;
     virtual long long do_get_time(void) = 0;
     virtual void do_delay(long ns) = 0;
+    static int find_rt_cpu_number();
+    static void set_namef(const char *fmt, ...);
     int policy;
     long period;
     static struct rtapi_task *task_array[MAX_TASKS];
@@ -118,9 +120,6 @@ struct RtapiApp {
 template <class T = rtapi_task> T *rtapi_get_task(int task_id) {
     return static_cast<T *>(RtapiApp::get_task(task_id));
 }
-
-int find_rt_cpu_number();
-void set_namef(const char *fmt, ...);
 
 #define WITH_ROOT WithRoot root
 #endif

--- a/src/rtapi/uspace_rtapi_app.hh
+++ b/src/rtapi/uspace_rtapi_app.hh
@@ -46,7 +46,16 @@ void rtapi_timespec_advance(struct timespec &result, const struct timespec &src,
 struct WithRoot {
     WithRoot();
     ~WithRoot();
+    static void init(uid_t ruid_ini, uid_t euid_ini);
+    static uid_t getRuid(){
+        return ruid;
+    }
+    static uid_t getEuid(){
+        return euid;
+    }
+private:
     static std::atomic_int level;
+    static uid_t ruid, euid;
 };
 
 struct rtapi_task {
@@ -112,8 +121,6 @@ template <class T = rtapi_task> T *rtapi_get_task(int task_id) {
 
 int find_rt_cpu_number();
 void set_namef(const char *fmt, ...);
-
-extern uid_t euid, ruid; //ToDo: Improve
 
 #define WITH_ROOT WithRoot root
 #endif

--- a/src/rtapi/uspace_rtapi_app.hh
+++ b/src/rtapi/uspace_rtapi_app.hh
@@ -108,7 +108,6 @@ struct RtapiApp {
     virtual void wait() = 0;
     virtual unsigned char do_inb(unsigned int port) = 0;
     virtual void do_outb(unsigned char value, unsigned int port) = 0;
-    virtual int run_threads(int fd, int (*callback)(int fd)) = 0;
     virtual long long do_get_time(void) = 0;
     virtual void do_delay(long ns) = 0;
     static int find_rt_cpu_number();

--- a/src/rtapi/uspace_rtapi_app.hh
+++ b/src/rtapi/uspace_rtapi_app.hh
@@ -59,8 +59,8 @@ struct WithRoot {
     static uid_t ruid, euid;
 };
 
-struct rtapi_task {
-    rtapi_task();
+struct RtapiTask {
+    RtapiTask();
 
     int magic; /* to check for valid handle */
     int id;
@@ -78,7 +78,7 @@ struct rtapi_task {
 
 #define MAX_TASKS 64
 #define TASK_MAGIC 21979 /* random numbers used as signatures */
-#define TASK_MAGIC_INIT ((rtapi_task *)(-1))
+#define TASK_MAGIC_INIT ((RtapiTask *)(-1))
 
 struct RtapiApp {
 
@@ -94,10 +94,10 @@ struct RtapiApp {
     int prio_next_lower(int prio) const;
     long clock_set_period(long int period_nsec);
     int task_new(void (*taskcode)(void *), void *arg, int prio, int owner, unsigned long int stacksize, int uses_fp);
-    virtual rtapi_task *do_task_new() = 0;
+    virtual RtapiTask *do_task_new() = 0;
     static int allocate_task_id();
-    static struct rtapi_task *get_task(int task_id);
-    void unexpected_realtime_delay(rtapi_task *task, int nperiod = 1);
+    static RtapiTask *get_task(int task_id);
+    void unexpected_realtime_delay(RtapiTask *task, int nperiod = 1);
     virtual int task_delete(int id) = 0;
     virtual int task_start(int task_id, unsigned long period_nsec) = 0;
     virtual int task_pause(int task_id) = 0;
@@ -114,10 +114,10 @@ struct RtapiApp {
     static void set_namef(const char *fmt, ...);
     int policy;
     long period;
-    static struct rtapi_task *task_array[MAX_TASKS];
+    static RtapiTask *task_array[MAX_TASKS];
 };
 
-template <class T = rtapi_task> T *rtapi_get_task(int task_id) {
+template <class T = RtapiTask> T *rtapi_get_task(int task_id) {
     return static_cast<T *>(RtapiApp::get_task(task_id));
 }
 

--- a/src/rtapi/uspace_rtapi_app.hh
+++ b/src/rtapi/uspace_rtapi_app.hh
@@ -34,42 +34,42 @@ static inline void rtapi_timespec_add(timespec &result, const timespec &ta, cons
 }
 
 static inline bool rtapi_timespec_less(const struct timespec &ta, const struct timespec &tb) {
-    if(ta.tv_sec < tb.tv_sec) return 1;
-    if(ta.tv_sec > tb.tv_sec) return 0;
+    if (ta.tv_sec < tb.tv_sec)
+        return 1;
+    if (ta.tv_sec > tb.tv_sec)
+        return 0;
     return ta.tv_nsec < tb.tv_nsec;
 }
 
 void rtapi_timespec_advance(struct timespec &result, const struct timespec &src, unsigned long nsec);
 
-struct WithRoot
-{
+struct WithRoot {
     WithRoot();
     ~WithRoot();
     static std::atomic_int level;
 };
 
 struct rtapi_task {
-  rtapi_task();
+    rtapi_task();
 
-  int magic;			/* to check for valid handle */
-  int id;
-  int owner;
-  int uses_fp;
-  size_t stacksize;
-  int prio;
-  long period;
-  struct timespec nextstart;
-  unsigned ratio;
-  long pll_correction;
-  long pll_correction_limit;
-  void *arg;
-  void (*taskcode) (void*);	/* pointer to task function */
+    int magic; /* to check for valid handle */
+    int id;
+    int owner;
+    int uses_fp;
+    size_t stacksize;
+    int prio;
+    long period;
+    struct timespec nextstart;
+    long pll_correction;
+    long pll_correction_limit;
+    void *arg;
+    void (*taskcode)(void *); /* pointer to task function */
 };
 
-struct RtapiApp
-{
+struct RtapiApp {
 
-    RtapiApp(int policy = SCHED_OTHER) : policy(policy), period(0) {}
+    RtapiApp(int policy = SCHED_OTHER) : policy(policy), period(0) {
+    }
 
     virtual int prio_highest() const;
     virtual int prio_lowest() const;
@@ -79,12 +79,11 @@ struct RtapiApp
     int prio_next_higher(int prio) const;
     int prio_next_lower(int prio) const;
     long clock_set_period(long int period_nsec);
-    int task_new(void (*taskcode)(void*), void *arg,
-            int prio, int owner, unsigned long int stacksize, int uses_fp);
+    int task_new(void (*taskcode)(void *), void *arg, int prio, int owner, unsigned long int stacksize, int uses_fp);
     virtual rtapi_task *do_task_new() = 0;
     static int allocate_task_id();
     static struct rtapi_task *get_task(int task_id);
-    void unexpected_realtime_delay(rtapi_task *task, int nperiod=1);
+    void unexpected_realtime_delay(rtapi_task *task, int nperiod = 1);
     virtual int task_delete(int id) = 0;
     virtual int task_start(int task_id, unsigned long period_nsec) = 0;
     virtual int task_pause(int task_id) = 0;
@@ -102,18 +101,20 @@ struct RtapiApp
     long period;
 };
 
-template<class T=rtapi_task>
-T *rtapi_get_task(int task_id) {
-    return static_cast<T*>(RtapiApp::get_task(task_id));
+template <class T = rtapi_task> T *rtapi_get_task(int task_id) {
+    return static_cast<T *>(RtapiApp::get_task(task_id));
 }
 
 int find_rt_cpu_number();
+void set_namef(const char *fmt, ...);
 
-#define MAX_TASKS  64
-#define TASK_MAGIC    21979	/* random numbers used as signatures */
-#define TASK_MAGIC_INIT   ((rtapi_task*)(-1))
+#define MAX_TASKS 64
+#define TASK_MAGIC 21979 /* random numbers used as signatures */
+#define TASK_MAGIC_INIT ((rtapi_task *)(-1))
 
 extern struct rtapi_task *task_array[MAX_TASKS];
+
+extern uid_t euid, ruid; //ToDo: Improve
 
 #define WITH_ROOT WithRoot root
 #endif

--- a/src/rtapi/uspace_rtapi_app.hh
+++ b/src/rtapi/uspace_rtapi_app.hh
@@ -47,13 +47,14 @@ struct WithRoot {
     WithRoot();
     ~WithRoot();
     static void init(uid_t ruid_ini, uid_t euid_ini);
-    static uid_t getRuid(){
+    static uid_t getRuid() {
         return ruid;
     }
-    static uid_t getEuid(){
+    static uid_t getEuid() {
         return euid;
     }
-private:
+
+  private:
     static std::atomic_int level;
     static uid_t ruid, euid;
 };

--- a/src/rtapi/uspace_rtapi_app.hh
+++ b/src/rtapi/uspace_rtapi_app.hh
@@ -66,6 +66,10 @@ struct rtapi_task {
     void (*taskcode)(void *); /* pointer to task function */
 };
 
+#define MAX_TASKS 64
+#define TASK_MAGIC 21979 /* random numbers used as signatures */
+#define TASK_MAGIC_INIT ((rtapi_task *)(-1))
+
 struct RtapiApp {
 
     RtapiApp(int policy = SCHED_OTHER) : policy(policy), period(0) {
@@ -99,6 +103,7 @@ struct RtapiApp {
     virtual void do_delay(long ns) = 0;
     int policy;
     long period;
+    static struct rtapi_task *task_array[MAX_TASKS];
 };
 
 template <class T = rtapi_task> T *rtapi_get_task(int task_id) {
@@ -107,12 +112,6 @@ template <class T = rtapi_task> T *rtapi_get_task(int task_id) {
 
 int find_rt_cpu_number();
 void set_namef(const char *fmt, ...);
-
-#define MAX_TASKS 64
-#define TASK_MAGIC 21979 /* random numbers used as signatures */
-#define TASK_MAGIC_INIT ((rtapi_task *)(-1))
-
-extern struct rtapi_task *task_array[MAX_TASKS];
 
 extern uid_t euid, ruid; //ToDo: Improve
 

--- a/src/rtapi/uspace_rtapi_main.cc
+++ b/src/rtapi/uspace_rtapi_main.cc
@@ -776,17 +776,17 @@ static RtapiApp *makeDllApp(std::string dllName, int policy) {
 static RtapiApp *makeApp() {
     RtapiApp *app;
     if (WithRoot::getEuid() != 0 || harden_rt() < 0) {
-        app = makeDllApp("libuspace-posix.so.0", SCHED_OTHER);
+        app = makeDllApp("liblinuxcnc-uspace-posix.so.0", SCHED_OTHER);
     } else {
         WithRoot r;
         if (detect_xenomai_evl()) {
-            app = makeDllApp("libuspace-xenomai-evl.so.0", SCHED_FIFO);
+            app = makeDllApp("liblinuxcnc-uspace-xenomai-evl.so.0", SCHED_FIFO);
         } else if (detect_xenomai()) {
-            app = makeDllApp("libuspace-xenomai.so.0", SCHED_FIFO);
+            app = makeDllApp("liblinuxcnc-uspace-xenomai.so.0", SCHED_FIFO);
         } else if (detect_rtai()) {
-            app = makeDllApp("libuspace-rtai.so.0", SCHED_FIFO);
+            app = makeDllApp("liblinuxcnc-uspace-rtai.so.0", SCHED_FIFO);
         } else {
-            app = makeDllApp("libuspace-posix.so.0", SCHED_FIFO);
+            app = makeDllApp("liblinuxcnc-uspace-posix.so.0", SCHED_FIFO);
         }
     }
 

--- a/src/rtapi/uspace_rtapi_main.cc
+++ b/src/rtapi/uspace_rtapi_main.cc
@@ -641,28 +641,33 @@ struct rtapi_module {
 #define MAX_MODULES 64
 #define MODULE_OFFSET 32768
 
+#define WRITE_STDERR_STR(str) ((void)!write(STDERR_FILENO, str, strlen(str)))
 static void signal_handler(int sig, siginfo_t * /*si*/, void * /*uctx*/) {
+    //Read: https://www.man7.org/linux/man-pages/man7/signal-safety.7.html
     switch (sig) {
     case SIGXCPU:
-        // should not happen - must be handled in RTAPI if enabled
-        rtapi_print_msg(RTAPI_MSG_ERR, "rtapi_app: BUG: SIGXCPU received - exiting\n");
-        _exit(0);
+        WRITE_STDERR_STR("rtapi_app: SIGXCPU - shutting down\n");
         break;
-
+    case SIGSEGV:
+        WRITE_STDERR_STR("rtapi_app: SIGSEGV - shutting down\n");
+        break;
+    case SIGILL:
+        WRITE_STDERR_STR("rtapi_app: SIGILL - shutting down\n");
+        break;
+    case SIGFPE:
+        WRITE_STDERR_STR("rtapi_app: SIGFPE - shutting down\n");
+        break;
     case SIGTERM:
-        rtapi_print_msg(RTAPI_MSG_ERR, "rtapi_app: SIGTERM - shutting down\n");
-        _exit(0);
+        WRITE_STDERR_STR("rtapi_app: SIGTERM - shutting down\n");
         break;
-
-    default: // pretty bad
-        rtapi_print_msg(RTAPI_MSG_ERR, "rtapi_app: caught signal %d - dumping core\n", sig);
-        sleep(1); // let syslog drain
-        signal(sig, SIG_DFL);
-        // for reasons unknown raise(sig); doesn't lead to core dump file
-        // but this will
-        kill(getpid(), sig);
+    case SIGINT:
+        WRITE_STDERR_STR("rtapi_app: SIGINT - shutting down\n");
+        break;
+    default:
+        WRITE_STDERR_STR("rtapi_app: UNKNOWN - shutting down\n");
         break;
     }
+
     _exit(1);
 }
 
@@ -772,6 +777,7 @@ static int harden_rt() {
     sig_act.sa_sigaction = signal_handler;
     sig_act.sa_flags = SA_SIGINFO;
 
+    sigaction(SIGXCPU, &sig_act, (struct sigaction *)NULL);
     sigaction(SIGSEGV, &sig_act, (struct sigaction *)NULL);
     sigaction(SIGILL, &sig_act, (struct sigaction *)NULL);
     sigaction(SIGFPE, &sig_act, (struct sigaction *)NULL);

--- a/src/rtapi/uspace_rtapi_main.cc
+++ b/src/rtapi/uspace_rtapi_main.cc
@@ -764,20 +764,6 @@ become_master:
     }
 }
 
-
-/* These structs hold data associated with objects like tasks, etc. */
-/* Task handles are pointers to these structs.                      */
-
-struct rtapi_module {
-    int magic;
-};
-
-#define MODULE_MAGIC 30812
-#define SHMEM_MAGIC 25453
-
-#define MAX_MODULES 64
-#define MODULE_OFFSET 32768
-
 static inline void write_string(int fd, const char *str) {
     (void)!write(fd, str, strlen(str));
 }

--- a/src/rtapi/uspace_rtapi_main.cc
+++ b/src/rtapi/uspace_rtapi_main.cc
@@ -556,6 +556,17 @@ static bool master_process_socket_command(int fd) {
     } else {
         int result;
         std::vector<std::string> args;
+
+        //Set timeout, so master doesn't hang forever
+        struct timeval timeout;
+        timeout.tv_sec = 10;
+        timeout.tv_usec = 0;
+        if (setsockopt(fd1, SOL_SOCKET, SO_RCVTIMEO, &timeout, sizeof(timeout)) < 0){
+            rtapi_print_msg(RTAPI_MSG_ERR, "rtapi_app: setsockopt timeout failed: %s\n", strerror(errno));
+            close(fd1);
+            return true; //If there is a socket error, just continue
+        }
+
         if (!recv_args(fd1, args)) {
             rtapi_print_msg(RTAPI_MSG_ERR, "rtapi_app: failed to read from slave\n");
             close(fd1);

--- a/src/rtapi/uspace_rtapi_main.cc
+++ b/src/rtapi/uspace_rtapi_main.cc
@@ -297,6 +297,54 @@ static int do_debug_cmd(const std::string &value) {
 }
 
 /*
+ * Fully checked send/recv
+ * Will retry on EINTR, so to abort a send_data/recv_data on a
+ * signal, change to something like while(remaining > 0 && !exit_flag)
+ * and set exit_flag in signal handler
+ */
+static int send_data(int fd, const void *buf, size_t n, int flags) {
+    const uint8_t *ptr = (const uint8_t *)buf;
+    size_t n_rem = n;
+    while (n_rem > 0) {
+        ssize_t n_ret = send(fd, ptr, n_rem, flags);
+        if (n_ret == -1) {
+            if (errno == EINTR) {
+                // Retry
+            } else {
+                return -1; // Other error, fail
+            }
+        } else if (n_ret == 0) {
+            return (n - n_rem); // No more data
+        } else {
+            ptr += n_ret;
+            n_rem -= n_ret;
+        }
+    }
+    return n; // All sent
+}
+
+static int recv_data(int fd, void *buf, size_t n, int flags) {
+    uint8_t *ptr = (uint8_t *)buf;
+    size_t n_rem = n;
+    while (n_rem > 0) {
+        ssize_t n_ret = recv(fd, ptr, n_rem, flags);
+        if (n_ret == -1) {
+            if (errno == EINTR) {
+                // Retry
+            } else {
+                return -1; // Other error, fail
+            }
+        } else if (n_ret == 0) {
+            return (n - n_rem); // No more data
+        } else {
+            ptr += n_ret;
+            n_rem -= n_ret;
+        }
+    }
+    return n; // All read
+}
+
+/*
  * Protocol:
  * 
  * client->master: std::vector<std::string> args
@@ -318,12 +366,12 @@ static int do_debug_cmd(const std::string &value) {
  */
 
 static bool send_result(int fd, int result) {
-    ssize_t res = send(fd, &result, sizeof(int), 0);
+    ssize_t res = send_data(fd, &result, sizeof(int), 0);
     return res == sizeof(int);
 }
 
 static bool recv_result(int fd, int *result) {
-    ssize_t res = recv(fd, result, sizeof(int), 0);
+    ssize_t res = recv_data(fd, result, sizeof(int), 0);
     return res == sizeof(int);
 }
 
@@ -339,7 +387,7 @@ static uint16_t get_uint16(const std::vector<char> &buf, size_t idx) {
 static bool recv_args(int fd, std::vector<std::string> &args) {
     //Get size
     uint16_t tmp;
-    ssize_t res = recv(fd, &tmp, sizeof(uint16_t), 0);
+    ssize_t res = recv_data(fd, &tmp, sizeof(uint16_t), 0);
     if (res != sizeof(uint16_t)) {
         return false;
     }
@@ -347,7 +395,7 @@ static bool recv_args(int fd, std::vector<std::string> &args) {
 
     //Get data
     std::vector<char> buf(buff_size);
-    res = recv(fd, buf.data(), buff_size, 0);
+    res = recv_data(fd, buf.data(), buff_size, 0);
     if (res != (ssize_t)buff_size) {
         return false;
     }
@@ -360,7 +408,7 @@ static bool recv_args(int fd, std::vector<std::string> &args) {
     for (size_t i = 0; i < n_args; i++) {
         size_t arg_size = get_uint16(buf, idx);
         idx += sizeof(uint16_t);
-        args[i]=std::string(buf.begin() + idx, buf.begin() + idx + arg_size);
+        args[i] = std::string(buf.begin() + idx, buf.begin() + idx + arg_size);
         idx += arg_size;
     }
     if (idx + sizeof(uint16_t) != buff_size) {
@@ -405,7 +453,7 @@ static bool send_args(int fd, const std::vector<std::string> &args) {
     }
 
     //Send
-    ssize_t res = send(fd, buf.data(), buf.size(), 0);
+    ssize_t res = send_data(fd, buf.data(), buf.size(), 0);
     if (res != (ssize_t)buf.size()) {
         return false;
     }
@@ -463,7 +511,7 @@ static bool master_process_socket_command(int fd) {
     int fd1 = accept(fd, (sockaddr *)&client_addr, &len);
     if (fd1 < 0) {
         rtapi_print_msg(RTAPI_MSG_ERR, "rtapi_app: failed to accept connection from slave: %s\n", strerror(errno));
-        return true; //If there is a socket error, just continue
+        return true; //If there is a socket error, just continue, no need to check errno
     } else {
         int result;
         std::vector<std::string> args;
@@ -607,7 +655,7 @@ become_master:
 
     // plus one because we use the abstract namespace, it will show up in
     // /proc/net/unix prefixed with an @
-    int result = ::bind(fd, (sockaddr *)&addr, sizeof(addr));
+    int result = bind(fd, (sockaddr *)&addr, sizeof(addr));
 
     if (result == 0) {
         //If called in master mode with exit command, no need to start master

--- a/src/rtapi/uspace_rtapi_main.cc
+++ b/src/rtapi/uspace_rtapi_main.cc
@@ -87,8 +87,6 @@ static void *queue_function(void * /*arg*/) {
     return nullptr;
 }
 
-static int sim_rtapi_run_threads(int fd, int (*callback)(int fd));
-
 template <class T> T DLSYM(void *handle, const std::string &name) {
     return (T)(dlsym(handle, name.c_str()));
 }
@@ -454,21 +452,25 @@ static int slave(int fd, const std::vector<std::string> &args) {
     }
 }
 
-static int callback(int fd) {
+//Processes incoming command on socket
+//This function blocks on accept until a client connects
+//return: true if master should continue
+//        false if master should exit
+static bool master_process_socket_command(int fd) {
     struct sockaddr_un client_addr;
     memset(&client_addr, 0, sizeof(client_addr));
     socklen_t len = sizeof(client_addr);
     int fd1 = accept(fd, (sockaddr *)&client_addr, &len);
     if (fd1 < 0) {
         rtapi_print_msg(RTAPI_MSG_ERR, "rtapi_app: failed to accept connection from slave: %s\n", strerror(errno));
-        return -1;
+        return true; //If there is a socket error, just continue
     } else {
         int result;
         std::vector<std::string> args;
         if (!recv_args(fd1, args)) {
             rtapi_print_msg(RTAPI_MSG_ERR, "rtapi_app: failed to read from slave: %s\n", strerror(errno));
             close(fd1);
-            return -1;
+            return true; //If there is a socket error, just continue
         }
 
         result = handle_command(args);
@@ -501,7 +503,8 @@ static int master(int fd, const std::vector<std::string> &args) {
         if (force_exit || instance_count == 0)
             goto out;
     }
-    sim_rtapi_run_threads(fd, callback);
+    //Process commands as long as master should not exit
+    while(master_process_socket_command(fd));
 out:
     pthread_cancel(queue_thread);
     pthread_join(queue_thread, nullptr);
@@ -960,10 +963,6 @@ unsigned char rtapi_inb(unsigned int port) {
 
 long int simple_strtol(const char *nptr, char **endptr, int base) {
     return strtol(nptr, endptr, base);
-}
-
-int sim_rtapi_run_threads(int fd, int (*callback)(int fd)) {
-    return App().run_threads(fd, callback);
 }
 
 long long rtapi_get_time() {

--- a/src/rtapi/uspace_rtapi_main.cc
+++ b/src/rtapi/uspace_rtapi_main.cc
@@ -508,8 +508,9 @@ int main(int argc, char **argv) {
         }
         fprintf(stderr, "Running with fallback_uid.  getuid()=%d geteuid()=%d\n", getuid(), geteuid());
     }
-    ruid = getuid();
-    euid = geteuid();
+    uid_t ruid = getuid();
+    uid_t euid = geteuid();
+    WithRoot::init(ruid, euid);
     if (setresuid(euid, euid, ruid) != 0) {
         perror("setresuid");
         abort();
@@ -774,7 +775,7 @@ static RtapiApp *makeDllApp(std::string dllName, int policy) {
 
 static RtapiApp *makeApp() {
     RtapiApp *app;
-    if (euid != 0 || harden_rt() < 0) {
+    if (WithRoot::getEuid() != 0 || harden_rt() < 0) {
         app = makeDllApp("libuspace-posix.so.0", SCHED_OTHER);
     } else {
         WithRoot r;

--- a/src/rtapi/uspace_rtapi_main.cc
+++ b/src/rtapi/uspace_rtapi_main.cc
@@ -775,17 +775,17 @@ static RtapiApp *makeDllApp(std::string dllName, int policy) {
 static RtapiApp *makeApp() {
     RtapiApp *app;
     if (euid != 0 || harden_rt() < 0) {
-        app = makeDllApp(EMC2_HOME "/lib/libuspace-posix.so.0", SCHED_OTHER);
+        app = makeDllApp("libuspace-posix.so.0", SCHED_OTHER);
     } else {
         WithRoot r;
         if (detect_xenomai_evl()) {
-            app = makeDllApp(EMC2_HOME "/lib/libuspace-xenomai-evl.so.0", SCHED_FIFO);
+            app = makeDllApp("libuspace-xenomai-evl.so.0", SCHED_FIFO);
         } else if (detect_xenomai()) {
-            app = makeDllApp(EMC2_HOME "/lib/libuspace-xenomai.so.0", SCHED_FIFO);
+            app = makeDllApp("libuspace-xenomai.so.0", SCHED_FIFO);
         } else if (detect_rtai()) {
-            app = makeDllApp(EMC2_HOME "/lib/libuspace-rtai.so.0", SCHED_FIFO);
+            app = makeDllApp("libuspace-rtai.so.0", SCHED_FIFO);
         } else {
-            app = makeDllApp(EMC2_HOME "/lib/libuspace-posix.so.0", SCHED_FIFO);
+            app = makeDllApp("libuspace-posix.so.0", SCHED_FIFO);
         }
     }
 

--- a/src/rtapi/uspace_rtapi_main.cc
+++ b/src/rtapi/uspace_rtapi_main.cc
@@ -59,17 +59,17 @@
 #include "hal/hal_priv.h"
 #include "uspace_common.h"
 
-RtapiApp &App();
+static RtapiApp &App();
 
 struct message_t {
     msg_level_t level;
     char msg[1024 - sizeof(level)];
 };
 
-boost::lockfree::queue<message_t, boost::lockfree::capacity<128>> rtapi_msg_queue;
+static boost::lockfree::queue<message_t, boost::lockfree::capacity<128>> rtapi_msg_queue;
 
-pthread_t queue_thread;
-void *queue_function(void * /*arg*/) {
+static pthread_t queue_thread;
+static void *queue_function(void * /*arg*/) {
     set_namef("rtapi_app:mesg");
     // note: can't use anything in this function that requires App() to exist
     // but it's OK to use functions that aren't safe for realtime (that's the
@@ -163,7 +163,7 @@ static int do_one_item(
     return 0;
 }
 
-void remove_quotes(std::string &s) {
+static void remove_quotes(std::string &s) {
     s.erase(remove_copy(s.begin(), s.end(), s.begin(), '"'), s.end());
 }
 
@@ -624,7 +624,7 @@ static void signal_handler(int sig, siginfo_t * /*si*/, void * /*uctx*/) {
     exit(1);
 }
 
-const size_t PRE_ALLOC_SIZE = 1024 * 1024 * 32;
+const static size_t PRE_ALLOC_SIZE = 1024 * 1024 * 32;
 const static struct rlimit unlimited = {RLIM_INFINITY, RLIM_INFINITY};
 static void configure_memory() {
     int res = setrlimit(RLIMIT_MEMLOCK, &unlimited);
@@ -799,9 +799,6 @@ RtapiApp &App() {
     static RtapiApp *app = makeApp();
     return *app;
 }
-
-/* data for all tasks */
-struct rtapi_task *task_array[MAX_TASKS];
 
 int rtapi_prio_highest(void) {
     return App().prio_highest();

--- a/src/rtapi/uspace_rtapi_main.cc
+++ b/src/rtapi/uspace_rtapi_main.cc
@@ -220,6 +220,15 @@ static int do_comp_args(void *module, const std::vector<std::string> &args) {
 static int do_load_cmd(const std::string &name, const std::vector<std::string> &args) {
     void *w = modules[name];
     if (w == NULL) {
+        //Sanitize the name
+        if (name.find("/") != std::string::npos || name.find("..") != std::string::npos) {
+            rtapi_print_msg(
+                RTAPI_MSG_ERR,
+                "%s: Not allowed as module name. Slashes or with \"..\" (even /a..b/) are not allowed.\n",
+                name.c_str()
+            );
+            return -1;
+        }
         std::string what;
         what = fmt::format("{}/{}.so", EMC2_RTLIB_DIR, name);
         void *module = modules[name] = dlopen(what.c_str(), RTLD_GLOBAL | RTLD_NOW);

--- a/src/rtapi/uspace_rtapi_main.cc
+++ b/src/rtapi/uspace_rtapi_main.cc
@@ -357,11 +357,12 @@ static bool recv_args(int fd, std::vector<std::string> &args) {
     //Deserialize
     size_t idx = 0;
     size_t n_args = get_uint16(buf, idx);
+    args.resize(n_args);
     idx += sizeof(uint16_t);
     for (size_t i = 0; i < n_args; i++) {
         size_t arg_size = get_uint16(buf, idx);
         idx += sizeof(uint16_t);
-        args.push_back(std::string(buf.begin() + idx, buf.begin() + idx + arg_size));
+        args[i]=std::string(buf.begin() + idx, buf.begin() + idx + arg_size);
         idx += arg_size;
     }
     if (idx + sizeof(uint16_t) != buff_size) {

--- a/src/rtapi/uspace_rtapi_main.cc
+++ b/src/rtapi/uspace_rtapi_main.cc
@@ -467,13 +467,13 @@ static std::string get_fifo_path() {
     return s;
 }
 
-static int get_fifo_path(char *buf, size_t bufsize) {
+static int get_fifo_path_to_addr(struct sockaddr_un *addr) {
     int len;
     const std::string s = get_fifo_path();
     if (s.empty()) {
         return -1;
     }
-    if (s.size() + 1 > sizeof(sockaddr_un::sun_path)) {
+    if (s.size() + 1 > sizeof(addr->sun_path)) {
         rtapi_print_msg(
             RTAPI_MSG_ERR,
             "rtapi_app: rtapi fifo path is too long (arch limit %zd): %s\n",
@@ -482,7 +482,10 @@ static int get_fifo_path(char *buf, size_t bufsize) {
         );
         return -1;
     }
-    len = snprintf(buf + 1, bufsize - 1, "%s", s.c_str());
+    //See: https://www.man7.org/linux/man-pages/man7/unix.7.html abstract
+    //sun_path[0] is a null byte ('\0')
+    addr->sun_path[0]=0;
+    len = snprintf(addr->sun_path + 1, sizeof(addr->sun_path) - 1, "%s", s.c_str());
     return len;
 }
 
@@ -536,7 +539,7 @@ become_master:
     struct sockaddr_un addr;
     memset(&addr, 0x0, sizeof(addr));
     addr.sun_family = AF_UNIX;
-    if ((len = get_fifo_path(addr.sun_path, sizeof(addr.sun_path))) < 0)
+    if ((len = get_fifo_path_to_addr(&addr)) < 0)
         exit(1);
 
     // plus one because we use the abstract namespace, it will show up in

--- a/src/rtapi/uspace_rtapi_main.cc
+++ b/src/rtapi/uspace_rtapi_main.cc
@@ -466,7 +466,7 @@ static bool send_args(int fd, const std::vector<std::string> &args) {
 
     //This is the largest value set by set_int16()
     if (buff_size > std::numeric_limits<uint16_t>::max()) {
-        rtapi_print_msg(RTAPI_MSG_ERR, "rtapi_app: Bug send_args: args to big, size = %li!\n", buff_size);
+        rtapi_print_msg(RTAPI_MSG_ERR, "rtapi_app: send_args: args to big, size = %li!\n", buff_size);
         return false;
     }
 

--- a/src/rtapi/uspace_rtapi_main.cc
+++ b/src/rtapi/uspace_rtapi_main.cc
@@ -367,12 +367,34 @@ static int recv_data(int fd, void *buf, size_t n, int flags) {
 
 static bool send_result(int fd, int result) {
     ssize_t res = send_data(fd, &result, sizeof(int), 0);
-    return res == sizeof(int);
+    if (res != sizeof(int)) {
+        if (res == -1) {
+            rtapi_print_msg(RTAPI_MSG_ERR, "rtapi_app: send_result failed: %s\n", strerror(errno));
+        } else {
+            rtapi_print_msg(
+                RTAPI_MSG_ERR, "rtapi_app: send_result failed, send only %li of %li bytes\n", res, sizeof(int)
+            );
+        }
+        return false;
+    } else {
+        return true;
+    }
 }
 
 static bool recv_result(int fd, int *result) {
     ssize_t res = recv_data(fd, result, sizeof(int), 0);
-    return res == sizeof(int);
+    if (res != sizeof(int)) {
+        if (res == -1) {
+            rtapi_print_msg(RTAPI_MSG_ERR, "rtapi_app: recv_result failed: %s\n", strerror(errno));
+        } else {
+            rtapi_print_msg(
+                RTAPI_MSG_ERR, "rtapi_app: recv_result failed, recv only %li of %li bytes\n", res, sizeof(int)
+            );
+        }
+        return false;
+    } else {
+        return true;
+    }
 }
 
 static void set_uint16(std::vector<char> &buf, uint16_t value, size_t idx) {
@@ -389,6 +411,13 @@ static bool recv_args(int fd, std::vector<std::string> &args) {
     uint16_t tmp;
     ssize_t res = recv_data(fd, &tmp, sizeof(uint16_t), 0);
     if (res != sizeof(uint16_t)) {
+        if (res == -1) {
+            rtapi_print_msg(RTAPI_MSG_ERR, "rtapi_app: recv_args 1 failed: %s\n", strerror(errno));
+        } else {
+            rtapi_print_msg(
+                RTAPI_MSG_ERR, "rtapi_app: recv_args 1 failed, recv only %li of %li bytes\n", res, sizeof(uint16_t)
+            );
+        }
         return false;
     }
     size_t buff_size = tmp;
@@ -397,6 +426,13 @@ static bool recv_args(int fd, std::vector<std::string> &args) {
     std::vector<char> buf(buff_size);
     res = recv_data(fd, buf.data(), buff_size, 0);
     if (res != (ssize_t)buff_size) {
+        if (res == -1) {
+            rtapi_print_msg(RTAPI_MSG_ERR, "rtapi_app: recv_args 2 failed: %s\n", strerror(errno));
+        } else {
+            rtapi_print_msg(
+                RTAPI_MSG_ERR, "rtapi_app: recv_args 2 failed, recv only %li of %li bytes\n", res, buff_size
+            );
+        }
         return false;
     }
 
@@ -455,6 +491,13 @@ static bool send_args(int fd, const std::vector<std::string> &args) {
     //Send
     ssize_t res = send_data(fd, buf.data(), buf.size(), 0);
     if (res != (ssize_t)buf.size()) {
+        if (res == -1) {
+            rtapi_print_msg(RTAPI_MSG_ERR, "rtapi_app: send_args failed: %s\n", strerror(errno));
+        } else {
+            rtapi_print_msg(
+                RTAPI_MSG_ERR, "rtapi_app: send_args failed, sent only %li of %li bytes\n", res, buf.size()
+            );
+        }
         return false;
     }
     return true;
@@ -487,13 +530,13 @@ static int handle_command(std::vector<std::string> args) {
 
 static int slave(int fd, const std::vector<std::string> &args) {
     if (!send_args(fd, args)) {
-        rtapi_print_msg(RTAPI_MSG_ERR, "rtapi_app: failed to write to master: %s\n", strerror(errno));
+        rtapi_print_msg(RTAPI_MSG_ERR, "rtapi_app: failed to write to master\n");
         return -1;
     }
 
     int result = -1;
     if (!recv_result(fd, &result)) {
-        rtapi_print_msg(RTAPI_MSG_ERR, "rtapi_app: failed to read from master: %s\n", strerror(errno));
+        rtapi_print_msg(RTAPI_MSG_ERR, "rtapi_app: failed to read from master\n");
         return -1;
     } else {
         return result;
@@ -516,7 +559,7 @@ static bool master_process_socket_command(int fd) {
         int result;
         std::vector<std::string> args;
         if (!recv_args(fd1, args)) {
-            rtapi_print_msg(RTAPI_MSG_ERR, "rtapi_app: failed to read from slave: %s\n", strerror(errno));
+            rtapi_print_msg(RTAPI_MSG_ERR, "rtapi_app: failed to read from slave\n");
             close(fd1);
             return true; //If there is a socket error, just continue
         }
@@ -524,7 +567,7 @@ static bool master_process_socket_command(int fd) {
         result = handle_command(args);
 
         if (!send_result(fd1, result)) {
-            rtapi_print_msg(RTAPI_MSG_ERR, "rtapi_app: failed to write to slave: %s\n", strerror(errno));
+            rtapi_print_msg(RTAPI_MSG_ERR, "rtapi_app: failed to write to slave\n");
         }
         close(fd1);
     }

--- a/src/rtapi/uspace_rtapi_main.cc
+++ b/src/rtapi/uspace_rtapi_main.cc
@@ -489,6 +489,10 @@ static int get_fifo_path_to_addr(struct sockaddr_un *addr) {
     return len;
 }
 
+static double diff_timespec(const struct timespec *time1, const struct timespec *time0) {
+  return (time1->tv_sec - time0->tv_sec) + (time1->tv_nsec - time0->tv_nsec) / 1000000000.0;
+}
+
 int main(int argc, char **argv) {
     if (getuid() == 0) {
         char *fallback_uid_str = getenv("RTAPI_UID");
@@ -561,17 +565,17 @@ become_master:
         result = master(fd, args);
         return result;
     } else if (errno == EADDRINUSE) {
-        struct timeval t0, t1;
-        gettimeofday(&t0, NULL);
-        gettimeofday(&t1, NULL);
-        for (int i = 0; i < 3 || (t1.tv_sec < 3 + t0.tv_sec); i++) {
+        struct timespec start, now;
+        clock_gettime(CLOCK_MONOTONIC, &start);
+        clock_gettime(CLOCK_MONOTONIC, &now);
+        srand48(start.tv_sec ^ start.tv_nsec);
+        while(diff_timespec(&now, &start) < 3.0) {
             result = connect(fd, (sockaddr *)&addr, sizeof(addr));
             if (result == 0)
                 break;
-            if (i == 0)
-                srand48(t0.tv_sec ^ t0.tv_usec);
-            usleep(lrand48() % 100000);
-            gettimeofday(&t1, NULL);
+            
+            usleep(lrand48() % 100000 + 100); //Random sleep min 100us max 100100us
+            clock_gettime(CLOCK_MONOTONIC, &now);
         }
         if (result < 0 && errno == ECONNREFUSED) {
             fprintf(stderr, "Waited 3 seconds for master.  giving up.\n");

--- a/src/rtapi/uspace_rtapi_main.cc
+++ b/src/rtapi/uspace_rtapi_main.cc
@@ -605,12 +605,12 @@ static void signal_handler(int sig, siginfo_t * /*si*/, void * /*uctx*/) {
     case SIGXCPU:
         // should not happen - must be handled in RTAPI if enabled
         rtapi_print_msg(RTAPI_MSG_ERR, "rtapi_app: BUG: SIGXCPU received - exiting\n");
-        exit(0);
+        _exit(0);
         break;
 
     case SIGTERM:
         rtapi_print_msg(RTAPI_MSG_ERR, "rtapi_app: SIGTERM - shutting down\n");
-        exit(0);
+        _exit(0);
         break;
 
     default: // pretty bad
@@ -622,7 +622,7 @@ static void signal_handler(int sig, siginfo_t * /*si*/, void * /*uctx*/) {
         kill(getpid(), sig);
         break;
     }
-    exit(1);
+    _exit(1);
 }
 
 const static size_t PRE_ALLOC_SIZE = 1024 * 1024 * 32;

--- a/src/rtapi/uspace_rtapi_main.cc
+++ b/src/rtapi/uspace_rtapi_main.cc
@@ -519,13 +519,13 @@ static bool get_fifo_path_to_addr(struct sockaddr_un *addr) {
     }
     //See: https://www.man7.org/linux/man-pages/man7/unix.7.html abstract
     //sun_path[0] is a null byte ('\0')
-    addr->sun_path[0]=0;
+    addr->sun_path[0] = 0;
     strncpy(addr->sun_path + 1, s.c_str(), sizeof(addr->sun_path) - 2);
     return true;
 }
 
 static double diff_timespec(const struct timespec *time1, const struct timespec *time0) {
-  return (time1->tv_sec - time0->tv_sec) + (time1->tv_nsec - time0->tv_nsec) / 1000000000.0;
+    return (time1->tv_sec - time0->tv_sec) + (time1->tv_nsec - time0->tv_nsec) / 1000000000.0;
 }
 
 int main(int argc, char **argv) {
@@ -603,11 +603,11 @@ become_master:
         clock_gettime(CLOCK_MONOTONIC, &start);
         clock_gettime(CLOCK_MONOTONIC, &now);
         srand48(start.tv_sec ^ start.tv_nsec);
-        while(diff_timespec(&now, &start) < 3.0) {
+        while (diff_timespec(&now, &start) < 3.0) {
             result = connect(fd, (sockaddr *)&addr, sizeof(addr));
             if (result == 0)
                 break;
-            
+
             usleep(lrand48() % 100000 + 100); //Random sleep min 100us max 100100us
             clock_gettime(CLOCK_MONOTONIC, &now);
         }

--- a/src/rtapi/uspace_rtapi_main.cc
+++ b/src/rtapi/uspace_rtapi_main.cc
@@ -298,6 +298,27 @@ static int do_debug_cmd(const std::string &value) {
     }
 }
 
+/*
+ * Protocol:
+ * 
+ * client->master: std::vector<std::string> args
+ * master processes the args and returns result
+ * master->client: int result
+ *
+ * Packing:
+ * args are serialized as:
+ * uint16_t size (full package size including the size field)
+ * uint16_t n_args
+ * n_args times:
+ * {
+ *      uint16_t arg_size
+ *      char[arg_size] argument
+ * }
+ * 
+ * result is serialized as:
+ * int
+ */
+
 static bool send_result(int fd, int result) {
     ssize_t res = send(fd, &result, sizeof(int), 0);
     return res == sizeof(int);
@@ -313,7 +334,7 @@ static void set_uint16(std::vector<char> &buf, uint16_t value, size_t idx) {
     buf[idx + 1] = 0xff & (value >> 8);
 }
 
-static uint16_t get_uint16(std::vector<char> &buf, size_t idx) {
+static uint16_t get_uint16(const std::vector<char> &buf, size_t idx) {
     return ((uint16_t)buf[idx] << 0) | ((uint16_t)buf[idx + 1] << 8);
 }
 

--- a/src/rtapi/uspace_rtapi_main.cc
+++ b/src/rtapi/uspace_rtapi_main.cc
@@ -168,7 +168,7 @@ static std::string remove_quotes(const std::string &s) {
 }
 
 static int do_comp_args(void *module, const std::vector<std::string> &args) {
-    for (unsigned i = 0; i < args.size(); i++) {
+    for (size_t i = 0; i < args.size(); i++) {
         std::string s = remove_quotes(args[i]);
         size_t idx = s.find('=');
         if (idx == std::string::npos) {
@@ -312,7 +312,11 @@ static int do_debug_cmd(const std::string &value) {
  * signal, change to something like while(remaining > 0 && !exit_flag)
  * and set exit_flag in signal handler
  */
-static int send_data(int fd, const void *buf, size_t n, int flags) {
+static ssize_t send_data(int fd, const void *buf, size_t n, int flags) {
+    if(n > SSIZE_MAX){
+        errno=EFBIG;
+        return -1;
+    }
     const uint8_t *ptr = (const uint8_t *)buf;
     size_t n_rem = n;
     while (n_rem > 0) {
@@ -333,7 +337,11 @@ static int send_data(int fd, const void *buf, size_t n, int flags) {
     return n; // All sent
 }
 
-static int recv_data(int fd, void *buf, size_t n, int flags) {
+static ssize_t recv_data(int fd, void *buf, size_t n, int flags) {
+    if(n > SSIZE_MAX){
+        errno=EFBIG;
+        return -1;
+    }
     uint8_t *ptr = (uint8_t *)buf;
     size_t n_rem = n;
     while (n_rem > 0) {
@@ -408,8 +416,8 @@ static bool recv_result(int fd, int *result) {
 }
 
 static void push_uint16(std::vector<char> &buf, uint16_t value) {
-    buf.push_back(0xff & (value >> 0));
-    buf.push_back(0xff & (value >> 8));
+    buf.push_back((char)(0xff & (value >> 0)));
+    buf.push_back((char)(0xff & (value >> 8)));
 }
 
 static uint16_t get_uint16(const std::vector<char> &buf, size_t idx) {
@@ -486,19 +494,25 @@ static bool send_args(int fd, const std::vector<std::string> &args) {
         buff_size += args[i].size();
     }
 
-    //This is the largest value set by set_int16()
+    //Check uint16_t conversions
+    //Buffer size is > sum(args[i].size()) so they don't need a separate check
     if (buff_size > std::numeric_limits<uint16_t>::max()) {
         rtapi_print_msg(RTAPI_MSG_ERR, "rtapi_app: send_args: args to big, size = %li!\n", buff_size);
+        return false;
+    }
+    //Edge case: One could in theory send many size zero args
+    if (args.size() > std::numeric_limits<uint16_t>::max()) {
+        rtapi_print_msg(RTAPI_MSG_ERR, "rtapi_app: send_args: arg count to big, size = %li!\n", args.size());
         return false;
     }
 
     //Serialize
     std::vector<char> buf;
     buf.reserve(buff_size);
-    push_uint16(buf, buff_size);
-    push_uint16(buf, args.size());
+    push_uint16(buf, (uint16_t)buff_size);
+    push_uint16(buf, (uint16_t)args.size());
     for (size_t i = 0; i < args.size(); i++) {
-        push_uint16(buf, args[i].size());
+        push_uint16(buf, (uint16_t)args[i].size());
         buf.insert(buf.end(), args[i].begin(), args[i].end());
     }
     if (buf.size() != buff_size) {
@@ -672,7 +686,7 @@ static bool get_fifo_path_to_addr(struct sockaddr_un *addr) {
 }
 
 static double diff_timespec(const struct timespec *time1, const struct timespec *time0) {
-    return (time1->tv_sec - time0->tv_sec) + (time1->tv_nsec - time0->tv_nsec) / 1000000000.0;
+    return (double)(time1->tv_sec - time0->tv_sec) + (double)(time1->tv_nsec - time0->tv_nsec) / 1000000000.0;
 }
 
 int main(int argc, char **argv) {
@@ -755,7 +769,7 @@ become_master:
             if (result == 0)
                 break;
 
-            usleep(lrand48() % 100000 + 100); //Random sleep min 100us max 100100us
+            usleep((useconds_t)(lrand48() % 100000) + 100); //Random sleep min 100us max 100100us
             clock_gettime(CLOCK_MONOTONIC, &now);
         }
         if (result < 0 && errno == ECONNREFUSED) {
@@ -941,8 +955,7 @@ static int harden_rt() {
     if (fd < 0) {
         rtapi_print_msg(RTAPI_MSG_WARN, "failed to open /dev/cpu_dma_latency: %s\n", strerror(errno));
     } else {
-        int r;
-        r = write(fd, "\0\0\0\0", 4);
+        ssize_t r = write(fd, "\0\0\0\0", 4);
         if (r != 4) {
             rtapi_print_msg(RTAPI_MSG_WARN, "failed to write to /dev/cpu_dma_latency: %s\n", strerror(errno));
         }

--- a/src/rtapi/uspace_rtapi_main.cc
+++ b/src/rtapi/uspace_rtapi_main.cc
@@ -298,66 +298,98 @@ static int do_debug_cmd(const std::string &value) {
     }
 }
 
-struct ReadError : std::exception {};
-struct WriteError : std::exception {};
+static bool send_result(int fd, int result) {
+    ssize_t res = send(fd, &result, sizeof(int), 0);
+    return res == sizeof(int);
+}
 
-static int read_number(int fd) {
-    int r = 0, neg = 1;
-    char ch;
+static bool recv_result(int fd, int *result) {
+    ssize_t res = recv(fd, result, sizeof(int), 0);
+    return res == sizeof(int);
+}
 
-    while (1) {
-        int res = read(fd, &ch, 1);
-        if (res != 1)
-            return -1;
-        if (ch == '-')
-            neg = -1;
-        else if (ch == ' ')
-            return r * neg;
-        else
-            r = 10 * r + ch - '0';
+static void set_uint16(std::vector<char> &buf, uint16_t value, size_t idx) {
+    buf[idx] = 0xff & (value >> 0);
+    buf[idx + 1] = 0xff & (value >> 8);
+}
+
+static uint16_t get_uint16(std::vector<char> &buf, size_t idx) {
+    return ((uint16_t)buf[idx] << 0) | ((uint16_t)buf[idx + 1] << 8);
+}
+
+static bool recv_args(int fd, std::vector<std::string> &args) {
+    //Get size
+    uint16_t tmp;
+    ssize_t res = recv(fd, &tmp, sizeof(uint16_t), 0);
+    if (res != sizeof(uint16_t)) {
+        return false;
     }
-}
+    size_t buff_size = tmp;
 
-static std::string read_string(int fd) {
-    int len = read_number(fd);
-    if (len < 0)
-        throw ReadError();
-    if (!len)
-        return std::string();
-    std::string str(len, 0);
-    if (read(fd, str.data(), len) != len)
-        throw ReadError();
-    return str;
-}
-
-static std::vector<std::string> read_strings(int fd) {
-    std::vector<std::string> result;
-    int count = read_number(fd);
-    if (count < 0)
-        return result;
-    for (int i = 0; i < count; i++) {
-        result.push_back(read_string(fd));
+    //Get data
+    std::vector<char> buf(buff_size);
+    res = recv(fd, buf.data(), buff_size, 0);
+    if (res != (ssize_t)buff_size) {
+        return false;
     }
-    return result;
-}
 
-static void write_number(std::string &buf, int num) {
-    buf = buf + fmt::format("{} ", num);
-}
-
-static void write_string(std::string &buf, const std::string &s) {
-    write_number(buf, s.size());
-    buf += s;
-}
-
-static void write_strings(int fd, const std::vector<std::string> &strings) {
-    std::string buf;
-    write_number(buf, strings.size());
-    for (unsigned int i = 0; i < strings.size(); i++) {
-        write_string(buf, strings[i]);
+    //Deserialize
+    size_t idx = 0;
+    size_t n_args = get_uint16(buf, idx);
+    idx += sizeof(uint16_t);
+    for (size_t i = 0; i < n_args; i++) {
+        size_t arg_size = get_uint16(buf, idx);
+        idx += sizeof(uint16_t);
+        args.push_back(std::string(buf.begin() + idx, buf.begin() + idx + arg_size));
+        idx += arg_size;
     }
-    if (write(fd, buf.data(), buf.size()) != (ssize_t)buf.size())
-        throw WriteError();
+    if (idx + sizeof(uint16_t) != buff_size) {
+        rtapi_print_msg(RTAPI_MSG_ERR, "rtapi_app: Bug recv_args: idx %li != buff_size %li\n", idx, buff_size);
+        return false;
+    }
+
+    return true;
+}
+
+static bool send_args(int fd, const std::vector<std::string> &args) {
+    //Calculate size
+    size_t buff_size = 0;
+    buff_size += 2 * sizeof(uint16_t);
+    for (size_t i = 0; i < args.size(); i++) {
+        buff_size += sizeof(uint16_t);
+        buff_size += args[i].size();
+    }
+
+    //This is the largest value set by set_int16()
+    if (buff_size > std::numeric_limits<uint16_t>::max()) {
+        rtapi_print_msg(RTAPI_MSG_ERR, "rtapi_app: Bug send_args: args to big, size = %li!\n", buff_size);
+        return false;
+    }
+
+    //Serialize
+    std::vector<char> buf(buff_size);
+    size_t idx = 0;
+    set_uint16(buf, buff_size, idx);
+    idx += sizeof(uint16_t);
+    set_uint16(buf, args.size(), idx);
+    idx += sizeof(uint16_t);
+    for (size_t i = 0; i < args.size(); i++) {
+        set_uint16(buf, args[i].size(), idx);
+        idx += sizeof(uint16_t);
+        buf.insert(buf.begin() + idx, args[i].begin(), args[i].end());
+        idx += args[i].size();
+    }
+    if (idx != buff_size) {
+        rtapi_print_msg(RTAPI_MSG_ERR, "rtapi_app: Bug send_args: idx %li != buff_size %li\n", idx, buff_size);
+        return false;
+    }
+
+    //Send
+    ssize_t res = send(fd, buf.data(), buf.size(), 0);
+    if (res != (ssize_t)buf.size()) {
+        return false;
+    }
+    return true;
 }
 
 static int handle_command(std::vector<std::string> args) {
@@ -386,14 +418,18 @@ static int handle_command(std::vector<std::string> args) {
 }
 
 static int slave(int fd, const std::vector<std::string> &args) {
-    try {
-        write_strings(fd, args);
-    } catch (WriteError &e) {
+    if (!send_args(fd, args)) {
         rtapi_print_msg(RTAPI_MSG_ERR, "rtapi_app: failed to write to master: %s\n", strerror(errno));
+        return -1;
     }
 
-    int result = read_number(fd);
-    return result;
+    int result = -1;
+    if (!recv_result(fd, &result)) {
+        rtapi_print_msg(RTAPI_MSG_ERR, "rtapi_app: failed to read from master: %s\n", strerror(errno));
+        return -1;
+    } else {
+        return result;
+    }
 }
 
 static int callback(int fd) {
@@ -406,18 +442,18 @@ static int callback(int fd) {
         return -1;
     } else {
         int result;
-        try {
-            result = handle_command(read_strings(fd1));
-        } catch (ReadError &e) {
+        std::vector<std::string> args;
+        if (!recv_args(fd1, args)) {
             rtapi_print_msg(RTAPI_MSG_ERR, "rtapi_app: failed to read from slave: %s\n", strerror(errno));
             close(fd1);
             return -1;
         }
-        std::string buf;
-        write_number(buf, result);
-        if (write(fd1, buf.data(), buf.size()) != (ssize_t)buf.size()) {
+
+        result = handle_command(args);
+
+        if (!send_result(fd1, result)) {
             rtapi_print_msg(RTAPI_MSG_ERR, "rtapi_app: failed to write to slave: %s\n", strerror(errno));
-        };
+        }
         close(fd1);
     }
     return !force_exit && instance_count > 0;

--- a/src/rtapi/uspace_rtapi_main.cc
+++ b/src/rtapi/uspace_rtapi_main.cc
@@ -397,9 +397,9 @@ static bool recv_result(int fd, int *result) {
     }
 }
 
-static void set_uint16(std::vector<char> &buf, uint16_t value, size_t idx) {
-    buf[idx] = 0xff & (value >> 0);
-    buf[idx + 1] = 0xff & (value >> 8);
+static void push_uint16(std::vector<char> &buf, uint16_t value) {
+    buf.push_back(0xff & (value >> 0));
+    buf.push_back(0xff & (value >> 8));
 }
 
 static uint16_t get_uint16(const std::vector<char> &buf, size_t idx) {
@@ -420,7 +420,7 @@ static bool recv_args(int fd, std::vector<std::string> &args) {
         }
         return false;
     }
-    size_t buff_size = tmp;
+    size_t buff_size = tmp - sizeof(uint16_t); //Size already consumed
 
     //Get data
     std::vector<char> buf(buff_size);
@@ -447,7 +447,7 @@ static bool recv_args(int fd, std::vector<std::string> &args) {
         args[i] = std::string(buf.begin() + idx, buf.begin() + idx + arg_size);
         idx += arg_size;
     }
-    if (idx + sizeof(uint16_t) != buff_size) {
+    if (idx != buff_size) {
         rtapi_print_msg(RTAPI_MSG_ERR, "rtapi_app: Bug recv_args: idx %li != buff_size %li\n", idx, buff_size);
         return false;
     }
@@ -471,20 +471,18 @@ static bool send_args(int fd, const std::vector<std::string> &args) {
     }
 
     //Serialize
-    std::vector<char> buf(buff_size);
-    size_t idx = 0;
-    set_uint16(buf, buff_size, idx);
-    idx += sizeof(uint16_t);
-    set_uint16(buf, args.size(), idx);
-    idx += sizeof(uint16_t);
+    std::vector<char> buf;
+    buf.reserve(buff_size);
+    push_uint16(buf, buff_size);
+    push_uint16(buf, args.size());
     for (size_t i = 0; i < args.size(); i++) {
-        set_uint16(buf, args[i].size(), idx);
-        idx += sizeof(uint16_t);
-        buf.insert(buf.begin() + idx, args[i].begin(), args[i].end());
-        idx += args[i].size();
+        push_uint16(buf, args[i].size());
+        buf.insert(buf.end(), args[i].begin(), args[i].end());
     }
-    if (idx != buff_size) {
-        rtapi_print_msg(RTAPI_MSG_ERR, "rtapi_app: Bug send_args: idx %li != buff_size %li\n", idx, buff_size);
+    if (buf.size() != buff_size) {
+        rtapi_print_msg(
+            RTAPI_MSG_ERR, "rtapi_app: Bug send_args: buf.size() %li != buff_size %li\n", buf.size(), buff_size
+        );
         return false;
     }
 

--- a/src/rtapi/uspace_rtapi_main.cc
+++ b/src/rtapi/uspace_rtapi_main.cc
@@ -161,14 +161,15 @@ static int do_one_item(
     return 0;
 }
 
-static void remove_quotes(std::string &s) {
-    s.erase(remove_copy(s.begin(), s.end(), s.begin(), '"'), s.end());
+static std::string remove_quotes(const std::string &s) {
+    std::string ret;
+    std::remove_copy(s.begin(), s.end(), std::back_inserter(ret), '"');
+    return ret;
 }
 
-static int do_comp_args(void *module, std::vector<std::string> args) {
-    for (unsigned i = 1; i < args.size(); i++) {
-        std::string &s = args[i];
-        remove_quotes(s);
+static int do_comp_args(void *module, const std::vector<std::string> &args) {
+    for (unsigned i = 0; i < args.size(); i++) {
+        std::string s = remove_quotes(args[i]);
         size_t idx = s.find('=');
         if (idx == std::string::npos) {
             rtapi_print_msg(RTAPI_MSG_ERR, "Invalid parameter `%s'\n", s.c_str());
@@ -513,7 +514,7 @@ static bool send_args(int fd, const std::vector<std::string> &args) {
     return true;
 }
 
-static int handle_command(std::vector<std::string> args) {
+static int handle_command(const std::vector<std::string> &args) {
     if (args.size() == 0) {
         return 0;
     }
@@ -522,8 +523,8 @@ static int handle_command(std::vector<std::string> args) {
         return 0;
     } else if (args.size() >= 2 && args[0] == "load") {
         std::string name = args[1];
-        args.erase(args.begin());
-        return do_load_cmd(name, args);
+        std::vector<std::string> args_rem(args.begin() + 2, args.end());
+        return do_load_cmd(name, args_rem);
     } else if (args.size() == 2 && args[0] == "unload") {
         return do_unload_cmd(args[1]);
     } else if (args.size() == 3 && args[0] == "newinst") {

--- a/src/rtapi/uspace_rtapi_main.cc
+++ b/src/rtapi/uspace_rtapi_main.cc
@@ -70,7 +70,7 @@ static boost::lockfree::queue<message_t, boost::lockfree::capacity<128>> rtapi_m
 
 static pthread_t queue_thread;
 static void *queue_function(void * /*arg*/) {
-    set_namef("rtapi_app:mesg");
+    RtapiApp::set_namef("rtapi_app:mesg");
     // note: can't use anything in this function that requires App() to exist
     // but it's OK to use functions that aren't safe for realtime (that's the
     // point of running this in a thread)

--- a/src/rtapi/uspace_rtapi_main.cc
+++ b/src/rtapi/uspace_rtapi_main.cc
@@ -753,7 +753,7 @@ static int harden_rt() {
     return 0;
 }
 
-static RtapiApp *makeDllApp(std::string dllName, int policy) {
+static RtapiApp *makeDllApp(const std::string &dllName, int policy) {
     void *dll = nullptr;
     dll = dlopen(dllName.c_str(), RTLD_NOW);
     if (!dll) {

--- a/src/rtapi/uspace_rtapi_main.cc
+++ b/src/rtapi/uspace_rtapi_main.cc
@@ -403,7 +403,8 @@ static void push_uint16(std::vector<char> &buf, uint16_t value) {
 }
 
 static uint16_t get_uint16(const std::vector<char> &buf, size_t idx) {
-    return ((uint16_t)buf[idx] << 0) | ((uint16_t)buf[idx + 1] << 8);
+    //at() will check index and throw std::out_of_range
+    return ((uint16_t)buf.at(idx) << 0) | ((uint16_t)buf.at(idx + 1) << 8);
 }
 
 static bool recv_args(int fd, std::vector<std::string> &args) {
@@ -437,18 +438,29 @@ static bool recv_args(int fd, std::vector<std::string> &args) {
     }
 
     //Deserialize
-    size_t idx = 0;
-    size_t n_args = get_uint16(buf, idx);
-    args.resize(n_args);
-    idx += sizeof(uint16_t);
-    for (size_t i = 0; i < n_args; i++) {
-        size_t arg_size = get_uint16(buf, idx);
+    try {
+        size_t idx = 0;
+        size_t n_args = get_uint16(buf, idx);
+        args.resize(n_args);
         idx += sizeof(uint16_t);
-        args[i] = std::string(buf.begin() + idx, buf.begin() + idx + arg_size);
-        idx += arg_size;
-    }
-    if (idx != buff_size) {
-        rtapi_print_msg(RTAPI_MSG_ERR, "rtapi_app: Bug recv_args: idx %li != buff_size %li\n", idx, buff_size);
+        for (size_t i = 0; i < n_args; i++) {
+            size_t arg_size = get_uint16(buf, idx);
+            idx += sizeof(uint16_t);
+            //Bound checked, unpack argument
+            auto start = buf.begin() + idx;
+            auto end = start + arg_size;
+            if (end > buf.end()) {
+                throw std::out_of_range("recv_args: arg size not in buffer range");
+            }
+            args[i] = std::string(start, end);
+            idx += arg_size;
+        }
+        if (idx != buff_size) {
+            rtapi_print_msg(RTAPI_MSG_ERR, "rtapi_app: Bug recv_args: idx %li != buff_size %li\n", idx, buff_size);
+            return false;
+        }
+    } catch (std::out_of_range &e) {
+        rtapi_print_msg(RTAPI_MSG_ERR, "rtapi_app: Bug recv_args: %s\n", e.what());
         return false;
     }
 
@@ -561,7 +573,7 @@ static bool master_process_socket_command(int fd) {
         struct timeval timeout;
         timeout.tv_sec = 10;
         timeout.tv_usec = 0;
-        if (setsockopt(fd1, SOL_SOCKET, SO_RCVTIMEO, &timeout, sizeof(timeout)) < 0){
+        if (setsockopt(fd1, SOL_SOCKET, SO_RCVTIMEO, &timeout, sizeof(timeout)) < 0) {
             rtapi_print_msg(RTAPI_MSG_ERR, "rtapi_app: setsockopt timeout failed: %s\n", strerror(errno));
             close(fd1);
             return true; //If there is a socket error, just continue

--- a/src/rtapi/uspace_rtapi_main.cc
+++ b/src/rtapi/uspace_rtapi_main.cc
@@ -1,0 +1,952 @@
+/* Copyright (C) 2006-2014 Jeff Epler <jepler@unpythonic.net>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include "config.h"
+#include <linuxcnc.h>
+
+#ifdef __linux__
+#include <sys/fsuid.h>
+#endif
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <sys/un.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <errno.h>
+#include <dlfcn.h>
+#include <signal.h>
+#include <vector>
+#include <string>
+#include <map>
+#include <algorithm>
+#include <sys/time.h>
+#include <time.h>
+#include <stdlib.h>
+#include <stdio.h>
+#ifdef HAVE_SYS_IO_H
+#include <sys/io.h>
+#endif
+#include <sys/resource.h>
+#include <sys/mman.h>
+#ifdef __linux__
+#include <malloc.h>
+#include <sys/prctl.h>
+#endif
+#ifdef __FreeBSD__
+#include <pthread_np.h>
+#endif
+
+#include <fmt/format.h>
+#include <boost/lockfree/queue.hpp>
+
+#include "rtapi.h"
+#include <hal.h>
+#include "hal/hal_priv.h"
+#include "uspace_common.h"
+
+RtapiApp &App();
+
+struct message_t {
+    msg_level_t level;
+    char msg[1024 - sizeof(level)];
+};
+
+boost::lockfree::queue<message_t, boost::lockfree::capacity<128>> rtapi_msg_queue;
+
+pthread_t queue_thread;
+void *queue_function(void * /*arg*/) {
+    set_namef("rtapi_app:mesg");
+    // note: can't use anything in this function that requires App() to exist
+    // but it's OK to use functions that aren't safe for realtime (that's the
+    // point of running this in a thread)
+    while (1) {
+        pthread_testcancel();
+        pthread_setcancelstate(PTHREAD_CANCEL_DISABLE, nullptr);
+        rtapi_msg_queue.consume_all([](const message_t &m) {
+            fputs(m.msg, m.level == RTAPI_MSG_ALL ? stdout : stderr);
+        });
+        pthread_setcancelstate(PTHREAD_CANCEL_ENABLE, nullptr);
+        struct timespec ts = {0, 10000000};
+        rtapi_clock_nanosleep(CLOCK_MONOTONIC, 0, &ts, NULL, NULL);
+    }
+    return nullptr;
+}
+
+static int sim_rtapi_run_threads(int fd, int (*callback)(int fd));
+
+template <class T> T DLSYM(void *handle, const std::string &name) {
+    return (T)(dlsym(handle, name.c_str()));
+}
+
+template <class T> T DLSYM(void *handle, const char *name) {
+    return (T)(dlsym(handle, name));
+}
+
+static std::map<std::string, void *> modules;
+
+static int instance_count = 0;
+static int force_exit = 0;
+
+static int do_newinst_cmd(const std::string &type, const std::string &name, const std::string &arg) {
+    void *module = modules["hal_lib"];
+    if (!module) {
+        rtapi_print_msg(RTAPI_MSG_ERR, "newinst: hal_lib is required, but not loaded\n");
+        return -1;
+    }
+
+    hal_comp_t *(*find_comp_by_name)(char *) = DLSYM<hal_comp_t *(*)(char *)>(module, "halpr_find_comp_by_name");
+    if (!find_comp_by_name) {
+        rtapi_print_msg(RTAPI_MSG_ERR, "newinst: halpr_find_comp_by_name not found\n");
+        return -1;
+    }
+
+    hal_comp_t *comp = find_comp_by_name((char *)type.c_str());
+    if (!comp) {
+        rtapi_print_msg(RTAPI_MSG_ERR, "newinst: component %s not found\n", type.c_str());
+        return -1;
+    }
+
+    return comp->make((char *)name.c_str(), (char *)arg.c_str());
+}
+
+static int do_one_item(
+    char item_type_char, const std::string &param_name, const std::string &param_value, void *vitem, int idx = 0
+) {
+    char *endp;
+    switch (item_type_char) {
+    case 'l': {
+        long *litem = *(long **)vitem;
+        litem[idx] = strtol(param_value.c_str(), &endp, 0);
+        if (*endp) {
+            rtapi_print_msg(
+                RTAPI_MSG_ERR, "`%s' invalid for parameter `%s'\n", param_value.c_str(), param_name.c_str()
+            );
+            return -1;
+        }
+        return 0;
+    }
+    case 'i': {
+        int *iitem = *(int **)vitem;
+        iitem[idx] = strtol(param_value.c_str(), &endp, 0);
+        if (*endp) {
+            rtapi_print_msg(
+                RTAPI_MSG_ERR, "`%s' invalid for parameter `%s'\n", param_value.c_str(), param_name.c_str()
+            );
+            return -1;
+        }
+        return 0;
+    }
+    case 's': {
+        char **sitem = *(char ***)vitem;
+        sitem[idx] = strdup(param_value.c_str());
+        return 0;
+    }
+    default:
+        rtapi_print_msg(RTAPI_MSG_ERR, "%s: Invalid type character `%c'\n", param_name.c_str(), item_type_char);
+        return -1;
+    }
+    return 0;
+}
+
+void remove_quotes(std::string &s) {
+    s.erase(remove_copy(s.begin(), s.end(), s.begin(), '"'), s.end());
+}
+
+static int do_comp_args(void *module, std::vector<std::string> args) {
+    for (unsigned i = 1; i < args.size(); i++) {
+        std::string &s = args[i];
+        remove_quotes(s);
+        size_t idx = s.find('=');
+        if (idx == std::string::npos) {
+            rtapi_print_msg(RTAPI_MSG_ERR, "Invalid parameter `%s'\n", s.c_str());
+            return -1;
+        }
+        std::string param_name(s, 0, idx);
+        std::string param_value(s, idx + 1);
+        void *item = DLSYM<void *>(module, "rtapi_info_address_" + param_name);
+        if (!item) {
+            rtapi_print_msg(RTAPI_MSG_ERR, "Unknown parameter `%s'\n", s.c_str());
+            return -1;
+        }
+        char **item_type = DLSYM<char **>(module, "rtapi_info_type_" + param_name);
+        if (!item_type || !*item_type) {
+            rtapi_print_msg(RTAPI_MSG_ERR, "Unknown parameter `%s' (type information missing)\n", s.c_str());
+            return -1;
+        }
+
+        int *max_size_ptr = DLSYM<int *>(module, "rtapi_info_size_" + param_name);
+
+        char item_type_char = **item_type;
+        if (max_size_ptr) {
+            int max_size = *max_size_ptr;
+            size_t idx = 0;
+            int i = 0;
+            while (idx != std::string::npos) {
+                if (i == max_size) {
+                    rtapi_print_msg(RTAPI_MSG_ERR, "%s: can only take %d arguments\n", s.c_str(), max_size);
+                    return -1;
+                }
+                size_t idx1 = param_value.find(",", idx);
+                std::string substr(param_value, idx, idx1 - idx);
+                int result = do_one_item(item_type_char, s, substr, item, i);
+                if (result != 0)
+                    return result;
+                i++;
+                idx = idx1 == std::string::npos ? idx1 : idx1 + 1;
+            }
+        } else {
+            int result = do_one_item(item_type_char, s, param_value, item);
+            if (result != 0)
+                return result;
+        }
+    }
+    return 0;
+}
+
+static int do_load_cmd(const std::string &name, const std::vector<std::string> &args) {
+    void *w = modules[name];
+    if (w == NULL) {
+        std::string what;
+        what = fmt::format("{}/{}.so", EMC2_RTLIB_DIR, name);
+        void *module = modules[name] = dlopen(what.c_str(), RTLD_GLOBAL | RTLD_NOW);
+        if (!module) {
+            rtapi_print_msg(RTAPI_MSG_ERR, "%s: dlopen: %s\n", name.c_str(), dlerror());
+            modules.erase(name);
+            return -1;
+        }
+        /// XXX handle arguments
+        int (*start)(void) = DLSYM<int (*)(void)>(module, "rtapi_app_main");
+        if (!start) {
+            rtapi_print_msg(RTAPI_MSG_ERR, "%s: dlsym: %s\n", name.c_str(), dlerror());
+            dlclose(module);
+            modules.erase(name);
+            return -1;
+        }
+        if(!DLSYM<void(*)(void)>(module, "rtapi_app_exit")) {
+            rtapi_print_msg(RTAPI_MSG_ERR, "%s: component is missing rtapi_app_exit\n", name.c_str());
+            dlclose(module);
+            modules.erase(name);
+            return -1;
+        }
+        int result;
+
+        result = do_comp_args(module, args);
+        if (result < 0) {
+            dlclose(module);
+            modules.erase(name);
+            return -1;
+        }
+
+        if ((result = start()) < 0) {
+            rtapi_print_msg(RTAPI_MSG_ERR, "%s: rtapi_app_main: %s (%d)\n", name.c_str(), strerror(-result), result);
+            dlclose(module);
+            modules.erase(name);
+            return result;
+        } else {
+            instance_count++;
+            return 0;
+        }
+    } else {
+        rtapi_print_msg(RTAPI_MSG_ERR, "%s: already exists\n", name.c_str());
+        return -1;
+    }
+}
+
+static int do_unload_cmd(const std::string &name) {
+    void *w = modules[name];
+    if (w == NULL) {
+        rtapi_print_msg(RTAPI_MSG_ERR, "%s: not loaded\n", name.c_str());
+        return -1;
+    } else {
+        void (*stop)(void) = DLSYM<void(*)(void)>(w, "rtapi_app_exit");
+        if (stop)
+            stop();
+        modules.erase(modules.find(name));
+        dlclose(w);
+        instance_count--;
+    }
+    return 0;
+}
+
+static int do_debug_cmd(const std::string &value) {
+    try {
+        int new_level = stoi(value);
+        if (new_level < 0 || new_level > 5) {
+            rtapi_print_msg(RTAPI_MSG_ERR, "Debug level must be >=0 and <= 5\n");
+            return -EINVAL;
+        }
+        return rtapi_set_msg_level(new_level);
+    } catch (std::invalid_argument &e) {
+        //stoi will throw an exception if parsing is not possible
+        rtapi_print_msg(RTAPI_MSG_ERR, "Debug level is not a number\n");
+        return -EINVAL;
+    }
+}
+
+struct ReadError : std::exception {};
+struct WriteError : std::exception {};
+
+static int read_number(int fd) {
+    int r = 0, neg = 1;
+    char ch;
+
+    while (1) {
+        int res = read(fd, &ch, 1);
+        if (res != 1)
+            return -1;
+        if (ch == '-')
+            neg = -1;
+        else if (ch == ' ')
+            return r * neg;
+        else
+            r = 10 * r + ch - '0';
+    }
+}
+
+static std::string read_string(int fd) {
+    int len = read_number(fd);
+    if (len < 0)
+        throw ReadError();
+    if (!len)
+        return std::string();
+    std::string str(len, 0);
+    if (read(fd, str.data(), len) != len)
+        throw ReadError();
+    return str;
+}
+
+static std::vector<std::string> read_strings(int fd) {
+    std::vector<std::string> result;
+    int count = read_number(fd);
+    if (count < 0)
+        return result;
+    for (int i = 0; i < count; i++) {
+        result.push_back(read_string(fd));
+    }
+    return result;
+}
+
+static void write_number(std::string &buf, int num) {
+    buf = buf + fmt::format("{} ", num);
+}
+
+static void write_string(std::string &buf, const std::string &s) {
+    write_number(buf, s.size());
+    buf += s;
+}
+
+static void write_strings(int fd, const std::vector<std::string> &strings) {
+    std::string buf;
+    write_number(buf, strings.size());
+    for (unsigned int i = 0; i < strings.size(); i++) {
+        write_string(buf, strings[i]);
+    }
+    if (write(fd, buf.data(), buf.size()) != (ssize_t)buf.size())
+        throw WriteError();
+}
+
+static int handle_command(std::vector<std::string> args) {
+    if (args.size() == 0) {
+        return 0;
+    }
+    if (args.size() == 1 && args[0] == "exit") {
+        force_exit = 1;
+        return 0;
+    } else if (args.size() >= 2 && args[0] == "load") {
+        std::string name = args[1];
+        args.erase(args.begin());
+        return do_load_cmd(name, args);
+    } else if (args.size() == 2 && args[0] == "unload") {
+        return do_unload_cmd(args[1]);
+    } else if (args.size() == 3 && args[0] == "newinst") {
+        return do_newinst_cmd(args[1], args[2], "");
+    } else if (args.size() == 4 && args[0] == "newinst") {
+        return do_newinst_cmd(args[1], args[2], args[3]);
+    } else if (args.size() == 2 && args[0] == "debug") {
+        return do_debug_cmd(args[1]);
+    } else {
+        rtapi_print_msg(RTAPI_MSG_ERR, "Unrecognized command starting with %s\n", args[0].c_str());
+        return -1;
+    }
+}
+
+static int slave(int fd, const std::vector<std::string> &args) {
+    try {
+        write_strings(fd, args);
+    } catch (WriteError &e) {
+        rtapi_print_msg(RTAPI_MSG_ERR, "rtapi_app: failed to write to master: %s\n", strerror(errno));
+    }
+
+    int result = read_number(fd);
+    return result;
+}
+
+static int callback(int fd) {
+    struct sockaddr_un client_addr;
+    memset(&client_addr, 0, sizeof(client_addr));
+    socklen_t len = sizeof(client_addr);
+    int fd1 = accept(fd, (sockaddr *)&client_addr, &len);
+    if (fd1 < 0) {
+        rtapi_print_msg(RTAPI_MSG_ERR, "rtapi_app: failed to accept connection from slave: %s\n", strerror(errno));
+        return -1;
+    } else {
+        int result;
+        try {
+            result = handle_command(read_strings(fd1));
+        } catch (ReadError &e) {
+            rtapi_print_msg(RTAPI_MSG_ERR, "rtapi_app: failed to read from slave: %s\n", strerror(errno));
+            close(fd1);
+            return -1;
+        }
+        std::string buf;
+        write_number(buf, result);
+        if (write(fd1, buf.data(), buf.size()) != (ssize_t)buf.size()) {
+            rtapi_print_msg(RTAPI_MSG_ERR, "rtapi_app: failed to write to slave: %s\n", strerror(errno));
+        };
+        close(fd1);
+    }
+    return !force_exit && instance_count > 0;
+}
+
+static pthread_t main_thread{};
+
+static int master(int fd, const std::vector<std::string> &args) {
+    main_thread = pthread_self();
+    int result;
+    if ((result = pthread_create(&queue_thread, nullptr, &queue_function, nullptr)) != 0) {
+        errno = result;
+        perror("pthread_create (queue function)");
+        return -1;
+    }
+    do_load_cmd("hal_lib", std::vector<std::string>());
+    instance_count = 0;
+    App(); // force rtapi_app to be created
+    if (args.size()) {
+        result = handle_command(args);
+        if (result != 0)
+            goto out;
+        if (force_exit || instance_count == 0)
+            goto out;
+    }
+    sim_rtapi_run_threads(fd, callback);
+out:
+    pthread_cancel(queue_thread);
+    pthread_join(queue_thread, nullptr);
+    rtapi_msg_queue.consume_all([](const message_t &m) {
+        fputs(m.msg, m.level == RTAPI_MSG_ALL ? stdout : stderr);
+    });
+    return result;
+}
+
+static std::string get_fifo_path() {
+    std::string s;
+    if (getenv("RTAPI_FIFO_PATH")) {
+        s = getenv("RTAPI_FIFO_PATH");
+    } else if (getenv("HOME")) {
+        s = std::string(getenv("HOME")) + "/.rtapi_fifo";
+    } else {
+        rtapi_print_msg(
+            RTAPI_MSG_ERR, "rtapi_app: RTAPI_FIFO_PATH and HOME are unset.  rtapi fifo creation is unsafe.\n"
+        );
+    }
+    return s;
+}
+
+static int get_fifo_path(char *buf, size_t bufsize) {
+    int len;
+    const std::string s = get_fifo_path();
+    if (s.empty()) {
+        return -1;
+    }
+    if (s.size() + 1 > sizeof(sockaddr_un::sun_path)) {
+        rtapi_print_msg(
+            RTAPI_MSG_ERR,
+            "rtapi_app: rtapi fifo path is too long (arch limit %zd): %s\n",
+            sizeof(sockaddr_un::sun_path),
+            s.c_str()
+        );
+        return -1;
+    }
+    len = snprintf(buf + 1, bufsize - 1, "%s", s.c_str());
+    return len;
+}
+
+int main(int argc, char **argv) {
+    if (getuid() == 0) {
+        char *fallback_uid_str = getenv("RTAPI_UID");
+        int fallback_uid = fallback_uid_str ? atoi(fallback_uid_str) : 0;
+        if (fallback_uid == 0) {
+            // Cppcheck cannot see EMC2_BIN_DIR when RTAPI is defined, but that
+            // doesn't happen in uspace.
+            fprintf(
+                stderr,
+                "Refusing to run as root without fallback UID specified\n"
+                "To run under a debugger with I/O, use e.g.,\n"
+                // cppcheck-suppress unknownMacro
+                "    sudo env RTAPI_UID=`id -u` RTAPI_FIFO_PATH=$HOME/.rtapi_fifo gdb " EMC2_BIN_DIR "/rtapi_app\n"
+            );
+            exit(1);
+        }
+        if (setreuid(fallback_uid, 0) != 0) {
+            perror("setreuid");
+            abort();
+        }
+        fprintf(stderr, "Running with fallback_uid.  getuid()=%d geteuid()=%d\n", getuid(), geteuid());
+    }
+    ruid = getuid();
+    euid = geteuid();
+    if (setresuid(euid, euid, ruid) != 0) {
+        perror("setresuid");
+        abort();
+    }
+#ifdef __linux__
+    setfsuid(ruid);
+#endif
+    std::vector<std::string> args;
+    for (int i = 1; i < argc; i++) {
+        args.push_back(std::string(argv[i]));
+    }
+
+become_master:
+    int len = 0;
+    int fd = socket(PF_UNIX, SOCK_STREAM, 0);
+    if (fd == -1) {
+        perror("socket");
+        exit(1);
+    }
+
+    int enable = 1;
+    setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &enable, sizeof(enable));
+    struct sockaddr_un addr;
+    memset(&addr, 0x0, sizeof(addr));
+    addr.sun_family = AF_UNIX;
+    if ((len = get_fifo_path(addr.sun_path, sizeof(addr.sun_path))) < 0)
+        exit(1);
+
+    // plus one because we use the abstract namespace, it will show up in
+    // /proc/net/unix prefixed with an @
+    int result = ::bind(fd, (sockaddr *)&addr, len + sizeof(addr.sun_family) + 1);
+
+    if (result == 0) {
+        //If called in master mode with exit command, no need to start master
+        //and exit again
+        if (args.size() == 1 && args[0] == "exit") {
+            return 0;
+        }
+        int result = listen(fd, 10);
+        if (result != 0) {
+            perror("listen");
+            exit(1);
+        }
+        setsid(); // create a new session if we can...
+        result = master(fd, args);
+        return result;
+    } else if (errno == EADDRINUSE) {
+        struct timeval t0, t1;
+        gettimeofday(&t0, NULL);
+        gettimeofday(&t1, NULL);
+        for (int i = 0; i < 3 || (t1.tv_sec < 3 + t0.tv_sec); i++) {
+            result = connect(fd, (sockaddr *)&addr, len + sizeof(addr.sun_family) + 1);
+            if (result == 0)
+                break;
+            if (i == 0)
+                srand48(t0.tv_sec ^ t0.tv_usec);
+            usleep(lrand48() % 100000);
+            gettimeofday(&t1, NULL);
+        }
+        if (result < 0 && errno == ECONNREFUSED) {
+            fprintf(stderr, "Waited 3 seconds for master.  giving up.\n");
+            close(fd);
+            goto become_master;
+        }
+        if (result < 0) {
+            fprintf(stderr, "connect %s: %s", addr.sun_path, strerror(errno));
+            exit(1);
+        }
+        return slave(fd, args);
+    } else {
+        perror("bind");
+        exit(1);
+    }
+}
+
+
+/* These structs hold data associated with objects like tasks, etc. */
+/* Task handles are pointers to these structs.                      */
+
+struct rtapi_module {
+    int magic;
+};
+
+#define MODULE_MAGIC 30812
+#define SHMEM_MAGIC 25453
+
+#define MAX_MODULES 64
+#define MODULE_OFFSET 32768
+
+static void signal_handler(int sig, siginfo_t * /*si*/, void * /*uctx*/) {
+    switch (sig) {
+    case SIGXCPU:
+        // should not happen - must be handled in RTAPI if enabled
+        rtapi_print_msg(RTAPI_MSG_ERR, "rtapi_app: BUG: SIGXCPU received - exiting\n");
+        exit(0);
+        break;
+
+    case SIGTERM:
+        rtapi_print_msg(RTAPI_MSG_ERR, "rtapi_app: SIGTERM - shutting down\n");
+        exit(0);
+        break;
+
+    default: // pretty bad
+        rtapi_print_msg(RTAPI_MSG_ERR, "rtapi_app: caught signal %d - dumping core\n", sig);
+        sleep(1); // let syslog drain
+        signal(sig, SIG_DFL);
+        // for reasons unknown raise(sig); doesn't lead to core dump file
+        // but this will
+        kill(getpid(), sig);
+        break;
+    }
+    exit(1);
+}
+
+const size_t PRE_ALLOC_SIZE = 1024 * 1024 * 32;
+const static struct rlimit unlimited = {RLIM_INFINITY, RLIM_INFINITY};
+static void configure_memory() {
+    int res = setrlimit(RLIMIT_MEMLOCK, &unlimited);
+    if (res < 0)
+        perror("setrlimit");
+
+    res = mlockall(MCL_CURRENT | MCL_FUTURE);
+    if (res < 0)
+        perror("mlockall");
+
+#ifdef __linux__
+    /* Turn off malloc trimming.*/
+    if (!mallopt(M_TRIM_THRESHOLD, -1)) {
+        rtapi_print_msg(RTAPI_MSG_WARN, "mallopt(M_TRIM_THRESHOLD, -1) failed\n");
+    }
+    /* Turn off mmap usage. */
+    if (!mallopt(M_MMAP_MAX, 0)) {
+        rtapi_print_msg(RTAPI_MSG_WARN, "mallopt(M_MMAP_MAX, -1) failed\n");
+    }
+#endif
+    /*
+     * The following code seems pointless, but there is a non-observable effect
+     * in the allocation and loop.
+     *
+     * The malloc() is forced to set brk() because mmap() allocation is
+     * disabled in a call to mallopt() above. All touched pages become resident
+     * and locked in the loop because of above mlockall() call (see notes in
+     * mlockall(2)). The mallopt() trim setting prevents the brk() from being
+     * reduced after free(), effectively creating an open space for future
+     * allocations that will not generate page faults.
+     *
+     * The qualifier 'volatile' on the buffer pointer is required because newer
+     * clang would remove the malloc(), for()-loop and free() completely.
+     * Marking 'buf' volatile ensures that the code will remain in place.
+     */
+    volatile char *buf = static_cast<volatile char *>(malloc(PRE_ALLOC_SIZE));
+    if (buf == NULL) {
+        rtapi_print_msg(RTAPI_MSG_WARN, "malloc(PRE_ALLOC_SIZE) failed\n");
+        return;
+    }
+    long pagesize = sysconf(_SC_PAGESIZE);
+    /* Touch each page in this piece of memory to get it mapped into RAM */
+    for (size_t i = 0; i < PRE_ALLOC_SIZE; i += pagesize) {
+        /* Each write to this buffer will generate a pagefault.
+             * Once the pagefault is handled a page will be locked in
+             * memory and never given back to the system. */
+        buf[i] = 0;
+    }
+    free((void *)buf);
+}
+
+static int harden_rt() {
+    if (!rtapi_is_realtime())
+        return -EINVAL;
+
+    WITH_ROOT;
+#if defined(__linux__) && (defined(__x86_64__) || defined(__i386__))
+    if (iopl(3) < 0) {
+        rtapi_print_msg(
+            RTAPI_MSG_ERR,
+            "iopl() failed: %s\n"
+            "cannot gain I/O privileges - "
+            "forgot 'sudo make setuid' or using secure boot? -"
+            "parallel port access is not allowed\n",
+            strerror(errno)
+        );
+    }
+#endif
+
+    struct sigaction sig_act = {};
+#ifdef __linux__
+    // enable realtime
+    if (setrlimit(RLIMIT_RTPRIO, &unlimited) < 0) {
+        rtapi_print_msg(RTAPI_MSG_WARN, "setrlimit(RTLIMIT_RTPRIO): %s\n", strerror(errno));
+        return -errno;
+    }
+
+    // enable core dumps
+    if (setrlimit(RLIMIT_CORE, &unlimited) < 0)
+        rtapi_print_msg(
+            RTAPI_MSG_WARN, "setrlimit: %s - core dumps may be truncated or non-existent\n", strerror(errno)
+        );
+
+    // even when setuid root
+    if (prctl(PR_SET_DUMPABLE, 1) < 0)
+        rtapi_print_msg(
+            RTAPI_MSG_WARN,
+            "prctl(PR_SET_DUMPABLE) failed: no core dumps will be created - %d - %s\n",
+            errno,
+            strerror(errno)
+        );
+#endif /* __linux__ */
+
+    configure_memory();
+
+    sigemptyset(&sig_act.sa_mask);
+    sig_act.sa_handler = SIG_IGN;
+    sig_act.sa_sigaction = NULL;
+
+    // prevent stopping of RT threads by ^Z
+    sigaction(SIGTSTP, &sig_act, (struct sigaction *)NULL);
+
+    sig_act.sa_sigaction = signal_handler;
+    sig_act.sa_flags = SA_SIGINFO;
+
+    sigaction(SIGSEGV, &sig_act, (struct sigaction *)NULL);
+    sigaction(SIGILL, &sig_act, (struct sigaction *)NULL);
+    sigaction(SIGFPE, &sig_act, (struct sigaction *)NULL);
+    sigaction(SIGTERM, &sig_act, (struct sigaction *)NULL);
+    sigaction(SIGINT, &sig_act, (struct sigaction *)NULL);
+
+#ifdef __linux__
+    int fd = open("/dev/cpu_dma_latency", O_WRONLY | O_CLOEXEC);
+    if (fd < 0) {
+        rtapi_print_msg(RTAPI_MSG_WARN, "failed to open /dev/cpu_dma_latency: %s\n", strerror(errno));
+    } else {
+        int r;
+        r = write(fd, "\0\0\0\0", 4);
+        if (r != 4) {
+            rtapi_print_msg(RTAPI_MSG_WARN, "failed to write to /dev/cpu_dma_latency: %s\n", strerror(errno));
+        }
+        // deliberately leak fd until program exit
+    }
+#endif /* __linux__ */
+    return 0;
+}
+
+static RtapiApp *makeDllApp(std::string dllName, int policy) {
+    void *dll = nullptr;
+    dll = dlopen(dllName.c_str(), RTLD_NOW);
+    if (!dll) {
+        fprintf(stderr, "dlopen: %s\n", dlerror());
+        return nullptr;
+    }
+    auto fn = reinterpret_cast<RtapiApp *(*)(int policy)>(dlsym(dll, "make"));
+    if (!fn) {
+        fprintf(stderr, "dlsym: %s\n", dlerror());
+        return nullptr;
+    }
+    auto result = fn(policy);
+    if (!result) {
+        fprintf(stderr, "dlsym: %s\n", dlerror());
+        return nullptr;
+    }
+    return result;
+}
+
+static RtapiApp *makeApp() {
+    RtapiApp *app;
+    if (euid != 0 || harden_rt() < 0) {
+        app = makeDllApp(EMC2_HOME "/lib/libuspace-posix.so.0", SCHED_OTHER);
+    } else {
+        WithRoot r;
+        if (detect_xenomai_evl()) {
+            app = makeDllApp(EMC2_HOME "/lib/libuspace-xenomai-evl.so.0", SCHED_FIFO);
+        } else if (detect_xenomai()) {
+            app = makeDllApp(EMC2_HOME "/lib/libuspace-xenomai.so.0", SCHED_FIFO);
+        } else if (detect_rtai()) {
+            app = makeDllApp(EMC2_HOME "/lib/libuspace-rtai.so.0", SCHED_FIFO);
+        } else {
+            app = makeDllApp(EMC2_HOME "/lib/libuspace-posix.so.0", SCHED_FIFO);
+        }
+    }
+
+    if (!app) {
+        throw std::invalid_argument("Could not load rtapi dll");
+    } else {
+        return app;
+    }
+}
+RtapiApp &App() {
+    static RtapiApp *app = makeApp();
+    return *app;
+}
+
+/* data for all tasks */
+struct rtapi_task *task_array[MAX_TASKS];
+
+int rtapi_prio_highest(void) {
+    return App().prio_highest();
+}
+
+int rtapi_prio_lowest(void) {
+    return App().prio_lowest();
+}
+
+int rtapi_prio_next_higher(int prio) {
+    return App().prio_next_higher(prio);
+}
+
+int rtapi_prio_next_lower(int prio) {
+    return App().prio_next_lower(prio);
+}
+
+long rtapi_clock_set_period(long nsecs) {
+    return App().clock_set_period(nsecs);
+}
+
+int rtapi_task_new(void (*taskcode)(void *), void *arg, int prio, int owner, unsigned long int stacksize, int uses_fp) {
+    return App().task_new(taskcode, arg, prio, owner, stacksize, uses_fp);
+}
+
+int rtapi_task_delete(int id) {
+    return App().task_delete(id);
+}
+
+int rtapi_task_start(int task_id, unsigned long period_nsec) {
+    int ret = App().task_start(task_id, period_nsec);
+    if (ret != 0) {
+        errno = -ret;
+        perror("rtapi_task_start()");
+    }
+    return ret;
+}
+
+int rtapi_task_pause(int task_id) {
+    return App().task_pause(task_id);
+}
+
+int rtapi_task_resume(int task_id) {
+    return App().task_resume(task_id);
+}
+
+int rtapi_task_self() {
+    return App().task_self();
+}
+
+long long rtapi_task_pll_get_reference(void) {
+    return App().task_pll_get_reference();
+}
+
+int rtapi_task_pll_set_correction(long value) {
+    return App().task_pll_set_correction(value);
+}
+
+void rtapi_wait(void) {
+    App().wait();
+}
+
+void rtapi_outb(unsigned char byte, unsigned int port) {
+    App().do_outb(byte, port);
+}
+
+unsigned char rtapi_inb(unsigned int port) {
+    return App().do_inb(port);
+}
+
+long int simple_strtol(const char *nptr, char **endptr, int base) {
+    return strtol(nptr, endptr, base);
+}
+
+int sim_rtapi_run_threads(int fd, int (*callback)(int fd)) {
+    return App().run_threads(fd, callback);
+}
+
+long long rtapi_get_time() {
+    return App().do_get_time();
+}
+
+void default_rtapi_msg_handler(msg_level_t level, const char *fmt, va_list ap) {
+    if (main_thread && pthread_self() != main_thread) {
+        message_t m;
+        m.level = level;
+        vsnprintf(m.msg, sizeof(m.msg), fmt, ap);
+        rtapi_msg_queue.push(m);
+    } else {
+        vfprintf(level == RTAPI_MSG_ALL ? stdout : stderr, fmt, ap);
+    }
+}
+
+long int rtapi_delay_max() {
+    return 10000;
+}
+
+void rtapi_delay(long ns) {
+    if (ns > rtapi_delay_max())
+        ns = rtapi_delay_max();
+    App().do_delay(ns);
+}
+
+const unsigned long ONE_SEC_IN_NS = 1000000000;
+void rtapi_timespec_advance(struct timespec &result, const struct timespec &src, unsigned long nsec) {
+    time_t sec = src.tv_sec;
+    while (nsec >= ONE_SEC_IN_NS) {
+        ++sec;
+        nsec -= ONE_SEC_IN_NS;
+    }
+    nsec += src.tv_nsec;
+    if (nsec >= ONE_SEC_IN_NS) {
+        ++sec;
+        nsec -= ONE_SEC_IN_NS;
+    }
+    result.tv_sec = sec;
+    result.tv_nsec = nsec;
+}
+
+int rtapi_open_as_root(const char *filename, int mode) {
+    WITH_ROOT;
+    int r = open(filename, mode);
+    if (r < 0)
+        return -errno;
+    return r;
+}
+
+int rtapi_spawn_as_root(
+    pid_t *pid,
+    const char *path,
+    const posix_spawn_file_actions_t *file_actions,
+    const posix_spawnattr_t *attrp,
+    char *const argv[],
+    char *const envp[]
+) {
+    return posix_spawn(pid, path, file_actions, attrp, argv, envp);
+}
+
+int rtapi_spawnp_as_root(
+    pid_t *pid,
+    const char *path,
+    const posix_spawn_file_actions_t *file_actions,
+    const posix_spawnattr_t *attrp,
+    char *const argv[],
+    char *const envp[]
+) {
+    return posix_spawnp(pid, path, file_actions, attrp, argv, envp);
+}

--- a/src/rtapi/uspace_rtapi_main.cc
+++ b/src/rtapi/uspace_rtapi_main.cc
@@ -541,7 +541,7 @@ become_master:
 
     // plus one because we use the abstract namespace, it will show up in
     // /proc/net/unix prefixed with an @
-    int result = ::bind(fd, (sockaddr *)&addr, len + sizeof(addr.sun_family) + 1);
+    int result = ::bind(fd, (sockaddr *)&addr, sizeof(addr));
 
     if (result == 0) {
         //If called in master mode with exit command, no need to start master
@@ -562,7 +562,7 @@ become_master:
         gettimeofday(&t0, NULL);
         gettimeofday(&t1, NULL);
         for (int i = 0; i < 3 || (t1.tv_sec < 3 + t0.tv_sec); i++) {
-            result = connect(fd, (sockaddr *)&addr, len + sizeof(addr.sun_family) + 1);
+            result = connect(fd, (sockaddr *)&addr, sizeof(addr));
             if (result == 0)
                 break;
             if (i == 0)

--- a/src/rtapi/uspace_rtapi_main.cc
+++ b/src/rtapi/uspace_rtapi_main.cc
@@ -644,31 +644,47 @@ struct rtapi_module {
 #define WRITE_STDERR_STR(str) ((void)!write(STDERR_FILENO, str, strlen(str)))
 static void signal_handler(int sig, siginfo_t * /*si*/, void * /*uctx*/) {
     //Read: https://www.man7.org/linux/man-pages/man7/signal-safety.7.html
+    bool doAbort = true;
     switch (sig) {
     case SIGXCPU:
-        WRITE_STDERR_STR("rtapi_app: SIGXCPU - shutting down\n");
+        WRITE_STDERR_STR("rtapi_app: SIGXCPU - aborting\n");
         break;
     case SIGSEGV:
-        WRITE_STDERR_STR("rtapi_app: SIGSEGV - shutting down\n");
+        WRITE_STDERR_STR("rtapi_app: SIGSEGV - aborting\n");
         break;
     case SIGILL:
-        WRITE_STDERR_STR("rtapi_app: SIGILL - shutting down\n");
+        WRITE_STDERR_STR("rtapi_app: SIGILL - aborting\n");
         break;
     case SIGFPE:
-        WRITE_STDERR_STR("rtapi_app: SIGFPE - shutting down\n");
+        WRITE_STDERR_STR("rtapi_app: SIGFPE - aborting\n");
         break;
     case SIGTERM:
         WRITE_STDERR_STR("rtapi_app: SIGTERM - shutting down\n");
+        doAbort = false; //TERM is a user signal, no need for a coredump
         break;
     case SIGINT:
         WRITE_STDERR_STR("rtapi_app: SIGINT - shutting down\n");
+        doAbort = false; //INT is a user signal, no need for a coredump
         break;
     default:
-        WRITE_STDERR_STR("rtapi_app: UNKNOWN - shutting down\n");
+        WRITE_STDERR_STR("rtapi_app: UNKNOWN - aborting\n");
         break;
     }
 
-    _exit(1);
+    //Write remaining messages
+    rtapi_msg_queue.consume_all([](const message_t &m) {
+        WRITE_STDERR_STR(m.msg);
+    });
+
+    if(doAbort){
+        //Call abort to generate a coredump if enabled
+        //To enable coredumps for setuid applications:
+        //echo 1 | sudo tee /proc/sys/fs/suid_dumpable #rtapi_app is setuid
+        //In general:
+        //ulimit -c unlimited or coredumpctl
+        abort();
+    }
+    _exit(128+sig); //128+n: Fatal error signal "n"
 }
 
 const static size_t PRE_ALLOC_SIZE = 1024 * 1024 * 32;

--- a/src/rtapi/uspace_rtapi_main.cc
+++ b/src/rtapi/uspace_rtapi_main.cc
@@ -663,42 +663,45 @@ struct rtapi_module {
 #define MAX_MODULES 64
 #define MODULE_OFFSET 32768
 
-#define WRITE_STDERR_STR(str) ((void)!write(STDERR_FILENO, str, strlen(str)))
+static inline void write_string(int fd, const char *str) {
+    (void)!write(fd, str, strlen(str));
+}
+
 static void signal_handler(int sig, siginfo_t * /*si*/, void * /*uctx*/) {
     //Read: https://www.man7.org/linux/man-pages/man7/signal-safety.7.html
     bool doAbort = true;
     switch (sig) {
     case SIGXCPU:
-        WRITE_STDERR_STR("rtapi_app: SIGXCPU - aborting\n");
+        write_string(STDERR_FILENO, "rtapi_app: SIGXCPU - aborting\n");
         break;
     case SIGSEGV:
-        WRITE_STDERR_STR("rtapi_app: SIGSEGV - aborting\n");
+        write_string(STDERR_FILENO, "rtapi_app: SIGSEGV - aborting\n");
         break;
     case SIGILL:
-        WRITE_STDERR_STR("rtapi_app: SIGILL - aborting\n");
+        write_string(STDERR_FILENO, "rtapi_app: SIGILL - aborting\n");
         break;
     case SIGFPE:
-        WRITE_STDERR_STR("rtapi_app: SIGFPE - aborting\n");
+        write_string(STDERR_FILENO, "rtapi_app: SIGFPE - aborting\n");
         break;
     case SIGTERM:
-        WRITE_STDERR_STR("rtapi_app: SIGTERM - shutting down\n");
+        write_string(STDERR_FILENO, "rtapi_app: SIGTERM - shutting down\n");
         doAbort = false; //TERM is a user signal, no need for a coredump
         break;
     case SIGINT:
-        WRITE_STDERR_STR("rtapi_app: SIGINT - shutting down\n");
+        write_string(STDERR_FILENO, "rtapi_app: SIGINT - shutting down\n");
         doAbort = false; //INT is a user signal, no need for a coredump
         break;
     default:
-        WRITE_STDERR_STR("rtapi_app: UNKNOWN - aborting\n");
+        write_string(STDERR_FILENO, "rtapi_app: UNKNOWN - aborting\n");
         break;
     }
 
     //Write remaining messages
     rtapi_msg_queue.consume_all([](const message_t &m) {
-        WRITE_STDERR_STR(m.msg);
+        write_string(STDERR_FILENO, m.msg);
     });
 
-    if(doAbort){
+    if (doAbort) {
         //Call abort to generate a coredump if enabled
         //To enable coredumps for setuid applications:
         //echo 1 | sudo tee /proc/sys/fs/suid_dumpable #rtapi_app is setuid
@@ -706,7 +709,7 @@ static void signal_handler(int sig, siginfo_t * /*si*/, void * /*uctx*/) {
         //ulimit -c unlimited or coredumpctl
         abort();
     }
-    _exit(128+sig); //128+n: Fatal error signal "n"
+    _exit(128 + sig); //128+n: Fatal error signal "n"
 }
 
 const static size_t PRE_ALLOC_SIZE = 1024 * 1024 * 32;

--- a/src/rtapi/uspace_rtapi_main.cc
+++ b/src/rtapi/uspace_rtapi_main.cc
@@ -467,26 +467,25 @@ static std::string get_fifo_path() {
     return s;
 }
 
-static int get_fifo_path_to_addr(struct sockaddr_un *addr) {
-    int len;
+static bool get_fifo_path_to_addr(struct sockaddr_un *addr) {
     const std::string s = get_fifo_path();
     if (s.empty()) {
-        return -1;
+        return false;
     }
-    if (s.size() + 1 > sizeof(addr->sun_path)) {
+    if (s.size() + 2 > sizeof(addr->sun_path)) {
         rtapi_print_msg(
             RTAPI_MSG_ERR,
             "rtapi_app: rtapi fifo path is too long (arch limit %zd): %s\n",
             sizeof(sockaddr_un::sun_path),
             s.c_str()
         );
-        return -1;
+        return false;
     }
     //See: https://www.man7.org/linux/man-pages/man7/unix.7.html abstract
     //sun_path[0] is a null byte ('\0')
     addr->sun_path[0]=0;
-    len = snprintf(addr->sun_path + 1, sizeof(addr->sun_path) - 1, "%s", s.c_str());
-    return len;
+    strncpy(addr->sun_path + 1, s.c_str(), sizeof(addr->sun_path) - 2);
+    return true;
 }
 
 static double diff_timespec(const struct timespec *time1, const struct timespec *time0) {
@@ -531,7 +530,6 @@ int main(int argc, char **argv) {
     }
 
 become_master:
-    int len = 0;
     int fd = socket(PF_UNIX, SOCK_STREAM, 0);
     if (fd == -1) {
         perror("socket");
@@ -543,7 +541,7 @@ become_master:
     struct sockaddr_un addr;
     memset(&addr, 0x0, sizeof(addr));
     addr.sun_family = AF_UNIX;
-    if ((len = get_fifo_path_to_addr(&addr)) < 0)
+    if (!get_fifo_path_to_addr(&addr))
         exit(1);
 
     // plus one because we use the abstract namespace, it will show up in

--- a/src/rtapi/uspace_rtapi_parport.cc
+++ b/src/rtapi/uspace_rtapi_parport.cc
@@ -19,7 +19,7 @@
 #include <map>
 #include <rtapi.h>
 #include <rtapi_parport.h>
-#include "rtapi_uspace.hh"
+#include "uspace_rtapi_app.hh"
 #include <stdio.h>
 #include <string.h>
 #include <sys/ioctl.h>

--- a/src/rtapi/uspace_xenomai.cc
+++ b/src/rtapi/uspace_xenomai.cc
@@ -188,13 +188,6 @@ struct XenomaiApp : RtapiApp {
 #endif
     }
 
-    int run_threads(int fd, int (*callback)(int fd)) {
-        while (callback(fd)) {
-            /* nothing */
-        }
-        return 0;
-    }
-
     int task_self() {
         struct rtapi_task *task = reinterpret_cast<rtapi_task *>(pthread_getspecific(key));
         if (!task)

--- a/src/rtapi/uspace_xenomai.cc
+++ b/src/rtapi/uspace_xenomai.cc
@@ -27,8 +27,8 @@
 #endif
 
 namespace {
-struct XenomaiTask : rtapi_task {
-    XenomaiTask() : rtapi_task{}, cancel{}, thr{} {
+struct XenomaiTask : RtapiTask {
+    XenomaiTask() : RtapiTask{}, cancel{}, thr{} {
     }
     std::atomic_int cancel;
     pthread_t thr;
@@ -40,7 +40,7 @@ struct XenomaiApp : RtapiApp {
         pthread_once(&key_once, init_key);
     }
 
-    struct rtapi_task *do_task_new() {
+    RtapiTask *do_task_new() {
         return new XenomaiTask;
     }
 
@@ -133,14 +133,14 @@ struct XenomaiApp : RtapiApp {
     }
 
     long long task_pll_get_reference(void) {
-        struct rtapi_task *task = reinterpret_cast<rtapi_task *>(pthread_getspecific(key));
+        RtapiTask *task = reinterpret_cast<RtapiTask *>(pthread_getspecific(key));
         if (!task)
             return 0;
         return task->nextstart.tv_sec * 1000000000LL + task->nextstart.tv_nsec;
     }
 
     int task_pll_set_correction(long value) {
-        struct rtapi_task *task = reinterpret_cast<rtapi_task *>(pthread_getspecific(key));
+        RtapiTask *task = reinterpret_cast<RtapiTask *>(pthread_getspecific(key));
         if (!task)
             return -EINVAL;
         if (value > task->pll_correction_limit)
@@ -189,7 +189,7 @@ struct XenomaiApp : RtapiApp {
     }
 
     int task_self() {
-        struct rtapi_task *task = reinterpret_cast<rtapi_task *>(pthread_getspecific(key));
+        RtapiTask *task = reinterpret_cast<RtapiTask *>(pthread_getspecific(key));
         if (!task)
             return -EINVAL;
         return task->id;

--- a/src/rtapi/uspace_xenomai_evl.cc
+++ b/src/rtapi/uspace_xenomai_evl.cc
@@ -38,8 +38,8 @@
 #endif
 
 namespace {
-struct EvlTask : rtapi_task {
-    EvlTask() : rtapi_task{}, cancel{}, thr{} {
+struct EvlTask : RtapiTask {
+    EvlTask() : RtapiTask{}, cancel{}, thr{} {
     }
     std::atomic_int cancel;
     pthread_t thr;
@@ -51,7 +51,7 @@ struct EvlApp : RtapiApp {
         pthread_once(&key_once, init_key);
     }
 
-    struct rtapi_task *do_task_new() {
+    RtapiTask *do_task_new() {
         return new EvlTask;
     }
 
@@ -154,14 +154,14 @@ struct EvlApp : RtapiApp {
     }
 
     long long task_pll_get_reference(void) {
-        struct rtapi_task *task = reinterpret_cast<rtapi_task *>(pthread_getspecific(key));
+        RtapiTask *task = reinterpret_cast<RtapiTask *>(pthread_getspecific(key));
         if (!task)
             return 0;
         return task->nextstart.tv_sec * 1000000000LL + task->nextstart.tv_nsec;
     }
 
     int task_pll_set_correction(long value) {
-        struct rtapi_task *task = reinterpret_cast<rtapi_task *>(pthread_getspecific(key));
+        RtapiTask *task = reinterpret_cast<RtapiTask *>(pthread_getspecific(key));
         if (!task)
             return -EINVAL;
         if (value > task->pll_correction_limit)
@@ -210,7 +210,7 @@ struct EvlApp : RtapiApp {
     }
 
     int task_self() {
-        struct rtapi_task *task = reinterpret_cast<rtapi_task *>(pthread_getspecific(key));
+        RtapiTask *task = reinterpret_cast<RtapiTask *>(pthread_getspecific(key));
         if (!task)
             return -EINVAL;
         return task->id;

--- a/src/rtapi/uspace_xenomai_evl.cc
+++ b/src/rtapi/uspace_xenomai_evl.cc
@@ -1,6 +1,25 @@
+/* Copyright (C) 2016 Jeff Epler <jepler@unpythonic.net>
+ * Copyright (C) 2026 Hannes Diethelm <hannes.diethelm@gmail.com>
+ *   Copy uspace_xenomai.cc and adapted to Xenomai4 EVL
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
 #include "config.h"
 #include "rtapi.h"
-#include "rtapi_uspace.hh"
+#include "uspace_rtapi_app.hh"
 
 #include <sched.h>
 
@@ -13,31 +32,33 @@
 #include <errno.h>
 #include <stdio.h>
 #include <cstring>
+#include <stdexcept>
 #ifdef HAVE_SYS_IO_H
 #include <sys/io.h>
 #endif
 
-namespace
-{
-struct RtaiTask : rtapi_task {
-    RtaiTask() : rtapi_task{}, cancel{}, thr{} {}
+namespace {
+struct EvlTask : rtapi_task {
+    EvlTask() : rtapi_task{}, cancel{}, thr{} {
+    }
     std::atomic_int cancel;
     pthread_t thr;
 };
 
 
-struct XenomaiApp : RtapiApp {
-    XenomaiApp() : RtapiApp(SCHED_FIFO) {
+struct EvlApp : RtapiApp {
+    EvlApp() : RtapiApp(SCHED_FIFO) {
         pthread_once(&key_once, init_key);
     }
 
-    RtaiTask *do_task_new() {
-        return new RtaiTask;
+    struct rtapi_task *do_task_new() {
+        return new EvlTask;
     }
 
     int task_delete(int id) {
-        auto task = ::rtapi_get_task<RtaiTask>(id);
-        if(!task) return -EINVAL;
+        auto task = ::rtapi_get_task<EvlTask>(id);
+        if (!task)
+            return -EINVAL;
 
         task->cancel = 1;
         pthread_join(task->thr, nullptr);
@@ -48,8 +69,9 @@ struct XenomaiApp : RtapiApp {
     }
 
     int task_start(int task_id, unsigned long period_nsec) {
-        auto task = ::rtapi_get_task<RtaiTask>(task_id);
-        if(!task) return -EINVAL;
+        auto task = ::rtapi_get_task<EvlTask>(task_id);
+        if (!task)
+            return -EINVAL;
 
         task->period = period_nsec;
         struct sched_param param;
@@ -60,39 +82,39 @@ struct XenomaiApp : RtapiApp {
         task->pll_correction_limit = period_nsec / 100;
         task->pll_correction = 0;
 
-        int nprocs = sysconf( _SC_NPROCESSORS_ONLN );
+        int nprocs = sysconf(_SC_NPROCESSORS_ONLN);
 
-        int ret;
         pthread_attr_t attr;
-        if((ret = pthread_attr_init(&attr)) != 0)
+        int ret;
+        if ((ret = pthread_attr_init(&attr)) != 0)
             return -ret;
-        if((ret = pthread_attr_setstacksize(&attr, task->stacksize)) != 0)
+        if ((ret = pthread_attr_setstacksize(&attr, task->stacksize)) != 0)
             return -ret;
-        if((ret = pthread_attr_setschedpolicy(&attr, policy)) != 0)
+        if ((ret = pthread_attr_setschedpolicy(&attr, policy)) != 0)
             return -ret;
-        if((ret = pthread_attr_setschedparam(&attr, &param)) != 0)
+        if ((ret = pthread_attr_setschedparam(&attr, &param)) != 0)
             return -ret;
-        if((ret = pthread_attr_setinheritsched(&attr, PTHREAD_EXPLICIT_SCHED)) != 0)
+        if ((ret = pthread_attr_setinheritsched(&attr, PTHREAD_EXPLICIT_SCHED)) != 0)
             return -ret;
-        if(nprocs > 1){
+        if (nprocs > 1) {
             const static int rt_cpu_number = find_rt_cpu_number();
             rtapi_print_msg(RTAPI_MSG_INFO, "rt_cpu_number = %i\n", rt_cpu_number);
-            if(rt_cpu_number != -1) {
+            if (rt_cpu_number != -1) {
                 cpu_set_t cpuset;
                 CPU_ZERO(&cpuset);
                 CPU_SET(rt_cpu_number, &cpuset);
-                if((ret = pthread_attr_setaffinity_np(&attr, sizeof(cpuset), &cpuset)) != 0)
+                if ((ret = pthread_attr_setaffinity_np(&attr, sizeof(cpuset), &cpuset)) != 0)
                     return -ret;
             }
         }
-        if((ret = pthread_create(&task->thr, &attr, &wrapper, reinterpret_cast<void*>(task))) != 0)
+        if ((ret = pthread_create(&task->thr, &attr, &wrapper, reinterpret_cast<void *>(task))) != 0)
             return -ret;
 
         return 0;
     }
 
     static void *wrapper(void *arg) {
-        auto task = reinterpret_cast<RtaiTask*>(arg);
+        auto task = reinterpret_cast<EvlTask *>(arg);
         pthread_setspecific(key, arg);
 
         {
@@ -100,7 +122,7 @@ struct XenomaiApp : RtapiApp {
             /* Attach to the core. */
             rtapi_print("linuxcnc-task:%d\n", gettid());
             int tfd = evl_attach_self("linuxcnc-thread:%d", gettid());
-            if (tfd < 0){
+            if (tfd < 0) {
                 rtapi_print("evl_attach_self() failed ret %i errno %i\n", tfd, errno);
             }
         }
@@ -115,7 +137,7 @@ struct XenomaiApp : RtapiApp {
         // encountered on: 3.18.20-xenomai-2.6.5 with a 2-thread SMP system
         rtapi_timespec_advance(task->nextstart, now, task->period + task->pll_correction);
 
-        (task->taskcode) (task->arg);
+        (task->taskcode)(task->arg);
 
         rtapi_print("ERROR: reached end of wrapper for task %d\n", task->id);
         return nullptr;
@@ -132,38 +154,40 @@ struct XenomaiApp : RtapiApp {
     }
 
     long long task_pll_get_reference(void) {
-        struct rtapi_task *task = reinterpret_cast<rtapi_task*>(pthread_getspecific(key));
-        if(!task) return 0;
+        struct rtapi_task *task = reinterpret_cast<rtapi_task *>(pthread_getspecific(key));
+        if (!task)
+            return 0;
         return task->nextstart.tv_sec * 1000000000LL + task->nextstart.tv_nsec;
     }
 
     int task_pll_set_correction(long value) {
-        struct rtapi_task *task = reinterpret_cast<rtapi_task*>(pthread_getspecific(key));
-        if(!task) return -EINVAL;
-        if (value > task->pll_correction_limit) value = task->pll_correction_limit;
-        if (value < -(task->pll_correction_limit)) value = -(task->pll_correction_limit);
+        struct rtapi_task *task = reinterpret_cast<rtapi_task *>(pthread_getspecific(key));
+        if (!task)
+            return -EINVAL;
+        if (value > task->pll_correction_limit)
+            value = task->pll_correction_limit;
+        if (value < -(task->pll_correction_limit))
+            value = -(task->pll_correction_limit);
         task->pll_correction = value;
         return 0;
     }
 
     void wait() {
         int task_id = task_self();
-        auto task = ::rtapi_get_task<RtaiTask>(task_id);
-        if(task->cancel) {
+        auto task = ::rtapi_get_task<EvlTask>(task_id);
+        if (task->cancel) {
             pthread_exit(nullptr);
         }
         rtapi_timespec_advance(task->nextstart, task->nextstart, task->period + task->pll_correction);
         struct timespec now;
         evl_read_clock(EVL_CLOCK_MONOTONIC, &now);
-        if(rtapi_timespec_less(task->nextstart, now))
-        {
-            if(policy == SCHED_FIFO)
+        if (rtapi_timespec_less(task->nextstart, now)) {
+            if (policy == SCHED_FIFO)
                 unexpected_realtime_delay(task);
-        }
-        else
-        {
+        } else {
             int res = evl_sleep_until(EVL_CLOCK_MONOTONIC, &task->nextstart);
-            if(res < 0) perror("evl_sleep_until");
+            if (res < 0)
+                perror("evl_sleep_until");
         }
     }
 
@@ -171,6 +195,7 @@ struct XenomaiApp : RtapiApp {
 #ifdef HAVE_SYS_IO_H
         return inb(port);
 #else
+        (void)port;
         return 0;
 #endif
     }
@@ -179,18 +204,22 @@ struct XenomaiApp : RtapiApp {
 #ifdef HAVE_SYS_IO_H
         return outb(val, port);
 #else
-        return 0;
+        (void)val;
+        (void)port;
 #endif
     }
 
     int run_threads(int fd, int (*callback)(int fd)) {
-        while(callback(fd)) { /* nothing */ }
+        while (callback(fd)) {
+            /* nothing */
+        }
         return 0;
     }
 
     int task_self() {
-        struct rtapi_task *task = reinterpret_cast<rtapi_task*>(pthread_getspecific(key));
-        if(!task) return -EINVAL;
+        struct rtapi_task *task = reinterpret_cast<rtapi_task *>(pthread_getspecific(key));
+        if (!task)
+            return -EINVAL;
         return task->id;
     }
 
@@ -214,13 +243,16 @@ struct XenomaiApp : RtapiApp {
     }
 };
 
-pthread_once_t XenomaiApp::key_once;
-pthread_key_t XenomaiApp::key;
-}
+pthread_once_t EvlApp::key_once;
+pthread_key_t EvlApp::key;
+} // namespace
 
-extern "C" RtapiApp *make();
+extern "C" RtapiApp *make(int policy);
 
-RtapiApp *make() {
+RtapiApp *make(int policy) {
+    if (policy != SCHED_FIFO) {
+        throw std::invalid_argument("Only SCHED_FIFO allowed");
+    }
     rtapi_print_msg(RTAPI_MSG_ERR, "Note: Using XENOMAI4 EVL realtime\n");
-    return new XenomaiApp;
+    return new EvlApp();
 }

--- a/src/rtapi/uspace_xenomai_evl.cc
+++ b/src/rtapi/uspace_xenomai_evl.cc
@@ -209,13 +209,6 @@ struct EvlApp : RtapiApp {
 #endif
     }
 
-    int run_threads(int fd, int (*callback)(int fd)) {
-        while (callback(fd)) {
-            /* nothing */
-        }
-        return 0;
-    }
-
     int task_self() {
         struct rtapi_task *task = reinterpret_cast<rtapi_task *>(pthread_getspecific(key));
         if (!task)


### PR DESCRIPTION
Continuation of https://github.com/LinuxCNC/linuxcnc/pull/3908 reverted in https://github.com/LinuxCNC/linuxcnc/pull/3918

Target: Move some classes out of the huge uspace_rtapi_app.cc

uspace_rtapi_main: Contains the main function and helpers
uspace_rtapi_app: Contains the RtapiApp class
uspace_posix: Contains the PosixApp class

Other fixes:
- Don't start master just for exit: https://github.com/LinuxCNC/linuxcnc/pull/3908/changes/371793cdd9187a8872c9ed1dea6e76ea1d6ac59c
- Remove unused rtapi_task::ratio: https://github.com/LinuxCNC/linuxcnc/pull/3908/changes/309757829b986bc60817f646c8813d124f0ea01d
  - Set but only read to force a fixed ratio which probably was not the intention
- Slightly different lock to avoid needing reference to instance: https://github.com/LinuxCNC/linuxcnc/pull/3908/changes/c8af827762238ce5c85c83c34bdc6d0c22f97b17 
- All real time implementations are now library's and handled the same way: https://github.com/LinuxCNC/linuxcnc/commit/62e5ea6457af35ef4d7380168b962528f348a5f6
 - No hard-coded library paths https://github.com/LinuxCNC/linuxcnc/commit/e1bbaf4f57166b093e0abe739d9b48a8f7de575c
 - ... and many more that came up during review