### PR TITLE
build: fail configure if libcap-dev is missing

### DIFF
--- a/src/configure.ac
+++ b/src/configure.ac
@@ -1544,6 +1544,9 @@ if test "x$HAVE_LIBFMT" = "xno"; then
     AC_MSG_ERROR([libfmt header not found. Install with 'sudo apt-get install libfmt-dev'])
 fi
 
+AC_CHECK_HEADERS([sys/capability.h], [], [
+    AC_MSG_ERROR([libcap header not found. Please install libcap-dev])
+])
 AC_CHECK_HEADERS([editline/readline.h histedit.h], [], [
     AC_MSG_ERROR([libedit headers not found. Please install libedit-dev or libedit-devel.])
 ])


### PR DESCRIPTION
Fixes #4065. The rootless implementation uses libcap and the dev package needs to be installed. This patch will fail configure if the sys/capability.h header is missing.