### PR TITLE
task: unhome VOLATILE_HOME joints on any motion-disable edge

### DIFF
--- a/src/emc/task/emctaskmain.cc
+++ b/src/emc/task/emctaskmain.cc
@@ -3295,6 +3295,7 @@ int main(int argc, char *argv[])
     }
     while (!done) {
         static int gave_soft_limit_message = 0;
+        static int prev_traj_enabled = 0;
         task_beat++;  // Task's heartbeat
 
         check_ini_hal_items(emcStatus->motion.traj.joints);
@@ -3314,6 +3315,14 @@ int main(int argc, char *argv[])
 	// update subordinate status
 
 	emcMotionUpdate(&emcStatus->motion);
+	// On a motion enabled -> disabled edge (limit switch, amp fault,
+	// following error, etc.) unhome joints marked VOLATILE_HOME. The estop
+	// and machine-off paths already do their own unhome; this catches the
+	// remaining drive-disable causes that don't flip task state.
+	if (prev_traj_enabled && !emcStatus->motion.traj.enabled) {
+	    emcJointUnhome(-2); // only those joints which are volatile_home
+	}
+	prev_traj_enabled = emcStatus->motion.traj.enabled;
 	// synchronize subordinate states
 	if (emcStatus->io.aux.estop) {
 	    if (emcStatus->motion.traj.enabled) {


### PR DESCRIPTION
## Summary
- Fixes #3954. With VOLATILE_HOME=1, tripping a limit switch (or amp-fault, ferror, misc-error, spindle-fault) disables the drives but leaves all joints flagged as homed. Only ESTOP and F2/machine-off paths cleared the homed flag.
- Adds a 1->0 edge detector on `emcStatus->motion.traj.enabled` in the task main loop. On the edge it calls `emcJointUnhome(-2)`, which unhomes only joints marked VOLATILE_HOME. Estop and machine-off continue to do their own unhome and remain idempotent.

## Why this scope
- VOLATILE_HOME is opt-in. A user setting it has declared the joint cannot hold position when its drive is off, so the discriminating event is "drive disabled", not "task state went OFF".
- Three reports over five years (#3954, #3668, plus a 2021 forum thread linked in #3954) all hit the same gap. Per-cause patches would miss the next path; an edge detector covers limit, amp-fault, ferror, misc-error, spindle-fault and any future cause uniformly.
- Default is VOLATILE_HOME=0, so configs with absolute feedback are untouched.
- Soft limits do not disable motion, so they do not trigger an unhome. This matches the contract: home is only lost when the drive is actually cut.

## Test plan
- [x] Sim config, VOLATILE_HOME=1: home X, jog Y into a hard limit switch. X loses homed status.
- [x] Sim config, VOLATILE_HOME=1: home X, ESTOP. X loses homed status (existing path, regression check).
- [x] Sim config, VOLATILE_HOME=1: home X, F2 off. X loses homed status (regression check).
- [x] Sim config, VOLATILE_HOME=1: home X, hit a soft limit. X stays homed (drive not cut).
- [x] Sim config, VOLATILE_HOME=0: home X, trigger a fault. X stays homed (no regression).
- [ ] Hardware (stepper + limit switch): reproduce the exact #3954 scenario.