### PR TITLE
build: Filter rtapi module version scripts to defined symbols only

### DIFF
--- a/src/hal/components/enum.c
+++ b/src/hal/components/enum.c
@@ -184,6 +184,8 @@ int rtapi_app_main(void){
 
 }
 
+void rtapi_app_exit(void) {}
+
 static void decode(void *v_inst, long period){
     (void)period;
     int i;

--- a/src/rtapi/uspace_rtapi_app.cc
+++ b/src/rtapi/uspace_rtapi_app.cc
@@ -289,6 +289,12 @@ static int do_load_cmd(const string& name, const vector<string>& args) {
             modules.erase(name);
             return -1;
         }
+        if(!DLSYM<void(*)(void)>(module, "rtapi_app_exit")) {
+            rtapi_print_msg(RTAPI_MSG_ERR, "%s: component is missing rtapi_app_exit\n", name.c_str());
+            dlclose(module);
+            modules.erase(name);
+            return -1;
+        }
         int result;
 
         result = do_comp_args(module, args);
@@ -320,7 +326,7 @@ static int do_unload_cmd(const string& name) {
         rtapi_print_msg(RTAPI_MSG_ERR, "%s: not loaded\n", name.c_str());
 	return -1;
     } else {
-        int (*stop)(void) = DLSYM<int(*)(void)>(w, "rtapi_app_exit");
+        void (*stop)(void) = DLSYM<void(*)(void)>(w, "rtapi_app_exit");
 	if(stop) stop();
 	modules.erase(modules.find(name));
         dlclose(w);


### PR DESCRIPTION
rtapi_app.h unconditionally declares EXPORT_SYMBOL(rtapi_app_main) and EXPORT_SYMBOL(rtapi_app_exit), causing every module to list both names in its generated linker version script. Modules that only implement rtapi_app_main (e.g. hal/components/enum.c) then triggered lld's --no-undefined-version (default since LLD 17, see LLVM D135402):

    ld.lld: error: version script assignment of 'global' to symbol
    'rtapi_app_exit' failed: symbol not defined

Intersect the exported-name list with the actual defined symbols from nm -g --defined-only so the version script only mentions symbols that are really present in the linked object. Behavior under GNU ld is unchanged (the new list is a strict subset of the previous one), and LLD now accepts the build without needing --undefined-version.

Fixes #3191.