### PR TITLE
tcl: restore #INCLUDE handling in parse_ini to fix check_config.tcl after 2f57090

### DIFF
--- a/tcl/linuxcnc.tcl.in
+++ b/tcl/linuxcnc.tcl.in
@@ -136,12 +136,37 @@ proc linuxcnc::standard_fixed_font {} {
 
 proc parse_ini {filename} {
     # create associative arrays for all ini file sections
-    # like: ::EMC(VERSION), ::KINS(JOINTS), ... etc
+    # like: ::EMC(VERSION), ::KINS(JOINTS), ... etc.
+    #
+    # #INCLUDE <filename> directives are followed recursively, matching
+    # the semantics of the C++ INI parser's IniFileContent::parseLine()
+    # in src/emc/ini/inifile.cc. Relative includes resolve against the
+    # including file's directory.
+    #
+    # The recursive call uses `uplevel 1` so the included file's
+    # sections land in the same scope as the top-level file's sections
+    # — which for existing callers (check_config.tcl from file scope,
+    # twopass.tcl::tp::pass1 from a proc) matches the historical
+    # single-file upvar 1 semantics at every recursion depth.
     set f [open $filename]
+    set dir [file dirname $filename]
 
     while {[gets $f line] >= 0} {
         set line [string trim $line]
-        if {[regexp {^\[(.*)\]\s*$} $line _ section]} {
+        if {[regexp {^#INCLUDE\s+(.+)$} $line _ include_file]} {
+            # Resolve a relative #INCLUDE against the including file's
+            # directory, matching inifile.cc's dirname-prepend logic.
+            # On error (missing file, unreadable, parse failure), emit
+            # a warning to stderr and continue — matching the C parser's
+            # non-fatal behavior in inifile.cc: it prints a message and
+            # lets the caller see whatever was loaded up to that point.
+            if {[file pathtype $include_file] ne "absolute"} {
+                set include_file [file join $dir $include_file]
+            }
+            if {[catch {uplevel 1 [list parse_ini $include_file]} errmsg]} {
+                puts stderr "parse_ini: $filename: #INCLUDE $include_file: $errmsg"
+            }
+        } elseif {[regexp {^\[(.*)\]\s*$} $line _ section]} {
             # nothing
         } elseif {[regexp {^([^#]+?)\s*=\s*(.*?)\s*$} $line _  k v]} {
             upvar $section s


### PR DESCRIPTION
## Summary

Upstream commit 2f57090adb ("ini: Implement a new ini-file parser and adapt the code to use it") added native `#INCLUDE` support to the new C++ parser in `src/emc/ini/inifile.cc` and removed the 53-line `handle_includes()` shell preprocessor from `scripts/linuxcnc.in`, because the new parser handles `#INCLUDE` natively for the main launcher flow.

However, `lib/hallib/check_config.tcl` (called from `scripts/linuxcnc` during startup to validate the INI) uses the pure-Tcl `parse_ini` proc in `tcl/linuxcnc.tcl`, which has no `#INCLUDE` support. It relied on the shell preprocessor expanding the file before `parse_ini` ever saw it. After 2f57090adb, any INI file using `#INCLUDE` directives fails `check_config.tcl`'s mandatory-items pre-flight check.

## Observable symptom

On current upstream master, the shipped sim demo fails validation:

    $ tclsh8.6 lib/hallib/check_config.tcl \
          configs/sim/axis/ini_with_includes/includes_demo.ini

    check_config:
      Missing [KINS]KINEMATICS=
      Missing [KINS]JOINTS=

    check_config validation failed

`includes_demo.ini`'s master file has no `[KINS]` section — all sections come from `.inc` files via `#INCLUDE` directives that the pure-Tcl parser ignores.

## Fix

Extend `parse_ini` in `tcl/linuxcnc.tcl.in` to recognize `#INCLUDE <filename>` lines, resolve relative filenames against the including file's directory, and parse the referenced file recursively. Matches the semantics of `IniFileContent::parseLine()`'s `#INCLUDE` handling in `inifile.cc`. Errors during recursive parse (missing file, unreadable) are logged to stderr and the outer parse continues, matching the C parser's non-fatal behavior on bad includes.

Also switches the section-variable `upvar` from frame 1 (caller) to frame #0 (absolute global), so variables land in the global scope regardless of recursion depth. Behavior-preserving for existing callers (`check_config.tcl`, `twopass.tcl::tp::pass1`); only matters for the new recursive calls.

## Testing

Verified on upstream master with the same repro above — after the patch, the demo validates cleanly (only the two intentional error-demo directives at the end of `includes_demo.ini` surface as stderr warnings, matching the `#INCLUDE nosuchfile` error example the demo was designed to show).
