### PR TITLE
ini: fix maybe-uninitialized warning

### DIFF
--- a/src/emc/ini/inifile.cc
+++ b/src/emc/ini/inifile.cc
@@ -332,7 +332,7 @@ bool IniFileContent::processValue(std::string &value, const std::string &path, u
 	std::string realstr;
 	uint32_t hexval;
 	size_t pos;
-	char quote;
+	char quote = 0;
 	enum { ST_START, ST_COLLECT } state = ST_START;
 	for(pos = 0; pos < value.size(); pos++) {
 		char ch = value[pos];


### PR DESCRIPTION
Unfortunately, this uninitialized warning was not caught on Debian 11, 12 or 13 before it was merged. It is a gcc false positive breaking CI.

Now, with -Werror in place, the build fails. This fixes that. However, it does show that it works :-)

[we may see more of these problems when merging PRs that are from before the #3913 change]