### PR TITLE
refactor(hm2): drop _64 encoder pins, keep 64-bit internal

### DIFF
--- a/docs/src/man/man9/hostmot2.9.adoc
+++ b/docs/src/man/man9/hostmot2.9.adoc
@@ -322,9 +322,7 @@ following pins and parameters:
 *Pins:*
 
 count (s32 out)::
- Number of encoder counts since the previous reset.
-count_64 (s64 out)::
- Number of encoder counts since the previous reset (64 bit).
+ Number of encoder counts since the previous reset. 32-bit truncation of the 64-bit internal counter; position is computed from the full-width internal value so it does not wrap.
 position (float out)::
  Encoder position in position units (count / scale).
 position-interpolated (float out)::
@@ -355,13 +353,9 @@ probe-invert (bit r/w)::
  If set to True, the rising edge of the probe input pin triggers the latch event (if probe-enable is True).
  If set to False, the falling edge triggers. (only present if supported by firmware)
 rawcounts (s32 out)::
- Total number of encoder counts since the start, not adjusted for index or reset.
-rawcounts_64 (s64 out)::
- Total number of encoder counts since the start, not adjusted for index or reset. (64 bit)
+ Total number of encoder counts since the start, not adjusted for index or reset. Truncated view of the internal 64-bit counter.
 count_latch (s32 out)::
- Encoder count at latch event. (index or probe)
-count_latch_64 (s64 out)::
- Encoder count at latch event. (index or probe) (64 bit)
+ Encoder count at latch event (index or probe). Truncated view of the internal 64-bit latched count.
 input-a, input-b, input-index (bit out)::
  Real time filtered values of A,B,Index encoder signals
 quad-error-enable (bit in)::

--- a/src/hal/drivers/mesa-hostmot2/encoder.c
+++ b/src/hal/drivers/mesa-hostmot2/encoder.c
@@ -510,26 +510,12 @@ int hm2_encoder_parse_md(hostmot2_t *hm2, int md_index) {
                 goto fail1;
             }
 
-            rtapi_snprintf(name, sizeof(name), "%s.encoder.%02d.rawcounts_64", hm2->llio->name, i);
-            r = hal_pin_s64_new(name, HAL_OUT, &(hm2->encoder.instance[i].hal.pin.rawcounts_64), hm2->llio->comp_id);
-            if (r < 0) {
-                HM2_ERR("error adding pin '%s', aborting\n", name);
-                goto fail1;
-            }
-
             rtapi_snprintf(name, sizeof(name), "%s.encoder.%02d.rawlatch", hm2->llio->name, i);
             r = hal_pin_s32_new(name, HAL_OUT, &(hm2->encoder.instance[i].hal.pin.rawlatch), hm2->llio->comp_id);
             if (r < 0) {
                 HM2_ERR("error adding pin '%s', aborting\n", name);
                 goto fail1;
             }
-
-            rtapi_snprintf(name, sizeof(name), "%s.encoder.%02d.rawlatch_64", hm2->llio->name, i);
-            r = hal_pin_s64_new(name, HAL_OUT, &(hm2->encoder.instance[i].hal.pin.rawlatch_64), hm2->llio->comp_id);
-            if (r < 0) {
-                HM2_ERR("error adding pin '%s', aborting\n", name);
-                goto fail1;
-            }            
 
             rtapi_snprintf(name, sizeof(name), "%s.encoder.%02d.count", hm2->llio->name, i);
             r = hal_pin_s32_new(name, HAL_OUT, &(hm2->encoder.instance[i].hal.pin.count), hm2->llio->comp_id);
@@ -538,22 +524,8 @@ int hm2_encoder_parse_md(hostmot2_t *hm2, int md_index) {
                 goto fail1;
             }
 
-            rtapi_snprintf(name, sizeof(name), "%s.encoder.%02d.count_64", hm2->llio->name, i);
-            r = hal_pin_s64_new(name, HAL_OUT, &(hm2->encoder.instance[i].hal.pin.count_64), hm2->llio->comp_id);
-            if (r < 0) {
-                HM2_ERR("error adding pin '%s', aborting\n", name);
-                goto fail1;
-            }
-
             rtapi_snprintf(name, sizeof(name), "%s.encoder.%02d.count-latched", hm2->llio->name, i);
             r = hal_pin_s32_new(name, HAL_OUT, &(hm2->encoder.instance[i].hal.pin.count_latch), hm2->llio->comp_id);
-            if (r < 0) {
-                HM2_ERR("error adding pin '%s', aborting\n", name);
-                goto fail1;
-            }
- 
-            rtapi_snprintf(name, sizeof(name), "%s.encoder.%02d.count-latched_64", hm2->llio->name, i);
-            r = hal_pin_s64_new(name, HAL_OUT, &(hm2->encoder.instance[i].hal.pin.count_latch_64), hm2->llio->comp_id);
             if (r < 0) {
                 HM2_ERR("error adding pin '%s', aborting\n", name);
                 goto fail1;
@@ -779,13 +751,13 @@ void hm2_encoder_tram_init(hostmot2_t *hm2) {
 
         *hm2->encoder.instance[i].hal.pin.rawcounts = count;
         *hm2->encoder.instance[i].hal.pin.rawlatch = count;
-        *hm2->encoder.instance[i].hal.pin.rawcounts_64 = count;
-        *hm2->encoder.instance[i].hal.pin.rawlatch_64 = count;
+        hm2->encoder.instance[i].rawcounts_64 = count;
+        hm2->encoder.instance[i].rawlatch_64 = count;
 
         *hm2->encoder.instance[i].hal.pin.count = 0;
         *hm2->encoder.instance[i].hal.pin.count_latch = 0;
-        *hm2->encoder.instance[i].hal.pin.count_64 = 0;
-        *hm2->encoder.instance[i].hal.pin.count_latch_64 = 0;
+        hm2->encoder.instance[i].count_64 = 0;
+        hm2->encoder.instance[i].count_latch_64 = 0;
         *hm2->encoder.instance[i].hal.pin.position = 0.0;
         *hm2->encoder.instance[i].hal.pin.position_latch = 0.0;
         *hm2->encoder.instance[i].hal.pin.velocity = 0.0;
@@ -831,29 +803,22 @@ void hm2_encoder_tram_init(hostmot2_t *hm2) {
 
 static void hm2_encoder_instance_update_rawcounts_and_handle_index(hostmot2_t *hm2, int instance) {
     rtapi_u16 reg_count;
-    rtapi_s32 reg_count_diff;
-    rtapi_s32 prev_rawcounts;
     rtapi_s64 prev_rawcounts_64;
 
     hm2_encoder_instance_t *e;
 
     e = &hm2->encoder.instance[instance];
-    prev_rawcounts = *e->hal.pin.rawcounts;
-    prev_rawcounts_64 = *e->hal.pin.rawcounts_64;
+    prev_rawcounts_64 = e->rawcounts_64;
 
 
-    // 
+    //
     // figure out current rawcounts accumulated by the driver
-    // 
+    //
 
     reg_count = hm2_encoder_get_reg_count(hm2, instance);
 
-    reg_count_diff = (rtapi_s32)reg_count - (rtapi_s32)e->prev_reg_count;
-    if (reg_count_diff > 32768) reg_count_diff -= 65536;
-    if (reg_count_diff < -32768) reg_count_diff += 65536;
-
-    *e->hal.pin.rawcounts += reg_count_diff;
-    *e->hal.pin.rawcounts_64 += reg_count_diff;
+    e->rawcounts_64 = hal_extend_counter(e->rawcounts_64, reg_count, 16);
+    *e->hal.pin.rawcounts = (rtapi_s32)e->rawcounts_64;
 
 
     //
@@ -870,18 +835,17 @@ static void hm2_encoder_instance_update_rawcounts_and_handle_index(hostmot2_t *h
             // hm2 reports index event occurred
 
             rtapi_u16 latched_count;
+            rtapi_s64 latched_64;
 
             latched_count = (latch_ctrl >> 16) & 0xffff;
 
-            reg_count_diff = (rtapi_s32)latched_count - (rtapi_s32)e->prev_reg_count;
-            if (reg_count_diff > 32768) reg_count_diff -= 65536;
-            if (reg_count_diff < -32768) reg_count_diff += 65536;
+            latched_64 = hal_extend_counter(prev_rawcounts_64, latched_count, 16);
             if (!*(e->hal.pin.no_clear_on_index)) {
-              e->zero_offset = prev_rawcounts + reg_count_diff;
-              e->zero_offset_64 = prev_rawcounts_64 + (rtapi_s64)reg_count_diff;
+              e->zero_offset_64 = latched_64;
+              e->zero_offset = (rtapi_s32)latched_64;
             }
-            *(e->hal.pin.rawlatch) = prev_rawcounts + reg_count_diff;
-            *(e->hal.pin.rawlatch_64) = prev_rawcounts_64 + (rtapi_s64)reg_count_diff;
+            e->rawlatch_64 = latched_64;
+            *(e->hal.pin.rawlatch) = (rtapi_s32)latched_64;
             *e->hal.pin.index_enable = 0;
             // may need to update interpolated position after index event because
             // this _may_ happen without a count but its pretty ugly...
@@ -897,15 +861,13 @@ static void hm2_encoder_instance_update_rawcounts_and_handle_index(hostmot2_t *h
                 // hm2 reports probe event occurred
 
                 rtapi_u16 latched_count;
+                rtapi_s64 latched_64;
 
                 latched_count = (latch_ctrl >> 16) & 0xffff;
 
-                reg_count_diff = (rtapi_s32)latched_count - (rtapi_s32)e->prev_reg_count;
-                if (reg_count_diff > 32768) reg_count_diff -= 65536;
-                if (reg_count_diff < -32768) reg_count_diff += 65536;
-
-                *(e->hal.pin.rawlatch) = prev_rawcounts + reg_count_diff;
-                *(e->hal.pin.rawlatch_64) = prev_rawcounts_64 + (rtapi_s64)reg_count_diff;
+                latched_64 = hal_extend_counter(prev_rawcounts_64, latched_count, 16);
+                e->rawlatch_64 = latched_64;
+                *(e->hal.pin.rawlatch) = (rtapi_s32)latched_64;
                 *e->hal.pin.latch_enable = 0;
             }
         }
@@ -953,15 +915,15 @@ static void hm2_encoder_instance_update_position(hostmot2_t *hm2, int instance) 
 
     if (*e->hal.pin.reset) {
         e->zero_offset = *e->hal.pin.rawcounts;
-        e->zero_offset_64 = *e->hal.pin.rawcounts_64;
+        e->zero_offset_64 = e->rawcounts_64;
         *e->hal.pin.rawlatch = e->zero_offset;
-        *e->hal.pin.rawlatch_64 =  e->zero_offset_64;
-        *e->hal.pin.position_interpolated = *e->hal.pin.position; 
+        e->rawlatch_64 = e->zero_offset_64;
+        *e->hal.pin.position_interpolated = *e->hal.pin.position;
 
     }
 
 
-    // 
+    //
     // Now we know the current rawcounts and zero_offset, which together
     // tell us the current count.
     //
@@ -969,18 +931,19 @@ static void hm2_encoder_instance_update_position(hostmot2_t *hm2, int instance) 
     //
 
     *e->hal.pin.count = *e->hal.pin.rawcounts - e->zero_offset;
-    *e->hal.pin.count_64 = *e->hal.pin.rawcounts_64 - e->zero_offset_64;
+    e->count_64 = e->rawcounts_64 - e->zero_offset_64;
     *e->hal.pin.count_latch = *e->hal.pin.rawlatch - e->zero_offset;
-    *e->hal.pin.count_latch_64 = *e->hal.pin.rawlatch_64 - e->zero_offset_64;
+    e->count_latch_64 = e->rawlatch_64 - e->zero_offset_64;
 
 
     //
     // Now we know the current current .count, from this we easily compute
-    // the scaled position.
+    // the scaled position. Float position uses the 64-bit internal count
+    // to avoid wrap on high-resolution encoders.
     //
 
-    *e->hal.pin.position = *e->hal.pin.count_64 / e->hal.param.scale;
-    *e->hal.pin.position_latch = *e->hal.pin.count_latch_64 / e->hal.param.scale;
+    *e->hal.pin.position = e->count_64 / e->hal.param.scale;
+    *e->hal.pin.position_latch = e->count_latch_64 / e->hal.param.scale;
 }
 
 
@@ -1023,7 +986,6 @@ static void hm2_encoder_instance_process_tram_read(hostmot2_t *hm2, int instance
             hm2_encoder_instance_update_position(hm2, instance);
 
             e->prev_event_rawcounts = *e->hal.pin.rawcounts;
-            e->prev_event_rawcounts_64 = *e->hal.pin.rawcounts_64;
             e->prev_event_reg_timestamp = hm2_encoder_get_reg_timestamp(hm2, instance);
             e->prev_dS_counts = 0;
 

--- a/src/hal/drivers/mesa-hostmot2/hostmot2.h
+++ b/src/hal/drivers/mesa-hostmot2/hostmot2.h
@@ -281,14 +281,10 @@ typedef struct {
     struct {
 
         struct {
-            hal_s32_t *rawcounts;       // raw encoder counts
-            hal_s32_t *rawlatch;        // raw encoder of latch
-            hal_s32_t *count;           // (rawcounts - zero_offset)
-            hal_s32_t *count_latch;     // (rawlatch - zero_offset)
-            hal_s64_t *rawcounts_64;    // raw encoder counts
-            hal_s64_t *rawlatch_64;     // raw encoder of latch
-            hal_s64_t *count_64;        // (rawcounts - zero_offset)
-            hal_s64_t *count_latch_64;  // (rawlatch - zero_offset)
+            hal_s32_t *rawcounts;       // raw encoder counts (truncated view of 64-bit internal)
+            hal_s32_t *rawlatch;        // raw encoder of latch (truncated view)
+            hal_s32_t *count;           // (rawcounts - zero_offset), truncated view
+            hal_s32_t *count_latch;     // (rawlatch - zero_offset), truncated view
             hal_float_t *position;
             hal_float_t *position_latch;
             hal_float_t *position_interpolated;
@@ -321,7 +317,13 @@ typedef struct {
     } hal;
 
     rtapi_s32 zero_offset;     // *hal.pin.counts == (*hal.pin.rawcounts - zero_offset)
-    rtapi_s64 zero_offset_64;  // *hal.pin.counts_64 == (*hal.pin.rawcounts_64 - zero_offset_64)
+    // 64-bit internals prevent float position wrap on high-count encoders.
+    // Not exposed as HAL pins; s32 pins above are truncated views.
+    rtapi_s64 rawcounts_64;
+    rtapi_s64 rawlatch_64;
+    rtapi_s64 count_64;
+    rtapi_s64 count_latch_64;
+    rtapi_s64 zero_offset_64;
 
     rtapi_u16 prev_reg_count;  // from this and the current count in the register we compute a change-in-counts, which we add to rawcounts
 
@@ -335,7 +337,6 @@ typedef struct {
 
     // these two are the datapoint last time we moved (only valid if state == HM2_ENCODER_MOVING)
     rtapi_s32 prev_event_rawcounts;
-    rtapi_s64 prev_event_rawcounts_64;
     rtapi_u16 prev_event_reg_timestamp;
 
     rtapi_s32 tsc_num_rollovers;


### PR DESCRIPTION
RFC #3286 narrow option 1: fix float position wrap on high-count encoders via 64-bit internal counters, without exposing new HAL pin types. s32 count/rawcounts/rawlatch/ count-latched remain as truncated views of the internal 64-bit counters. Float position is computed from the full 64-bit value so it does not wrap.

Avoids committing four integer pin types (s32/u32/s64/u64) into 2.10 ABI before the getter/setter direction in #3286 is decided. The overflow fix from 8a3ac3f3 is preserved; only the pin exposure is reverted. Unused
prev_event_rawcounts_64 dropped.

BREAKING CHANGE: count_64, rawcounts_64, rawlatch_64 and count-latched_64 pins added post-2.9 are removed. HAL surface matches 2.9.

Refs #3286 #2331