### PR TITLE
Convert qtpdf to poppler, convert poppler to pdfium

### DIFF
--- a/lib/python/qtvcp/lib/qt_pdf/PDFViewer.py
+++ b/lib/python/qtvcp/lib/qt_pdf/PDFViewer.py
@@ -7,24 +7,26 @@ from qtpy.QtCore import Qt
 from qtvcp import logger
 LOG = logger.getLogger(__name__)
 
-USE_QTPDF = False
 USE_POPPLER = False
+USE_PDFIUM = False
 
 try:
-    from qtpy.QtPdf import QPdfDocument, QPdfDocumentRenderOptions
-    _QTPDF_RENDER_OPTS = QPdfDocumentRenderOptions()
-    _QTPDF_RENDER_OPTS.setRenderFlags(
-        QPdfDocumentRenderOptions.RenderFlag.Annotations
-    )
-    USE_QTPDF = True
+    import popplerqt5
+    USE_POPPLER = True
+    print("PDFViewer: Using Poppler backend.")
 except Exception:
     try:
-        import popplerqt5
-        USE_POPPLER = True
+        from qtpy.QtPdf import QPdfDocument, QPdfDocumentRenderOptions
+        _PDFIUM_RENDER_OPTS = QPdfDocumentRenderOptions()
+        _PDFIUM_RENDER_OPTS.setRenderFlags(
+            QPdfDocumentRenderOptions.RenderFlag.Annotations
+        )
+        USE_PDFIUM = True
+        print("PDFViewer: Using PDFium (QtPdf) backend.")
     except Exception:
-        LOG.warning('PDFViewer - Neither QtPdf nor python3-poppler-qt5 is available.')
+        LOG.warning('PDFViewer - Neither python3-poppler-qt5 nor Qt6 QtPdf (PDFium) is available.')
 
-LIB_BAD = not USE_QTPDF and not USE_POPPLER
+LIB_BAD = not USE_POPPLER and not USE_PDFIUM
 
 class PDFView(QtWidgets.QScrollArea):
     def __init__(self, parent=None):
@@ -39,11 +41,11 @@ class PDFView(QtWidgets.QScrollArea):
         self._doc = None
 
         if LIB_BAD:
-            label = QtWidgets.QLabel('<b>Missing PDF backend: install python3-poppler-qt5 or use Qt6 with QtPdf</b>')
+            label = QtWidgets.QLabel('<b>Missing PDF backend: install python3-poppler-qt5 or Qt6 QtPdf (PDFium)</b>')
             self.vbox.addWidget(label)
 
     def loadSample(self, name):
-        n = os.path.join(os.path.dirname(__file__),name+'.pdf')
+        n = os.path.join(os.path.dirname(__file__), name + '.pdf')
         if os.path.exists(n):
             self.loadView(n)
         else:
@@ -58,14 +60,16 @@ class PDFView(QtWidgets.QScrollArea):
         if LIB_BAD:
             return
 
-        if USE_QTPDF:
-            if self._doc is None:
-                self._doc = QPdfDocument(self)
-            self._doc.load(filename)
-        else:
+        if USE_POPPLER:
+            print(f"Loading {filename} with Poppler...")
             self._doc = popplerqt5.Poppler.Document.load(filename)
             self._doc.setRenderHint(popplerqt5.Poppler.Document.Antialiasing)
             self._doc.setRenderHint(popplerqt5.Poppler.Document.TextAntialiasing)
+        else:
+            print(f"Loading {filename} with PDFium...")
+            if self._doc is None:
+                self._doc = QPdfDocument(self)
+            self._doc.load(filename)
         self.refreshPages()
 
     def refreshPages(self):
@@ -75,22 +79,21 @@ class PDFView(QtWidgets.QScrollArea):
         for i in reversed(range(self.vbox.count())):
             self.vbox.itemAt(i).widget().setParent(None)
 
-        # convert pages to images in a label
-        if USE_QTPDF:
-            for i in range(self._doc.pageCount()):
-                label = QtWidgets.QLabel()
-                label.setScaledContents(True)
-                page_size = self._doc.pagePointSize(i)
-                render_size = (page_size * self._zoom).toSize()
-                image = self._doc.render(i, render_size, _QTPDF_RENDER_OPTS)
-                label.setPixmap(QtGui.QPixmap.fromImage(image))
-                self.vbox.addWidget(label)
-        else:
+        if USE_POPPLER:
             for i in range(self._doc.numPages()):
                 label = QtWidgets.QLabel()
                 label.setScaledContents(True)
                 page = self._doc.page(i)
                 image = page.renderToImage(72.0 * self._zoom, 72.0 * self._zoom)
+                label.setPixmap(QtGui.QPixmap.fromImage(image))
+                self.vbox.addWidget(label)
+        else:
+            for i in range(self._doc.pageCount()):
+                label = QtWidgets.QLabel()
+                label.setScaledContents(True)
+                page_size = self._doc.pagePointSize(i)
+                render_size = (page_size * self._zoom).toSize()
+                image = self._doc.render(i, render_size, _PDFIUM_RENDER_OPTS)
                 label.setPixmap(QtGui.QPixmap.fromImage(image))
                 self.vbox.addWidget(label)
 
@@ -114,17 +117,8 @@ def pdf_view(filename):
     widget = QtWidgets.QWidget()
     vbox = QtWidgets.QVBoxLayout()
 
-    if USE_QTPDF:
-        doc = QPdfDocument()
-        doc.load(filename)
-        for i in range(doc.pageCount()):
-            label = QtWidgets.QLabel()
-            label.setScaledContents(True)
-            page_size = doc.pagePointSize(i)
-            image = doc.render(i, page_size.toSize(), _QTPDF_RENDER_OPTS)
-            label.setPixmap(QtGui.QPixmap.fromImage(image))
-            vbox.addWidget(label)
-    else:
+    if USE_POPPLER:
+        print("Rendering view via Poppler")
         doc = popplerqt5.Poppler.Document.load(filename)
         doc.setRenderHint(popplerqt5.Poppler.Document.Antialiasing)
         doc.setRenderHint(popplerqt5.Poppler.Document.TextAntialiasing)
@@ -133,6 +127,17 @@ def pdf_view(filename):
             label.setScaledContents(True)
             page = doc.page(i)
             image = page.renderToImage()
+            label.setPixmap(QtGui.QPixmap.fromImage(image))
+            vbox.addWidget(label)
+    else:
+        print("Rendering view via PDFium")
+        doc = QPdfDocument()
+        doc.load(filename)
+        for i in range(doc.pageCount()):
+            label = QtWidgets.QLabel()
+            label.setScaledContents(True)
+            page_size = doc.pagePointSize(i)
+            image = doc.render(i, page_size.toSize(), _PDFIUM_RENDER_OPTS)
             label.setPixmap(QtGui.QPixmap.fromImage(image))
             vbox.addWidget(label)
 
@@ -145,7 +150,7 @@ def main():
     app = QtWidgets.QApplication(sys.argv)
     argv = QtWidgets.QApplication.arguments()
     if len(argv) < 2:
-        filename = '~/emc/nc_files/3D_Chips.pdf'
+        filename = '~/linuxcnc/nc_files/3D_Chips.pdf'
     else:
         filename = argv[-1]
     view = pdf_view(filename)


### PR DESCRIPTION
I cannot get qtpdf working in Debian however the poppler back-end is working fine. PDFium actually has better quality than poppler however the transparent background is grey as opposed to white. Does this matter, and if so, I can make transparent colors white instead.

LinuxCNC now prints out which back-end is being used to help with debugging.

Tested on Debian (poppler) and Gentoo (PDFium)

Poppler is the default back-end for Okular which is great as well.

Feedback is appreciated!

Thanks!