### PR TITLE
build: hard-fail configure if asciidoctor is missing

### DIFF
--- a/debian/configure
+++ b/debian/configure
@@ -110,7 +110,7 @@ elif [ -f /etc/lsb-release ]; then
 fi
 
 if [ -n "$ENABLE_BUILD_DOCUMENTATION" ]; then
-    DOC_DEPENDS="asciidoctor,\n    asciidoctor-pdf | ruby-asciidoctor-pdf,\n    fonts-dejavu,\n    fonts-noto-cjk,\n    ghostscript,\n    graphviz,\n    librsvg2-bin,\n    python3-fonttools,\n    ruby-rouge,\n    w3c-linkchecker"
+    DOC_DEPENDS="asciidoctor-pdf | ruby-asciidoctor-pdf,\n    fonts-dejavu,\n    fonts-noto-cjk,\n    ghostscript,\n    graphviz,\n    librsvg2-bin,\n    python3-fonttools,\n    ruby-rouge,\n    w3c-linkchecker"
 else
     DOC_DEPENDS=''
 fi

--- a/debian/control.top.in
+++ b/debian/control.top.in
@@ -14,7 +14,7 @@ Build-Depends:
     @EXTRA_BUILD@,
     groff-base <!nodoc>,
     imagemagick <!nodoc>,
-    asciidoctor <!nodoc>,
+    asciidoctor,
     libunicode-linebreak-perl <!nodoc>,
     autoconf,
     automake,

--- a/src/configure.ac
+++ b/src/configure.ac
@@ -1067,16 +1067,15 @@ AC_ARG_ENABLE(build-documentation,
 # --enable-build-documentation=html).  =html itself warn-and-disables
 # only the missing PDF tools; users who want PDF best-effort can pass
 # =html and rebuild after installing the missing tools.
-if ( test "$BUILD_DOCS" = "yes" ) ; then
-    AC_PATH_PROG(ASCIIDOCTOR,asciidoctor,"none")
-    if ( test "none" = "$ASCIIDOCTOR" ) ; then
-        AC_MSG_WARN([no asciidoctor, documentation cannot be built
-install with "sudo apt-get install asciidoctor"])
-        BUILD_DOCS=no
-        BUILD_DOCS_PDF=no
-        BUILD_DOCS_HTML=no
-    fi
+# halcompile manpages need asciidoctor regardless of BUILD_DOCS.
+AC_PATH_PROG(ASCIIDOCTOR,asciidoctor,"none")
+if ( test "none" = "$ASCIIDOCTOR" ) ; then
+    AC_MSG_ERROR([no asciidoctor, manpages cannot be built
+install with "sudo apt-get install asciidoctor" on Debian / Ubuntu,
+"sudo dnf install rubygem-asciidoctor" on Fedora, or "gem install asciidoctor"])
+fi
 
+if ( test "$BUILD_DOCS" = "yes" ) ; then
     if ( test "$BUILD_DOCS" = "yes" ) ; then
         AC_PATH_PROG(GS,gs,"none")
         if ( test "none" = "$GS" ) ; then


### PR DESCRIPTION
## Summary

Fixes #4084.

`docs/src/Submakefile` builds manpages for halcompile components (`5axisgui.1` etc.) via `asciidoctor`, regardless of `--enable-build-documentation`. The configure probe added by #4053 was nested inside `if BUILD_DOCS = yes`, so `./configure --enable-run-in-place` (no docs opt-in) silently passed and `make` later crashed with `asciidoctor: command not found`.

Changes:
- `src/configure.ac`: probe moved out of the `BUILD_DOCS` gate; missing asciidoctor is now `AC_MSG_ERROR` with apt / dnf / gem install hints. PDF / HTML / Rouge probes stay gated.
- `debian/control.top.in`: drop `&lt;!nodoc&gt;` from `asciidoctor` (per @BsAtHome; even `nodoc` builds need it).
- `debian/configure`: remove now-duplicate `asciidoctor` from the head of `DOC_DEPENDS`.

## Test plan

- [x] `./configure --enable-run-in-place` with asciidoctor present: succeeds; `make ../docs/man/man1/5axisgui.1` builds.
- [x] After `apt remove asciidoctor`: configure aborts with `no asciidoctor, manpages cannot be built` + install hint, instead of failing inside `make`.
- [x] `./configure --enable-run-in-place --enable-build-documentation=html` + `make` builds full English HTML (585 pages, 453 manpage HTMLs, link checker clean).
- [x] Indentation of untouched lines preserved (blame intact on the GS / RSVG / Rouge probe blocks).
