### PR TITLE
Fix most shellcheck issues

### DIFF
--- a/scripts/gladevcp_demo
+++ b/scripts/gladevcp_demo
@@ -68,15 +68,15 @@ fi
 
 case $# in
   0) usage;;
-  *) ARGS="$@";;
+  *) ;;
 esac
 
 if [ -n "$debug" ] ; then
   echo "debug=$debug"
   echo "REALTIME=$REALTIME"
-  echo "ARGS=$ARGS"
+  echo "ARGS=$*"
 pwd
 fi
 
-eval gladevcp "$ARGS"
+gladevcp "$@"
 halrun -U

--- a/scripts/halcmd_twopass.in
+++ b/scripts/halcmd_twopass.in
@@ -1,5 +1,4 @@
 #!/bin/sh
-DASHI="" INIARG=""
 HALLIB_DIR=@HALLIB_DIR@; export HALLIB_DIR
 LINUXCNC_TCL_DIR=@EMC2_TCL_DIR@; export LINUXCNC_TCL_DIR
 if [ $# -ne 1 ]; then echo 1>&2 Usage: "$0" inifile; exit 1; fi

--- a/scripts/halrun.in
+++ b/scripts/halrun.in
@@ -71,7 +71,7 @@ fi
 #    as parameter for -f ('f filename')
 # or as trailing parameter
 if [ $# -gt 0 ] ; then
-  if [ "X$filename" = "X" ] ; then
+  if [ -z "$filename" ] ; then
     filename=$1
     shift
   else
@@ -151,8 +151,11 @@ if $HAVEFILE ; then
         halcmd_twopass "$filename"; result=$?    
     fi
   elif $IS_HALTCL; then
+    # Arguments need to be word split
+    # shellcheck disable=SC2068
     haltcl $@; result=$?
   else
+    # shellcheck disable=SC2068
     halcmd $@; result=$?
   fi
 fi

--- a/scripts/linuxcnc.in
+++ b/scripts/linuxcnc.in
@@ -36,14 +36,16 @@ fi
 ################################################################################
 # 0. Values that come from configure
 ################################################################################
+# Shellcheck doesn't know about substitution
+# shellcheck disable=SC2034
 prefix=@prefix@
+# shellcheck disable=SC2034
 exec_prefix=@exec_prefix@
 
 PIDOF="@PIDOF@ -x"
 PS=@PS@
 AWK=@AWK@
 GREP=@GREP@
-IPCS=@IPCS@
 KILL=@KILL@
 
 LINUXCNC_HOME=@EMC2_HOME@; export LINUXCNC_HOME
@@ -52,11 +54,13 @@ LINUXCNC_BIN_DIR=@EMC2_BIN_DIR@
 LINUXCNC_TCL_DIR=@EMC2_TCL_DIR@
 LINUXCNC_HELP_DIR=@EMC2_HELP_DIR@
 LINUXCNC_RTLIB_DIR=@EMC2_RTLIB_DIR@
+# shellcheck disable=SC2034
 LINUXCNC_CONFIG_PATH="@LINUXCNC_CONFIG_PATH@"
 LINUXCNC_NCFILES_DIR=@EMC2_NCFILES_DIR@
 LINUXCNC_LANG_DIR=@EMC2_LANG_DIR@
 REALTIME=@REALTIME@
 LINUXCNC_IMAGEDIR=@EMC2_IMAGE_DIR@
+# shellcheck disable=SC2034
 LINUXCNC_TCL_LIB_DIR=@EMC2_TCL_LIB_DIR@
 HALLIB_DIR=@HALLIB_DIR@; export HALLIB_DIR
 
@@ -94,7 +98,7 @@ else
 fi
 export PYTHONPATH
 
-if test "xyes" != "x@RUN_IN_PLACE@"; then
+if [ "yes" != "@RUN_IN_PLACE@" ]; then
     if [ -z "$TCLLIBPATH" ]; then
          TCLLIBPATH=$LINUXCNC_HOME/lib/tcltk
     else
@@ -239,7 +243,7 @@ fi
 fi
 
 # Stop complaining unreachable. It is trap code.
-# shellcheck disable=SC2317
+# shellcheck disable=SC2317,SC2329
 function ErrorCheck () {
     result=$?
     if [ -n "$DISPLAY" ]; then
@@ -382,7 +386,7 @@ function run_applications () {
           *) # try local first then PATH
              exe_name=$(pwd)/$app_name
              if [ ! -x "$exe_name" ] ; then
-               exe_name=$(command -v $app_name)
+               exe_name=$(command -v "$app_name")
              fi
        esac
        if [ ! -f "$exe_name" ] ; then
@@ -496,7 +500,7 @@ esac
 # 2.2. get param file
 
 GetFromIni PARAMETER_FILE RS274NGC 
-RS274NGC_PARAMFILE=$retval
+#RS274NGC_PARAMFILE=$retval
 
 # 2.3. get mot information
 GetFromIniEx MOT MOT EMCMOT EMCMOT motmod
@@ -534,8 +538,13 @@ HALBRIDGE=$retval
 
 # 2.8. get display information
 GetFromIni DISPLAY DISPLAY
-EMCDISPLAY=$( (set -- $retval ; echo "$1") )
-EMCDISPLAYARGS=$( (set -- $retval ; shift; echo "$*") )
+# Intentional split to make it values of an array.
+# Then split the array into the program and its args.
+# shellcheck disable=SC2206
+__emcdisplay=( $retval )
+EMCDISPLAY="${__emcdisplay[*]:0:1}"
+EMCDISPLAYARGS=( "${__emcdisplay[@]:1}" )
+unset __emcdisplay
 
 case $EMCDISPLAY in
     tkemc) EMCDISPLAY=tklinuxcnc ;;
@@ -577,17 +586,17 @@ function KillTaskWithTimeout() {
     fi
     local NPROCS
     for KILL_PID in $KILL_PIDS ; do
-        if $PS -o stat= -o comm= "$KILL_PID" | $GREP -q '^Z'; then
+        if "$PS" -o stat= -o comm= "$KILL_PID" | "$GREP" -q '^Z'; then
             echo "Skipping defunct task $KILL_TASK, PID=$KILL_PID" >> "$PRINT_FILE"
             continue
         fi
 	# first a "gentle" kill with signal TERM
-	$KILL "$KILL_PID"
+	"$KILL" "$KILL_PID"
 	WAIT=$KILL_TIMEOUT
 	# wait and see if it disappears
 	while [ $WAIT -gt 1 ] ; do
 	    # see if it's still alive
-            NPROCS=$($PS -o stat= -o comm= "$KILL_PID" | $GREP -v '^Z' | wc -l)
+            NPROCS=$("$PS" -o stat= -o comm= "$KILL_PID" | "$GREP" -v '^Z' | wc -l)
             if [ "$NPROCS" -gt 0 ]; then
 		WAIT=$((WAIT - 1))
 		sleep .1
@@ -598,12 +607,12 @@ function KillTaskWithTimeout() {
 	if [ $WAIT -gt 0 ] ; then
 	    # gentle didn't work, get serious
 	    echo "Timeout, trying kill -9" >> "$PRINT_FILE"
-	    $KILL -9 "$KILL_PID"
+	    "$KILL" -9 "$KILL_PID"
 	    WAIT=$KILL_TIMEOUT
 	    # wait and see if it disappears
 	    while [ $WAIT -gt 1 ] ; do
 		# see if it's still alive
-                NPROCS=$($PS -o stat= -o comm= "$KILL_PID" | $GREP -v '^Z' | wc -l)
+                NPROCS=$("$PS" -o stat= -o comm= "$KILL_PID" | "$GREP" -v '^Z' | wc -l)
                 if [ "$NPROCS" -gt 0 ]; then
 		    WAIT=$((WAIT - 1))
 		    sleep .1
@@ -805,7 +814,10 @@ fi
 # "halcmd loadrt" can find them
 HAL_RTMOD_DIR=$LINUXCNC_RTLIB_DIR; export HAL_RTMOD_DIR
 echo "$(basename "$0") TPMOD=$TPMOD HOMEMOD=$HOMEMOD EMCMOT=${EMCMOT%.*}"
+# The HALCMD variable must be split because it may contain options.
+# shellcheck disable=SC2086
 eval $HALCMD loadrt "$TPMOD"
+# shellcheck disable=SC2086
 eval $HALCMD loadrt "$HOMEMOD"
 
 # 4.3.7. Run task in background
@@ -832,6 +844,8 @@ fi
 # run hal bridge program IF requested
 if [ -n "$HALBRIDGE" ] ; then
     echo "Starting HAL User Interface program: $HALBRIDGE" >> "$PRINT_FILE"
+    # HALBRIDGE must be word split
+    # shellcheck disable=SC2086
     $HALCMD loadusr -Wn bridge $HALBRIDGE
 fi
 
@@ -897,6 +911,8 @@ else
         CFGFILE="$foundfile"
         case $CFGFILE in
         *.tcl)
+            # CFGFILE_ARGS must be word split
+            # shellcheck disable=SC2086
             if ! haltcl -i "$INIFILE" "$CFGFILE" $CFGFILE_ARGS \
                && [ -z "$DASHK" ]; then
                 Cleanup
@@ -944,7 +960,7 @@ run_applications
 # wait for traj to process for up to 10s before screen loading do to race condition
 RACE_TIMEOUT=$((SECONDS + 10))
 chk=$(halcmd getp ini.traj_max_velocity)
-while (( $($AWK 'BEGIN {print ('"$chk"' == 0)}') )); do
+while (( $("$AWK" 'BEGIN {print ('"$chk"' == 0)}') )); do
     if [ $SECONDS -ge $RACE_TIMEOUT ]; then
         echo "ini.traj_max_velocity still 0.0 after $SECONDS seconds" | tee -a "$PRINT_FILE" "$DEBUG_FILE"
         break
@@ -959,11 +975,11 @@ case $EMCDISPLAY in
   tklinuxcnc)
     # tklinuxcnc is in the tcl directory, not the bin directory
     if [ ! -x "$LINUXCNC_TCL_DIR/$EMCDISPLAY.tcl" ] ; then
-	echo "Can't execute DISPLAY program $LINUXCNC_TCL_DIR/$EMCDISPLAY.tcl $EMCDISPLAYARGS"
+	echo "Can't execute DISPLAY program $LINUXCNC_TCL_DIR/$EMCDISPLAY.tcl ${EMCDISPLAYARGS[*]}"
 	Cleanup
 	exit 1
     fi
-    "$LINUXCNC_TCL_DIR/$EMCDISPLAY.tcl" -ini "$INIFILE" $EMCDISPLAYARGS
+    "$LINUXCNC_TCL_DIR/$EMCDISPLAY.tcl" -ini "$INIFILE" "${EMCDISPLAYARGS[@]}"
     result=$?
   ;;
   dummy)
@@ -972,16 +988,16 @@ case $EMCDISPLAY in
     read -r ;
   ;;
   linuxcncrsh)
-    $EMCDISPLAY $EMCDISPLAYARGS "${EXTRA_ARGS[@]}" -- -ini "$INIFILE"
+    $EMCDISPLAY "${EMCDISPLAYARGS[@]}" "${EXTRA_ARGS[@]}" -- -ini "$INIFILE"
   ;;
   *)
     # all other displays are assumed to be commands on the PATH
     if ! program_available "$EMCDISPLAY"; then
-        echo "Can't execute DISPLAY program $EMCDISPLAY $EMCDISPLAYARGS ${EXTRA_ARGS[*]}"
+        echo "Can't execute DISPLAY program $EMCDISPLAY ${EMCDISPLAYARGS[*]} ${EXTRA_ARGS[*]}"
         Cleanup
         exit 1
     fi
-    $EMCDISPLAY -ini "$INIFILE" $EMCDISPLAYARGS "${EXTRA_ARGS[@]}"
+    $EMCDISPLAY -ini "$INIFILE" "${EMCDISPLAYARGS[@]}" "${EXTRA_ARGS[@]}"
     result=$?
   ;;
 esac

--- a/scripts/linuxcnc_info.in
+++ b/scripts/linuxcnc_info.in
@@ -40,7 +40,7 @@ git_commit () {
   if [ "${dir}" = "/usr/bin" ] ; then
     echo NA
   else
-    echo "$(cd "$dir" && git rev-parse --short HEAD 2>/dev/null)"
+    ( cd "$dir" && git rev-parse --short HEAD 2>/dev/null )
   fi
 }
 

--- a/scripts/make-docs-pdf-index
+++ b/scripts/make-docs-pdf-index
@@ -21,7 +21,7 @@ rm -f index.html
     echo "<body><h1>${TITLE}</h1><p>"
 } >> index.html
 
-for F in $(ls -1 ./*.pdf | sort); do
+for F in $(find . -maxdepth 1 -name '*.pdf' | sort); do
     echo "    <a href=\"${F}\">$F</a><br>" >> index.html
 done
 

--- a/scripts/realtime.in
+++ b/scripts/realtime.in
@@ -46,7 +46,10 @@ if [ $RUN_IN_PLACE = yes ]; then
 fi
 
 CheckConfig(){
+    # Shellcheck doesn't know about substitution
+    # shellcheck disable=SC2034
     prefix=@prefix@
+    # shellcheck disable=SC2034
     exec_prefix=@exec_prefix@
     sysconfdir=@sysconfdir@
     if [ "$RUN_IN_PLACE" = "yes" ]; then

--- a/src/hal/components/mkconv.sh
+++ b/src/hal/components/mkconv.sh
@@ -73,18 +73,20 @@ minval() {
 #
 
 # Enable (val > MAX) test
+V=1
 test	"$1" = 'float' -o \
 	"$2" = 'bit' -o \
 	\( "$2" = 's32' -a "$1" != 'bit' \) -o \
 	\( "$1" = 'u64' -a "$2" != 'float' \) -o \
-	\( "$1" = 's64' -a "$2" = 'u32' \)
-MAXEN="s,@MAXEN@,$?,g"
+	\( "$1" = 's64' -a "$2" = 'u32' \) && V=0
+MAXEN="s,@MAXEN@,$V,g"
 
 # Enable (val < MIN) test
+V=1
 test	"$1" = 'float' -o \
 	\( "$1" = 's64' -a "$2" != 'float' \) -o \
-	\( "$1" = 's32' -a \( "$2" = 'u32' -o "$2" = 'u64' -o "$2" = 'bit' \) \)
-MINEN="s,@MINEN@,$?,g"
+	\( "$1" = 's32' -a \( "$2" = 'u32' -o "$2" = 'u64' -o "$2" = 'bit' \) \) && V=0
+MINEN="s,@MINEN@,$V,g"
 
 # Disable clamp code
 if test	"$2" = 'float' -o \

--- a/src/po/git-merge-po
+++ b/src/po/git-merge-po
@@ -9,6 +9,8 @@
 # - When merging branches, conflicts in PO files will be marked with "#-#-#-#"
 #
 set -x
+# O is nerver used. We ignore it.
+# shellcheck disable=SC2034
 O="$1"
 A="$2"
 B="$3"

--- a/tests/build/header-sanity/test.sh
+++ b/tests/build/header-sanity/test.sh
@@ -5,6 +5,8 @@ for i in "$HEADERS"/*.h; do
     case $i in
     */rtapi_app.h) continue ;;
     esac
+    # CPPFLAGS is supposed to be word split
+    # shellcheck disable=SC2086
     gcc ${CPPFLAGS} -DULAPI -I"$HEADERS" -E -x c "$i" > /dev/null
 done
 for i in "$HEADERS"/*.h "$HEADERS"/*.hh; do
@@ -13,10 +15,12 @@ for i in "$HEADERS"/*.h "$HEADERS"/*.hh; do
     */rtapi_app.h) continue ;;
     */interp_internal.hh) continue ;;
     esac
+    # shellcheck disable=SC2086
     if g++ ${CPPFLAGS} -std=c++11 -S -o /dev/null -xcxx /dev/null > /dev/null 2>&1; then
         ELEVEN=-std=c++11
     else
         ELEVEN=-std=c++0x
     fi
+    # shellcheck disable=SC2086
     g++ ${CPPFLAGS} "$ELEVEN" -DULAPI -I"$HEADERS" -E -x c++ "$i" > /dev/null
 done

--- a/tests/halcompile/personalities_mod/checkresult
+++ b/tests/halcompile/personalities_mod/checkresult
@@ -4,10 +4,7 @@ RETVAL=0
 for EXPECTED in *.expected ; do
     BASE=$(basename "$EXPECTED" .expected)
     RESULT=$BASE.result
-    diff -u "$EXPECTED" "$RESULT"
-    if [ $? -ne 0 ]; then
-        RETVAL=1
-    fi
+    diff -u "$EXPECTED" "$RESULT" || RETVAL=1
 done
 exit $RETVAL
 

--- a/tests/halcompile/userspace-count-names/checkresult
+++ b/tests/halcompile/userspace-count-names/checkresult
@@ -4,9 +4,6 @@ RETVAL=0
 for EXPECTED in *.expected ; do
     BASE=$(basename "$EXPECTED" .expected)
     RESULT=$BASE.result
-    diff -u "$EXPECTED" "$RESULT"
-    if [ $? -ne 0 ]; then
-        RETVAL=1
-    fi
+    diff -u "$EXPECTED" "$RESULT" || RETVAL=1
 done
 exit $RETVAL

--- a/tests/inifile/ini_api_c/test.sh
+++ b/tests/inifile/ini_api_c/test.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 FLGS=( -O2 -Wall -Wextra -Werror -I"${HEADERS}" -DULAPI -L"${LIBDIR}" )
 gcc "${FLGS[@]}" -o initest  initest.c -llinuxcncini || { echo "Failed compile"; exit 1; }
 

--- a/tests/inifile/missing_values/test.sh
+++ b/tests/inifile/missing_values/test.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+# We don't want a single redirect because the output must be very specific.
+# shellcheck disable=SC2129
 true > result
 inivar -ini missing_section.ini -sec section1 -var key1 >> result 2>&1
 inivar -ini missing_value.ini -var key1 >> result 2>&1

--- a/tests/interp/compile/test.sh
+++ b/tests/interp/compile/test.sh
@@ -1,6 +1,8 @@
 #!/bin/sh
 set -xe
 
+# PYTHON_CPPFLAGS is supposed to be word split
+# shellcheck disable=SC2086
 g++ -o use-rs274 use-rs274.cc \
     -Wall -Wextra -Wno-return-type -Wno-unused-parameter \
     -I "$HEADERS" $PYTHON_CPPFLAGS -L "$LIBDIR" -Wl,-rpath,"$LIBDIR" $PYTHON_EXTRA_LDFLAGS $PYTHON_LIBS $PYTHON_EXTRA_LIBS -lrs274

--- a/tests/interp/g71-endless-loop_2/test.sh
+++ b/tests/interp/g71-endless-loop_2/test.sh
@@ -12,7 +12,7 @@ pid=$!
 count=10
 while [ 0 -lt $count ] && kill -0 $pid > /dev/null 2>&1 ; do
     sleep 1
-    count=$(($count - 1))
+    count=$((count - 1))
 done
 
 if kill -0 $pid > /dev/null 2>&1; then

--- a/tests/overrun/test.sh
+++ b/tests/overrun/test.sh
@@ -2,7 +2,6 @@
 TMPDIR=$(mktemp -d /tmp/overrun.XXXXXX)
 trap 'rm -rf "$TMPDIR"' 0 1 2 3 15
 
-TEST_HAL=$TMPDIR/test.hal
 echo loadusr -w echo overrun > "$TMPDIR/test.hal"
 
 ! $RUNTESTS "$TMPDIR" 2>&1

--- a/tests/trajectory-planner/circular-arcs/process_runlog.sh
+++ b/tests/trajectory-planner/circular-arcs/process_runlog.sh
@@ -20,7 +20,7 @@
 set -o nounset                              # Treat unset variables as an error
 set -e
 
-if [ -a "$1" ] 
+if [ -e "$1" ]
 then
     awk '/total movement/ {print $2,$6,$9}' "$1" > movement.log
 fi

--- a/tests/trajectory-planner/circular-arcs/test-simple.sh
+++ b/tests/trajectory-planner/circular-arcs/test-simple.sh
@@ -6,7 +6,7 @@ cp position.blank position.txt
 mv constraints.log constraints_old.log
 linuxcnc circular_arcs.ini > test.log
 ./process_runlog.sh test.log movement.txt
-if [ -a movement.txt ] 
+if [ -e movement.txt ]
 then
     octave --persist ./octave/plot_movement.m
 fi

--- a/tests/trajectory-planner/circular-arcs/util/save_activate.sh
+++ b/tests/trajectory-planner/circular-arcs/util/save_activate.sh
@@ -2,7 +2,7 @@
 set -o nounset                              # Treat unset variables as an error
 set -e
 
-if [ -a "$1" ] 
+if [ -e "$1" ]
 then
     awk '/Activate tc/ {print $5,$8,$11,$14}' "$1" > segment_data.log
 fi

--- a/tests/trajectory-planner/circular-arcs/util/save_arc_data.sh
+++ b/tests/trajectory-planner/circular-arcs/util/save_arc_data.sh
@@ -2,22 +2,22 @@
 set -o nounset                              # Treat unset variables as an error
 set -e
 
-if [ -a "$1" ] 
+if [ -e "$1" ]
 then
     awk '/tangent angle/ {print $4}' "$1" > tangent_data.txt
 fi
 
-if [ -a "$1" ] 
+if [ -e "$1" ]
 then
     awk '/circ[12] angle/ {print $4}' "$1" > angle_data.txt
 fi
 
-if [ -a "$1" ] 
+if [ -e "$1" ]
 then
     awk '/circ[12] spiral/ {print $4}' "$1" > spiral_data.txt
 fi
 
-if [ -a "$1" ] 
+if [ -e "$1" ]
 then
     awk '/circ[12] spiral/ {print $4}' "$1" > spiral_data.txt
 fi

--- a/tests/trajectory-planner/circular-arcs/util/save_displacement.sh
+++ b/tests/trajectory-planner/circular-arcs/util/save_displacement.sh
@@ -2,7 +2,7 @@
 set -o nounset                              # Treat unset variables as an error
 set -e
 
-if [ -a "$1" ] 
+if [ -e "$1" ]
 then
     awk '/tp_displacement/ {print $8,$3,$4,$5}' "$1" > displacement_data.log
 fi

--- a/tests/trajectory-planner/circular-arcs/util/save_lengths.sh
+++ b/tests/trajectory-planner/circular-arcs/util/save_lengths.sh
@@ -2,7 +2,7 @@
 set -o nounset                              # Treat unset variables as an error
 set -e
 
-if [ -a "$1" ] 
+if [ -e "$1" ]
 then
     awk '/L_prev/ {print $3,$6,$9,$12}' "$1" > length_data.log
 fi

--- a/tests/trajectory-planner/circular-arcs/util/save_state.sh
+++ b/tests/trajectory-planner/circular-arcs/util/save_state.sh
@@ -2,7 +2,7 @@
 set -o nounset                              # Treat unset variables as an error
 set -e
 
-if [ -a "$1" ] 
+if [ -e "$1" ]
 then
     awk '/tc state/ {print $5,$8,$11}' "$1" > state_data.log
 fi

--- a/tests/trajectory-planner/circular-arcs/util/save_tangent_angle.sh
+++ b/tests/trajectory-planner/circular-arcs/util/save_tangent_angle.sh
@@ -2,7 +2,7 @@
 set -o nounset                              # Treat unset variables as an error
 set -e
 
-if [ -a "$1" ] 
+if [ -e "$1" ]
 then
     awk '/tangent angle/ {print $4}' "$1" > tangent_data.log
 fi

--- a/tests/trajectory-planner/circular-arcs/util/save_vel.sh
+++ b/tests/trajectory-planner/circular-arcs/util/save_vel.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -o nounset                              # Treat unset variables as an error
 
-if [ -a "$1" ]
+if [ -e "$1" ]
 then
     awk '/tc state/ {print $5,$8,$11}' "$1" > vel_data.log
 fi


### PR DESCRIPTION
Most shellcheck diagnostic messages are taken care of with this PR. Many diagnostics are ignored because a specific construct is required (like additional word splitting) and cannot be easily fixed without rewriting a lot more. Many others were simple small fixes.

Some issues still remain because they are more difficult to assess without extra work and simply ignoring them without good reason is not a good strategy.