### PR TITLE
qtvcp probe help: load first help page lazily

### DIFF
--- a/lib/python/qtvcp/widgets/basic_probe.py
+++ b/lib/python/qtvcp/widgets/basic_probe.py
@@ -609,10 +609,10 @@ class HelpDialog(QtWidgets.QDialog, GeometryMixin):
         l.addWidget(bBox)
         self.setLayout(l)
 
-        try:
-            self.next(t)
-        except Exception as e:
-                t.setText('Basic Probe Help file Unavailable:\n\n{}'.format(e))
+        # Load the first help page lazily (on first show): pre-scaling its
+        # images at construction can hang or crash qtvcp headless.
+        self._helpText = t
+        self._helpLoaded = False
 
     def _set_scaled_html(self, t, html):
         # QTextEdit scales raster images with a nearest-neighbour filter, which
@@ -686,6 +686,12 @@ class HelpDialog(QtWidgets.QDialog, GeometryMixin):
         super(HelpDialog, self).close()
 
     def showDialog(self):
+        if not self._helpLoaded:
+            try:
+                self.next(self._helpText)
+            except Exception as e:
+                self._helpText.setText('Basic Probe Help file Unavailable:\n\n{}'.format(e))
+            self._helpLoaded = True
         self.setWindowTitle(self._title);
         self.set_geometry()
         retval = self.exec()

--- a/lib/python/qtvcp/widgets/versa_probe.py
+++ b/lib/python/qtvcp/widgets/versa_probe.py
@@ -683,10 +683,10 @@ class HelpDialog(QtWidgets.QDialog, GeometryMixin):
         l.addWidget(bBox)
         self.setLayout(l)
 
-        try:
-            self.next(t)
-        except Exception as e:
-                t.setText('Versa Probe Help file Unavailable:\n\n{}'.format(e))
+        # Load the first help page lazily (on first show): pre-scaling its
+        # images at construction can hang or crash qtvcp headless.
+        self._helpText = t
+        self._helpLoaded = False
 
     def _set_scaled_html(self, t, html):
         # QTextEdit scales raster images with a nearest-neighbour filter, which
@@ -757,6 +757,12 @@ class HelpDialog(QtWidgets.QDialog, GeometryMixin):
         super(HelpDialog, self).close()
 
     def showDialog(self):
+        if not self._helpLoaded:
+            try:
+                self.next(self._helpText)
+            except Exception as e:
+                self._helpText.setText('Versa Probe Help file Unavailable:\n\n{}'.format(e))
+            self._helpLoaded = True
         self.setWindowTitle(self._title);
         self.set_geometry()
         retval = self.exec()


### PR DESCRIPTION
## Problem

qtdragon (and any qtvcp screen using the basic-probe or versa-probe widgets) can hang or crash at startup on a headless / no-GPU Qt platform (`QT_QPA_PLATFORM=offscreen`, no GPU). I hit this consistently on a CI runner and reproduced it in a plain `ubuntu:24.04` container with no GPU: qtvcp never finishes coming up, so the GUI fails to start.

## Root cause

The basic-probe and versa-probe help dialogs preload their first help page during widget construction (`buildWidget`, called from `hal_init`). Since the help loader gained smooth image pre-scaling (`_set_scaled_html`, `QImage` with `SmoothTransformation`), that preload now builds and scales the raster help diagrams at startup.

That scaling on the startup path is what breaks headless: in my no-GPU container qtvcp hangs there; on the CI runner it segfaults. I confirmed it by bisecting the qtvcp Python in the container:

- qtdragon ui-smoke as-is: fail (hang in container, segfault on CI)
- revert `versa_probe.py` + `basic_probe.py` to before the smooth-scale change: pass
- keep the files but stub `_set_scaled_html` to a plain `setHtml` (kill only the scaling): pass

So the regression is specifically the image scaling running during construction. It is also wasted work whenever the operator never opens the help dialog.

## Fix

Defer the first-page load from `buildWidget` to the first `showDialog()` call, in both `basic_probe.py` and `versa_probe.py`. The help looks and behaves identically when opened; the image scaling just no longer runs on the startup path.

## Testing

In a no-GPU `ubuntu:24.04` container (RIP build, offscreen platform), running the qtdragon GUI smoke test:

- before: qtdragon fails to come up
- after: qtdragon `UI_SMOKE_OK`; touchy smoke unchanged (control)
