### PR TITLE
fix(interp): don't fseek(NULL) on M99 in MDI

### DIFF
--- a/src/emc/rs274ngc/interp_convert.cc
+++ b/src/emc/rs274ngc/interp_convert.cc
@@ -5150,16 +5150,21 @@ int Interp::convert_stop(block_pointer block,    //!< pointer to a block of RS27
     PROGRAM_STOP();
   } else if (block->m_modes[4] == 1) {
     OPTIONAL_PROGRAM_STOP();
-  } else if (block->m_modes[4] == 99 && _setup.loop_on_main_m99) {
+  } else if (block->m_modes[4] == 99 && _setup.loop_on_main_m99 &&
+             settings->file_pointer != NULL) {
 
     // Fanuc-style M99 main program endless loop
+    // Only loops when running from a file; in MDI there is no file to
+    // seek back to, so M99 falls through to the M2/M30 program-end path
+    // below (avoids a fseek(NULL) segfault).
     logDebug("M99 main program endless loop");
 
     loop_to_beginning(settings);  // return control to beginning of file
     FINISH();  // Output any final linked segments
     return INTERP_EXECUTE_FINISH;  // tell task to issue any queued commands
   } else if ((block->m_modes[4] == 2) || (block->m_modes[4] == 30) ||
-            (block->m_modes[4] == 99 && !_setup.loop_on_main_m99)
+            (block->m_modes[4] == 99 &&
+             (!_setup.loop_on_main_m99 || settings->file_pointer == NULL))
             ) {   /* reset stuff here */
 
 /*1*/

--- a/src/emc/rs274ngc/interp_o_word.cc
+++ b/src/emc/rs274ngc/interp_o_word.cc
@@ -523,7 +523,8 @@ void Interp::loop_to_beginning(setup_pointer settings)
 	     settings->filename);
 
     // scroll back to beginning of file/first block
-    fseek(settings->file_pointer, 0, SEEK_SET);
+    if (settings->file_pointer != NULL)
+        fseek(settings->file_pointer, 0, SEEK_SET);
     settings->sequence_number = 0;
 }
 


### PR DESCRIPTION
## Problem

Entering `M99` as an MDI command crashes `milltask` with SIGSEGV. Gmoccapy and QTdragon die; AXIS happens to survive. Reported in #4094.

Backtrace:
```
#5  fseek () from libc.so.6
#6  Interp::loop_to_beginning (...) at emc/rs274ngc/interp_o_word.cc:526
#7  Interp::convert_stop (...) at emc/rs274ngc/interp_convert.cc
#8  Interp::execute_block (...)
...
#12 emcTaskPlanExecute (command="m99", ...)
```

## Cause

Task always enables `loop_on_main_m99` (`emctask.cc`), so `M99` in the main program takes the Fanuc endless-loop branch in `convert_stop()`, which calls `loop_to_beginning()` -> `fseek(settings->file_pointer, 0, SEEK_SET)`. In MDI there is no open g-code file, so `file_pointer` is `NULL` and `fseek(NULL)` segfaults.

## Fix

- Require `file_pointer != NULL` to take the M99 loop branch. In MDI, `M99` now falls through to the existing `M2`/`M30` program-end path, which already null-guards `file_pointer`. This matches AXIS-style "end" behavior.
- Add a defensive `NULL` check in `loop_to_beginning()`.

## Testing

Built against current master. Verified on Gmoccapy: `M99` in MDI no longer crashes.

Fixes #4094