### PR TITLE
axis: link _togl with -lGL (partially addresses #4034)

### DIFF
--- a/src/emc/usr_intf/axis/Submakefile
+++ b/src/emc/usr_intf/axis/Submakefile
@@ -17,7 +17,7 @@ $(EMCMODULE): $(call TOOBJS, $(EMCMODULESRCS)) ../lib/liblinuxcnc.a ../lib/libnm
 
 $(TOGLMODULE): $(call TOOBJS, $(TOGLMODULESRCS))
 	$(ECHO) Linking python module $(notdir $@)
-	$(Q)$(CC) $(LDFLAGS) -shared -o $@ $(TCL_CFLAGS) $^ -L/usr/X11R6/lib -lX11 -lepoxy -lXmu $(TCL_LIBS)
+	$(Q)$(CC) $(LDFLAGS) -shared -o $@ $(TCL_CFLAGS) $^ -L/usr/X11R6/lib -lX11 -lepoxy -lGL -lXmu $(TCL_LIBS)
 
 PYTARGETS += $(EMCMODULE) $(TOGLMODULE)
 


### PR DESCRIPTION
## Summary
- `_toglmodule.c` calls raw GLX (`glXDestroyContext` etc.). libepoxy is runtime dispatch only, does not provide link-time GLX symbols.
- Without `-lGL` the built `_togl.so` has 9 unresolved `glX*` symbols. On x86_64 the transitive libepoxy -> libGL chain hides it; on aarch64 it fails import with `undefined symbol: glXDestroyContext`.
- Backport of the togl hunk from ceed26dc72 (already on master).

Partially addresses #4034 (togl ImportError). The separate AXIS segfault on UTM/virgl/ANGLE is unrelated.

## Test plan
- [x] Reproduced ImportError in qemu-user arm64 bookworm chroot with stock 2.9 build.
- [x] Confirmed `-lGL` adds `libGL.so.1` to NEEDED and resolves all `glX*` symbols.
- [x] Verify x86_64 build still links cleanly (opened and tested axis UI works proper).