### PR TITLE
fix: cast char to unsigned char in get_uint16 to prevent sign-extension

### DIFF
--- a/src/rtapi/uspace_rtapi_main.cc
+++ b/src/rtapi/uspace_rtapi_main.cc
@@ -422,7 +422,7 @@ static void push_uint16(std::vector<char> &buf, uint16_t value) {
 
 static uint16_t get_uint16(const std::vector<char> &buf, size_t idx) {
     //at() will check index and throw std::out_of_range
-    return ((uint16_t)buf.at(idx) << 0) | ((uint16_t)buf.at(idx + 1) << 8);
+    return ((uint16_t)(unsigned char)buf.at(idx)) | ((uint16_t)(unsigned char)buf.at(idx + 1) << 8);
 }
 
 static bool recv_args(int fd, std::vector<std::string> &args) {


### PR DESCRIPTION
get_uint16() in uspace_rtapi_main.cc casts char directly to uint16_t. On x86-64 GCC where char is signed, any byte >= 0x80 sign-extends (e.g. 0xA3 becomes 0xFFA3), corrupting the deserialized argument length.

This breaks loadrt for any module argument longer than 127 bytes — the master gets garbage in recv_args and the slave sees "recv_result failed, recv only 0 of 4 bytes".

Fix: cast through unsigned char before widening. The companion push_uint16 already masks with 0xff, so only the read side was affected.