### PR TITLE
Remove rtapi_get_clocks()

### DIFF
--- a/docs/src/config/core-components.adoc
+++ b/docs/src/config/core-components.adoc
@@ -170,10 +170,8 @@ change or removal at any time.
 * 'motion.debug-float-3' - (float, RO) This is used for debugging purposes.
 * 'motion.debug-s32-0' - (s32, RO) This is used for debugging purposes.
 * 'motion.debug-s32-1' - (s32, RO) This is used for debugging purposes.
-* 'motion.servo.last-period' - (u32, RO) The number of CPU cycles between invocations of the servo thread.
-  Typically, this number divided by the CPU speed gives the time in seconds,
-  and can be used to determine whether the realtime motion controller is meeting its timing constraints
-* 'motion.servo.last-period-ns' - (float, RO)
+* 'motion.servo.last-period' - (u32, RO) The time in ns between invocations of the servo thread.
+  This number can be used to determine whether the realtime motion controller is meeting its timing constraints
 
 === Functions
 

--- a/docs/src/hal/basic-hal.adoc
+++ b/docs/src/hal/basic-hal.adoc
@@ -373,12 +373,13 @@ If you used the Stepper Config Wizard to generate your config you will have up t
 == HAL Parameter
 
 (((HAL Parameters)))
-Two parameters are automatically added to each HAL component when it is created.
-These parameters allow you to scope the execution time of a component.
+One pin and two parameters are automatically added to each HAL component when it is created.
+These allow you to scope the execution time of a component.
 
 [horizontal]
-`.time`(((HAL time))):: Time is the number of CPU cycles it took to execute the function.
-`.tmax`(((HAL tmax))):: Tmax is the maximum number of CPU cycles it took to execute the function.
+`.time`(((HAL time))):: Pin time shows in ns how long it took to execute the function.
+`.tmax`(((HAL tmax))):: Parameter tmax is the maximum time in ns it took to execute the function.
+`.tmax-increased`(((HAL tmax-increased))):: This parameter is set to true for one cycle if tmax increased.
 
 `tmax` is a read/write parameter so the user can set it to 0 to get rid of the first time initialization on the function's execution time.
 

--- a/docs/src/hal/components.adoc
+++ b/docs/src/hal/components.adoc
@@ -511,7 +511,6 @@ rtapi_clock_set_period.3
 rtapi_delay.3
 rtapi_delay_max.3
 rtapi_exit.3
-rtapi_get_clocks.3
 rtapi_get_msg_level.3
 rtapi_get_time.3
 rtapi_inb.3

--- a/docs/src/man/man3/rtapi_get_time.3.adoc
+++ b/docs/src/man/man3/rtapi_get_time.3.adoc
@@ -4,14 +4,13 @@
 
 == NAME
 
-rtapi_get_time, rtapi_get_clocks - get the current time
+rtapi_get_time - get the current time in ns
 
 == SYNTAX
 
 [source,c]
 ----
 long long rtapi_get_time();
-long long rtapi_get_clocks();
 ----
 
 == DESCRIPTION
@@ -25,22 +24,6 @@ resolution of the returned value may be as good as one nano-second, or
 as poor as several microseconds. May be called from init/cleanup code,
 and from within realtime tasks.
 
-*rtapi_get_clocks* returns the current time in CPU clocks. It is fast,
-since it just reads the TSC in the CPU instead of calling a kernel or
-RTOS function. Of course, times measured in CPU clocks are not as
-convenient, but for relative measurements this works fine. Its absolute
-value means nothing, but it is monotonically increasing and can be used
-to schedule future events, or to time the duration of some activity. (On
-SMP machines, the two TSC's may get out of sync, so if a task reads the
-TSC, gets swapped to the other CPU, and reads again, the value may
-decrease. RTAPI tries to force all RT tasks to run on one CPU.) Returns
-a 64 bit value. The resolution of the returned value is one CPU clock,
-which is usually a few nanoseconds to a fraction of a nanosecond. Note
-that _long long_ math may be poorly supported on some platforms,
-especially in kernel space. Also note that rtapi_print() will NOT print
-__long long__s. Most time measurements are relative, and should be done
-like this:
-
 [source,c]
 ----
 deltat = (long int)(end_time - start_time);
@@ -48,32 +31,12 @@ deltat = (long int)(end_time - start_time);
 
 where end_time and start_time are longlong values returned from
 rtapi_get_time, and deltat is an ordinary long int (32 bits). This will
-work for times up to a second or so, depending on the CPU clock
-frequency. It is best used for millisecond and microsecond scale
+work for times up to 2.1s. It is best used for millisecond and microsecond scale
 measurements though.
 
 == RETURN VALUE
 
-Returns the current time in nanoseconds or CPU clocks.
-
-== NOTES
-
-Certain versions of the Linux kernel provide a global variable *cpu_khz*. Computing
-
-[source,c]
-----
-deltat = (end_clocks - start_clocks) / cpu_khz:
-----
-
-gives the duration measured in milliseconds. Computing
-
-[source,c]
-----
-deltat = (end_clocks - start_clocks) * 1000000 / cpu_khz:
-----
-
-gives the duration measured in nanoseconds for deltas less than about 9
-trillion clocks (e.g., 3000 seconds at 3 GHz).
+Returns the current time in nanoseconds.
 
 == REALTIME CONSIDERATIONS
 

--- a/docs/src/man/man9/encoder.9.adoc
+++ b/docs/src/man/man9/encoder.9.adoc
@@ -139,7 +139,7 @@ The *encoder*.__N__. format is shown in the following descriptions.
   for counting the output of a single channel (non-quadrature) sensor.
   When false (the default), it counts in quadrature mode.
 **encoder**.__N__.**capture-position.tmax** s32 rw::
-  Maximum number of CPU cycles it took to execute this function.
+  Maximum time in ns it took to execute this function.
 
 == PARAMETERS
 

--- a/docs/src/man/man9/motion.9.adoc
+++ b/docs/src/man/man9/motion.9.adoc
@@ -106,9 +106,9 @@ digital pins and two analog pins.
 == MOTION PINS
 
 *motion-command-handler.time* OUT S32::
-  Time (in CPU clocks) for the motion module motion-command-handler
+  Time (in ns) for the motion module motion-command-handler
 *motion-controller.time* OUT S32::
-  Time (in CPU clocks) for the motion module motion-controller
+  Time (in ns) for the motion module motion-controller
 *motion.adaptive-feed* IN FLOAT::
   When adaptive feed is enabled with M52 P1, the commanded velocity is
   multiplied by this value. This effect is multiplicative with the
@@ -246,7 +246,7 @@ Note: feed-inhibit applies to G-code commands -- not jogs.
   possibly reduced to accommodate machine velocity and acceleration limits.
   The value on this pin does not reflect the feed override or any other adjustments.
 *motion.servo.last-period* OUT U32::
-  The number of CPU clocks between invocations of the servo thread.
+  Time (in ns) between invocations of the servo thread.
   Typically, this number divided by the CPU speed gives the time in seconds,
   and can be used to determine whether the realtime motion
   controller is meeting its timing constraints
@@ -544,12 +544,12 @@ the M19 command fails with an error message.
 Many of the parameters serve as debugging aids, and are subject to change or removal at any time.
 
 *motion-command-handler.tmax* RW S32::
-  Show information about the execution time of these HAL functions in CPU clocks.
+  Show information about the execution time of these HAL functions in ns.
 
 *motion-command-handler.tmax-increased* RO S32::
 
 *motion-controller.tmax* RW S32::
-  Show information about the execution time of these HAL functions in CPU clocks.
+  Show information about the execution time of these HAL functions in ns.
 
 *motion-controller.tmax-increased* RO BIT::
   +

--- a/src/emc/motion/control.c
+++ b/src/emc/motion/control.c
@@ -225,12 +225,9 @@ void emcmotController(void *arg, long period)
 
     static long long int last = 0;
 
-    long long int now = rtapi_get_clocks();
+    long long int now = rtapi_get_time();
     long int this_run = (long int)(now - last);
     *(emcmot_hal_data->last_period) = this_run;
-#ifdef HAVE_CPU_KHZ
-    *(emcmot_hal_data->last_period_ns) = this_run * 1e6 / cpu_khz;
-#endif
 
     // we need this for next time
     last = now;

--- a/src/emc/motion/mot_priv.h
+++ b/src/emc/motion/mot_priv.h
@@ -172,8 +172,7 @@ typedef struct {
     hal_float_t tc_acc[4];	/* RPA: traj internals, for debugging */
 
     // realtime overrun detection
-    hal_u32_t   *last_period;	/* pin: last period in clocks */
-    hal_float_t *last_period_ns;	/* pin: last period in nanoseconds */
+    hal_u32_t   *last_period;	/* pin: last period in nanoseconds */
 
     hal_float_t *tooloffset_x;
     hal_float_t *tooloffset_y;
@@ -347,9 +346,5 @@ int joint_is_lockable(int joint_num);
 #define GET_JOINT_FAULT_FLAG(joint) ((joint)->flag & EMCMOT_JOINT_FAULT_BIT ? 1 : 0)
 
 #define SET_JOINT_FAULT_FLAG(joint,fl) if (fl) (joint)->flag |= EMCMOT_JOINT_FAULT_BIT; else (joint)->flag &= ~EMCMOT_JOINT_FAULT_BIT;
-
-#if defined(__KERNEL__)
-#define HAVE_CPU_KHZ
-#endif
 
 #endif /* MOT_PRIV_H */

--- a/src/emc/motion/motion.c
+++ b/src/emc/motion/motion.c
@@ -593,9 +593,6 @@ static int init_hal_io(void)
 
     // export timing related HAL pins so they can be scoped and/or connected
     CALL_CHECK(hal_pin_u32_newf(HAL_OUT, &(emcmot_hal_data->last_period), mot_comp_id, "motion.servo.last-period"));
-#ifdef HAVE_CPU_KHZ
-    CALL_CHECK(hal_pin_float_newf(HAL_OUT, &(emcmot_hal_data->last_period_ns), mot_comp_id, "motion.servo.last-period-ns"));
-#endif
 
     // export timing related HAL pins so they can be scoped
     CALL_CHECK(hal_pin_float_newf(HAL_OUT, &(emcmot_hal_data->tooloffset_x), mot_comp_id, "motion.tooloffset.x"));

--- a/src/hal/drivers/hal_gpio.c
+++ b/src/hal/drivers/hal_gpio.c
@@ -50,9 +50,6 @@ MODULE_AUTHOR("Andy Pugh");
 MODULE_DESCRIPTION("GPIO driver using gpiod / libgpiod");
 MODULE_LICENSE("GPL");
 
-static unsigned long ns2tsc_factor;
-#define ns2tsc(x) (((x) * (unsigned long long)ns2tsc_factor) >> 12)
-
 // There isn't really any limit except for in the MP_ARRAY macros. 
 #define MAX_CHAN 128
 
@@ -358,14 +355,6 @@ int rtapi_app_main(void){
     const char *line_name;
 
 rtapi_print_msg(RTAPI_MSG_INFO, "Libgpiod is %i\n", LIBGPIOD_VER);
-
-#ifdef __KERNEL__
-    // this calculation fits in a 32-bit unsigned
-    // as long as CPUs are under about 6GHz
-    ns2tsc_factor = (cpu_khz << 6) / 15625ul;
-#else
-    ns2tsc_factor = 1ll<<12;
-#endif
     
     comp_id = hal_init("hal_gpio");
     if (comp_id < 0) {
@@ -520,7 +509,7 @@ static void hal_gpio_write(void *arg, __attribute__((unused)) long period)
 #endif
     }
     // store the time (in CPU clocks) for the reset function
-    last_reset = rtapi_get_clocks();
+    last_reset = rtapi_get_time();
 }
 
 static void hal_gpio_reset(void *arg, long period)
@@ -537,8 +526,8 @@ static void hal_gpio_reset(void *arg, long period)
 	    }
 	}
 	if (*gpio->reset_ns > period/4) *gpio->reset_ns = period/4;
-	deadline = last_reset + ns2tsc(*gpio->reset_ns);
-        while(rtapi_get_clocks() < deadline) {} // busy-wait!
+	deadline = last_reset + *gpio->reset_ns;
+        while(rtapi_get_time() < deadline) {} // busy-wait!
 #if LIBGPIOD_VER > 200
 	gpiod_line_request_set_values(gpio->out_chips[c].lines, gpio->out_chips[c].vals);
 #else

--- a/src/hal/drivers/hal_parport.c
+++ b/src/hal/drivers/hal_parport.c
@@ -153,9 +153,6 @@ static parport_t *port_data_array;
 static int comp_id;		/* component ID */
 static int num_ports;		/* number of ports configured */
 
-static unsigned long ns2tsc_factor;
-#define ns2tsc(x) (((x) * (unsigned long long)ns2tsc_factor) >> 12)
-
 /***********************************************************************
 *                  LOCAL FUNCTION DECLARATIONS                         *
 ************************************************************************/
@@ -198,15 +195,6 @@ int rtapi_app_main(void)
     char *cp;
     char *argv[MAX_TOK];
     int n, retval;
-
-
-#ifdef __KERNEL__
-    // this calculation fits in a 32-bit unsigned 
-    // as long as CPUs are under about 6GHz
-    ns2tsc_factor = (cpu_khz << 6) / 15625ul;
-#else
-    ns2tsc_factor = 1ll<<12;
-#endif
 
     /* test for config string */
     if (cfg == 0) {
@@ -359,15 +347,14 @@ static void read_port(void *arg, long period)
 
 static void reset_port(void *arg, long period) {
     parport_t *port = arg;
-    long long deadline, reset_time_tsc;
+    long long deadline;
     unsigned char outdata = (unsigned char)((port->outdata&~port->reset_mask) ^ port->reset_val);
    
     if(port->reset_time > period/4) port->reset_time = period/4;
-    reset_time_tsc = ns2tsc(port->reset_time);
 
     if(outdata != port->outdata) {
-        deadline = port->write_time + reset_time_tsc;
-        while(rtapi_get_clocks() < deadline) {}
+        deadline = port->write_time + port->reset_time;
+        while(rtapi_get_time() < deadline) {}
         rtapi_outb(outdata, port->base_addr);
         port->outdata = outdata;
     }
@@ -375,8 +362,8 @@ static void reset_port(void *arg, long period) {
     outdata = (unsigned char)((port->outdata_ctrl&~port->reset_mask_ctrl)^port->reset_val_ctrl);
 
     if(outdata != port->outdata_ctrl) {
-        deadline = port->write_time_ctrl + reset_time_tsc;
-        while(rtapi_get_clocks() < deadline) {}
+        deadline = port->write_time_ctrl + port->reset_time;
+        while(rtapi_get_time() < deadline) {}
 	/* correct for hardware inverters on pins 1, 14, & 17 */
         rtapi_outb(outdata ^ 0x0B, port->base_addr + 2);
         port->outdata_ctrl = outdata;
@@ -416,7 +403,7 @@ static void write_port(void *arg, long period)
 	{
 	    /* write it to the hardware */
 	    rtapi_outb(outdata, port->base_addr);
-	    port->write_time = rtapi_get_clocks();
+	    port->write_time = rtapi_get_time();
 	    port->outdata = outdata;
         }
 	port->reset_val = reset_val;
@@ -457,7 +444,7 @@ static void write_port(void *arg, long period)
         /* write it to the hardware */
         /* correct for hardware inverters on pins 1, 14, & 17 */
         rtapi_outb(outdata ^ 0x0B, port->base_addr + 2);
-        port->write_time_ctrl = rtapi_get_clocks();
+        port->write_time_ctrl = rtapi_get_time();
         port->outdata_ctrl = outdata;
     }
 }

--- a/src/hal/drivers/mesa-hostmot2/hm2_eth.c
+++ b/src/hal/drivers/mesa-hostmot2/hm2_eth.c
@@ -808,11 +808,11 @@ static int eth_socket_recv(int sockfd, void *buffer, int len, int flags) {
 }
 
 static int eth_socket_recv_loop(int sockfd, void *buffer, int len, int flags, long timeout) {
-    long long end = rtapi_get_clocks() + timeout;
+    long long end = rtapi_get_time() + timeout;
     int result;
     do {
         result = eth_socket_recv(sockfd, buffer, len, flags);
-    } while(result < 0 && rtapi_get_clocks() < end);
+    } while(result < 0 && rtapi_get_time() < end);
     return result;
 }
 

--- a/src/hal/hal_lib.c
+++ b/src/hal/hal_lib.c
@@ -3187,7 +3187,7 @@ static void thread_task(void *arg)
 	    funct_root = (hal_funct_entry_t *) & (thread->funct_list);
 	    funct_entry = SHMPTR(funct_root->links.next);
 	    /* execution time logging */
-	    start_time = rtapi_get_clocks();
+	    start_time = rtapi_get_time();
 	    end_time = start_time;
 	    thread_start_time = start_time;
 	    /* run thru function list */
@@ -3195,7 +3195,7 @@ static void thread_task(void *arg)
 		/* call the function */
 		funct_entry->funct(funct_entry->arg, thread->period);
 		/* capture execution time */
-		end_time = rtapi_get_clocks();
+		end_time = rtapi_get_time();
 		/* point to function structure */
 		funct = SHMPTR(funct_entry->funct_ptr);
 		/* update execution time data */

--- a/src/hal/hal_priv.h
+++ b/src/hal/hal_priv.h
@@ -392,8 +392,8 @@ struct hal_thread_t {
     long int period;		/* period of the thread, in nsec */
     int priority;		/* priority of the thread */
     int task_id;		/* ID of the task that runs this thread */
-    hal_s32_t* runtime;	/* (pin) duration of last run, in CPU cycles */
-    hal_s32_t maxtime;	/* (param) duration of longest run, in CPU cycles */
+    hal_s32_t* runtime;	/* (pin) duration of last run, in ns */
+    hal_s32_t maxtime;	/* (param) duration of longest run, in ns */
     hal_list_t funct_list;	/* list of functions to run */
     hal_list_t init_funct_list;	/* list of init functions, run once before first cyclic cycle */
     int init_done;		/* 0 = init pending, 1 = init cycle has executed */

--- a/src/rtapi/rtai_rtapi.c
+++ b/src/rtapi/rtai_rtapi.c
@@ -527,24 +527,6 @@ long long int rtapi_get_time(void)
     return rt_get_cpu_time_ns();    
 }
 
-/* This returns a result in clocks instead of nS, and needs to be used
-   with care around CPUs that change the clock speed to save power and
-   other disgusting, non-realtime oriented behavior.  But at least it
-   doesn't take a week every time you call it.
-*/
-
-long long int rtapi_get_clocks(void)
-{
-    long long int retval;
-
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,4,0)
-    retval = rdtsc_ordered();
-#else
-    rdtscll(retval);
-#endif
-    return retval;
-}
-
 void rtapi_delay(long int nsec)
 {
     if (nsec > max_delay) {
@@ -1731,7 +1713,6 @@ EXPORT_SYMBOL(rtapi_set_msg_handler);
 EXPORT_SYMBOL(rtapi_get_msg_handler);
 EXPORT_SYMBOL(rtapi_clock_set_period);
 EXPORT_SYMBOL(rtapi_get_time);
-EXPORT_SYMBOL(rtapi_get_clocks);
 EXPORT_SYMBOL(rtapi_delay);
 EXPORT_SYMBOL(rtapi_delay_max);
 EXPORT_SYMBOL(rtapi_prio_highest);

--- a/src/rtapi/rtapi.h
+++ b/src/rtapi/rtapi.h
@@ -278,12 +278,6 @@ RTAPI_BEGIN_DECLS
  * the returned value may be as good as one nano-second, or as poor as several
  * microseconds.
  *
- * Experience has shown that the implementation of this function in some
- * RTOS/Kernel combinations is horrible. It can take up to  several
- * microseconds, which is at least 100 times longer than it should, and perhaps
- * a thousand times longer. Use it only if you MUST have results in seconds
- * instead of clocks, and use it sparingly. See rtapi_get_clocks() instead.
- *
  * Most time measurements are relative, and should be done like this:
  * @code
  * deltat = (long int)(end_time - start_time);
@@ -299,36 +293,6 @@ RTAPI_BEGIN_DECLS
  * @return Current time in nanoseconds
  */
     extern long long int rtapi_get_time(void);
-
-/**
- * @brief Returns the current time in CPU clocks.
- *
- * It is  fast, since it just reads the TSC in the CPU instead of calling a
- * kernel or RTOS function. Of course, times measured in CPU clocks are not as
- * convenient, but for relative measurements this works fine. Its absolute value
- * means nothing, but it is monotonically increasing* and can be used to
- * schedule future events, or to time the duration of some activity. (* on SMP
- * machines, the two TSC's may get out of sync, so if a task reads the TSC, gets
- * swapped to the other CPU, and reads again, the value may decrease. RTAPI
- * tries to force all RT tasks to run on one CPU.)
- *
- * Most time measurements are relative, and should be done like this:
- * @code
- * deltat = (long int)(end_time - start_time);
- * @endcode
- * where @c end_time and @c start_time are longlong values returned from
- * rtapi_get_time(), and deltat is an ordinary long int (32 bits). This will
- * work for times up to a second or so, depending on the CPU clock frequency.
- * It is best used for millisecond and microsecond scale measurements though.
- * @return A 64 bit value.  The resolution of the returned value is one CPU
- *         clock, which is usually a few nanoseconds to a fraction of a
- *         nanosecond.
- * @note May be called from init/cleanup code, and from within realtime tasks.
- * @note longlong math may be poorly supported on some platforms, especially in
- *       kernel space. Also note that rtapi_print() will NOT print longlong.
-
- */
-    extern long long int rtapi_get_clocks(void);
 
 
 /***********************************************************************

--- a/src/rtapi/uspace_common.h
+++ b/src/rtapi/uspace_common.h
@@ -288,20 +288,6 @@ int rtapi_get_msg_level() {
     return msg_level;
 }
 
-#if defined(__i386) || defined(__amd64)
-#define rdtscll(val) ((val) = __builtin_ia32_rdtsc())
-#else
-#define rdtscll(val) ((val) = rtapi_get_time())
-#endif
-
-long long rtapi_get_clocks(void)
-{
-    long long int retval;
-
-    rdtscll(retval);
-    return retval;
-}
-
 typedef struct {
     rtapi_mutex_t mutex;
     int           uuid;


### PR DESCRIPTION
As discussed in https://github.com/LinuxCNC/linuxcnc/issues/4029, I think it would make sense to remove `rtapi_get_clocks()`. 

An optimized function using rdtsc() and calculating the ration to ns would be possible, but I see no point in over complicating things due to my tests showed next to no impact.

On my setup, I don't see any change before and after this PR. Tested with:
Debian Trixie / i5-6500 / Latest RT kernel

Both latency_test and linuxcnc with my CNC show the exact same CPU load (+-0.1%) and timing behavior.

This PR also fixes a few bugs where the CPU frequency was assumed to be 1GHz, so some timings where applied wrongly.

Additionally, all thread.time values are now in ns and not an arbitrary clock count.

Open points:

- ~~Test with RTAI: My PC is unstable with RTAI, so I can not test this.~~
- ~~Docs: I updated the man page. But I do not really know how to manage all translation files. Can someone help me or show me the tools needed to do that? I can do English / German.~~
- ~~Test on different systems~~
  - Only x86/amd64, all other systems never used this functionality: https://github.com/LinuxCNC/linuxcnc/blob/master/src/rtapi/uspace_common.h#L291
 - Test hal_gpio / hal_parport: I have no parport on my PC. Can someone  do this?