### PR TITLE
touchy: exit cleanly on SIGTERM

### DIFF
--- a/src/emc/usr_intf/touchy/touchy.py
+++ b/src/emc/usr_intf/touchy/touchy.py
@@ -905,4 +905,13 @@ if __name__ == "__main__":
                 else:
                     res = os.spawnvp(os.P_WAIT, "halcmd", ["halcmd", "-i", inifile, "-f", f])
                 if res: raise SystemExit(res)
+
+        # Exit cleanly on SIGTERM. Without this touchy ignores the signal
+        # (GLib/PyGObject absorbs it), so a caller has to escalate to SIGKILL.
+        # The handler defers the quit to the main loop, since GTK calls are not
+        # safe directly from a signal handler.
+        def _signal_quit(signum, frame):
+            GLib.idle_add(Gtk.main_quit)
+        signal.signal(signal.SIGTERM, _signal_quit)
+
         Gtk.main()


### PR DESCRIPTION
touchy ignored SIGTERM: PyGObject/GLib absorbed it, so the process never exited and the ui-smoke teardown had to escalate to SIGKILL after the grace period.

This installs a SIGTERM handler that requests `Gtk.main_quit()` via the idle queue, so the GTK loop unwinds normally and touchy's existing atexit cleanup (child panels, saved prefs) still runs.

Known cosmetic wart: PyGObject prints one `KeyboardInterrupt` line on exit, emitted from its C-level wakeup-fd bridge. It is not suppressible from Python (`signal.signal`, `GLib.unix_signal_add`, `sys.excepthook`, `sys.unraisablehook` all tried); only `os._exit` hides it, which would skip the atexit cleanup. Pre-existing, so no regression.

Part of the SIGTERM clean-shutdown work discussed in #4054.
