### PR TITLE
touchy: stop pegging the X server with redundant button relayouts

### DIFF
--- a/src/emc/usr_intf/touchy/touchy.py
+++ b/src/emc/usr_intf/touchy/touchy.py
@@ -789,9 +789,9 @@ class touchy:
                 else:
                         incs = ["0.01", "0.001", "0.0001"]
 
-                self.wTree.get_object("wheelinc1").set_label(incs[0])
-                self.wTree.get_object("wheelinc2").set_label(incs[1])
-                self.wTree.get_object("wheelinc3").set_label(incs[2])
+                set_label(self.wTree.get_object("wheelinc1"), incs[0])
+                set_label(self.wTree.get_object("wheelinc2"), incs[1])
+                set_label(self.wTree.get_object("wheelinc3"), incs[2])
 
                 self.hal.jogincrement(self.wheelinc, list(map(float,incs)))
 
@@ -820,9 +820,9 @@ class touchy:
                         d0 = d * 10 ** (2-self.wheelinc)
                         if d != 0: self.listing.next(None, d0)
 
-                self.wTree.get_object("fo").set_label("FO: %d%%" % self.fo_val)
-                self.wTree.get_object("so").set_label("SO: %d%%" % self.so_val)
-                self.wTree.get_object("mv").set_label("MV: %d" % self.mv_val)
+                set_label(self.wTree.get_object("fo"), "FO: %d%%" % self.fo_val)
+                set_label(self.wTree.get_object("so"), "SO: %d%%" % self.so_val)
+                set_label(self.wTree.get_object("mv"), "MV: %d" % self.mv_val)
 
                         
                 return True


### PR DESCRIPTION
Fixes #4070.

touchy's `periodic_radiobuttons()` runs at 10 Hz and called `set_label()` directly on six buttons (`wheelinc1-3`, `fo`, `so`, `mv`) every cycle. `gtk_button_set_label()` unconditionally rebuilds the button's label child and queues a resize, so even when the text is unchanged each cycle forces a full window relayout and redraw. Headless under Xvfb this pegged the X server while touchy's own Python sat idle in the GTK main loop, which is the 100%-of-one-core behaviour reported in #4070.

The fix routes those six calls through the `set_label()` helper that already exists in the file, which skips the call when the label is unchanged (the same guard `set_text()`/`set_active()` already use everywhere else).

Measured on a uspace RIP build, touchy sim under xvfb, idle:

| | before | after |
|--|--|--|
| Xvfb CPU | ~96-110% | <2% |
| touchy CPU | ~10% | <2% |

Behaviour is unchanged: the increment and override labels still update whenever their values actually change; only the redundant same-value writes are dropped.
