### PR TITLE
docs: blank line before paragraph->bullet boundaries

### DIFF
--- a/docs/src/config/core-components.adoc
+++ b/docs/src/config/core-components.adoc
@@ -199,6 +199,7 @@ The __N__ (integer between 0 and 7) substitutes the spindle number.
 === Pins
 
 (((spindle (HAL pins))))
+
 * 'spindle.__N__.at-speed' - (bit, in)
   Motion will pause until this pin is TRUE, under the following conditions:
 ** before the first feed move after each spindle start or speed change;
@@ -308,6 +309,7 @@ iocontrol's HAL pins are turned on and off in non-realtime context.  If you have
 === Pins
 
 (((iocontrol (HAL pins))))
+
 * 'iocontrol.0.coolant-flood' (bit, out) TRUE when flood coolant is requested.
 * 'iocontrol.0.coolant-mist' (bit, out) TRUE when mist coolant is requested.
 * 'iocontrol.0.emc-enable-in' (bit, in) Should be driven FALSE when an external E-Stop condition exists.

--- a/docs/src/config/ini-config.adoc
+++ b/docs/src/config/ini-config.adoc
@@ -886,6 +886,7 @@ If you want to travel along a path at 1 IPS = 60 IPM, and your servo period 
 If you set Naive CAM tolerance to around this min length, overly short segments will be combined together to eliminate this bottleneck.
 Of course, setting the tolerance too high means big path deviations, so you have to play with it a bit to find a good value.
 I'd start at 1/2 of the min_length, then work up as needed.
+
 * `ARC_BLEND_GAP_CYCLES = 4` How short the previous segment must be before the trajectory planner 'consumes' it.
 +
 Often, a circular arc blend will leave short line segments in between the blends.
@@ -894,6 +895,7 @@ Since the trajectory planner has to touch each segment at least once, it means t
 My fix to this way to "consume" the short segment by making it a part of the blend arc.
 Since the line+blend is one segment, we don't have to slow down to hit the very short segment.
 Likely, you won't need to touch this setting.
+
 * `ARC_BLEND_RAMP_FREQ = 20` - This is a 'cutoff' frequency for using ramped velocity.
 +
 'Ramped velocity' in this case just means constant acceleration over the whole segment.

--- a/docs/src/config/stepconf.adoc
+++ b/docs/src/config/stepconf.adoc
@@ -84,6 +84,7 @@ to those of the driver. You may find it necessary to add some time to the
 drive requirements to allow for this.
 +
 The LinuxCNC Configuration Selector has configs for Sherline already configured.
+
 * 'Step Time' - How long the step pulse is 'on' in nano seconds. If your not
   sure about this setting a value of 20,000 will work with most drives.
 * 'Step Space' - Minimum time between step pulses in nano seconds. If your

--- a/docs/src/gcode/m-code.adoc
+++ b/docs/src/gcode/m-code.adoc
@@ -42,6 +42,7 @@
 == M0, M1 Program Pause
 
 (((M0, M1 Program Pause)))(((M0 Mandatory Program Pause)))(((M1 Optional Program Pause)))
+
 * 'M0' - pause a running program temporarily. LinuxCNC remains in the Auto Mode
   so MDI and other manual actions are not enabled. Pressing the resume
   button will restart the program at the following line.
@@ -60,6 +61,7 @@ to stop after each line of input anyway.
 == M2, M30 Program End
 
 (((M2 Program End)))(((M30 Pallet Exchange and Program End)))
+
 * 'M2' - end the program. Pressing `Cycle Start` ("R" in the Axis GUI)
   will restart the program at the beginning of the file.
 * 'M30' - exchange pallet shuttles and end the program.
@@ -91,6 +93,7 @@ on what using % does not do.
 == M60 Pallet Change Pause
 
 (((M60 Pallet Change Pause)))
+
 * 'M60' - exchange pallet shuttles and then pause a running program
   temporarily (regardless of the setting of the optional stop
   switch). Pressing the cycle start button
@@ -100,6 +103,7 @@ on what using % does not do.
 == M3, M4, M5 Spindle Control
 
 (((M3, M4, M5 Spindle Control)))
+
 * 'M3 [$n]' - start the selected spindle clockwise at the 'S' speed.
 * 'M4 [$n]' - start the selected spindle counterclockwise at the 'S' speed.
 * 'M5 [$n]' - stop the selected spindle.
@@ -199,6 +203,7 @@ ClassicLadder.
 == M7, M8, M9 Coolant Control
 
 (((M7, M8, M9 Coolant Control)))
+
 * 'M7' - turn mist coolant on. M7 controls iocontrol.0.coolant-mist pin.
 * 'M8' - turn flood coolant on. M8 controls iocontrol.0.coolant-flood pin.
 * 'M9' - turn both M7 and M8 off.
@@ -264,6 +269,7 @@ INI Settings in the [RS274NGC] section:
 == M48, M49 Speed and Feed Override Control
 
 (((M48, M49 Speed and Feed Override Control)))
+
 * 'M48' - enable the spindle speed and feed rate override controls.
 * 'M49' - disable both controls.
 
@@ -281,6 +287,7 @@ see below.
 == M50 Feed Override Control
 
 (((M50 Feed Override Control)))
+
 * 'M50 <P1>' - enable the feed rate override control. The P1
   is optional.
 * 'M50 P0' - disable the feed rate control.
@@ -293,6 +300,7 @@ and the motion will be executed at programmed feed rate.
 == M51 Spindle Speed Override Control
 
 (((M51 Spindle Speed Override)))
+
 * 'M51 <P1> <$->'- enable the spindle speed override control for the
   selected spindle. The  P1 is optional.
 * 'M51 P0 <$->'  - disable the spindle speed override control program.
@@ -306,6 +314,7 @@ exact program specified value of the S-word
 == M52 Adaptive Feed Control
 
 (((M52 Adaptive Feed Control)))
+
 * 'M52 <P1>' - use an adaptive feed. The P1 is optional.
 * 'M52 P0' - stop using adaptive feed.
 
@@ -326,6 +335,7 @@ cutters and wire spark eroders but it is not limited to such applications.
 == M53 Feed Stop Control
 
 (((M53 Feed Stop Control)))
+
 * 'M53 <P1>' - enable the feed stop switch. The P1 is optional.
   Enabling the feed stop switch will allow motion to be
   interrupted by means of the feed stop control. In LinuxCNC,
@@ -338,6 +348,7 @@ cutters and wire spark eroders but it is not limited to such applications.
 == M61 Set Current Tool
 
 (((M61 Set Current Tool)))
+
 * 'M61 Q-' - change the current tool number while in MDI or Manual mode without
   a tool change. One use is when you power up LinuxCNC with a tool
   currently in the spindle you can set that tool number without
@@ -355,6 +366,7 @@ It is an error if:
 == M62 - M65 Digital Output Control
 
 (((M62 - M65 Digital Output Control)))
+
 * 'M62 P-' - turn on digital output synchronized with motion.
 * 'M63 P-' - turn off digital output synchronized with motion.
 * 'M64 P-' - turn on digital output immediately.

--- a/docs/src/gcode/overview.adoc
+++ b/docs/src/gcode/overview.adoc
@@ -558,6 +558,7 @@ can be added easily without changes to the source code.
 === System Parameters
 
 (((System Parameters)))
+
 * '#<_spindle_rpm_mode>' - Return 1 if spindle rpm mode (G97) is on, else 0.
 * '#<_spindle_css_mode>' - Return 1 if constant surface speed mode (G96) is on, else 0.
 * '#<_ijk_absolute_mode>' - Return 1 if Absolute Arc distance mode (G90.1) is on, else 0.
@@ -1048,6 +1049,7 @@ NOTE: Inline comments on O-codes should not be used see the O-code
 == Messages
 
 (((Messages)))
+
 * '(MSG,)' - displays message if 'MSG' appears after the left parenthesis
   and before any other printing characters. Variants of 'MSG' which include
   white space and lower case characters are allowed. The rest of the
@@ -1064,6 +1066,7 @@ NOTE: Inline comments on O-codes should not be used see the O-code
 == Probe Logging
 
 (((Probe Logging)))
+
 * '(PROBEOPEN filename.txt)' - will open filename.txt and store the 9-number
   coordinate consisting of XYZABCUVW of each successful straight probe in it.
 * '(PROBECLOSE)' - will close the open probelog file.
@@ -1074,6 +1077,7 @@ For more information on probing see the <<gcode:g38,G38>> section.
 == Logging
 
 (((Logging)))
+
 * '(LOGOPEN,filename.txt)' - opens the named log file. If the file already
   exists, it is truncated.
 * '(LOGAPPEND,filename)' - opens the named log file. If the file already
@@ -1088,6 +1092,7 @@ Examples of logging are in 'nc_files/examples/smartprobe.ngc' and in
 == Abort Messages
 
 (((Abort Messages)))
+
 * '(ABORT,)' - displays a message like '(MSG,)' with the addition of special
   handling for comment parameters as described below and of aborting the current running process.
 
@@ -1095,6 +1100,7 @@ Examples of logging are in 'nc_files/examples/smartprobe.ngc' and in
 == Debug Messages
 
 (((Debug Messages)))
+
 * '(DEBUG,)' - displays a message like '(MSG,)' with the addition of special
   handling for comment parameters as described below.
 
@@ -1102,6 +1108,7 @@ Examples of logging are in 'nc_files/examples/smartprobe.ngc' and in
 == Print Messages
 
 (((Print Messages)))
+
 * '(PRINT,)' - messages are output to 'stderr' with special handling for
   comment parameters as described below.
 

--- a/docs/src/getting-started/about-linuxcnc.adoc
+++ b/docs/src/getting-started/about-linuxcnc.adoc
@@ -12,6 +12,7 @@ are entirely licensed under the GNU General Public License and Lesser
 GNU General Public License (GPL and LGPL).
 
 To lower the entry-hurdle, LinuxCNC provides:
+
 * easy discovery and testing without installation with the Live Image,
 * easy installation from the Live Image,
 * easy to use graphical configuration wizards to rapidly create a configuration
@@ -19,6 +20,7 @@ To lower the entry-hurdle, LinuxCNC provides:
 * directly availability as regular packages of recent releases of Debian (since Bookworm) and Ubuntu (since Kinetic Kudu).
 
 LinuxCNC provides a graphical user interface with many flavours to choose from to match your personal preferences and technical needs. Advanced users may directly exploit
+
 * graphical interface creation tools (Glade, Qt),
 * the interpreter for 'G-code' (the RS-274 machine tool programming language),
 * operation of low-level machine electronics such as sensors and motor drives,
@@ -26,6 +28,7 @@ LinuxCNC provides a graphical user interface with many flavours to choose from t
 * a software PLC programmable with ladder diagrams.
 
 Under the hood, LinuxCNC provides
+
 * a realtime motion planning system with look-ahead,
 * support for non-Cartesian motion systems is provided via custom
   kinematics modules. Available architectures include hexapods (Stewart

--- a/docs/src/gui/ngcgui.adoc
+++ b/docs/src/gui/ngcgui.adoc
@@ -16,6 +16,7 @@ image::images/ngcgui.png[align="center"]
 == Overview
 
 (((NGCGUI)))
+
 * 'NGCGUI' is a Tcl application to work with subroutines. It allows you to
   have a conversational interface with LinuxCNC. You can organize the
   subroutines in the order you need them to run and concatenate the

--- a/docs/src/gui/pyvcp.adoc
+++ b/docs/src/gui/pyvcp.adoc
@@ -794,6 +794,7 @@ up or down as the wheel is turned, either by dragging in a circular
 motion, or by rolling the mouse-wheel.
 
 Optional tags:
+
 * '<text>"My Text"</text>' displays text
 * '<bgcolor>"grey"</bgcolor> <fillcolor>"green"</fillcolor>' background & active colors
 * '<scale_pin>1</scale_pin>' creates scale text and a `FLOAT.scale` pin to display jog scale

--- a/docs/src/hal/rtcomps.adoc
+++ b/docs/src/hal/rtcomps.adoc
@@ -82,6 +82,7 @@ On the step type and control type selected.
 === Parameters
 
 (((HAL stepgen parameters)))
+
 * (float) `stepgen.`__<chan>__`.position-scale` - Steps per position unit. This parameter is used for both output and feedback.
 * (float) `stepgen.`__<chan>__`.maxvel` - Maximum velocity, in position units per second. If 0.0, has no effect.
 * (float) `stepgen.`__<chan>__`.maxaccel` - Maximum accel/decel rate, in positions units per second squared.


### PR DESCRIPTION
## Summary

A column-0 `* ` bullet that follows column-0 paragraph text with
no blank line between gets folded into the paragraph and no list
is rendered. Affects both asciidoctor and asciidoc-py. Inserts
the blank at the 30 affected boundaries across 9 doc pages.

Each insert was verified empirically: rendering the file before
vs after with both asciidoctor 2.0.23 and asciidoc-py 10.2.1
yields more `<li>` elements in at least one renderer.

## Test plan

- [x] `git diff --check` clean
- [x] `make htmldocs` clean; affected pages render bullets as
      proper `<li>` (verified at the ARC_BLEND_GAP_CYCLES spot
      and at the about-linuxcnc "LinuxCNC provides:" list).