### PR TITLE
build: Fix date/time assignment and add output sync

### DIFF
--- a/debian/rules.in
+++ b/debian/rules.in
@@ -26,9 +26,9 @@ export DEB_BUILD_MAINT_OPTIONS = hardening=+all
 export SOURCE_DATE_EPOCH ?= $(shell dpkg-parsechangelog -STimestamp)
 
 # Set time & date to the most recent release, for repeatable builds.
-TIMESTAMP=$(shell dpkg-parsechangelog -S timestamp)
-export DATE=$(shell LANG=C date --date='@$(TIMESTAMP)' '+%d\ %b\ %Y')
-export TIME=$(shell LANG=C date --date='@$(TIMESTAMP)' '+%T')
+TIMESTAMP:=$(shell dpkg-parsechangelog -S timestamp)
+export DATE:=$(shell LANG=C date --date='@$(TIMESTAMP)' '+%d\ %b\ %Y')
+export TIME:=$(shell LANG=C date --date='@$(TIMESTAMP)' '+%T')
 
 kernel_version = @KERNEL_VERSION@
 configure_realtime_arg = @CONFIGURE_REALTIME_ARG@
@@ -54,14 +54,14 @@ override_dh_auto_configure:
 	    --disable-check-runtime-deps
 
 override_dh_auto_build-arch:
-	dh_auto_build -- build-software
+	dh_auto_build -- -O build-software
 
 override_dh_auto_build-indep:
 ifeq (,$(filter nodocs,$(DEB_BUILD_OPTIONS)))
 ifneq "$(enable_build_documentation)" ""
-	dh_auto_build -- manpages
-	dh_auto_build -- translateddocs
-	dh_auto_build -- docs
+	dh_auto_build -- -O manpages
+	dh_auto_build -- -O translateddocs
+	dh_auto_build -- -O docs
 endif
 endif
 


### PR DESCRIPTION
Fixes #4014.
The TIMESTAMP/DATE/TIME assignment was recursively evaluated instead of simple assignment.
Also add -O option to build to enable output sync in parallel build.