### PR TITLE
tp: reduce trajectory planner stack frames (fixes #4049)

### DIFF
--- a/src/emc/tp/tp.c
+++ b/src/emc/tp/tp.c
@@ -1011,7 +1011,8 @@ STATIC tc_blend_type_t tpChooseBestBlend(TP_STRUCT const * const tp,
 }
 
 
-STATIC tp_err_t tpCreateLineArcBlend(TP_STRUCT * const tp, TC_STRUCT * const prev_tc, TC_STRUCT * const tc, TC_STRUCT * const blend_tc)
+STATIC __attribute__((__noinline__))
+tp_err_t tpCreateLineArcBlend(TP_STRUCT * const tp, TC_STRUCT * const prev_tc, TC_STRUCT * const tc, TC_STRUCT * const blend_tc)
 {
     tp_debug_print("-- Starting LineArc blend arc --\n");
 
@@ -1169,7 +1170,8 @@ STATIC tp_err_t tpCreateLineArcBlend(TP_STRUCT * const tp, TC_STRUCT * const pre
 }
 
 
-STATIC tp_err_t tpCreateArcLineBlend(TP_STRUCT * const tp, TC_STRUCT * const prev_tc, TC_STRUCT * const tc, TC_STRUCT * const blend_tc)
+STATIC __attribute__((__noinline__))
+tp_err_t tpCreateArcLineBlend(TP_STRUCT * const tp, TC_STRUCT * const prev_tc, TC_STRUCT * const tc, TC_STRUCT * const blend_tc)
 {
 
     tp_debug_print("-- Starting ArcLine blend arc --\n");
@@ -1310,7 +1312,8 @@ STATIC tp_err_t tpCreateArcLineBlend(TP_STRUCT * const tp, TC_STRUCT * const pre
     return TP_ERR_OK;
 }
 
-STATIC tp_err_t tpCreateArcArcBlend(TP_STRUCT * const tp, TC_STRUCT * const prev_tc, TC_STRUCT * const tc, TC_STRUCT * const blend_tc)
+STATIC __attribute__((__noinline__))
+tp_err_t tpCreateArcArcBlend(TP_STRUCT * const tp, TC_STRUCT * const prev_tc, TC_STRUCT * const tc, TC_STRUCT * const blend_tc)
 {
 
     tp_debug_print("-- Starting ArcArc blend arc --\n");
@@ -1479,7 +1482,8 @@ STATIC tp_err_t tpCreateArcArcBlend(TP_STRUCT * const tp, TC_STRUCT * const prev
 }
 
 
-STATIC tp_err_t tpCreateLineLineBlend(TP_STRUCT * const tp, TC_STRUCT * const prev_tc,
+STATIC __attribute__((__noinline__))
+tp_err_t tpCreateLineLineBlend(TP_STRUCT * const tp, TC_STRUCT * const prev_tc,
         TC_STRUCT * const tc, TC_STRUCT * const blend_tc)
 {
 
@@ -2082,7 +2086,8 @@ static bool tpCreateBlendIfPossible(
  * blend arc. Essentially all of the blend arc functions are called through
  * here to isolate the process.
  */
-STATIC tc_blend_type_t tpHandleBlendArc(TP_STRUCT * const tp, TC_STRUCT * const tc) {
+STATIC __attribute__((__noinline__))
+tc_blend_type_t tpHandleBlendArc(TP_STRUCT * const tp, TC_STRUCT * const tc) {
 
     tp_debug_print("*****************************************\n** Handle Blend Arc **\n");
 


### PR DESCRIPTION
## Summary

Fixes #4049. Marks `tpHandleBlendArc` and the four `tpCreate*Blend` functions `noinline` to prevent the queue-add chain (`tpAdd{Line,Circle,RigidTap}` -> `tpHandleBlendArc` -> `tpCreate*Blend`) from collapsing into one stack frame. Without this, aggressive inlining accumulates multiple 1704-byte `TC_STRUCT`s plus `BlendGeom3` and `BlendParameters` in the same frame, producing 5-6 KB frames in the RTAI CI build and triggering `-Wframe-larger-than` warnings, especially with UBSan (`-fsanitize=undefined,bool,float-cast-overflow`).

## Background

Per @BsAtHome's confirmation in #4049, `noinline` is the preferred fix here. It matches the structural-first pattern from his Jan 2025 commit 94496c56f2 and the existing use of `__attribute__((__noinline__))` in `src/hal/drivers/mesa-hostmot2/stepgen.c:243`. Bertho also identified that the warnings escalate with `-fsanitize=undefined,bool,float-cast-overflow` enabled, which inflates stack usage further.

The blend creation path runs once per G-code segment at queue time, not per servo cycle, so the lost inlining cost is negligible.

## Measurements

gcc 14, uspace, `-O2`:

| Function | Before | After |
|----------|--------|-------|
| `tpHandleBlendArc.isra` | 2752 | 1904 |
| `tpAddLine` | 1744 | 1712 |
| `tpAddCircle` | 1744 | 1712 |
| `tpAddRigidTap` | 1728 | 1696 |
| `tpCreateLineLineBlend` | (inlined) | 992 |
| `tpCreateLineArcBlend` | (inlined) | 944 |
| `tpCreateArcArcBlend` | (inlined) | 944 |
| `tpCreateArcLineBlend` | (inlined) | 944 |

All frames in `tp.c` now stay below the default 2048-byte `-Wframe-larger-than` threshold under both stock and UBSan builds.

For the RTAI CI build reported in #4049 (5584/6528 B), where the inliner is more aggressive, the same blocking eliminates the chain collapse and should bring those frames down to the same range.

## Test plan

- [x] uspace build clean, no new warnings
- [x] uspace build with `-fsanitize=undefined,bool,float-cast-overflow` clean, no frame warnings
- [ ] CI to confirm on RTAI build (the original failing configuration)