### PR TITLE
Fix gcc -fsanitize detected problems

### DIFF
--- a/src/emc/ini/inifile.cc
+++ b/src/emc/ini/inifile.cc
@@ -855,6 +855,14 @@ IniFile::IniFile(const std::string &path)
 	Open(path);
 }
 
+IniFile::IniFile(const std::string *path)
+	: _inifilecontent(nullptr),
+	  _filepath{}
+{
+	if(path)
+		Open(*path);
+}
+
 bool IniFile::Open(const std::string &path)
 {
 	Close();

--- a/src/emc/ini/inifile.hh
+++ b/src/emc/ini/inifile.hh
@@ -144,6 +144,7 @@ class IniFile
 {
 public:
 	IniFile(const std::string &filePath);
+	IniFile(const std::string *filePath);
 
 	operator bool() const { return isOpen(); }
 	bool isOpen() const { return _inifilecontent != nullptr; }

--- a/src/emc/kinematics/genserfuncs.c
+++ b/src/emc/kinematics/genserfuncs.c
@@ -48,8 +48,8 @@
 #if __GNUC__ && !defined(__clang__)
 // The matrix and vector storage is just big.
 // genser_kin_jac_inv() is 2112
-// genserKinematicsInverse() is 2576
-  #pragma GCC diagnostic warning "-Wframe-larger-than=2600"
+// genserKinematicsInverse() is 2640
+  #pragma GCC diagnostic warning "-Wframe-larger-than=2648"
 #endif
 
 static struct haldata {

--- a/src/emc/rs274ngc/interp_o_word.cc
+++ b/src/emc/rs274ngc/interp_o_word.cc
@@ -567,7 +567,7 @@ int Interp::control_back_to( block_pointer block, // pointer to block
                 logOword("filename too long: %s", op->filename);
                 ERS(NCE_UNABLE_TO_OPEN_FILE, op->filename);
             }
-            strncpy(settings->filename, op->filename, sizeof(settings->filename));
+            strncpy(settings->filename, op->filename, sizeof(settings->filename)-1);
 
 	    if (newFP) {
 		// close the old file...

--- a/src/emc/rs274ngc/interp_write.cc
+++ b/src/emc/rs274ngc/interp_write.cc
@@ -226,7 +226,7 @@ int Interp::write_state_tag(block_pointer block,
     bool in_sub = (settings->call_level > 0 && settings->remap_level == 0);
     bool external_sub = strcmp(settings->filename,
 			       settings->sub_context[0].filename);
-    strncpy(state.filename, settings->filename, sizeof(state.filename));
+    rtapi_strxcpy(state.filename, settings->filename);
     state.filename[sizeof(state.filename)-1] = 0;
 
     state.flags[GM_FLAG_IN_REMAP] = in_remap;

--- a/src/emc/task/emccanon.cc
+++ b/src/emc/task/emccanon.cc
@@ -3433,7 +3433,7 @@ void MESSAGE(char *s)
     auto operator_display_msg = std::make_unique<EMC_OPERATOR_DISPLAY>();
 
     flush_segments();
-    strncpy(operator_display_msg->display, s, LINELEN);
+    strncpy(operator_display_msg->display, s, LINELEN-1);
     operator_display_msg->display[LINELEN - 1] = 0;
     interp_list.append(std::move(operator_display_msg));
 }

--- a/src/emc/usr_intf/axis/extensions/emcmodule.cc
+++ b/src/emc/usr_intf/axis/extensions/emcmodule.cc
@@ -74,7 +74,9 @@ using namespace linuxcnc;
 
 struct pyIniFile {
     PyObject_HEAD
-    std::string inifile;
+    // The 'inifile' member is a pointer because we don't
+    // have C++ constructor semantics here
+    std::string *inifile;
 };
 
 struct pyStatChannel {
@@ -98,12 +100,15 @@ struct pyErrorChannel {
 static PyObject *m = NULL, *error = NULL;
 
 static int Ini_init(pyIniFile *self, PyObject *a, PyObject * /*k*/) {
-    char *inifile;
+    const char *inifile = NULL;
     if(!PyArg_ParseTuple(a, "s", &inifile)) return -1;
 
-    self->inifile = inifile;
+    if(!inifile)
+        return -1;
 
-    IniFile ini(inifile); // Test open (will parse and cache the file)
+    self->inifile = new std::string(inifile);
+
+    IniFile ini(self->inifile); // Test open (will parse and cache the file)
     if (!ini) {
         PyErr_Format( error, "inifile.open(%s) failed", inifile);
         return -1;
@@ -688,6 +693,10 @@ static PyObject *Ini_get_jointtype(pyIniFile *self, PyObject *args, PyObject *kw
 }
 
 static void Ini_dealloc(pyIniFile *self) {
+    if(self->inifile) {
+        delete self->inifile;
+        self->inifile = NULL;
+    }
     PyObject_Del(self);
 }
 

--- a/src/emc/usr_intf/emclcd.cc
+++ b/src/emc/usr_intf/emclcd.cc
@@ -1686,9 +1686,9 @@ static void initMain()
     emcStatus = 0;
 
     emcErrorBuffer = 0;
-    error_string[LINELEN-1] = 0;
-    operator_text_string[LINELEN-1] = 0;
-    operator_display_string[LINELEN-1] = 0;
+    error_string.clear();
+    operator_text_string.clear();
+    operator_display_string.clear();
     programStartLine = 0;
 }
 

--- a/src/emc/usr_intf/emcrsh.cc
+++ b/src/emc/usr_intf/emcrsh.cc
@@ -1876,12 +1876,11 @@ static cmdResponseType getError(connectionRecType &ctx)
 		return rtError;
 	}
 
-	// FIXME: static buffer 'error_string'
-	if (!error_string[0]) {
+	if (error_string.empty()) {
 		replynl(ctx, "ERROR OK");
 	} else {
 		replynl(ctx, fmt::format("ERROR {}", error_string));
-		error_string[0] = 0;
+		error_string.clear();
 	}
 	return rtOk;
 }
@@ -1894,12 +1893,11 @@ static cmdResponseType getOperatorDisplay(connectionRecType &ctx)
 		return rtError;
 	}
 
-	// FIXME: static buffer 'operator_display_string'
-	if (!operator_display_string[0])
+	if (operator_display_string.empty())
 		replynl(ctx, "OPERATOR_DISPLAY OK");
 	else {
 		replynl(ctx, fmt::format("OPERATOR_DISPLAY {}", operator_display_string));
-		operator_display_string[0] = 0;
+		operator_display_string.clear();
 	}
 	return rtOk;
 }
@@ -1912,12 +1910,11 @@ static cmdResponseType getOperatorText(connectionRecType &ctx)
 		return rtError;
 	}
 
-	// FIXME: static buffer 'operator_text_string'
-	if (!operator_text_string[0])
+	if (operator_text_string.empty())
 		replynl(ctx, "OPERATOR_TEXT OK");
 	else {
 		replynl(ctx, fmt::format("OPERATOR_TEXT {}", operator_text_string));
-		operator_text_string[0] = 0;
+		operator_text_string.clear();
 	}
 	return rtOk;
 }
@@ -3697,10 +3694,9 @@ int main(int argc, char *argv[])
 	emcStatusBuffer = NULL;
 	emcErrorBuffer = NULL;
 	emcStatus = NULL;
-	// FIXME: Get rid of static buffers
-	memset(error_string, 0, sizeof(error_string));
-	memset(operator_text_string, 0, sizeof(operator_text_string));
-	memset(operator_display_string, 0, sizeof(operator_display_string));
+	error_string.clear();
+	operator_text_string.clear();
+	operator_display_string.clear();
 	programStartLine = 0;
 
 	searchPath.push_back(getDefaultPath());

--- a/src/emc/usr_intf/emcsched.cc
+++ b/src/emc/usr_intf/emcsched.cc
@@ -300,7 +300,7 @@ void updateQueue() {
             queueStatus = qsError;
             }
           sendAuto();
-          rtapi_strxcpy(fileStr, defaultPath);
+          rtapi_strxcpy(fileStr, defaultPath.c_str());
           rtapi_strxcat(fileStr, q.front().getFileName().c_str());
           if (sendProgramOpen(fileStr) != 0) {
             queueStatus = qsError;

--- a/src/emc/usr_intf/emcsh.cc
+++ b/src/emc/usr_intf/emcsh.cc
@@ -868,17 +868,17 @@ static int emc_error(ClientData /*clientdata*/,
 
     CHECKEMC
     if (objc == 1) {
-	// get any new error, it's saved in global error_string[]
+	// get any new error, it's saved in global error_string
 	if (0 != updateError()) {
 	    setresult(interp,"emc_error: bad status from EMC");
 	    return TCL_ERROR;
 	}
 	// put error on result list
-	if (error_string[0] == 0) {
+	if (error_string.empty()) {
 	    setresult(interp,"ok");
 	} else {
-	    setresult(interp,error_string);
-	    error_string[0] = 0;
+	    setresult(interp,error_string.c_str());
+	    error_string.clear();
 	}
 	return TCL_OK;
     }
@@ -894,17 +894,17 @@ static int emc_operator_text(ClientData /*clientdata*/,
 
     CHECKEMC
     if (objc == 1) {
-	// get any new string, it's saved in global operator_text_string[]
+	// get any new string, it's saved in global operator_text_string
 	if (0 != updateError()) {
 	    setresult(interp,"emc_operator_text: bad status from EMC");
 	    return TCL_ERROR;
 	}
 	// put error on result list
-	if (operator_text_string[0] == 0) {
+	if (operator_text_string.empty()) {
 	    setresult(interp,"ok");
-	    operator_text_string[0] = 0;
 	} else {
-	    setresult(interp,operator_text_string);
+	    setresult(interp,operator_text_string.c_str());
+	    operator_text_string.clear();
 	}
 	return TCL_OK;
     }
@@ -920,17 +920,17 @@ static int emc_operator_display(ClientData /*clientdata*/,
 
     CHECKEMC
     if (objc == 1) {
-	// get any new string, it's saved in global operator_display_string[]
+	// get any new string, it's saved in global operator_display_string
 	if (0 != updateError()) {
 	    setresult(interp,"emc_operator_display: bad status from EMC");
 	    return TCL_ERROR;
 	}
 	// put error on result list
-	if (operator_display_string[0] == 0) {
+	if (operator_display_string.empty()) {
 	    setresult(interp,"ok");
 	} else {
-	    setresult(interp,operator_display_string);
-	    operator_display_string[0] = 0;
+	    setresult(interp,operator_display_string.c_str());
+	    operator_display_string.clear();
 	}
 	return TCL_OK;
     }
@@ -3640,9 +3640,9 @@ static void initMain()
     emcStatus = 0;
 
     emcErrorBuffer = 0;
-    error_string[LINELEN-1] = 0;
-    operator_text_string[LINELEN-1] = 0;
-    operator_display_string[LINELEN-1] = 0;
+    error_string.clear();
+    operator_text_string.clear();
+    operator_display_string.clear();
     programStartLine = 0;
 }
 

--- a/src/emc/usr_intf/schedrmt.cc
+++ b/src/emc/usr_intf/schedrmt.cc
@@ -1236,9 +1236,9 @@ static void initMain()
     emcStatus = 0;
 
     emcErrorBuffer = 0;
-    error_string[LINELEN-1] = 0;
-    operator_text_string[LINELEN-1] = 0;
-    operator_display_string[LINELEN-1] = 0;
+    error_string.clear();
+    operator_text_string.clear();
+    operator_display_string.clear();
     programStartLine = 0;
 }
 
@@ -1258,7 +1258,7 @@ int main(int argc, char *argv[])
         case 'p': sscanf(optarg, "%d", &port); break;
         case 's': sscanf(optarg, "%d", &maxSessions); break;
         case 'w': snprintf(pwd, sizeof(pwd), "%s", optarg); break;
-        case 'd': snprintf(defaultPath, sizeof(defaultPath), "%s", optarg); break;
+        case 'd': defaultPath = optarg; break;
         }
       }
 

--- a/src/emc/usr_intf/shcom.cc
+++ b/src/emc/usr_intf/shcom.cc
@@ -47,10 +47,10 @@ EMC_STAT *emcStatus;
 
 // the NML channel for errors
 NML *emcErrorBuffer;
-char error_string[NML_ERROR_LEN];
-char operator_text_string[NML_TEXT_LEN];
-char operator_display_string[NML_DISPLAY_LEN];
-char defaultPath[80] = DEFAULT_PATH;
+std::string error_string;
+std::string operator_text_string;
+std::string operator_display_string;
+std::string defaultPath = DEFAULT_PATH;
 // default value for timeout, 0 means wait forever
 double emcTimeout;
 int programStartLine;
@@ -173,6 +173,21 @@ int updateStatus()
 
 }
 
+// Copy a static char buffer from nml into a std::string.
+// We know the max size is the orginal buffer's size-1 (the len argument).
+// However, the content does not need to be that long and may be terminated
+// somewhere. Search the first embedded NUL to terminate early. If no embedded
+// NUL is found, then the string /might/ have been unterminated and will be
+// properly limited by the len argument. That way we don't depend on the
+// buffer's termination.
+static void cpy_str(std::string &target, const char *src, size_t len)
+{
+    target = std::string(src, len); // Copy entire buffer
+    size_t pos = target.find_first_of((char)0);  // Find first terminator (embedded NUL)
+    if(std::string::npos != pos)
+        target.erase(pos);          // Remove trailing if terminated before
+}
+
 /*
   updateError() updates "errors," which are true errors and also
   operator display and text messages.
@@ -192,7 +207,7 @@ int updateError()
 
     default:
 	// if not recognized, set the error string
-	snprintf(error_string, sizeof(error_string), "shcom:updateError(): unrecognized error %d", (int)type);
+	error_string = fmt::format("shcom:updateError(): unrecognized error {}", (int)type);
 	return 0;
 
     case 0:
@@ -200,45 +215,39 @@ int updateError()
 	break;
 
     case EMC_OPERATOR_ERROR_TYPE:
-	strncpy(error_string,
+	cpy_str(error_string,
 		(static_cast<EMC_OPERATOR_ERROR *>((emcErrorBuffer->get_address()))->error),
                 LINELEN - 1);
-	error_string[NML_ERROR_LEN - 1] = 0;
 	break;
 
     case EMC_OPERATOR_TEXT_TYPE:
-	strncpy(operator_text_string,
+	cpy_str(operator_text_string,
 		(static_cast<EMC_OPERATOR_TEXT *>((emcErrorBuffer->get_address()))->text),
                 LINELEN - 1);
-	operator_text_string[NML_TEXT_LEN - 1] = 0;
 	break;
 
     case EMC_OPERATOR_DISPLAY_TYPE:
-	strncpy(operator_display_string,
+	cpy_str(operator_display_string,
 		(static_cast<EMC_OPERATOR_DISPLAY *>((emcErrorBuffer->get_address()))->display),
 		LINELEN - 1);
-	operator_display_string[NML_DISPLAY_LEN - 1] = 0;
 	break;
 
     case NML_ERROR_TYPE:
-	strncpy(error_string,
+        cpy_str(error_string,
 		(static_cast<NML_ERROR *>((emcErrorBuffer->get_address()))->error),
 		NML_ERROR_LEN - 1);
-	error_string[NML_ERROR_LEN - 1] = 0;
 	break;
 
     case NML_TEXT_TYPE:
-	strncpy(operator_text_string,
+	cpy_str(operator_text_string,
 		(static_cast<NML_TEXT *>((emcErrorBuffer->get_address()))->text),
 		NML_TEXT_LEN - 1);
-	operator_text_string[NML_TEXT_LEN - 1] = 0;
 	break;
 
     case NML_DISPLAY_TYPE:
-	strncpy(operator_display_string,
+	cpy_str(operator_display_string,
 		(static_cast<NML_DISPLAY *>((emcErrorBuffer->get_address()))->display),
 		NML_DISPLAY_LEN - 1);
-	operator_display_string[NML_DISPLAY_LEN - 1] = 0;
 	break;
     }
 

--- a/src/emc/usr_intf/shcom.hh
+++ b/src/emc/usr_intf/shcom.hh
@@ -18,6 +18,7 @@
 #define SHCOM_HH
 
 #include <cmath>
+#include <string>
 
 #include <linuxcnc.h>           // INCH_PER_MM
 #include <inifile.hh>
@@ -52,10 +53,10 @@ extern RCS_STAT_CHANNEL *emcStatusBuffer;
 
 // the NML channel for errors
 extern NML *emcErrorBuffer;
-extern char error_string[NML_ERROR_LEN];
-extern char operator_text_string[NML_TEXT_LEN];
-extern char operator_display_string[NML_DISPLAY_LEN];
-extern char defaultPath[80];
+extern std::string error_string;
+extern std::string operator_text_string;
+extern std::string operator_display_string;
+extern std::string defaultPath;
 
 // default value for timeout, 0 means wait forever
 extern double emcTimeout;

--- a/src/hal/components/mesa_pktgyro_test.comp
+++ b/src/hal/components/mesa_pktgyro_test.comp
@@ -118,8 +118,8 @@ FUNCTION(receive){
 }
 // Only gcc/g++ supports the #pragma
 #if __GNUC__ && !defined(__clang__)
-// EXTRA_SETUP() is 2400
-#pragma GCC diagnostic warning "-Wframe-larger-than=2500"
+// EXTRA_SETUP() is 2544
+#pragma GCC diagnostic warning "-Wframe-larger-than=2552"
 #endif
 
 EXTRA_SETUP(){ // the names parameters are passed in 'prefix'.

--- a/src/hal/utils/halcmd_main.c
+++ b/src/hal/utils/halcmd_main.c
@@ -276,7 +276,7 @@ int main(int argc, char **argv)
             newLinePos = (int)strlen(raw_buf) - 1; // interactive
             if (raw_buf[newLinePos] == '\n') { raw_buf[newLinePos]=0; newLinePos--; }  // tty
 
-            if (raw_buf[newLinePos] == '\\') { // backslash
+            if (newLinePos >= 0 && raw_buf[newLinePos] == '\\') { // backslash
                 raw_buf[newLinePos] = 0;
                 newLinePos++;
                 if (!extend_ct) { //first extend

--- a/src/libnml/rcs/rcs_print.cc
+++ b/src/libnml/rcs/rcs_print.cc
@@ -423,6 +423,8 @@ int set_rcs_print_file(char *_file_name)
 
 int rcs_print(const char *_fmt, ...)
 {
+    if(!_fmt)
+        return rcs_fputs("internal error: rcs_print(NULL) detected\n");
     va_list args;
     // Determine the required size of the buffer (see EXAMPLES in printf(3))
     va_start(args, _fmt);


### PR DESCRIPTION
An issue was detected, while doing unrelated stuff, that required a deeper dive. A sanitizer switch to gcc/g++ revealed more issues when compiled using `-fsanitize=undefined,bool,float-cast-overflow` (see also #421).

The changes include:
* Get rid of static char buffers in shcom and use std::string instead. This has effect on several dependent files, which were all adapted and already had FIXME markers at those places.
* Fix linuxcnc python module where the ini filename storage was changed to std::string previously. However, the python object structure has no C++ constructor semantics. The string must be separately allocated and cannot be a "normal" member. Otherwise it would not be properly initialized.
* Several off-by-one compiler messages in char buffers were fixed.
* Guard rcs_print() when a NULL format argument is passed.
* Compiling with the sanitizer tripped some stack-frame size warnings. These were slightly increased.
* A char buffer in halcmd was indexed with -1 on continuation search causing an underflow. That eventuality is now guarded against.

There were also unrelated boost::python problems with "maybe-uninitialized" warnings on value extract. However, it was determined that these were false positives (see also #3931).

It may be prudent to run the code base with other -fsanitize options and see the fallout.