### PR TITLE
axis: fix Z jog after touch off on unhomed lathe (#3994)

### DIFF
--- a/src/emc/usr_intf/axis/scripts/axis.py
+++ b/src/emc/usr_intf/axis/scripts/axis.py
@@ -1936,7 +1936,11 @@ def ja_from_rbutton():
     # radiobuttons for joints set ja_rbutton to numeric value [0,MAX_JOINTS)
     # radiobuttons for axes   set ja_rbutton to one of: xyzabcuvw
     ja = vars.ja_rbutton.get()
-    if not all_homed() and lathe and not lathe_historical_config():
+    jjogmode = get_jog_mode()
+    # "xzabcuvw" remap is only valid for joint jog on a lathe missing the Y
+    # joint. Teleop axis indices are fixed (0=X,1=Y,2=Z,...) so the full
+    # "xyzabcuvw" map must be used there, otherwise Z collides into the Y slot.
+    if jjogmode and not all_homed() and lathe and not lathe_historical_config():
         axes = "xzabcuvw"
     else:
         axes = "xyzabcuvw"
@@ -1950,7 +1954,7 @@ def ja_from_rbutton():
         a = axes.index(ja) # letter specifies an axis coordinate
 
     # handle joint jogging for known identity kins
-    if get_jog_mode():
+    if jjogmode:
         # joint jogging
         if lathe_historical_config():
             a = "xyzabcuvw".index(ja)


### PR DESCRIPTION
## Summary
Fixes #3994. Z axis stops jogging after touch off on an unhomed lathe with `[TRAJ]NO_FORCE_HOMING = 1`.

## Cause
`touch_off_system()` calls `set_motion_teleop(1)` after the G10 L20 emit, putting motion in TELEOP. `ja_from_rbutton()` selected the compact `"xzabcuvw"` letter map whenever the machine was unhomed, which is correct for **joint** indices on a lathe (no Y joint) but wrong for **teleop axis** slots (fixed at 0=X, 1=Y, 2=Z, ...). After touch off the Z letter resolved to index 1, hitting the unused Y slot. X worked because index 0 matches in both maps.

## Fix
Gate the compact map on `jjogmode`. Teleop axis jogs always use the full `"xyzabcuvw"` slot map; joint jogs keep the existing remap and trivkins/historical overrides.

## Test plan
- [x] Lathe sim, `NO_FORCE_HOMING = 1`, do not home
- [x] Touch off X, jog Z+/- (was broken, now moves)
- [x] Touch off Z, jog X+/-, Z+/- (both move)
- [x] Home, touch off, jog all axes (regression check)
- [x] Mill regression check (3-axis trivkins identity)