### PR TITLE
cppcheck: Fix current issues

### DIFF
--- a/src/emc/rs274ngc/interp_setup.cc
+++ b/src/emc/rs274ngc/interp_setup.cc
@@ -187,6 +187,13 @@ setup::setup() :
     disable_fanuc_style_sub(false),
     loop_on_main_m99(false),
     disable_g92_persistence(0),
+    heading(0.0),
+    radius(0.0),
+    center_x(0.0),
+    center_y(0.0),
+    center_z(0.0),
+    normal_heading(0.0),
+    iscircle(false),
     pythis(),
     on_abort_command(NULL),
     init_once(CANON_STOPPED)

--- a/src/emc/usr_intf/schedrmt.cc
+++ b/src/emc/usr_intf/schedrmt.cc
@@ -322,7 +322,7 @@ static int initSockets()
   server_address.sin_addr.s_addr = htonl(INADDR_ANY);
   server_address.sin_port = htons(port);
   server_len = sizeof(server_address);
-  bind(server_sockfd, (struct sockaddr *)&server_address, server_len);
+  bind(server_sockfd, reinterpret_cast<struct sockaddr *>(&server_address), server_len);
   listen(server_sockfd, 5);
   signal(SIGCHLD, SIG_IGN);
   return 0;
@@ -1153,6 +1153,10 @@ void *readClient(void * /*arg*/)
   
 //  res = 1;
   context = (connectionRecType *) malloc(sizeof(connectionRecType));
+  if (!context) {
+    fprintf(stderr, "emcrsh: no memory\n");
+    goto fail;
+  }
   context->cliSock = client_sockfd;
   context->linked = false;
   context->echo = true;
@@ -1196,6 +1200,7 @@ void *readClient(void * /*arg*/)
 finished:
   close(context->cliSock);
   free(context);
+fail:
   pthread_exit((void *)0);
   sessions--;  // FIXME: not reached
 }
@@ -1209,7 +1214,7 @@ int sockMain()
       
       client_len = sizeof(client_address);
       client_sockfd = accept(server_sockfd,
-        (struct sockaddr *)&client_address, &client_len);
+        reinterpret_cast<struct sockaddr *>(&client_address), &client_len);
       if (client_sockfd < 0) exit(0);
       sessions++;
       if ((maxSessions == -1) || (sessions <= maxSessions))

--- a/src/hal/drivers/mesa-hostmot2/hm2_7i43.c
+++ b/src/hal/drivers/mesa-hostmot2/hm2_7i43.c
@@ -35,10 +35,8 @@
 
 static int comp_id;
 
-#ifdef MODULE_INFO
 MODULE_INFO(linuxcnc, "component:hm2_7i43:LinuxCNC HAL driver for the Mesa Electronics 7i43 EPP Anything IO board with HostMot2 firmware.");
 MODULE_INFO(linuxcnc, "license:GPL");
-#endif // MODULE_INFO
 
 MODULE_LICENSE("GPL");
 

--- a/src/hal/drivers/mesa-hostmot2/hm2_7i90.c
+++ b/src/hal/drivers/mesa-hostmot2/hm2_7i90.c
@@ -34,10 +34,8 @@
 
 static int comp_id;
 
-#ifdef MODULE_INFO
 MODULE_INFO(linuxcnc, "component:hm2_7i90:LinuxCNC HAL driver for the Mesa Electronics 7i90 EPP Anything IO board with HostMot2 firmware.");
 MODULE_INFO(linuxcnc, "license:GPL");
-#endif // MODULE_INFO
 
 MODULE_LICENSE("GPL");
 

--- a/src/hal/drivers/mesa-hostmot2/hm2_eth.c
+++ b/src/hal/drivers/mesa-hostmot2/hm2_eth.c
@@ -84,9 +84,7 @@ static void kvlist_free(struct rtapi_list_head *head) {
 MODULE_LICENSE("GPL");
 MODULE_AUTHOR("Michael Geszkiewicz");
 MODULE_DESCRIPTION("Driver for HostMot2 on the 7i80 Anything I/O board from Mesa Electronics");
-#ifdef MODULE_SUPPORTED_DEVICE
 MODULE_SUPPORTED_DEVICE("Mesa-AnythingIO-7i80");
-#endif
 
 static char *board_ip[MAX_ETH_BOARDS];
 RTAPI_MP_ARRAY_STRING(board_ip, MAX_ETH_BOARDS, "ip address of ethernet board(s)");

--- a/src/hal/user_comps/hy_gt_vfd.c
+++ b/src/hal/user_comps/hy_gt_vfd.c
@@ -524,7 +524,9 @@ int main(int argc, char **argv) {
         // Set the response timeout.
         t.tv_sec = 0;
         t.tv_usec = 16 * 1000;
-#if (LIBMODBUS_VERSION_CHECK(3, 1, 2))
+// Cppcheck fails to parse the function-like macro
+//#if (LIBMODBUS_VERSION_CHECK(3, 1, 2))
+#if LIBMODBUS_VERSION_HEX >= 0x030102
         modbus_set_response_timeout(mb, t.tv_sec, t.tv_usec);
 #else
         modbus_set_response_timeout(mb, &t);
@@ -532,7 +534,9 @@ int main(int argc, char **argv) {
 
         // Disable the byte timeout so it just waits for the complete
         // response timeout instead.
-#if (LIBMODBUS_VERSION_CHECK(3, 1, 2))
+// Cppcheck fails to parse the function-like macro
+//#if (LIBMODBUS_VERSION_CHECK(3, 1, 2))
+#if LIBMODBUS_VERSION_HEX >= 0x030102
         t.tv_sec = 0;
         t.tv_usec = 0;
         modbus_set_byte_timeout(mb, t.tv_sec, t.tv_usec);

--- a/src/hal/user_comps/mb2hal/mb2hal.c
+++ b/src/hal/user_comps/mb2hal/mb2hal.c
@@ -375,7 +375,9 @@ retCode get_tx_connection(const int this_mb_tx_num, int *ret_connected)
     //set response and byte timeout according to each mb_tx
     timeout.tv_sec  = this_mb_tx->mb_response_timeout_ms / 1000;
     timeout.tv_usec = (this_mb_tx->mb_response_timeout_ms % 1000) * 1000;
-#if LIBMODBUS_VERSION_CHECK(3, 1, 2)
+// Cppcheck fails to parse the function-like macro
+//#if (LIBMODBUS_VERSION_CHECK(3, 1, 2))
+# if LIBMODBUS_VERSION_HEX >= 0x030102
     modbus_set_response_timeout(this_mb_link->modbus, timeout.tv_sec, timeout.tv_usec);
 #else
     modbus_set_response_timeout(this_mb_link->modbus, &timeout);
@@ -386,7 +388,9 @@ retCode get_tx_connection(const int this_mb_tx_num, int *ret_connected)
 
     timeout.tv_sec  = this_mb_tx->mb_byte_timeout_ms / 1000;
     timeout.tv_usec = (this_mb_tx->mb_byte_timeout_ms % 1000) * 1000;
-#if LIBMODBUS_VERSION_CHECK(3, 1, 2)
+// Cppcheck fails to parse the function-like macro
+//#if (LIBMODBUS_VERSION_CHECK(3, 1, 2))
+# if LIBMODBUS_VERSION_HEX >= 0x030102
     modbus_set_byte_timeout(this_mb_link->modbus, timeout.tv_sec, timeout.tv_usec);
 #else
     modbus_set_byte_timeout(this_mb_link->modbus, &timeout);

--- a/src/hal/user_comps/svd-ps_vfd.c
+++ b/src/hal/user_comps/svd-ps_vfd.c
@@ -473,7 +473,9 @@ int main(int argc, char **argv) {
         // Set the response timeout.
         t.tv_sec = 0;
         t.tv_usec = 30 * 1000;
-#if (LIBMODBUS_VERSION_CHECK(3, 1, 2))
+// Cppcheck fails to parse the function-like macro
+//#if (LIBMODBUS_VERSION_CHECK(3, 1, 2))
+# if LIBMODBUS_VERSION_HEX >= 0x030102
         modbus_set_response_timeout(mb, t.tv_sec, t.tv_usec);
 #else
         modbus_set_response_timeout(mb, &t);
@@ -481,7 +483,9 @@ int main(int argc, char **argv) {
 
         // Disable the byte timeout so it just waits for the complete
         // response timeout instead.
-#if (LIBMODBUS_VERSION_CHECK(3, 1, 2))
+// Cppcheck fails to parse the function-like macro
+//#if (LIBMODBUS_VERSION_CHECK(3, 1, 2))
+# if LIBMODBUS_VERSION_HEX >= 0x030102
         t.tv_sec = 0;
         t.tv_usec = 0;
         modbus_set_byte_timeout(mb, t.tv_sec, t.tv_usec);

--- a/src/hal/utils/halsh.c
+++ b/src/hal/utils/halsh.c
@@ -190,7 +190,7 @@ static int halStreamCmd(ClientData cd, Tcl_Interp *interp, int argc, const char 
         return TCL_OK;
     }
     if (strcmp(sub, "maxdepth") == 0) {
-        char buf[16]; snprintf(buf, sizeof(buf), "%d", hal_stream_maxdepth(s));
+        char buf[16]; snprintf(buf, sizeof(buf), "%u", hal_stream_maxdepth(s));
         Tcl_AppendResult(interp, buf, NULL);
         return TCL_OK;
     }

--- a/src/rtapi/uspace_rtapi_app.hh
+++ b/src/rtapi/uspace_rtapi_app.hh
@@ -23,6 +23,7 @@
 #include <unistd.h>
 #include <pthread.h>
 #include "rtapi_atomic.h"
+#include "rtapi_stdint.h"
 
 static inline void rtapi_timespec_add(timespec &result, const timespec &ta, const timespec &tb) {
     result.tv_sec = ta.tv_sec + tb.tv_sec;
@@ -78,7 +79,7 @@ struct RtapiTask {
 
 #define MAX_TASKS 64
 #define TASK_MAGIC 21979 /* random numbers used as signatures */
-#define TASK_MAGIC_INIT ((RtapiTask *)(-1))
+#define TASK_MAGIC_INIT ((RtapiTask *)(rtapi_intptr_t)(-1))
 
 struct RtapiApp {
 


### PR DESCRIPTION
Take care of the current cppcheck messages. Some long standing, others recently introduced.

There may still be lurking some messages that appear due to some different versions of cppcheck. No messages appear on 2.19.1 (Fedora 43). On 2.17.1 (Debian 13/Trixie) there were a set of errors related to `#ifdef` statements for MODULE_INFO and friends macros. These checks were removed (redundant because the macros are always defined).