### PR TITLE
Fix for 2.9: uspace_xenomai.cc

### DIFF
--- a/src/rtapi/uspace_xenomai.cc
+++ b/src/rtapi/uspace_xenomai.cc
@@ -1,8 +1,10 @@
 #include "config.h"
 #include "rtapi.h"
 #include "rtapi_uspace.hh"
-#include <posix/pthread.h>
-#include <atomic>
+#include <pthread.h>
+#include <errno.h>
+#include <stdio.h>
+#include <cstring>
 #ifdef HAVE_SYS_IO_H
 #include <sys/io.h>
 #endif
@@ -11,7 +13,7 @@ namespace
 {
 struct RtaiTask : rtapi_task {
     RtaiTask() : rtapi_task{}, cancel{}, thr{} {}
-    std::atomic<int> cancel;
+    std::atomic_int cancel;
     pthread_t thr;
 };
 
@@ -97,10 +99,12 @@ struct XenomaiApp : RtapiApp {
     }
 
     int task_pause(int task_id) {
+        (void)task_id;
         return -ENOSYS;
     }
 
     int task_resume(int task_id) {
+        (void)task_id;
         return -ENOSYS;
     }
 
@@ -143,12 +147,16 @@ struct XenomaiApp : RtapiApp {
     unsigned char do_inb(unsigned int port) {
 #ifdef HAVE_SYS_IO_H
         return inb(port);
+#else
+        return 0;
 #endif
     }
 
     void do_outb(unsigned char val, unsigned int port) {
 #ifdef HAVE_SYS_IO_H
         return outb(val, port);
+#else
+        return 0;
 #endif
     }
 


### PR DESCRIPTION
Merge fixes from master, corrects error:
```
rtapi/uspace_xenomai.cc:4:10: fatal error: posix/pthread.h: Datei oder Verzeichnis nicht gefunden
    4 | #include <posix/pthread.h>
      |          ^~~~~~~~~~~~~~~~~
compilation terminated.
```
and
```
Compiling rtapi/uspace_xenomai.cc
rtapi/uspace_xenomai.cc: In member function ‘virtual int {anonymous}::XenomaiApp::task_delete(int)’:
rtapi/uspace_xenomai.cc:30:27: error: ‘EINVAL’ was not declared in this scope
   30 |         if(!task) return -EINVAL;
      |                           ^~~~~~
rtapi/uspace_xenomai.cc: In member function ‘virtual int {anonymous}::XenomaiApp::task_start(int, long unsigned int)’:
rtapi/uspace_xenomai.cc:42:27: error: ‘EINVAL’ was not declared in this scope
   42 |         if(!task) return -EINVAL;
      |                           ^~~~~~
rtapi/uspace_xenomai.cc:46:9: error: ‘memset’ was not declared in this scope
   46 |         memset(&param, 0, sizeof(param));
      |         ^~~~~~
rtapi/uspace_xenomai.cc:8:1: note: ‘memset’ is defined in header ‘<cstring>’; this is probably fixable by adding ‘#include <cstring>’
    7 | #include <sys/io.h>
  +++ |+#include <cstring>
    8 | #endif
rtapi/uspace_xenomai.cc: In member function ‘virtual int {anonymous}::XenomaiApp::task_pause(int)’:
rtapi/uspace_xenomai.cc:100:17: error: ‘ENOSYS’ was not declared in this scope
  100 |         return -ENOSYS;
      |                 ^~~~~~
rtapi/uspace_xenomai.cc: In member function ‘virtual int {anonymous}::XenomaiApp::task_resume(int)’:
rtapi/uspace_xenomai.cc:104:17: error: ‘ENOSYS’ was not declared in this scope
  104 |         return -ENOSYS;
      |                 ^~~~~~
rtapi/uspace_xenomai.cc: In member function ‘virtual int {anonymous}::XenomaiApp::task_pll_set_correction(long int)’:
rtapi/uspace_xenomai.cc:115:27: error: ‘EINVAL’ was not declared in this scope
  115 |         if(!task) return -EINVAL;
      |                           ^~~~~~
rtapi/uspace_xenomai.cc: In member function ‘virtual void {anonymous}::XenomaiApp::wait()’:
rtapi/uspace_xenomai.cc:139:25: error: ‘perror’ was not declared in this scope; did you mean ‘period’?
  139 |             if(res < 0) perror("clock_nanosleep");
      |                         ^~~~~~
      |                         period
rtapi/uspace_xenomai.cc: In member function ‘virtual int {anonymous}::XenomaiApp::task_self()’:
rtapi/uspace_xenomai.cc:162:27: error: ‘EINVAL’ was not declared in this scope
  162 |         if(!task) return -EINVAL;
      |                           ^~~~~~
make: *** [Makefile:287: objects/rtapi/uspace_xenomai.o] Fehler 1
```