### PR TITLE
docs: document initf command

### DIFF
--- a/docs/src/hal/basic-hal.adoc
+++ b/docs/src/hal/basic-hal.adoc
@@ -98,6 +98,26 @@ addf <function> <thread>
 addf mux4.0 servo-thread
 ----
 
+[[sub:hal-initf]]
+=== initf
+
+(((HAL initf,initf)))
+The `initf` command registers a function to run once in realtime context, on a dedicated init cycle of the thread before the cyclic function list runs.
+It is the realtime-thread analogue of `addf`, intended for one-shot setup that must execute in the realtime task (for example EtherCAT master activation via `lcec.0.activate`).
+
+`initf` adds function _functname_ to the init list of thread _threadname_.
+The init list runs once on the first cycle after `start`, then is drained.
+The cyclic list begins on the following period.
+Once the init cycle has run, further `initf` calls on that thread are rejected.
+`position` has the same meaning as in `addf`.
+
+.initf Syntax and Example
+[source,{hal}]
+----
+initf <function> <thread>
+initf lcec.0.activate servo-thread
+----
+
 [[sub:hal-loadusr]]
 === loadusr
 

--- a/docs/src/man/man1/halcmd.1.adoc
+++ b/docs/src/man/man1/halcmd.1.adoc
@@ -192,6 +192,13 @@ _pinname_ *=* _value_::
   _threadname_. _functname_ will run after any functions that were
   previously added to the thread. Fails if either _functname_ or
   _threadname_ does not exist, or if they are incompatible.
+*initf* _functname_ _threadname_::
+  (__init__ __f__unction) Registers _functname_ to run once in realtime
+  context on a dedicated init cycle of _threadname_, before the cyclic
+  function list executes. Intended for one-shot setup that must run in
+  the realtime task (for example EtherCAT slave configuration). Once
+  the init cycle has run, further *initf* calls on that thread are
+  rejected. Fails if either _functname_ or _threadname_ does not exist.
 *delf* _functname_ _threadname_::
   (__del__ete __f__unction) Removes function _functname_ from realtime
   thread _threadname_. Fails if either _functname_ or _threadname_ does

--- a/docs/src/man/man1/haltcl.1.adoc
+++ b/docs/src/man/man1/haltcl.1.adoc
@@ -56,7 +56,7 @@ The augmented commands can be listed with the command:
 
 `haltcl: hal --commands`+
 
-`addf alias delf delsig getp gets ptype stype help linkpp linkps linksp list loadrt loadusr lock net newsig save setexact_for_test_suite_only setp sets show source start status stop unalias unlinkp unload unloadrt unloadusr unlock waitusr`
+`addf alias delf delsig getp gets initf ptype stype help linkpp linkps linksp list loadrt loadusr lock net newsig save setexact_for_test_suite_only setp sets show source start status stop unalias unlinkp unload unloadrt unloadusr unlock waitusr`
 
 Two of the augmented commands, 'list' and 'gets', require special treatment
 to avoid conflict with Tcl built-in commands having the same names.


### PR DESCRIPTION
## Summary
- Add `initf` section to `docs/src/hal/basic-hal.adoc` next to `loadrt`/`addf`.
- Add `initf` entry to `halcmd(1)` and to the augmented-commands list in `haltcl(1)`.

The `initf` command was merged but had no user-facing documentation. This fills that gap, matching the style and brevity of the surrounding `loadrt`/`addf`/`delf` entries.

## Test plan
- [x] Build docs and confirm rendering.