### PR TITLE
libnml: gate CMS_DISPLAY_ASCII_UPDATER banner behind debug flag

### DIFF
--- a/src/libnml/cms/cms_dup.cc
+++ b/src/libnml/cms/cms_dup.cc
@@ -32,7 +32,12 @@
     CMS_DISPLAY_ASCII_UPDATER::CMS_DISPLAY_ASCII_UPDATER(CMS * _cms_parent):
 CMS_UPDATER(_cms_parent)
 {
-    fprintf(stderr,
+    // This updater is also used transiently by NML::msg2str()/str2msg() for
+    // ASCII string conversion of otherwise xdr-encoded buffers (e.g. task
+    // command logging under EMC_DEBUG_TASK_ISSUE), so the banner fired on
+    // normal startup. Gate it behind the CMS-constructor debug flag instead of
+    // printing unconditionally to stderr.
+    rcs_print_debug(PRINT_CMS_CONSTRUCTORS,
         "* * * * * * * * * * - - - - - WARNING - - - - - * * * * * * * * * *\n"
         "*    CMS_DISPLAY_ASCII_UPDATER may not function properly due      *\n"
         "*    to range limitations of some of the update() functions.      *\n"


### PR DESCRIPTION
The CMS_DISPLAY_ASCII_UPDATER constructor printed a multi-line WARNING
banner unconditionally to stderr. That updater is also created transiently
by NML::msg2str()/str2msg() to render an xdr buffer as an ASCII string, so
the banner fired during normal operation for a harmless use.

Route it through rcs_print_debug(PRINT_CMS_CONSTRUCTORS, ...) so it is
silent by default but still available with CMS constructor debug printing.

Complements the touchy DEBUG=0 change by fixing the noise at the source
for any config that legitimately uses the ASCII updater.

Surfaced in the ui-smoke review, PR #4054.

Test: touchy sim with DEBUG = 0x10 (instantiates the updater) under xvfb,
banner no longer printed.
