### PR TITLE
motion: axis_sync_teleop_tp_to_carte_pos resets velocity/acceleration

### DIFF
--- a/src/emc/motion/axis.c
+++ b/src/emc/motion/axis.c
@@ -440,10 +440,22 @@ void axis_sync_teleop_tp_to_carte_pos(int extfactor, double *pcmd_p[])
 {
     int n;
     // expect extfactor =  -1 || 0 || +1
+    //
+    // This function initializes the teleop trajectory planner to a REST
+    // state at the current cartesian position. Both callers (enabling
+    // motion, entering teleop mode) expect the joint to be stationary
+    // at the synced position. Without resetting curr_vel/curr_acc, stale
+    // values from a previous motion (e.g. a jog that was aborted with
+    // immediate=0, leaving a non-zero ramp-down velocity) would survive
+    // a mode transition and cause the trajectory to drift away from the
+    // synced curr_pos the next time simple_tp_update integrates one
+    // cycle of motion.
     for (n = 0; n < EMCMOT_MAX_AXIS; n++) {
         axis_array[n].teleop_tp.curr_pos = *pcmd_p[n]
                             + extfactor * axis_array[n].ext_offset_tp.curr_pos;
         axis_array[n].teleop_tp.pos_cmd = axis_array[n].teleop_tp.curr_pos;
+        axis_array[n].teleop_tp.curr_vel = 0.0;
+        axis_array[n].teleop_tp.curr_acc = 0.0;
     }
 }
 


### PR DESCRIPTION
`axis_sync_teleop_tp_to_carte_pos` in `src/emc/motion/axis.c` updates `teleop_tp.curr_pos` and `pos_cmd` to the current cartesian command but leaves `curr_vel` and `curr_acc` untouched. Both callers semantically represent "joint at rest at the current cartesian position" — enabling motion from `DISABLED`, and entering `TELEOP` after homing. Leaving residual velocity in the trajectory planner lets `simple_tp_update_normal` integrate one cycle of motion on the first pass after the sync, drifting `curr_pos` away from the synced value. The patch zeros `curr_vel` and `curr_acc` alongside the existing position sync.

Reproduction on an XYZZ setup where Z homes at `MAX_LIMIT`: home all, jog Z in the minus direction, release the jog key (`axis_jog_abort(immediate=0)` runs with residual velocity), re-home. Pre-fix: Z lands 1–3 mm below `HOME` depending on jog-settle timing. Post-fix: Z lands at `HOME` within machine resolution.

No upstream test harness exercises the `FREE -> TELEOP` transition after re-homing, so verification is by manual reproduction.