### PR TITLE
qtvcp: stop QPin update timer before hal_exit to prevent shutdown SIGSEGV

### DIFF
--- a/src/emc/usr_intf/qtvcp/qtvcp.py
+++ b/src/emc/usr_intf/qtvcp/qtvcp.py
@@ -523,6 +523,11 @@ Pressing cancel will close linuxcnc.""" % target)
         LOG.debug('Exiting HAL')
         if not HAL is None:
             try:
+                # Stop the QPin polling timer before hal_exit; otherwise its
+                # next tick dereferences pin->u after hal_exit has unmapped
+                # HAL shmem, causing SIGSEGV on glibc 2.39 (Ubuntu 24.04).
+                from qtvcp.qt_halobjects import QPin
+                QPin.update_stop()
                 HAL.exit()
             except Exception as e:
                 print(e)


### PR DESCRIPTION
## Problem

On Ubuntu 24.04 (glibc 2.39) shutting down a qtvcp screen (e.g. qtdragon) that uses the QPin update timer can SIGSEGV at exit time. Older systems hide the bug because the underlying HAL shared memory stays accessible after detach; newer glibc/kernel actually unmaps the pages.

## Root cause

`src/emc/usr_intf/qtvcp/qtvcp.py` `shutdown()` calls `HAL.exit()`, which routes to `Qhal.exit()` -> `_hal.component.exit()` -> `hal_exit(comp_id)`. When the last HAL component in the process exits, `src/hal/hal_lib.c` calls `rtapi_shmem_delete()`, detaching HAL shared memory.

`QPin.update_all` is driven by a QTimer started in init and never stopped. Each QPin in `QPin.REGISTRY` holds a value-snapshot of its `halitem`, whose `u` pointer points into HAL shared memory. After `hal_exit` returns, the timer fires one more time on the Qt event loop:

```
update_all -> p.update() -> self.get() -> pyhal_read_common
  -> deref *(item->u->pin.X)  -> unmapped page -> SIGSEGV
```

Verified with `mincore()` instrumentation in a custom build of `halmodule.cc`: pin `u` addresses report mapped=1 before `hal_exit`, mapped=0 within ~3ms after, with the timer still ticking against them.

## Fix

Stop the QPin polling timer before `HAL.exit()`. One line plus a comment.

## Test plan

- [x] Reproduced inside an `ubuntu:24.04` container running the qtdragon ui-smoke test. Before fix: SIGSEGV (or `RuntimeError: stale/unknown halitem` with safety guards) during shutdown. After fix: clean exit, no crash markers in the log.
