### PR TITLE
Optimize docs

### DIFF
--- a/docs/src/Master_Developer.adoc
+++ b/docs/src/Master_Developer.adoc
@@ -7,7 +7,7 @@
 
 == Introduction
 
-image::common/images/emc2-intro.png[]
+image::common/images/emc2-intro.png[pdfwidth=25%]
 
 include::common/overleaf.adoc[]
 

--- a/docs/src/Master_Getting_Started.adoc
+++ b/docs/src/Master_Getting_Started.adoc
@@ -9,7 +9,7 @@ The LinuxCNC Team
 
 :leveloffset: 1
 
-image::common/images/emc2-intro.png[]
+image::common/images/emc2-intro.png[pdfwidth=25%]
 
 include::common/overleaf.adoc[]
 

--- a/docs/src/Submakefile
+++ b/docs/src/Submakefile
@@ -766,7 +766,8 @@ objects/LinuxCNC_Manual_Pages.adoc: objects/var-PDF_MAN_ORDER $(MAN_SRCS) $(DOC_
 	    echo ":doctype: book"; \
 	    echo ":source-highlighter: rouge"; \
 	    echo ":toc:"; \
-	    echo ":numbered:"; \
+	    echo ":outlinelevels: 1"; \
+	    echo ":toclevels: 1"; \
 	    echo; \
 	    for M in $(PDF_MAN_ORDER); do \
 	        if   [ -r "$(DOC_SRCDIR)/man/$$M.adoc" ]; then \

--- a/docs/src/code/code-notes.adoc
+++ b/docs/src/code/code-notes.adoc
@@ -100,7 +100,7 @@ document, both from the design point of view and from the developers
 point of view (where to find needed data, how to easily extend/modify
 things, etc.).
 
-image::LinuxCNC-block-diagram-small.png[align="center"]
+image::LinuxCNC-block-diagram-small.png[align="center",pdfwidth=100%]
 
 === LinuxCNC software architecture
 
@@ -151,7 +151,7 @@ or command line options.  Custom modules must implement all
 functions used by the default modules.  The halcompile utility
 can be used to create a custom module.
 
-image::LinuxCNC-motion-controller-small.png[align="center"]
+image::LinuxCNC-motion-controller-small.png[align="center",pdfwidth=100%]
 
 == Block diagrams and Data Flow
 
@@ -164,7 +164,7 @@ visible in the block diagram, such as coarse_pos, pos_cmd, and
 motor_pos_fb.
 
 .Joint Controller Block Diagram
-image::emc2-motion-joint-controller-block-diag.png[align="center"]
+image::emc2-motion-joint-controller-block-diag.png[align="center",pdfwidth=100%]
 
 The above figure shows five of the
 seven sets of position information that form the main data flow through
@@ -218,11 +218,11 @@ the motion controller. The seven forms of position data are as follows:
 
 === Homing state diagram
 
-image::homing.svg[align="center"]
+image::homing.svg[align="center",pdfwidth=100%]
 
 === Another homing diagram
 
-image::hss.svg[align="center"]
+image::hss.svg[align="center",pdfwidth=60%]
 
 == Commands
 
@@ -749,7 +749,7 @@ FIXME Backlash and Screw Error Compensation
 Task has three possible internal states: *E-stop*, *E-stop Reset*,
 and *Machine On*.
 
-image::task-state-transitions.svg[align="center"]
+image::task-state-transitions.svg[align="center",pdfwidth=45%]
 
 == IO controller (EMCIO)
 
@@ -859,7 +859,7 @@ use and allow for the message to be encoded if this option is chosen
 (encoded data will be covered later). The following figure is an
 internal view of the buffer space.
 
-image::CMS_buffer.png[align="center"]
+image::CMS_buffer.png[align="center",pdfwidth=35%]
 
 .CMS buffer
 The CMS base class is primarily responsible for creating the

--- a/docs/src/extensions/image_resolver.rb
+++ b/docs/src/extensions/image_resolver.rb
@@ -100,6 +100,7 @@ module LinuxCNCDocs
           if abs
             node.set_attr('target', pdf ? abs : swapped)
             apply_default_width(node) if pdf
+            apply_default_alignment(node) if pdf
             return
           end
         end
@@ -112,6 +113,7 @@ module LinuxCNCDocs
       return unless abs
       node.set_attr('target', abs)
       apply_default_width(node)
+      apply_default_alignment(node) if pdf
     end
 
     # Rewrite an `*_en.<ext>` filename to `*_<lang>.<ext>`.  The check
@@ -206,6 +208,13 @@ module LinuxCNCDocs
       return if node.attr('scaledwidth')
       return if node.attr('width')
       node.set_attr('pdfwidth', '75%')
+    end
+  
+    # center images by default if no alignmen is given
+    def apply_default_alignment(node)
+      return if node.context == :inline_image
+      return if node.attr('align')
+      node.set_attr('align', 'center')
     end
 
     def resolve_extension(path)

--- a/docs/src/getting-started/about-linuxcnc.adoc
+++ b/docs/src/getting-started/about-linuxcnc.adoc
@@ -48,7 +48,7 @@ LinuxCNC expects G-code that if not entered manually is provided by another soft
 == Architecture - Context diagram
 
 .Roles of operators, integrators, developers and hardware
-image::images/LCNC_Architecture_C1.drawio.svg["LinuxCNC Architecture - Context diagram",align="center"]
+image::images/LCNC_Architecture_C1.drawio.svg["LinuxCNC Architecture - Context diagram",align="center",pdfwidth=100%]
 
 The diagram presents the components and players of the LinuxCNC ecosystem and how they interact. It is not intended to help you understand the functionality of LinuxCNC. Please refer to the following chapters for this.
 

--- a/docs/src/index.tmpl
+++ b/docs/src/index.tmpl
@@ -59,7 +59,7 @@
 </div>
 </details>
 
-<details open="open">
+<details>
 <summary>General User Information</summary>
 <div class="details-list">
 	<ul>
@@ -74,7 +74,7 @@
 </div>
 </details>
 
-<details open="open">
+<details>
 <summary>Configuration Wizards</summary>
 <div class="details-list">
 	<ul>
@@ -84,7 +84,7 @@
 </div>
 </details>
 
-<details open="open">
+<details>
 <summary>Configuration</summary>
 <div class="details-list">
 	<ul>
@@ -102,7 +102,7 @@
 </div>
 </details>
 
-<details open="open">
+<details>
 <summary>HAL (Hardware Abstraction Layer)</summary>
 <div class="details-list">
 	<ul>
@@ -125,7 +125,7 @@
 </div>
 </details>
 
-<details open="open">
+<details>
 <summary>Hardware Drivers</summary>
 <div class="details-list">
 	<ul>
@@ -151,7 +151,7 @@
 </div>
 </details>
 
-<details open="open">
+<details>
 <summary>Hardware Examples</summary>
 <div class="details-list">
 	<ul>
@@ -163,7 +163,7 @@
 </div>
 </details>
 
-<details open="open">
+<details>
 <summary>ClassicLadder</summary>
 <div class="details-list">
 
@@ -176,7 +176,7 @@
 </div>
 </details>
 
-<details open="open">
+<details>
 <summary>Advanced Topics</summary>
 <div class="details-list">
 	<ul>
@@ -194,7 +194,7 @@
 </div>
 </details>
 
-<details open="open">
+<details>
 <summary>Integrator Information</summary>
 <div class="details-list">
 	<ul>
@@ -207,7 +207,7 @@
 
 <h3>Usage</h3>
 
-<details open="open">
+<details>
 <summary>User Interfaces</summary>
 <div class="details-list">
 	<ul>
@@ -224,7 +224,7 @@
 </div>
 </details>
 
-<details open="open">
+<details>
 <summary>G-code Programming</summary>
 <div class="details-list">
 	<ul>
@@ -245,7 +245,7 @@
 
 <h3>Customization &amp; Development</h3>
 
-<details open="open">
+<details>
 <summary>Virtual Control Panels</summary>
 <div class="details-list">
 	<ul>
@@ -266,7 +266,7 @@
 </div>
 </details>
 
-<details open="open">
+<details>
 <summary>User Interface Programming</summary>
 <div class="details-list">
 	<ul>
@@ -280,7 +280,7 @@
 </details>
 
 
-<details open="open">
+<details>
 <summary>Developer Information</summary>
 <div class="details-list">
 	<ul>
@@ -299,7 +299,7 @@
 
 <h3>General Information</h3>
 
-<details open="open">
+<details>
 <summary>Glossary, Copyright, History &amp; Overview</summary>
 <div class="details-list">
 	<ul>

--- a/docs/src/lathe/lathe-user.adoc
+++ b/docs/src/lathe/lathe-user.adoc
@@ -70,18 +70,18 @@ In AXIS the following figures show what the Tool Positions look like, as entered
 (((Tool Positions 1, 2, 3 & 4)))
 [[fig:Outil-Positions-1-2-3-4]]
 .Tool Positions 1, 2, 3 & 4
-image:images/tool-pos-1_en.svg["Tool Position 1"]
-image:images/tool-pos-2_en.svg["Tool Position 2"]
-image:images/tool-pos-3_en.svg["Tool Position 3"]
-image:images/tool-pos-4_en.svg["Tool Position 4"]
+image:images/tool-pos-1_en.svg["Tool Position 1", align=left, pdfwidth=24%]
+image:images/tool-pos-2_en.svg["Tool Position 2", align=left, pdfwidth=24%]
+image:images/tool-pos-3_en.svg["Tool Position 3", align=left, pdfwidth=24%]
+image:images/tool-pos-4_en.svg["Tool Position 4", align=left, pdfwidth=24%]
 
 (((Tool Positions 5, 6, 7 & 8)))
 [[fig:Outil-Positions-5-6-7-8]]
 .Tool Positions 5, 6, 7 & 8
-image:images/tool-pos-5_en.svg["Tool Position 5"]
-image:images/tool-pos-6_en.svg["Tool Position 6"]
-image:images/tool-pos-7_en.svg["Tool Position 7"]
-image:images/tool-pos-8_en.svg["Tool Position 8"]
+image:images/tool-pos-5_en.svg["Tool Position 5", align=left, pdfwidth=24%]
+image:images/tool-pos-6_en.svg["Tool Position 6", align=left, pdfwidth=24%]
+image:images/tool-pos-7_en.svg["Tool Position 7", align=left, pdfwidth=24%]
+image:images/tool-pos-8_en.svg["Tool Position 8", align=left, pdfwidth=24%]
 
 == Tool Touch Off
 

--- a/docs/src/lcnc-overrides.css
+++ b/docs/src/lcnc-overrides.css
@@ -399,3 +399,9 @@ h1{font-size:revert}
 h2{font-size:revert}
 h3,#toctitle,.sidebarblock>.content>.title{font-size:revert}
 h4,h5{font-size:revert}}
+
+.imageblock.text-left   > .title { text-align: left; }
+.imageblock.text-center > .title { text-align: center; }
+.imageblock.text-right  > .title { text-align: right; }
+.imageblock             > .title { margin-top: 0.5em;}
+  

--- a/docs/src/lcnc-overrides.css
+++ b/docs/src/lcnc-overrides.css
@@ -392,3 +392,10 @@ body:not(.article):not(.book):not(.manpage) tr:has(> th:only-child) > * {
     color: #f0f0f0;
   }
 }
+
+@media screen and (min-width:768px){
+h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{line-height:revert}
+h1{font-size:revert}
+h2{font-size:revert}
+h3,#toctitle,.sidebarblock>.content>.title{font-size:revert}
+h4,h5{font-size:revert}}

--- a/docs/src/man/man1/hal_input.1.adoc
+++ b/docs/src/man/man1/hal_input.1.adoc
@@ -57,9 +57,8 @@ with a dash. Each letter in the subset option specifies a device feature
 to *include*. Features that are not specified are excluded. For
 instance, to export keyboard LEDs to HAL without exporting keys, use
 
-____
-hal_input -L _keyboard_ ...
-____
+`hal_input -L keyboard ...`
+
 
 == DEVICE FEATURES SUPPORTED
 

--- a/docs/src/man/man1/halcmd.1.adoc
+++ b/docs/src/man/man1/halcmd.1.adoc
@@ -302,22 +302,18 @@ variable substitution take place.
 
 Environment variables have the following formats:
 
-____
-*$ENVVAR* followed by end-of-line or whitespace
+- *$ENVVAR* followed by end-of-line or whitespace
 
-*$(ENVVAR)*
-____
+- *$(ENVVAR)*
 
 === INI file variables
 
 INI file variables are available only when an INI file was specified
 with the halcmd *-i* flag. They have the following formats:
 
-____
-*[SECTION]VAR* followed by end-of-line or whitespace
+- *[SECTION]VAR* followed by end-of-line or whitespace
 
-*[SECTION](VAR)*
-____
+- *[SECTION](VAR)*
 
 == LINE CONTINUATION
 

--- a/docs/src/man/man1/vfdb_vfd.1.adoc
+++ b/docs/src/man/man1/vfdb_vfd.1.adoc
@@ -22,7 +22,6 @@ VFD-B must be reconfigured via the face plate by the integrator before
 it will work. This section gives a brief description of what changes
 need to be made, consult your Delta VFD-B manual for more details.
 
-____
 Switch the VFD-B to Modbus RTU frame format::
   Switch parameter 09-04 from the factory default of 0 (Ascii framing) to 3, 4, or 5 (RTU framing).
   The setting you choose will determine several serial parameters in addition to the Modbus framing protocol.
@@ -30,7 +29,6 @@ Set the frequency control source to be Modbus, not the keypad::
   Switch parameter 02-00 from factory default of 00 (keypad control) to 5 (control from RS-485).
 Set the run/stop control source to be Modbus, not the keypad:: Switch parameter 02-01 from the factory default of 0 (control from
   keypad) to 3 (control from Modbus, with Stop enabled on the keypad).
-____
 
 == OPTIONS
 

--- a/docs/src/man/man3/hal_type_t.3.adoc
+++ b/docs/src/man/man3/hal_type_t.3.adoc
@@ -27,7 +27,7 @@ typedef ... *real_t*;::
 typedef ... *ireal_t*;::
   A nonvolatile unsigned integral type the same size as *hal_float_t*.
 typedef enum *hal_type_t*;::
-  +
+  
   *HAL_BIT*;;
     Corresponds to the type *hal_bit_t*.
   *HAL_FLOAT*;;
@@ -43,10 +43,8 @@ typedef enum *hal_type_t*;::
 larger than just 0 and 1. When testing the value of a *hal_bit_t*, never
 compare it to 1. Prefer one of the following:
 
-____
 * if(b)
 * if(b != 0)
-____
 
 It is often useful to refer to a type that can represent all the values
 as a HAL type, but without the volatile qualifier. The following types

--- a/docs/src/man/man3/hm2_bspi_set_read_function.3.adoc
+++ b/docs/src/man/man3/hm2_bspi_set_read_function.3.adoc
@@ -20,9 +20,9 @@ to be called every time that the main Hostmot2 driver calls the generic
 printed with rtapi_print_msg during the driver loading process and take
 the form:
 
-____
+----
 hm2_<board name>.<board index>.bspi.<index>
-____
+----
 
 For example hm2_5i23.0.bspi.0.
 

--- a/docs/src/man/man9/hm2_7i43.9.adoc
+++ b/docs/src/man/man9/hm2_7i43.9.adoc
@@ -9,11 +9,10 @@ Anything IO board with HostMot2 firmware.
 
 **loadrt hm2_7i43 [ ioaddr=**__N__[,_N_...] ] [ **ioaddr_hi=**__N__[,_N_...] ] [ **epp_wide=**__N__[,_N_...] ] [ pass:[<strong>config=&quot;</strong>]__str[,str...]pass:[<strong>&quot;</strong>] ] [**debug_epp=**__N__[,_N_...] ]
 
-____
 *ioaddr* [default: 0 (parport0)]::
   The base address of the parallel port.
-
-The number of ioaddr indexes/addresses given is used by the driver to
+  +
+  The number of ioaddr indexes/addresses given is used by the driver to
 determine how many boards to search for.
 
 *ioaddr_hi* [default: 0]::
@@ -27,7 +26,6 @@ determine how many boards to search for.
   HostMot2 config strings, described in the hostmot2(9) manpage.
 *debug_epp* [default: 0]::
   Developer/debug use only! Enable debug logging of most EPP transfers.
-____
 
 == DESCRIPTION
 

--- a/docs/src/man/man9/hm2_7i90.9.adoc
+++ b/docs/src/man/man9/hm2_7i90.9.adoc
@@ -9,9 +9,8 @@ Anything IO board with HostMot2 firmware.
 
 **loadrt hm2_7i90** [**ioaddr=**__N__[,_N_...]] [**ioaddr_hi=**__N__[,_N_...]] [**epp_wide=**__N__[,_N_...]] [**debug_epp=**__N__[,_N_...]]
 
-____
 *ioaddr* [default: 0 (parport0)]:: The base address of the parallel port.
-
++
 The number of ioaddr indexes/addresses given is used by the driver to
 determine how many boards to search for. Previously the number of config
 strings was used, but a blank config string is perfectly acceptable for
@@ -28,7 +27,6 @@ strings was used, but a blank config string is perfectly acceptable for
   HostMot2 config strings, described in the hostmot2(9) manpage.
 *debug_epp* [default: 0]::
   Developer/debug use only! Enable debug logging of most EPP transfers.
-____
 
 == DESCRIPTION
 

--- a/docs/src/man/man9/hm2_eth.9.adoc
+++ b/docs/src/man/man9/hm2_eth.9.adoc
@@ -9,7 +9,6 @@ IO boards, with HostMot2 firmware.
 
 *loadrt hm2_eth* [**config=**"__str__[,__str__...]"] [**board_ip=**__ip__[,__ip__...] ] [**board_mac=**__mac__[,__mac__...] ] [**no_iptables=**__0|1__]
 
-____
 *config* [default: ""]::
   HostMot2 config strings, described in the hostmot2(9) manpage.
 *board_ip* [default: ""]::
@@ -25,7 +24,6 @@ ____
   rules manually using the recipe in the NOTES section below.  Set
   *no_iptables=1* when iptables is reachable but you prefer to manage
   the firewall externally (nftables, firewalld, systemd units).
-____
 
 == DESCRIPTION
 

--- a/docs/src/man/man9/hm2_pci.9.adoc
+++ b/docs/src/man/man9/hm2_pci.9.adoc
@@ -9,10 +9,8 @@ Anything IO boards, with HostMot2 firmware.
 
 *loadrt hm2_pci* [**config=**"__str__[,__str__...]"]
 
-____
 *config* [default: ""]::
   HostMot2 config strings, described in the hostmot2(9) manpage.
-____
 
 == DESCRIPTION
 

--- a/docs/src/man/man9/hm2_spi.9.adoc
+++ b/docs/src/man/man9/hm2_spi.9.adoc
@@ -9,7 +9,6 @@ driver for the Mesa Electronics SPI Anything IO boards, with HostMot2 firmware.
 
 *loadrt hm2_spi* [**config=**"__str__[,__str__...]"] [ **spidev_path=**_path_[,_path_...] ] [**spidev_rate=**__rate__[,__rate__...] ]
 
-____
 *config* [default: ""]::
   HostMot2 config strings, described in the hostmot2(9) manpage.
 *spidev_path* [default: "/dev/spidev1.0"]::
@@ -18,7 +17,6 @@ ____
   The desired rate of the SPI clock in kHz. If the exact specified clock
   is not available, a lower clock is used. Due to shortcomings in the
   spidev API, it is not possible for hal to report the actual clock used.
-____
 
 == DESCRIPTION
 

--- a/docs/src/pdf-theme.yml
+++ b/docs/src/pdf-theme.yml
@@ -128,3 +128,8 @@ table:
     border_bottom_width: 1
   border_color: CCCCCC
   cell_padding: 4
+
+image:
+  caption:
+    align: inherit
+    text-align: inherit

--- a/docs/src/plasma/plasma-cnc-primer.adoc
+++ b/docs/src/plasma/plasma-cnc-primer.adoc
@@ -83,7 +83,7 @@ A slight variation in cut angles may be normal, as long as it is within toleranc
 The ability to precisely control the cutting height in such a hostile and ever changing environment is a very difficult challenge.
 Fortunately there is a very linear relationship between Torch height (Arc length) and arc voltage as this graph shows.
 
-image::images/primer_volts-height.png[width=50%]
+image::images/primer_volts-height.png[width=75%]
 
 This graph was prepared from a sample of about 16,000 readings at varying cut height and the regression analysis shows 7.53 V/mm with 99.4% confidence.
 In this particular instance this sample was taken from an Everlast 50 A machine being controlled by LinuxCNC.


### PR DESCRIPTION
Some optical fixes:

1. The default asciidoctor CSS scales the font up the window width > 768px, this looks too big --> revert this rule.
2. Align the caption of images according to the alignment of the image itself, default center align images .
3. Remove the "Chapter ###" from the PDF sidebar TOC, set inline level to so that we get a flat list of the man pages there
4. Set image width for images that doesn't fit into the default 75% scheme
5. Fix formatting of those block which renders as quote with asciidoctor
    ```
     ____
    ...
     ____ 
    ```