### PR TITLE
axis: fix Z jog after touch off on unhomed lathe (2.9 backport of #4007)

### DIFF
--- a/src/emc/usr_intf/axis/scripts/axis.py
+++ b/src/emc/usr_intf/axis/scripts/axis.py
@@ -1914,7 +1914,11 @@ def ja_from_rbutton():
     # radiobuttons for joints set ja_rbutton to numeric value [0,MAX_JOINTS)
     # radiobuttons for axes   set ja_rbutton to one of: xyzabcuvw
     ja = vars.ja_rbutton.get()
-    if not all_homed() and lathe and not lathe_historical_config():
+    jjogmode = get_jog_mode()
+    # "xzabcuvw" remap is only valid for joint jog on a lathe missing the Y
+    # joint. Teleop axis indices are fixed (0=X,1=Y,2=Z,...) so the full
+    # "xyzabcuvw" map must be used there, otherwise Z collides into the Y slot.
+    if jjogmode and not all_homed() and lathe and not lathe_historical_config():
         axes = "xzabcuvw"
     else:
         axes = "xyzabcuvw"
@@ -1928,7 +1932,7 @@ def ja_from_rbutton():
         a = axes.index(ja) # letter specifies an axis coordinate
 
     # handle joint jogging for known identity kins
-    if get_jog_mode():
+    if jjogmode:
         # joint jogging
         if lathe_historical_config():
             a = "xyzabcuvw".index(ja)


### PR DESCRIPTION
## Summary

Backport of #4007 (merged to master/2.10) to the 2.9 branch.

Fixes #3994: on an unhomed lathe, touching off forces teleop mode via `set_motion_teleop(1)`. A follow-up Z jog then hit the teleop axis slot 1 (Y) instead of slot 2 (Z) and silently no-op'd, because `ja_from_rbutton` used the compact `xzabcuvw` letter map whenever the machine was unhomed, regardless of jog mode.

Fix gates the compact map on `jjogmode` so teleop axis jogs always use the full `xyzabcuvw` slot map.

Cherry-pick of 7a6dfdd onto 2.9, no conflicts.

## Context

I communicated with the original reporter of #3994. They are on stable 2.9.8 and do not want to build from source. The best I can offer is a PR against 2.9 so the fix lands in the next stable release.

## Test plan

- [x] Verify Z jog works after touch off on unhomed lathe (the original repro from #3994)
- [x] Verify joint jog mode on lathes without Y still uses compact `xzabcuvw` map
- [x] Verify non-lathe configs unaffected