### PR TITLE
test: suppress audio output in ui-smoke launcher

### DIFF
--- a/tests/ui-smoke/_lib/asound.conf
+++ b/tests/ui-smoke/_lib/asound.conf
@@ -1,0 +1,10 @@
+# Loaded via ALSA_CONFIG_PATH by ui-smoke launch.sh. Redirect the
+# default PCM/CTL to alsa-lib's null devices to silence the tests.
+<confdir:alsa.conf>
+
+pcm.!default {
+    type null
+}
+ctl.!default {
+    type null
+}

--- a/tests/ui-smoke/_lib/launch.sh
+++ b/tests/ui-smoke/_lib/launch.sh
@@ -41,6 +41,14 @@ export QT_QUICK_BACKEND=software
 export QSG_RHI_BACKEND=software
 export QT_OPENGL=software
 
+# Silence audio: xvfb covers X but not sound. Demote every Gst
+# Audio/Sink and disable canberra/SDL/pulse/ALSA-default paths.
+export ALSA_CONFIG_PATH="$LIB_DIR/asound.conf"
+export CANBERRA_DRIVER=null
+export GST_PLUGIN_FEATURE_RANK="pulsesink:NONE,alsasink:NONE,osssink:NONE,oss4sink:NONE,jackaudiosink:NONE,pipewiresink:NONE,openalsink:NONE"
+export PULSE_SERVER=/dev/null
+export SDL_AUDIODRIVER=dummy
+
 # Export the per-invocation values so the inner bash -c receives them
 # as proper env vars (avoids embedding paths into the inner script
 # via quoting, which breaks on apostrophes / spaces).


### PR DESCRIPTION
## Summary
- Fixes #4058. The new UI smoke tests beep on CI hosts with a real sound card because xvfb isolates X but not audio.
- gmoccapy (`player.py`) and qtdragon (`qtvcp/lib/audio_player.py`) both feed alerts through GStreamer `playbin`; espeak, libcanberra and SDL paths also exist.
- Point each backend at a null/fake sink via env in `tests/ui-smoke/_lib/launch.sh`:
  - `GST_AUDIO_SINK=fakesink` (gstreamer playbin)
  - `SDL_AUDIODRIVER=dummy`
  - `ALSA_CARD=Dummy`
  - `CANBERRA_DRIVER=null`
  - `PULSE_SERVER=/dev/null`

## Test plan
- [x] Run `runtests tests/ui-smoke` locally on a host with a sound card; confirm no audible output during axis/touchy/gmoccapy/qtdragon runs.
- [x] Confirm all four ui-smoke tests still pass (`UI_SMOKE_OK` in `ui-smoke.out`).
- [x] CI: ui-smoke job still green.