### PR TITLE
touchy: don't crash on startup when nc_files dir is missing

### DIFF
--- a/src/emc/usr_intf/touchy/filechooser.py
+++ b/src/emc/usr_intf/touchy/filechooser.py
@@ -86,8 +86,12 @@ class filechooser:
         self.populate()
 
     def reload(self, b):
-        self.files = os.listdir(self.dir)
-        self.files = [i for i in self.files if i.endswith('.ngc') and
+        try:
+            entries = os.listdir(self.dir)
+        except OSError as e:
+            print("touchy: filechooser cannot read %s: %s" % (self.dir, e))
+            entries = []
+        self.files = [i for i in entries if i.endswith('.ngc') and
                       os.path.isfile(os.path.join(self.dir, i))]
         self.files.sort()
         self.selected = -1


### PR DESCRIPTION
## Summary

[lib/python/touchy/filechooser.py:reload()](https://github.com/LinuxCNC/linuxcnc/blob/master/lib/python/touchy/filechooser.py#L88-L94) calls `os.listdir(self.dir)` with no error handling, where `self.dir` is hardcoded to `$HOME/linuxcnc/nc_files`. If that directory does not exist (fresh install, clean `$HOME`, sysadmin keeping NGC programs elsewhere) the `FileNotFoundError` propagates up and aborts touchy startup before any window appears.

Catch `OSError`, log the path that could not be read, continue with an empty file list. Touchy still starts; the user reaches programs through the normal file menu, and the quick-pick list populates the next time `reload()` is called once files exist.

Closes #4005.

## Test plan

- [x] Local: `HOME=/tmp/x linuxcnc -r configs/sim/touchy/touchy.ini` now launches touchy with an empty quick-pick list and a stderr line `touchy: filechooser cannot read /tmp/x/linuxcnc/nc_files: ...`
- [x] Local: with the directory present, behaviour unchanged
- [x] Caught by the new ui-smoke tests in #3999 (which currently work around the bug by `mkdir -p $HOME/linuxcnc/nc_files`); the workaround can be removed once this lands

## Notes

- Source path: `src/emc/usr_intf/touchy/filechooser.py`. The build copies this into `lib/python/touchy/`; that copy is gitignored.
- Behaviour change is print-only on the failure path; no API changes.