### PR TITLE
interp: add new ini setting disabling auto reset to G54 on M2,M30

### DIFF
--- a/docs/src/config/ini-config.adoc
+++ b/docs/src/config/ini-config.adoc
@@ -635,6 +635,8 @@ The maximum number of `USER_M_PATH` directories is defined at compile time (typ:
   Warn rather than error in case of errors in O-word subroutines.
 * `DISABLE_G92_PERSISTENCE = 0` (Default: 0)
   Allow to clear the G92 offset automatically when config start-up.
+* `DISABLE_AUTO_G54 = 0` (bool, Default: 0) +
+  When set M2 and M30 will no longer automatically reset the active WCS to 'G54'.
 * `DISABLE_FANUC_STYLE_SUB = 0` (Default: 0)
   If there is reason to disable Fanuc subroutines set it to 1.
 * 'G73_PECK_CLEARANCE = .020' (default: Metric machine: 1mm, imperial machine: .050 inches)

--- a/docs/src/gcode/m-code.adoc
+++ b/docs/src/gcode/m-code.adoc
@@ -67,7 +67,7 @@ to stop after each line of input anyway.
 Both of these commands have the following effects:
 
 * Change from Auto mode to MDI mode.
-* Origin offsets are set to the default (like 'G54').
+* Origin offsets are set to the default (like 'G54') unless disabled by INI setting 'DISABLE_AUTO_G54 = 1'.
 * Selected plane is set to XY plane (like 'G17').
 * Distance mode is set to absolute mode (like 'G90').
 * Feed rate mode is set to units per minute (like 'G94').

--- a/src/emc/ini/linuxcnc_check_ini.py
+++ b/src/emc/ini/linuxcnc_check_ini.py
@@ -236,6 +236,7 @@ def check_bools():
                 ("RS274NGC", "NO_DOWNCASE_OWORD"),
                 ("RS274NGC", "OWORD_WARN_ONLY"),
                 ("RS274NGC", "DISABLE_G92_PERSISTENCE"),
+                ("RS274NGC", "DISABLE_AUTO_G54"),
                 ("RS274NGC", "DISABLE_FANUC_STYLE_SUB"),
                 ("DISPLAY", "DISABLE_CONE_SCALING"),
                 ("DISPLAY", "HOMING_PROMPT"),

--- a/src/emc/rs274ngc/interp_convert.cc
+++ b/src/emc/rs274ngc/interp_convert.cc
@@ -5163,52 +5163,55 @@ int Interp::convert_stop(block_pointer block,    //!< pointer to a block of RS27
             ) {   /* reset stuff here */
 
 /*1*/
-    rotate(&settings->current_x, &settings->current_y, settings->rotation_xy);
-    settings->current_x += settings->origin_offset_x;
-    settings->current_y += settings->origin_offset_y;
-    settings->current_z += settings->origin_offset_z;
-    settings->AA_current += settings->AA_origin_offset;
-    settings->BB_current += settings->BB_origin_offset;
-    settings->CC_current += settings->CC_origin_offset;
-    settings->u_current += settings->u_origin_offset;
-    settings->v_current += settings->v_origin_offset;
-    settings->w_current += settings->w_origin_offset;
 
-    settings->origin_index = 1;
-    settings->parameters[5220] = 1.0;
-    settings->origin_offset_x = USER_TO_PROGRAM_LEN(settings->parameters[5221]);
-    settings->origin_offset_y = USER_TO_PROGRAM_LEN(settings->parameters[5222]);
-    settings->origin_offset_z = USER_TO_PROGRAM_LEN(settings->parameters[5223]);
-    settings->AA_origin_offset = USER_TO_PROGRAM_ANG(settings->parameters[5224]);
-    settings->BB_origin_offset = USER_TO_PROGRAM_ANG(settings->parameters[5225]);
-    settings->CC_origin_offset = USER_TO_PROGRAM_ANG(settings->parameters[5226]);
-    settings->u_origin_offset = USER_TO_PROGRAM_LEN(settings->parameters[5227]);
-    settings->v_origin_offset = USER_TO_PROGRAM_LEN(settings->parameters[5228]);
-    settings->w_origin_offset = USER_TO_PROGRAM_LEN(settings->parameters[5229]);
-    settings->rotation_xy = settings->parameters[5230];
+    if (!settings->disable_auto_g54) {
+        rotate(&settings->current_x, &settings->current_y, settings->rotation_xy);
+        settings->current_x += settings->origin_offset_x;
+        settings->current_y += settings->origin_offset_y;
+        settings->current_z += settings->origin_offset_z;
+        settings->AA_current += settings->AA_origin_offset;
+        settings->BB_current += settings->BB_origin_offset;
+        settings->CC_current += settings->CC_origin_offset;
+        settings->u_current += settings->u_origin_offset;
+        settings->v_current += settings->v_origin_offset;
+        settings->w_current += settings->w_origin_offset;
 
-    settings->current_x -= settings->origin_offset_x;
-    settings->current_y -= settings->origin_offset_y;
-    settings->current_z -= settings->origin_offset_z;
-    settings->AA_current -= settings->AA_origin_offset;
-    settings->BB_current -= settings->BB_origin_offset;
-    settings->CC_current -= settings->CC_origin_offset;
-    settings->u_current -= settings->u_origin_offset;
-    settings->v_current -= settings->v_origin_offset;
-    settings->w_current -= settings->w_origin_offset;
-    rotate(&settings->current_x, &settings->current_y, -settings->rotation_xy);
+        settings->origin_index = 1;
+        settings->parameters[5220] = 1.0;
+        settings->origin_offset_x = USER_TO_PROGRAM_LEN(settings->parameters[5221]);
+        settings->origin_offset_y = USER_TO_PROGRAM_LEN(settings->parameters[5222]);
+        settings->origin_offset_z = USER_TO_PROGRAM_LEN(settings->parameters[5223]);
+        settings->AA_origin_offset = USER_TO_PROGRAM_ANG(settings->parameters[5224]);
+        settings->BB_origin_offset = USER_TO_PROGRAM_ANG(settings->parameters[5225]);
+        settings->CC_origin_offset = USER_TO_PROGRAM_ANG(settings->parameters[5226]);
+        settings->u_origin_offset = USER_TO_PROGRAM_LEN(settings->parameters[5227]);
+        settings->v_origin_offset = USER_TO_PROGRAM_LEN(settings->parameters[5228]);
+        settings->w_origin_offset = USER_TO_PROGRAM_LEN(settings->parameters[5229]);
+        settings->rotation_xy = settings->parameters[5230];
 
-    SET_G5X_OFFSET(settings->origin_index,
-                   settings->origin_offset_x,
-                   settings->origin_offset_y,
-                   settings->origin_offset_z,
-                   settings->AA_origin_offset,
-                   settings->BB_origin_offset,
-                   settings->CC_origin_offset,
-                   settings->u_origin_offset,
-                   settings->v_origin_offset,
-                   settings->w_origin_offset);
-    SET_XY_ROTATION(settings->rotation_xy);
+        settings->current_x -= settings->origin_offset_x;
+        settings->current_y -= settings->origin_offset_y;
+        settings->current_z -= settings->origin_offset_z;
+        settings->AA_current -= settings->AA_origin_offset;
+        settings->BB_current -= settings->BB_origin_offset;
+        settings->CC_current -= settings->CC_origin_offset;
+        settings->u_current -= settings->u_origin_offset;
+        settings->v_current -= settings->v_origin_offset;
+        settings->w_current -= settings->w_origin_offset;
+        rotate(&settings->current_x, &settings->current_y, -settings->rotation_xy);
+
+        SET_G5X_OFFSET(settings->origin_index,
+                       settings->origin_offset_x,
+                       settings->origin_offset_y,
+                       settings->origin_offset_z,
+                       settings->AA_origin_offset,
+                       settings->BB_origin_offset,
+                       settings->CC_origin_offset,
+                       settings->u_origin_offset,
+                       settings->v_origin_offset,
+                       settings->w_origin_offset);
+        SET_XY_ROTATION(settings->rotation_xy);
+    }
 
 /*2*/ if (settings->plane != CANON_PLANE::XY) {
       SELECT_PLANE(CANON_PLANE::XY);

--- a/src/emc/rs274ngc/interp_internal.hh
+++ b/src/emc/rs274ngc/interp_internal.hh
@@ -825,6 +825,7 @@ struct setup
     bool loop_on_main_m99;
 
   int disable_g92_persistence;
+  bool disable_auto_g54;
 
 // add new geometric fields for our new tags
   double heading;

--- a/src/emc/rs274ngc/interp_setup.cc
+++ b/src/emc/rs274ngc/interp_setup.cc
@@ -187,6 +187,7 @@ setup::setup() :
     disable_fanuc_style_sub(false),
     loop_on_main_m99(false),
     disable_g92_persistence(0),
+    disable_auto_g54(false),
     heading(0.0),
     radius(0.0),
     center_x(0.0),

--- a/src/emc/rs274ngc/rs274ngc_pre.cc
+++ b/src/emc/rs274ngc/rs274ngc_pre.cc
@@ -1073,6 +1073,8 @@ int Interp::init()
 
           // INI file g52/g92 offset persistence default setting
           _setup.disable_g92_persistence = inifile.findBoolV("DISABLE_G92_PERSISTENCE", "RS274NGC", false);
+          // INI file automatic reset to g54 on program stop default setting
+          _setup.disable_auto_g54 = inifile.findBoolV("DISABLE_AUTO_G54", "RS274NGC", false);
 
           // INI file m98/m99 subprogram default setting
           _setup.disable_fanuc_style_sub = inifile.findBoolV("DISABLE_FANUC_STYLE_SUB", "RS274NGC", false);

--- a/src/emc/usr_intf/pncconf/build_INI.py
+++ b/src/emc/usr_intf/pncconf/build_INI.py
@@ -176,6 +176,9 @@ class INI:
         print(file=file)
         print("[RS274NGC]", file=file)
         print("PARAMETER_FILE = linuxcnc.var", file=file)
+        print("# Set 'DISABLE_AUTO_G54 = 1' to disable", file=file)
+        print("# automatic resetting of the active WCS to 'G54' on M2 and M30", file=file)
+        print("DISABLE_AUTO_G54 = 0", file=file)
         # qtplasmac has extra rs274ngc variables
         if self.d.frontend == _PD._QTPLASMAC:
             code = 21 if self.d.units == _PD._METRIC else 20


### PR DESCRIPTION
As requested here:
https://forum.linuxcnc.org/38-general-linuxcnc-questions/58821-how-to-remove-automatic-g54-after-m2-m30#346816

Adds a new ini file setting to disable the automatic resetting of the current WCS to G54 on M2 and M30.

Setting defaults to '0' so this modification is opt-in and default behavior is unchanged.


