### PR TITLE
gladevcp: move return out of finally in SAVE_PROGRAM

### DIFF
--- a/lib/python/gladevcp/gtk_action.py
+++ b/lib/python/gladevcp/gtk_action.py
@@ -309,7 +309,7 @@ class _Lcnc_Action(object):
                 outfile.close()
             except:
                 pass
-            return npath
+        return npath
 
     def SET_AXIS_ORIGIN(self, axis, value):
         if axis == '' or axis.upper() not in ("XYZABCUVW"):


### PR DESCRIPTION
gtk_action.py had `return npath` inside a finally: block. A return in
finally swallows any in-flight exception and overrides earlier returns,
so the except branch's `return None` (the error path) was always clobbered:
a failed save still returned the path and hid the exception.

Dedent the return out of the finally so the finally only closes the file.
On success the function returns the path; on a write error it now returns
None. Also silences the Python 3.12+ SyntaxWarning: 'return' in a 'finally'
block.

Surfaced in the ui-smoke review, PR #4054.

Fixes #4067

Test: py_compile clean with no SyntaxWarning; success returns path, write
error returns None.
