### PR TITLE
motion: Fix state tag truncation and replace float with double

### DIFF
--- a/src/emc/motion/state_tag.h
+++ b/src/emc/motion/state_tag.h
@@ -115,7 +115,7 @@ struct state_tag_t {
 
     // Float-type machine settings:  feed, speed, etc., indexed by the
     // StateFieldFloat enum above
-    float fields_float[GM_FIELD_FLOAT_MAX_FIELDS];
+    double fields_float[GM_FIELD_FLOAT_MAX_FIELDS];
 
     // Any G / M code states that doesn't pack nicely into a single bit
     // These are an array mostly because it's easier to pass an


### PR DESCRIPTION
The state tag is used in communication between interpreter and motion. Data put into it usually comes from double sized types and got truncated to float size. Afterwards, the values would, for example, be moved to HAL pins and the truncated value would be extended to double again. This is obviously a bad plan.

This PR makes the state tag field_float of double type.