### PR TITLE
docs/getting-started -document RIP vs install copy behavior in pickconfig

### DIFF
--- a/docs/src/getting-started/running-linuxcnc.adoc
+++ b/docs/src/getting-started/running-linuxcnc.adoc
@@ -153,18 +153,18 @@ that is used to describe a specific configuration.
 
 === When the copy happens
 
-The Configuration Selector decides whether to copy a sample
-configuration to ~/linuxcnc/configs based on where the source
-configuration lives:
+For the following cases the Configuration Selector copies the chosen sample
+configuration to ~/linuxcnc/configs:
 
 * *Package install (deb, rpm, distro packages)*: sample configurations
-  live under a system path. The selector copies the configuration to
-  ~/linuxcnc/configs before running it, so edits never touch the
-  system-wide files.
-* *Run-In-Place (RIP) build*: the source tree is normally writable by
-  the user who built it, so the selector runs the configuration
-  directly from the source tree without copying. Edits made through
-  the configuration apply to the files in the RIP tree.
+  live under a system path and are not writabe.
+* *The file is not in the directory tree of `CONFIG_DIR`* (environmental variable)
+* *The file is in a directory included in `LINUXCNC_AUX_EXAMPLES`* (environmental variable)
+
+For *Run-In-Place (RIP) builds* the source tree is normally writable by
+the user who built it, so the selector runs the configuration
+directly from the source tree without copying. Edits made through
+the configuration apply to the files in the RIP tree.
 
 === Forcing a copy from a RIP build
 

--- a/docs/src/getting-started/running-linuxcnc.adoc
+++ b/docs/src/getting-started/running-linuxcnc.adoc
@@ -151,6 +151,35 @@ for a configuration to a new subdirectory of ~/linuxcnc/configs
 created directory will include at least one INI file (iniflename.ini)
 that is used to describe a specific configuration.
 
+=== When the copy happens
+
+The Configuration Selector decides whether to copy a sample
+configuration to ~/linuxcnc/configs based on where the source
+configuration lives:
+
+* *Package install (deb, rpm, distro packages)*: sample configurations
+  live under a system path. The selector copies the configuration to
+  ~/linuxcnc/configs before running it, so edits never touch the
+  system-wide files.
+* *Run-In-Place (RIP) build*: the source tree is normally writable by
+  the user who built it, so the selector runs the configuration
+  directly from the source tree without copying. Edits made through
+  the configuration apply to the files in the RIP tree.
+
+=== Forcing a copy from a RIP build
+
+To test the copy-and-run path from a RIP build (or to keep a
+personal copy of a sample configuration outside the source tree),
+set the `debug_pickconfig` environment variable before launching
+LinuxCNC:
+
+----
+debug_pickconfig=1 linuxcnc
+----
+
+With this set, the selector copies the chosen sample configuration
+to ~/linuxcnc/configs even though the RIP source tree is writable.
+
 File resources within the copied directory will typically
 include one or more INI file (filename.ini) for related
 configurations and a tool table file (toolfilename.tbl).


### PR DESCRIPTION
## Summary

Documents the Configuration Selector copy-on-launch behavior in
`docs/src/getting-started/running-linuxcnc.adoc`:

- copy fires on package installs (deb, rpm) where sample configs live
  under a non-writable system path
- RIP builds run sample configs in place because the source tree is
  writable by the user who built it
- `debug_pickconfig=1` env var forces a copy from a RIP build

Behavior is unchanged since 2006 (commit 03ebae23, "prompt the user
to copy a read-only configuration"); this was previously only
documented in `tcl/bin/pickconfig.tcl` source comments.

Closes the documentation gap raised in #3924 by @rodw-au.

## Test plan

- [x] asciidoc renders the new sections without errors
- [x] visual check of rendered output