### PR TITLE
sim/touchy: disable EMC_DEBUG_TASK_ISSUE logging (DEBUG=0)

### DIFF
--- a/configs/sim/touchy/touchy.ini
+++ b/configs/sim/touchy/touchy.ini
@@ -10,7 +10,7 @@ MACHINE =               LinuxCNC-TOUCHY
 
 # Debug level, 0 means no messages. See src/emc/nml_int/emcglb.h for others
 #DEBUG =               0x7FFFFFFF
-DEBUG = 0x10
+DEBUG = 0
 
 [DISPLAY]
 


### PR DESCRIPTION
touchy.ini was the only sim config shipping a non-zero DEBUG (0x10 =
EMC_DEBUG_TASK_ISSUE). That makes task log every issued NML command as an
ASCII string via emcCommandBuffer->msg2str(), which instantiates a
CMS_DISPLAY_ASCII_UPDATER and prints its "may not function properly"
banner on startup. The emcCommand buffer is correctly xdr; the ASCII
updater is only a transient string helper for the debug log.

Set DEBUG = 0 (matching axis and gmoccapy). No functional change.

Surfaced in the ui-smoke review, PR #4054.

Test: touchy sim under xvfb, banner no longer printed, GUI starts normally.
