### PR TITLE
task: unblock tool-change abort by setting io.status=DONE

### DIFF
--- a/src/emc/task/taskclass.cc
+++ b/src/emc/task/taskclass.cc
@@ -369,6 +369,9 @@ int Task::emcIoAbort(EMC_ABORT /*reason*/)//EMC_TOOL_ABORT_TYPE
     iocontrol_data.coolant_flood = 0;                /* coolant flood output pin */
     iocontrol_data.tool_change = 0;                /* abort tool change if in progress */
     iocontrol_data.tool_prepare = 0;                /* abort tool prepare if in progress */
+    // release task wait on pending tool-change/prepare (old NML iocontrol
+    // returned RCS_DONE by default; in-process call must do it explicitly)
+    emcioStatus.status = RCS_STATUS::DONE;
     return 0;
 }
 


### PR DESCRIPTION
## Summary

Fixes #3675 (2.10 regression: aborting during a tool-change wedges the UI; MDI and further auto runs are dead until restart).

After 764655eb4d moved IO handling from the out-of-process `iocontrol` into `Task`, `EMC_TOOL_ABORT` no longer flips `emcioStatus.status` back to `RCS_DONE`. The old NML dispatcher in `ioControl.cc` set `RCS_DONE` by default for every command before the switch; the new in-process `Task::emcIoAbort` clears the `tool_change`/`tool_prepare` pins but leaves status stuck at `RCS_EXEC` from the prior `emcToolLoad`/`emcToolPrepare`.

`emctaskmain`'s MDI, auto and state-restore paths gate on `io.status == RCS_DONE`, so abort while tool-change is pending wedges everything.

One-line fix: set `emcioStatus.status = RCS_STATUS::DONE` at the end of `Task::emcIoAbort`, restoring the old default.

@rene-dev, sorry for stepping on this one. Bisect from #3675 pointed at 764655eb4d so I had a clear lead and went ahead. Happy to defer if you'd prefer to take it.

## Test plan

- [x] Reproduced original bug on master (sim/axis, sample G-code with `M6 T1 G43` / `M6 T2 G43`, `iocontrol.0.tool-changed` unlinked, `linuxcnc.command().abort()` while `tool-change=1`): UI sluggish/unresponsive, MDI dead.
- [x] With patch applied: abort recovers cleanly, MDI works, G-code can be re-run.
- [x] Reviewer to confirm on real hardware tool-changer.