### PR TITLE
task: tighten AUTO read-ahead wait-clear to match MDI (#3650)

### DIFF
--- a/src/emc/task/emctaskmain.cc
+++ b/src/emc/task/emctaskmain.cc
@@ -494,11 +494,18 @@ void readahead_reading(void)
                     int count = 0;
 interpret_again:
 		    if (emcTaskPlanIsWait()) {
-			// delay reading of next line until all is done
+			// delay reading of next line until all is done.
+			// Match the stricter check used by mdi_execute_hook:
+			// trusting only execState==DONE can race when motion
+			// hasn't yet processed a just-issued command (e.g. a
+			// G38 probe), letting the next read see a non-empty
+			// queue.
 			if (interp_list.len() == 0 &&
 			    emcTaskCommand == 0 &&
 			    emcStatus->task.execState ==
-			    EMC_TASK_EXEC::DONE) {
+			    EMC_TASK_EXEC::DONE &&
+			    emcStatus->motion.traj.queue == 0 &&
+			    emcStatus->io.status == RCS_STATUS::DONE) {
 			    emcTaskPlanClearWait();
 			 }
 		    } else {


### PR DESCRIPTION
Fixes the long-standing "Queue is not empty after probing" error.

`mdi_execute_hook` has, since 2012, gated wait-clear on `execState==DONE && motion.traj.queue==0 && io.status==DONE`. `readahead_reading` (AUTO mode) checks only `execState==DONE`, on the assumption that the prior `EMC_TASK_PLAN_SYNCH` precondition (`WAITING_FOR_MOTION_AND_IO`) had already drained motion.

That assumption breaks across cycles: `emcTaskIssueCommand` writes `EMC_TRAJ_PROBE` to motion via shared memory, then the same task cycle's `emcMotionUpdate` may snapshot `emcmotStatus` before the servo loop has added the new segment. `motion.status` reads `DONE` (stale), the SYNCH precondition transitions immediately, and the next `Interp::_read` runs `read_inputs` against a queue that is now non-empty. CHKS fires.

Patch: add the same two conjuncts to the AUTO check.

Closes #3650, #662, #263.

Complementary to #3537 (already merged): that fix handled probe re-trip during deceleration. This one handles the inter-command snapshot-lag race that lets the same family of bugs leak through.

cc @andypugh, @DauntlessAq, @rmu75, @BsAtHome: would value review on the wait-clear semantics.
cc @tiket18, @Cromaglious: could you test against your reproducing workload? Can use built artifacts for testing

### Test plan

- [ ] Cyclic G38.3/G38.5 sim loop (>20k iterations), error gone
- [ ] Single-probe + tool-setter still latch \`#5061..#5069\` correctly
- [ ] Reporter validation against XXYYZ scan + smartprobe workloads
- [ ] 2.9 backport candidate after master soak