### PR TITLE
Fix #3924: linuxcnc creates '$' folder in cwd

### DIFF
--- a/debian/rules.in
+++ b/debian/rules.in
@@ -88,16 +88,16 @@ override_dh_auto_install-arch:
 	rm -f $(DESTDIR)/usr/share/doc/@MAIN_PACKAGE_NAME@/examples/sample-configs/*/*position*.txt
 
 override_dh_installdocs-arch:
-ifeq (,$(filter nodocs,$(DEB_BUILD_OPTIONS)))
-	# Sample configs go in `usr/share/doc/linuxcnc` (not `.../doc/@MAIN_PACKAGE_NAME@`)
-	# because that's where the `linuxcnc` launcher script looks for them,
-	# and that's inconvenient to change.
+	# Sample configs are runtime data read by the launcher, not documentation,
+	# so they must be installed unconditionally (i.e. regardless of
+	# DEB_BUILD_OPTIONS=nodocs).  They go in `usr/share/doc/linuxcnc` (not
+	# `.../doc/@MAIN_PACKAGE_NAME@`) because that's where the `linuxcnc` launcher
+	# script looks for them, and that's inconvenient to change.
 	dh_installdocs --doc-main-package=@MAIN_PACKAGE_NAME@ --package=@MAIN_PACKAGE_NAME@
 	mkdir -p debian/@MAIN_PACKAGE_NAME@/usr/share/doc/linuxcnc
 	mv debian/@MAIN_PACKAGE_NAME@/usr/share/doc/@MAIN_PACKAGE_NAME@/examples debian/@MAIN_PACKAGE_NAME@/usr/share/doc/linuxcnc
 
 	dh_installdocs --doc-main-package=@MAIN_PACKAGE_NAME@ --package=@MAIN_PACKAGE_NAME@-dev
-endif
 
 override_dh_auto_install-indep:
 ifeq (,$(filter nodocs,$(DEB_BUILD_OPTIONS)))

--- a/scripts/linuxcnc.in
+++ b/scripts/linuxcnc.in
@@ -369,6 +369,14 @@ function make_ini_for_tcl() {
     [ -r "$inifile" ] || { echo "E: Cannot read '$inifile'"; exit 1; }
     inidir="$(dirname "$inifile")"
     outfile="$inidir/$(basename "$inifile").expanded"
+    # Fall back to a per-user cache dir if the inifile's directory is not
+    # writable (e.g. installed sample configs under /usr/share/doc/linuxcnc/).
+    if ! [ -w "$inidir" ]; then
+        cachedir="${XDG_RUNTIME_DIR:-${TMPDIR:-/tmp}}/linuxcnc-$UID"
+        mkdir -p "$cachedir" || { echo "E: Could not create cache dir '$cachedir'"; exit 1; }
+        outfile="$cachedir/$(basename "$inifile").expanded"
+    fi
+    export LINUXCNC_INI_EXPANDED="$outfile"
     true >|"$outfile" || { echo "E: Could not create expanded inifile '$outfile' for Tcl"; exit 1; }
     {
         echo "#*** Source: $inifile"

--- a/tcl/bin/pickconfig.tcl
+++ b/tcl/bin/pickconfig.tcl
@@ -181,7 +181,13 @@ proc ok_to_copy_config {filename} {
     #    then it is presumed to be a system dir running from an install (by
     #    a deb install typically) so copy the configuration to user directory.
     #
-    # 2) if the directory is included in ::user_aux_dirs (as
+    # 2) For non-RIP builds, if the file is not under the user's
+    #    myconfigs_node, force copy regardless of filesystem writability.
+    #    This catches distros where installed sample-configs happen to be
+    #    writable by the running user (e.g. Gentoo system-wide installs to
+    #    a group-writable path).
+    #
+    # 3) if the directory is included in ::user_aux_dirs (as
     #    specified by the environmental variable LINUXCNC_AUX_EXAMPLES),
     #    then the config is copied to user directory to avoid overwriting
     #    a developmental source directory.
@@ -198,6 +204,12 @@ proc ok_to_copy_config {filename} {
     if {    [info exists ::env(debug_pickconfig)] \
          && [string first $::myconfigs_node $filename]} {
       set forcecopy 1
+    }
+
+    set is_rip [expr {[info exists ::linuxcnc::RUN_IN_PLACE]
+                      && $::linuxcnc::RUN_IN_PLACE eq "yes"}]
+    if {!$is_rip && [string first $::myconfigs_node $filename] != 0} {
+        set forcecopy 1
     }
 
     if { [info exists ::user_aux_dirs] } {

--- a/tcl/linuxcnc.tcl.in
+++ b/tcl/linuxcnc.tcl.in
@@ -146,7 +146,13 @@ proc parse_ini {filename} {
     # like: ::EMC(VERSION), ::KINS(JOINTS), ... etc
     # The INI-file for this routine has been pre-formatted by the linuxcnc
     # startup script to handle includes, strings, comments and continuations.
-    if [catch {set f [open "${filename}.expanded"]} msg] {
+    # LINUXCNC_INI_EXPANDED is set by the startup script when the inifile's
+    # directory is not writable (e.g. installed sample configs), so the
+    # expanded file lives in a per-user cache dir instead of next to the INI.
+    if {[info exists ::env(LINUXCNC_INI_EXPANDED)]
+        && [file readable $::env(LINUXCNC_INI_EXPANDED)]} {
+        set f [open $::env(LINUXCNC_INI_EXPANDED)]
+    } elseif [catch {set f [open "${filename}.expanded"]} msg] {
         # This is a fallback open. It happens in test twopass-personality.
         # When this open is necessary, then a lot of errors are possible.
         set f [open "${filename}"]

--- a/tcl/linuxcnc.tcl.in
+++ b/tcl/linuxcnc.tcl.in
@@ -31,6 +31,7 @@ namespace eval linuxcnc {
     variable IMAGEDIR @EMC2_IMAGE_DIR@
     variable REALTIME @REALTIME@
     variable RTS @RTS@
+    variable RUN_IN_PLACE @RUN_IN_PLACE@
     variable CONFIG_DIR {}
     variable _dir
     foreach _dir  [split $CONFIG_PATH :] {

--- a/tcl/linuxcnc.tcl.in
+++ b/tcl/linuxcnc.tcl.in
@@ -25,7 +25,7 @@ namespace eval linuxcnc {
     variable TCL_SCRIPT_DIR @EMC2_TCL_DIR@/scripts
     variable HELP_DIR @EMC2_HELP_DIR@
     variable RTLIB_DIR @EMC2_RTLIB_DIR@
-    variable CONFIG_PATH {@LINUXCNC_CONFIG_PATH_TCL@}
+    variable CONFIG_PATH [subst -nocommands -nobackslashes {@LINUXCNC_CONFIG_PATH_TCL@}]
     variable NCFILES_DIR @EMC2_NCFILES_DIR@
     variable LANG_DIR @EMC2_LANG_DIR@
     variable IMAGEDIR @EMC2_IMAGE_DIR@
@@ -33,7 +33,7 @@ namespace eval linuxcnc {
     variable RTS @RTS@
     variable CONFIG_DIR {}
     variable _dir
-    foreach _dir  [split {@LINUXCNC_CONFIG_PATH_TCL@} :] {
+    foreach _dir  [split $CONFIG_PATH :] {
 	lappend CONFIG_DIR [file normalize $_dir]
     }
     unset _dir


### PR DESCRIPTION
## Summary
- Fixes the `$`-folder regression reported in #3924.
- Regression introduced by 6f0bf8b845 (@BsAtHome, #3739) when swapping tilde expansion for `$::env(HOME)` to support Tcl 9.
- `tcl/linuxcnc.tcl.in` wrapped `@LINUXCNC_CONFIG_PATH_TCL@` in `{}` braces, which blocked Tcl substitution. After autoconf substituted the literal `$::env(HOME)/linuxcnc/configs:...`, `split` on `:` chopped `::` into empty tokens, the first element became literal `$`, and `USER_CONFIG_DIR` resolved to `[pwd]/$`.
- Switched to `[subst -nocommands -nobackslashes {...}]` so `$::env(HOME)` expands while `[...]` command substitution stays disabled (safer than plain double-quoting in case a path ever contains brackets).

With the fix `USER_CONFIG_DIR` correctly resolves to `~/linuxcnc/configs`, and existing user configs reappear under "My Configurations".

## Test plan
- [x] Verified `USER_CONFIG_DIR` resolves to `/home/<user>/linuxcnc/configs` from `cwd=/etc` under RIP build (`RUN_IN_PLACE=yes`).
- [x] Verified same resolution under non-RIP build (`--prefix=/usr`, matching .deb config).
- [x] Verified no `$` folder created under RIP.
- [ ] Third-party retest on .deb install from `/etc` (cc @rodw-au @NTULINUX @thomam04).
- [x] Retest with Tcl 9 once available.