### PR TITLE
ci: install adduser explicitly in package-arch test step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -208,7 +208,7 @@ jobs:
         set -e
         set -x
         eatmydata apt-get --yes --quiet -o Acquire::Retries=5 install ../*.deb
-        eatmydata apt-get --yes --quiet -o Acquire::Retries=5 install sudo # some tests run sudo...
+        eatmydata apt-get --yes --quiet -o Acquire::Retries=5 install sudo adduser # some tests run sudo; adduser no longer pulled implicitly on sid
         eatmydata adduser --disabled-password --gecos "" testrunner
         eatmydata passwd -d testrunner
         eatmydata adduser testrunner sudo


### PR DESCRIPTION
## Summary

The package-arch *Test debian packages* step calls `eatmydata adduser ... testrunner` to set up a non-root user for runtests, but never installs the `adduser` package. It used to work because `adduser` was pulled transitively via Recommends of the installed `.deb` files; sid no longer pulls it, so builds fail with:

```
E: eatmydata: unable to find 'adduser' in PATH
##[error]Process completed with exit code 1.
```

Surfaced today on PR #3999 (all six package-arch jobs across bookworm/trixie/sid x amd64/arm64 failed). Same failure mode reproduces on rerun, so this is not transient.

## Fix

Add `adduser` to the existing `apt-get install sudo` line so the testrunner setup does not depend on a fragile Recommends chain.

## Test plan

- [ ] CI passes on this branch (this PR self-tests the fix)
- [ ] Re-run CI on PR #3999 after merge confirms package-arch jobs progress past testrunner setup