### PR TITLE
ci: install adduser explicitly in package-arch test step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,7 +166,7 @@ jobs:
         set -e
         set -x
         eatmydata apt-get --yes --quiet -o Acquire::Retries=5 install ../*.deb
-        eatmydata apt-get --yes --quiet -o Acquire::Retries=5 install sudo # some tests run sudo...
+        eatmydata apt-get --yes --quiet -o Acquire::Retries=5 install sudo adduser # some tests run sudo; adduser no longer pulled implicitly on sid
         eatmydata adduser --disabled-password --gecos "" testrunner
         eatmydata passwd -d testrunner
         eatmydata adduser testrunner sudo


### PR DESCRIPTION
Backport of master commit f9b363292c onto 2.9.

The test step runs `eatmydata adduser ... testrunner` but never installs `adduser`. It was pulled transitively via Recommends on the installed `.deb` files; sid no longer pulls it, so builds fail with:

```
eatmydata: unable to find adduser in PATH
```

Add it to the existing sudo install so testrunner setup does not depend on Recommends.

2.9's `ci.yml` has the same vulnerable line (line 169 pre-patch) as master had, so the fix is identical.