### PR TITLE
tests: Silence left-over (debug) message in tests

### DIFF
--- a/tests/module-loading/rtapi-app-main-fails/checkresult
+++ b/tests/module-loading/rtapi-app-main-fails/checkresult
@@ -8,13 +8,13 @@ fi
 
 # Linux spelling of ERANGE
 if grep -E -q 'rtapi_app_main_fails.* Numerical result out of range' "$STDERR"; then
-    echo "loadrt found the test component, and it failed to load"
+    #echo "loadrt found the test component, and it failed to load"
     exit 0
 fi
 
 # FreeBSD spelling of ERANGE
 if grep -E -q 'rtapi_app_main_fails.* Result too large' "$STDERR"; then
-    echo "loadrt found the test component, and it failed to load"
+    #echo "loadrt found the test component, and it failed to load"
     exit 0
 fi
 

--- a/tests/motion/g0/checkresult
+++ b/tests/motion/g0/checkresult
@@ -127,7 +127,7 @@ for i in range(i, len(samples) - 1):
         sys.exit(1)
 
     if accel_ipc2 == 0:
-        print("line %d: accel phase over" % i)
+        #print("line %d: accel phase over" % i)
         break
 
     old_v_ipc = new_v_ipc


### PR DESCRIPTION
This removes the redundant (annoying) message "line 1314: accel phase over" from tests/motion/g0.

It was a left-over debug message where the message starting the acceleration already was commented out. This PR takes care of the second message and has no functional change.