### PR TITLE
ci: remove firefox before apt upgrade to avoid snap store flake

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,7 @@ jobs:
         set -x
         sudo apt-get --yes -o Acquire::Retries=5 install eatmydata
         eatmydata ./scripts/travis-install-build-deps.sh
+        sudo apt-get remove -y firefox firefox-locale-* 2>/dev/null || true
         sudo eatmydata apt --yes --quiet -o Acquire::Retries=5 upgrade
         cd src
         eatmydata ./autogen.sh
@@ -71,6 +72,7 @@ jobs:
         sudo dpkg -i linux-headers-5.4.302-rtai-amd64_5.4.302-rtai-amd64-1_amd64.deb linux-image-5.4.302-rtai-amd64_5.4.302-rtai-amd64-1_amd64.deb rtai-modules-5.4.302_5.3.4-linuxcnc_amd64.deb
         #-----
         eatmydata ./scripts/travis-install-build-deps.sh
+        sudo apt-get remove -y firefox firefox-locale-* 2>/dev/null || true
         sudo eatmydata apt --yes --quiet -o Acquire::Retries=5 upgrade
         cd src
         eatmydata ./autogen.sh
@@ -96,6 +98,7 @@ jobs:
         sudo apt-get --yes -o Acquire::Retries=5 install eatmydata
         eatmydata ./scripts/travis-install-build-deps.sh
         sudo eatmydata apt-get -y -o Acquire::Retries=5 install clang
+        sudo apt-get remove -y firefox firefox-locale-* 2>/dev/null || true
         sudo eatmydata apt --yes --quiet -o Acquire::Retries=5 upgrade
         cd src
         eatmydata ./autogen.sh
@@ -120,6 +123,7 @@ jobs:
       run: |
         ./scripts/travis-install-build-deps.sh
         sudo apt-get -y -o Acquire::Retries=5 install eatmydata
+        sudo apt-get remove -y firefox firefox-locale-* 2>/dev/null || true
         sudo eatmydata apt --yes --quiet -o Acquire::Retries=5 upgrade
         cd src
         eatmydata ./autogen.sh


### PR DESCRIPTION
Fixes #3991.

The firefox snap transition package contacts the snap store from the runner VNet during apt upgrade. When the store is slow or unreachable the upgrade step retries for ~50 minutes then fails, killing the whole job before any LinuxCNC build runs.

Removing firefox before the upgrade sidesteps the snap path. Applied to the four ubuntu-24.04 jobs that run apt upgrade. Container-based package-arch / package-indep jobs are not affected.