### PR TITLE
Halshow: Add function to add items from HAL text

### DIFF
--- a/tcl/bin/halshow.tcl
+++ b/tcl/bin/halshow.tcl
@@ -704,6 +704,7 @@ proc makeWatch {} {
     bind $::cisp <Configure> {
         if {$::watchlist_len <= 20} reloadWatch
     }
+    bind $::cisp <Button-3> {popupmenu_watch_general %W %X %Y}
 }
 
 proc makeSettings {} {
@@ -957,6 +958,7 @@ proc watchHAL {which} {
     refreshItem $i $vartype $label
 }
 
+# Popup menu for selected items
 proc popupmenu_watch {vartype label index writable which x y} {
     # create menu
     set m [menu .popupMenu$index -tearoff false]
@@ -973,6 +975,49 @@ proc popupmenu_watch {vartype label index writable which x y} {
     # show menu
     tk_popup $m $x $y
     bind $m <FocusOut> [list destroy $m]
+}
+
+# Popup menu for background (no item selected)
+proc popupmenu_watch_general {w x y} {
+    # check if no other element is under cursor
+    if {![llength [$w find withtag current]]} {
+        # create menu
+        set m [menu .popupMenuText -tearoff false]
+        # add entries
+        $m add command -label [msgcat::mc "Add from clipboard"] -command {
+            catch {parse_hal_text [clipboard get]}
+        }
+        $m add command -label [msgcat::mc "Erase Watch"] -command {
+            watchReset all
+            setStatusbar [msgcat::mc "Watchlist cleared"]
+        }
+        # show menu
+        tk_popup $m $x $y
+        bind $m <FocusOut> [list destroy $m]
+    }
+}
+
+# Parse <text> as a HAL file to filter out pins, signals and parameters and add
+# the result to the  watchlist
+proc parse_hal_text {text} {
+    foreach line [split $text "\n"] {
+        set line [string trim $line]
+        # skip empty lines
+        if {$line eq ""} continue
+        # if line begins with 'net', take next as signal and rest as pins
+        if {[regexp {^\s*net\s+(\S+)\s*(.*)$} $line -> sig pin]} {
+            addToWatchFromSel sig $sig
+            if {$pin ne ""} {
+                addToWatchFromSel pin $pin
+            }
+        # first argument after setp is a parameter
+        } elseif {[regexp {^\s*setp\s+(\S+)} $line -> param]} {
+            addToWatchFromSel param $param
+        # try adding everything else as pin
+        } else {
+            addToWatchFromSel pin $line
+        }
+    }
 }
 
 proc popupmenu_text {x y} {

--- a/tcl/bin/halshow.tcl
+++ b/tcl/bin/halshow.tcl
@@ -266,6 +266,8 @@ set watchmenu [menu $menubar.watch -tearoff 1]
             -command {addToWatch sig [msgcat::mc "Signal"]}
         $watchmenu add command -label [msgcat::mc "Add parameter"] \
             -command {addToWatch param [msgcat::mc "Parameter"]}
+        $watchmenu add command -label [msgcat::mc "Add from HAL text"] \
+            -command addToWatchFromText
         $watchmenu add separator
         $watchmenu add command -label [msgcat::mc "Reload Watch"] \
             -command {reloadWatch}
@@ -987,6 +989,7 @@ proc popupmenu_watch_general {w x y} {
         $m add command -label [msgcat::mc "Add from clipboard"] -command {
             catch {parse_hal_text [clipboard get]}
         }
+        $m add command -label [msgcat::mc "Add from HAL text"] -command addToWatchFromText
         $m add command -label [msgcat::mc "Erase Watch"] -command {
             watchReset all
             setStatusbar [msgcat::mc "Watchlist cleared"]
@@ -1018,6 +1021,30 @@ proc parse_hal_text {text} {
             addToWatchFromSel pin $line
         }
     }
+}
+
+# Creates a window with a text box to add items to the watchlist
+proc addToWatchFromText {} {
+    # create toplevel dialog
+    set w .clipDialog
+    catch {destroy $w}
+    toplevel $w
+    wm title $w [msgcat::mc "Add to watch"]
+    # text widget
+    text $w.t -width 80 -height 20
+    pack $w.t -fill both -expand 1
+    # insert clipboard content
+    catch {$w.t insert 1.0 [clipboard get]}
+    # frame for buttons and buttons
+    frame $w.f
+    pack $w.f -fill x
+    button $w.f.ok -text "Add" -command "
+        set txt \[$w.t get 1.0 end\]
+        destroy $w
+        parse_hal_text \$txt
+    "
+    button $w.f.cancel -text "Cancel" -command "destroy $w"
+    pack $w.f.ok $w.f.cancel -side left -expand 1 -fill x
 }
 
 proc popupmenu_text {x y} {
@@ -1113,7 +1140,7 @@ proc entrybox {defVal buttonText label} {
         return "cancel"
     } else {
         set wn [toplevel .top]
-        wm title $wn [msgcat::mc "User input"]
+        wm title $wn [msgcat::mc "Input"]
         set xpos "[ expr {[winfo rootx [winfo parent $wn]]+ \
             ([winfo width [winfo parent $wn]]-[winfo reqwidth $wn])/2}]"
         set ypos "[ expr {[winfo rooty [winfo parent $wn]]+ \


### PR DESCRIPTION
This adds a functionality to add pins/signals/parameters from a text which is copied from a HAL file.

Currently it fills the text box with the clipboard. This is handy but could also be irritating. What do you guys think?

<img width="813" height="679" alt="grafik" src="https://github.com/user-attachments/assets/74a075fe-3854-4b0e-9731-9cc476ed8afa" />

<img width="816" height="682" alt="grafik" src="https://github.com/user-attachments/assets/2818890e-99e0-403c-b8c0-44885b551457" />

<img width="813" height="679" alt="grafik" src="https://github.com/user-attachments/assets/269e2823-2f43-4db0-a7a2-ff1ca3393f91" />

