### PR TITLE
add component 'output_buffer'

### DIFF
--- a/docs/src/hal/components.adoc
+++ b/docs/src/hal/components.adoc
@@ -206,6 +206,7 @@ To search in the man pages, use the UNIX tool `apropos`.
 | link:../man/man9/not.9.html[not]                 |Inverter ||
 | link:../man/man9/oneshot.9.html[oneshot]         |One-shot pulse generator ||
 | link:../man/man9/or2.9.html[or2]                 |Two-input OR gate ||
+| link:../man/man9/output_buffer.9.html[output_buffer] |Feed through multiple bits when enable pin is set ||
 | link:../man/man9/reset.9.html[reset]             |Resets an IO signal ||
 | link:../man/man9/select8.9.html[select8]         |8-bit binary match detector. ||
 | link:../man/man9/tof.9.html[tof]                 |IEC TOF timer - delay falling edge on a signal ||

--- a/src/hal/components/output_buffer.comp
+++ b/src/hal/components/output_buffer.comp
@@ -1,0 +1,48 @@
+component output_buffer "Feed through multiple bits when enable pin is set";
+pin in bit enable "Enable input";
+pin in bit off-level = 0 "Signal level when output is off (enable=0)";
+pin in bit in-#[32 : personality] "Inputs";
+pin out bit out-#[32 : personality] "Outputs (Follow inputs when enable=1)";
+
+function _;
+description """
+Feed through up to 32 bit inputs to their outputs when enable set,
+otherwise outputs will be the value of _off-level_ (default 0).
+
+                            ┌───────────┐
+  output-buffer.N.in-0 ─────┤  ──[>]──  ├───── output-buffer.N.out-0
+                            │   ┌─┘     │
+  output-buffer.N.in-1 ─────┤  ─┼[>]──  ├───── output-buffer.N.out-1
+                            │   ├─┘     │
+  output-buffer.N.in-2 ─────┤  ─┼[>]──  ├───── output-buffer.N.out-2
+                            │   ├─┘     │
+                   ... ─────┤   :       ├───── ...
+                            │   :       │
+  output-buffer.N.in-M ─────┤  ─┼[>]──  ├───── output-buffer.N.out-M
+                            │   ├─┘     │
+                enable ─────┤  ─┘       │
+                            │           │
+             off-level ─────┤ [0/1]     │
+                            └───────────┘
+
+The number of channels are determined by the value of 'personality'.
+""";
+examples """
+*loadrt output_buffer count=1 personality=8* will create a 8 bit buffer.
+""";
+license "GPL"; // indicates GPL v2 or later
+author "Hans Unzner";
+option period no;
+;;
+FUNCTION(_) {
+    if(enable) {
+        for(int i = 0; i < personality; i++) {
+            out(i) = in(i);
+        }
+    } else {
+        bool lvl = off_level;
+        for(int i = 0; i < personality; i++) {
+            out(i) = lvl;
+        }
+    }
+}


### PR DESCRIPTION
This adds a component that behaves like a tristate buffer, but the outputs will be zero instead of high-Z.

I haven't found a better name. Could also be named 'output_switch' or 'multiple_output_buffer' ...


```
                            ┌───────────┐
  output-buffer.N.in-0 ─────┤  ──[>]──  ├───── output-buffer.N.out-0
                            │   ┌─┘     │
  output-buffer.N.in-1 ─────┤  ─┼[>]──  ├───── output-buffer.N.out-1
                            │   ├─┘     │
  output-buffer.N.in-2 ─────┤  ─┼[>]──  ├───── output-buffer.N.out-2
                            │   ├─┘     │
                   ... ─────┤   :       ├───── ...
                            │   :       │
  output-buffer.N.in-M ─────┤  ─┼[>]──  ├───── output-buffer.N.out-M
                            │   ├─┘     │
                enable ─────┤  ─┘       │
                            └───────────┘
```