### PR TITLE
halui: fix inverted HOME_SEQUENCE polarity for halui.home-all pin creation (regression from 2f57090adb)

### DIFF
--- a/src/emc/usr_intf/halui.cc
+++ b/src/emc/usr_intf/halui.cc
@@ -1472,7 +1472,15 @@ static int iniLoad(const char *filename)
         }
     }
 
-    if (!inifile.isSet("HOME_SEQUENCE", "JOINT_0")) {
+    // Create halui.home-all pin only if [JOINT_0]HOME_SEQUENCE is properly
+    // defined (original semantics from commit 38d35cdf8e). Commit 2f57090adb
+    // ("ini: Implement a new ini-file parser...") ported the old
+    // `inifile.Find("HOME_SEQUENCE", "JOINT_0")` check to the new API as
+    // `!inifile.isSet("HOME_SEQUENCE", "JOINT_0")`, inadvertently flipping
+    // the polarity — the "!" should not be there. With the polarity
+    // inverted, properly-configured machines (which set HOME_SEQUENCE in
+    // [JOINT_0]) lose the halui.home-all convenience pin.
+    if (inifile.isSet("HOME_SEQUENCE", "JOINT_0")) {
         have_home_all = 1;
     }
 


### PR DESCRIPTION
## Summary

Upstream commit 2f57090adb ("ini: Implement a new ini-file parser and adapt the code to use it") ported halui.cc's `HOME_SEQUENCE` check from the old `inifile.Find()` API to the new `inifile.isSet()` API and accidentally flipped the polarity of the condition that gates `halui.home-all` pin creation.

Originally from commit 38d35cdf8e ("Add pin home-all to halui pin is created only if HOME_SEQUENCE is properly defined in inifile"):

    if (inifile.Find("HOME_SEQUENCE", "JOINT_0")) {
        have_home_all = 1;
    }

`Find()` returned truthy when the key was defined, so the pin was created *when* `HOME_SEQUENCE` was properly set — matching the commit message's stated intent.

After 2f57090adb:

    if (!inifile.isSet("HOME_SEQUENCE", "JOINT_0")) {
        have_home_all = 1;
    }

`isSet()` returns true when the key is set, so with the added `!` the condition fires only when `HOME_SEQUENCE` is NOT set — the opposite of the original semantics.

## Observable symptom

Properly-configured machines (which define `HOME_SEQUENCE` in `[JOINT_0]`) no longer get the `halui.home-all` convenience pin:

    $ halcmd setp halui.home-all 1
    <commandline>:0: parameter or pin 'halui.home-all' not found

This affects any GUI, HAL script, or test harness that triggers home-all via this pin.

## Fix

Remove the `!`. Added a comment documenting the regression and the original semantics from 38d35cdf8e.

## Testing

Built against upstream master and verified on a simulation configuration with `[JOINT_0] HOME_SEQUENCE = 0`. Before the fix: `halcmd show pin halui.home-all` returns nothing. After the fix: the pin exists, and pulsing it correctly triggers home-all.
