### PR TITLE
tp: fix cppcheck invalidPrintfArgType_uint regressions

### DIFF
--- a/src/emc/tp/tp.c
+++ b/src/emc/tp/tp.c
@@ -1706,7 +1706,8 @@ STATIC blend_type_t tpCheckBlendArcType(
 
     //If exact stop, we don't compute the arc
     if (prev_tc->term_cond != TC_TERM_COND_PARABOLIC) {
-        tp_debug_print("Wrong term cond = %u\n", prev_tc->term_cond);
+        // term_cond is signed int; use %d (cppcheck invalidPrintfArgType_uint)
+        tp_debug_print("Wrong term cond = %d\n", prev_tc->term_cond);
         return BLEND_NONE;
     }
 
@@ -1721,7 +1722,8 @@ STATIC blend_type_t tpCheckBlendArcType(
         return BLEND_NONE;
     }
 
-    tp_debug_print("Motion types: prev_tc = %u, tc = %u\n",
+    // motion_type is signed int; use %d (cppcheck invalidPrintfArgType_uint)
+    tp_debug_print("Motion types: prev_tc = %d, tc = %d\n",
             prev_tc->motion_type,tc->motion_type);
     //If not linear blends, we can't easily compute an arc
     if ((prev_tc->motion_type == TC_LINEAR) && (tc->motion_type == TC_LINEAR)) {


### PR DESCRIPTION
## Summary
- Restore `%d` format specifiers in two `tp_debug_print` calls in `src/emc/tp/tp.c`. `term_cond` and `motion_type` are signed `int`; `%u` requires unsigned.
- Fix was originally applied in b55ad81b22 but accidentally reverted by PR #3683 (commit 402828cd04, stale-base rebase clobber).
- Added inline comments noting field signedness so future rebases do not silently flip them back.

Fixes cppcheck warnings reported by @BsAtHome in https://github.com/LinuxCNC/linuxcnc/pull/3683#issuecomment-4350911810:
```
emc/tp/tp.c:1709:9: invalidPrintfArgType_uint
emc/tp/tp.c:1724:5: invalidPrintfArgType_uint (x2)
```

## Test plan
- [x] Builds clean with `make -j$(nproc)` from `src/`
- [x] cppcheck on tp.c no longer reports the three warnings