### PR TITLE
gmoccapy: exit cleanly on termination signal instead of error dialog

### DIFF
--- a/src/emc/usr_intf/gmoccapy/gmoccapy.py
+++ b/src/emc/usr_intf/gmoccapy/gmoccapy.py
@@ -51,10 +51,20 @@ from time import strftime  # needed for the clock in the GUI
 
 # Throws up a dialog with debug info when an error is encountered
 def excepthook(exc_type, exc_obj, exc_tb):
+    # A KeyboardInterrupt reaching the excepthook is a termination request:
+    # either SIGINT, or SIGTERM surfaced into the main loop by PyGObject's
+    # signal bridge. Quit cleanly instead of popping a modal error dialog,
+    # which would block in a nested loop and leave gmoccapy running until the
+    # caller escalates to SIGKILL.
+    if issubclass(exc_type, KeyboardInterrupt):
+        LOG.info("gmoccapy interrupted (signal), shutting down")
+        try:
+            Gtk.main_quit()
+        except Exception:
+            pass
+        return
     try:
         w = app.widgets.window1
-    except KeyboardInterrupt:
-        sys.exit()
     except NameError:
         w = None
     lines = traceback.format_exception(exc_type, exc_obj, exc_tb)


### PR DESCRIPTION
gmoccapy did not exit on SIGTERM; callers had to escalate to SIGKILL.

PyGObject's signal bridge surfaces a termination signal into the GTK main
loop as a Python KeyboardInterrupt. That reached the installed sys.excepthook,
which unconditionally popped a modal "Found an error ... KeyboardInterrupt"
dialog and blocked in the dialog's nested loop, so the process never quit.

Handle KeyboardInterrupt at the top of excepthook: log it and quit the main
loop instead of showing the modal dialog. The old broken
`except KeyboardInterrupt` on the window lookup (which could never fire there)
is removed.

Surfaced in the ui-smoke review, PR #4054.

Fixes #4069

Test: SIGTERM to the gmoccapy sim under xvfb. Verified with py-spy that the
process is in the real Gtk.main loop and now exits cleanly, with no SIGKILL
escalation and no error-dialog traceback.
