### PR TITLE
ci: cancel in-flight runs on PR push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,10 @@ on:
 permissions:
   contents: read #  to fetch code (actions/checkout)
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   DEBIAN_FRONTEND: noninteractive
 


### PR DESCRIPTION
Concurrency cancel-in-progress, gated on pull_request events only:

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.ref }}
  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
```

A fresh push to a PR cancels the prior in-flight run for that ref. `master`, release tags, and `check_suite` triggers are left alone, so a tagged release or a manually-rerequested check-suite never cancels itself.

Saves wasted runner minutes on force-pushes.

The DEB_BUILD_OPTIONS commit from the earlier revision was dropped: CI logs already show `make -j4`, so `debuild` was auto-parallelizing. No measurable gain, and `.github/scripts/*` does not run for local `dpkg-buildpackage` invocations either, so the "local build" justification did not hold up.

## Test plan

- [x] After merge, push a second commit to a PR and confirm the older run gets cancelled.