### PR TITLE
axis: Do not crash on non-tkinter event in key press/release tracking

### DIFF
--- a/src/emc/usr_intf/axis/scripts/axis.py
+++ b/src/emc/usr_intf/axis/scripts/axis.py
@@ -123,7 +123,7 @@ ap = AxisPreferences()
 # Handle repeated key press events
 pressed_keys_list = []
 def key_pressed(ev):
-    if None == ev:
+    if None == ev or not isinstance(ev, Tkinter.Event):
         return False
     if ev.keysym in pressed_keys_list:
         return True
@@ -131,7 +131,7 @@ def key_pressed(ev):
     return False
 
 def key_released(ev):
-    if None == ev:
+    if None == ev or not isinstance(ev, Tkinter.Event):
         return
     # KeyRelease without KeyPress may happen when a modifier is active when
     # the key is pressed without a KeyPress handler. No KeyPress event is


### PR DESCRIPTION
Make sure that only tkinter event messages are dereferenced while tracking key press/release events. This addresses the problem mentioned in https://github.com/LinuxCNC/linuxcnc/issues/3994#issuecomment-4366453498.