### PR TITLE
pickconfig: scale row height according to current font height

### DIFF
--- a/tcl/bin/pickconfig.tcl
+++ b/tcl/bin/pickconfig.tcl
@@ -409,7 +409,7 @@ $s1 configure -relief sunken -borderwidth 2
 set font_linespace [font metrics [linuxcnc::standard_font] -linespace]
 # the tree
 set ::tree [Tree $s1.tree -highlightthickness 0 \
-                          -width 25 -relief flat -padx 4 \
+                          -width [expr {int($font_linespace * 1.33)}] -relief flat -padx 4 \
                           -deltay $font_linespace\
                           ]
 $s1 setwidget $::tree

--- a/tcl/bin/pickconfig.tcl
+++ b/tcl/bin/pickconfig.tcl
@@ -405,9 +405,12 @@ set f2 [ frame $f1.f2 -borderwidth 0 -relief flat -padx 15 ]
 # Let the tree scroll
 set s1 [ SW $f2.f3 -auto both]
 $s1 configure -relief sunken -borderwidth 2
+# get the font height to scale the height of the tree rows
+set font_linespace [font metrics [linuxcnc::standard_font] -linespace]
 # the tree
 set ::tree [Tree $s1.tree -highlightthickness 0 \
                           -width 25 -relief flat -padx 4 \
+                          -deltay $font_linespace\
                           ]
 $s1 setwidget $::tree
 pack $s1 -fill y -expand n -side left


### PR DESCRIPTION
Fixes https://github.com/LinuxCNC/linuxcnc/issues/2398


Currently the row height of the treeview is fixed at ca. 15 px. With a higher DPI setting, the text overlaps. This sets a row height according to the font height.


Having a closer look at the current state, the text also overlaps with normal dpi scaling:

<img width="790" height="514" alt="grafik" src="https://github.com/user-attachments/assets/2a2794c1-1d84-484b-954d-cd18e209b688" />   





Default setting (96 DPI):
<img width="790" height="514" alt="grafik" src="https://github.com/user-attachments/assets/5bbf7bb0-0644-4012-9a89-bd2ce1d514b2" />  





192 DPI:
<img width="1217" height="857" alt="grafik" src="https://github.com/user-attachments/assets/89522315-54b3-4a08-9f11-e4f51b7ab643" />
