### PR TITLE
qtvcp: exit cleanly on SIGTERM/SIGINT

### DIFF
--- a/src/emc/usr_intf/qtvcp/qtvcp.py
+++ b/src/emc/usr_intf/qtvcp/qtvcp.py
@@ -448,8 +448,19 @@ Pressing cancel will close linuxcnc.""" % target)
                 window.setWindowTitle(INITITLE)
 
         # catch control c and terminate signals
-        signal.signal(signal.SIGTERM, self.shutdown)
-        signal.signal(signal.SIGINT, self.shutdown)
+        # Quit the Qt event loop on the signal so APP.exec() returns and the
+        # shutdown() below runs the normal cleanup once. Calling shutdown()
+        # directly from the handler would clean up but leave the loop running.
+        # Quitting the loop also bypasses the window-close confirmation dialog,
+        # which is correct for a terminate request and leaves that interactive
+        # feature untouched. Qt's C++ event loop does not return to Python often
+        # enough to run Python signal handlers, so a periodic no-op timer yields
+        # to the interpreter to let them fire.
+        signal.signal(signal.SIGTERM, lambda *a: APP.quit())
+        signal.signal(signal.SIGINT, lambda *a: APP.quit())
+        self._signal_timer = QtCore.QTimer()
+        self._signal_timer.timeout.connect(lambda: None)
+        self._signal_timer.start(200)
 
         # check for handler file and if it has 'before_loop' function in
         # ineach screen/embedded panel. (screen should be last)


### PR DESCRIPTION
qtvcp screens (qtdragon etc.) ignored SIGTERM and SIGINT: Python signal handlers do not run while `QApplication.exec()` blocks in the Qt C++ loop, so the process never exited and ui-smoke teardown escalated to SIGKILL.

This quits the Qt loop directly on SIGTERM and SIGINT, and adds a low-frequency `QTimer` so the interpreter periodically regains control to deliver the signal. The existing post-exec `shutdown()` still runs the cleanup. The X-button "are you sure?" confirmation dialog is left intact for interactive close; only the terminate signals bypass it, which is correct for SIGTERM.

Part of the SIGTERM clean-shutdown work discussed in #4054.
