### PR TITLE
qtvcp: close dbus bus when sys_notify init fails

### DIFF
--- a/lib/python/qtvcp/lib/sys_notify.py
+++ b/lib/python/qtvcp/lib/sys_notify.py
@@ -62,6 +62,7 @@ def init(app_name):
     interface = "org.freedesktop.Notifications"
 
     mainloop = None
+    bus = None
     try:
         if DBusQtMainLoop is not None:
             mainloop = DBusQtMainLoop(set_as_default=True)
@@ -76,6 +77,23 @@ def init(app_name):
             DBUS_IFACE.connect_to_signal('NotificationClosed', _onNotificationClosed)
     except Exception as e:
         LOG.warning('Desktop Notify not available:: {}'.format(e))
+        # When the SessionBus is constructed with a PyQt5/PyQt6 mainloop
+        # integration, dbus-python installs a QSocketNotifier on the
+        # connection fd. If the subsequent get_object/Interface setup
+        # raises (e.g. ServiceUnknown when no notification daemon owns
+        # org.freedesktop.Notifications), the Python-side bus reference
+        # is dropped on exception but the QSocketNotifier keeps the
+        # underlying C connection alive in a half-initialized state.
+        # The next QEventLoop tick dispatches a queued message via
+        # dbus_connection_dispatch() and segfaults inside
+        # _dbus_list_unlink. Close the bus explicitly so the notifier
+        # detaches and the connection is fully released.
+        DBUS_IFACE = None
+        if bus is not None:
+            try:
+                bus.close()
+            except Exception:
+                pass
 
 
 def _onActionInvoked(nid, action):


### PR DESCRIPTION
## Summary

`lib/python/qtvcp/lib/sys_notify.py` constructs a `dbus.SessionBus`
with the PyQt5 (or PyQt6) mainloop integration before probing for
`org.freedesktop.Notifications`. When the probe raises (e.g.
`org.freedesktop.DBus.Error.ServiceUnknown` because no notification
daemon owns the name on the session bus), the Python `bus` reference
is dropped on the exception but the mainloop layer has already
attached a `QSocketNotifier` to the connection's fd. That keeps the
C-level connection alive in a half-initialized state. On the next
Qt event-loop tick the queued message is dispatched via
`dbus_connection_dispatch()` and segfaults inside
`_dbus_list_unlink` because the connection's internal queue is no
longer consistent.

Closing the bus on the failure path detaches the notifier and lets
the connection be released. The `Desktop Notify not available`
warning continues to be the only user-visible side effect.

## Repro

Ubuntu 24.04 GitHub runner with xvfb + `QT_QPA_PLATFORM=offscreen`
and no session-bus notification daemon. Surfaced during PR #4054
qtdragon ui-smoke; captured under `gdb -batch` (Thread 1 only):

```
#0  _dbus_list_unlink            libdbus-1.so.3
#1  _dbus_list_pop_first_link    libdbus-1.so.3
#2  _dbus_connection_unlock      libdbus-1.so.3
#4  dbus_connection_dispatch     libdbus-1.so.3
#5  ???                          dbus/mainloop/pyqt5.abi3.so
#6  QObject::event               libQt5Core.so.5
#7  QApplicationPrivate::notify_helper  libQt5Widgets.so.5
#9  QCoreApplication::notifyInternal2   libQt5Core.so.5
#10 QCoreApplicationPrivate::sendPostedEvents
#14 g_main_context_iteration     libglib-2.0.so.0
#15 QEventDispatcherGlib::processEvents
#16 QEventLoop::exec
#17 QCoreApplication::exec()     ← qtvcp.py APP.exec()
```

Same investigation surfaced PR #4062 (shutdown-time `hal_exit`
use-after-free in QPin timer). The two are independent: #4062 is
the teardown path, this is the startup path.

## Test plan

- [x] qtdragon ui-smoke pre-fix: SIGSEGV in `_dbus_list_unlink` on
      Ubuntu 24.04 (PR #4054 CI runs 26561722252, 26572207672)
- [x] qtdragon ui-smoke post-fix: package-arch debian:sid passes in
      71s (matches pre-regression baseline)
- [x] `python3 -m py_compile lib/python/qtvcp/lib/sys_notify.py`
      clean

## Risk

The new `except` branch only runs when init has already failed.
`bus.close()` is the documented teardown for `dbus.Connection`;
swallowing exceptions from it is safe because the connection is
already being abandoned.