### PR TITLE
Fix wrong INT64_MIN/MAX defines and naked preprocessor expansion

### DIFF
--- a/src/hal/components/latencybinstream.comp
+++ b/src/hal/components/latencybinstream.comp
@@ -81,10 +81,10 @@ variable hal_stream_t fifo;
 variable rtapi_u64 nsamples;
 variable rtapi_u64 sum;
 variable rtapi_u64 sq_sum;
-variable rtapi_s64 lat_min = INT64_MAX;
-variable rtapi_s64 lat_max = INT64_MIN;
+variable rtapi_s64 lat_min = RTAPI_INT64_MAX;
+variable rtapi_s64 lat_max = RTAPI_INT64_MIN;
 
-license "GPL2+";
+license "GPL";
 author "B.Stultiens";
 ;;
 
@@ -126,8 +126,8 @@ FUNCTION(_) {
 	rtapi_s64 nsbs = nsbinsize;  // May not be zero, important to avoid divide by zero
 	if (first || binmax != last_binmax || !nsbs) {
 		first = 0;
-		lat_min = INT64_MAX;
-		lat_max = INT64_MIN;
+		lat_min = RTAPI_INT64_MAX;
+		lat_max = RTAPI_INT64_MIN;
 		ptail.u = ntail.u = 0;
 		memset(pbins, 0, sizeof(pbins));
 		memset(nbins, 0, sizeof(nbins));

--- a/src/hal/hal.h
+++ b/src/hal/hal.h
@@ -992,7 +992,7 @@ extern void hal_stream_wait_writable(hal_stream_t *stream, sig_atomic_t *stop);
 
 /** HAL_STATIC_ASSERT wrapper for compile time asserts
 */
-#if __STDC_VERSION__ >= 202311L || __cplusplus
+#if __STDC_VERSION__ >= 202311L || defined(__cplusplus)
 #define HAL_STATIC_ASSERT(expression, message) static_assert((expression), message)
 #else
 /* _Static_assert: GCC extension, in C standard since C11, deprecated in favour of


### PR DESCRIPTION
Fix #3978.
* Inadvertent use of the wrong INT64_MIN/MAX defines instead of RTAPI_INT64_MIN/MAX.
* Fix naked `__cplusplus` preprocessor usage of  that requires a defined() check.