### PR TITLE
latency/histo binstream: fix FIFO sizing and fail visibly on error

### DIFF
--- a/scripts/hal-histogram
+++ b/scripts/hal-histogram
@@ -135,6 +135,8 @@ proc set_defaults {} {
   set ::HH(warning_active)  0
   set ::HH(reread,ct)       0
   set ::HH(bump,ct)         0
+  set ::HH(timeout,ct)      0
+  set ::HH(timeout,warned)  0
   set ::HH(after,repeat)   ""
   set ::HH(after,monitor)  ""
   set ::HH(p,more)          0
@@ -427,6 +429,25 @@ proc finish {} {
   } ;# avoid some msgs on close
   exit 0
 } ;# finish
+
+# Report an unrecoverable error visibly, then tear down and quit so the
+# tool never lingers in a broken, non-updating state.
+proc fatal {msg} {
+  catch {after cancel $::HH(after,repeat)}
+  popup $msg
+  if {[info exists ::HH(stream,h)]} {
+    catch {hal_stream detach $::HH(stream,h)}
+    unset ::HH(stream,h)
+  }
+  catch {
+    hal delf $::HH(instance) $::HH(threadname)
+    hal unlinkp $::HH(inputpinname)
+    if $::HH(signame_is_new) {
+      hal delsig $::HH(signame)
+    }
+  } ;# avoid some msgs on close
+  exit 1
+} ;# fatal
 
 proc repeat {} {
   after cancel $::HH(after,repeat)
@@ -755,13 +776,23 @@ proc acquire_bins_stream {} {
     if {$tries > 250} {
       hal setp $::HH(instance).stream 0
       if {[hal getp $::HH(instance).stream-error]} {
-        puts "$::HH(prog): stream-error set (FIFO too small for $need records)"
-      } else {
-        puts "$::HH(prog): stream timeout (depth [hal_stream depth $h] < $need)"
+        # Hard error: the RT side reports the FIFO cannot hold a full
+        # set, so it never streams. This cannot recover, so report it
+        # visibly and quit rather than leaving a dead window spinning.
+        fatal "$::HH(prog): stream-error set (FIFO too small for $need records).\n\nThe histobinstream FIFO cannot hold a complete data set.\nThis is a build/configuration error and will not recover."
+      }
+      # A plain timeout may be transient. Surface it visibly once it
+      # persists rather than only spamming the console each cycle.
+      puts "$::HH(prog): stream timeout (depth [hal_stream depth $h] < $need)"
+      incr ::HH(timeout,ct)
+      if {$::HH(timeout,ct) >= 5 && !$::HH(timeout,warned)} {
+        set ::HH(timeout,warned) 1
+        popup "$::HH(prog): repeated stream timeouts (depth < $need).\n\nThe histogram is not updating."
       }
       return ""
     }
   }
+  set ::HH(timeout,ct) 0
   set vals [hal_stream drain $h]
   hal setp $::HH(instance).stream 0
   # After drain the FIFO must be empty; non-zero means we read out of

--- a/scripts/latency-histogram
+++ b/scripts/latency-histogram
@@ -593,6 +593,8 @@ proc start_collection {} {
   foreach thd $::LH(threads) {
     set ::LH($thd,reread,ct) 0
     set ::LH($thd,bump,ct) 0
+    set ::LH($thd,timeout,ct) 0
+    set ::LH($thd,timeout,warned) 0
     set availablebins [hal getp $::LH($thd,name).availablebins]
     if {$availablebins < $::LH($thd,maxbins)} {
        if $::LH(use_x) { wm iconify . }
@@ -747,13 +749,23 @@ proc update_bin_data {thd} {
       if {$tries > 250} {
         hal setp $::LH($thd,name).stream 0
         if {[hal getp $::LH($thd,name).stream-error]} {
-          puts "$thd: stream-error set (FIFO too small for $need records)"
-        } else {
-          puts "$thd: stream timeout (depth [hal_stream depth $h] < $need)"
+          # Hard error: the RT side reports the FIFO cannot hold a full
+          # set, so it never streams. This cannot recover, so report it
+          # visibly and quit rather than leaving a dead window spinning.
+          fatal "$thd: stream-error set (FIFO too small for $need records).\n\nThe latencybinstream FIFO cannot hold a complete data set.\nThis is a build/configuration error and will not recover."
+        }
+        # A plain timeout may be transient. Surface it visibly once it
+        # persists rather than only spamming the console each cycle.
+        puts "$thd: stream timeout (depth [hal_stream depth $h] < $need)"
+        incr ::LH($thd,timeout,ct)
+        if {$::LH($thd,timeout,ct) >= 5 && !$::LH($thd,timeout,warned)} {
+          set ::LH($thd,timeout,warned) 1
+          popup "$thd: repeated stream timeouts (depth < $need).\n\nThe histogram is not updating for this thread."
         }
         return
       }
     }
+    set ::LH($thd,timeout,ct) 0
     set vals [hal_stream drain $h]
     hal setp $::LH($thd,name).stream 0
     # After drain the FIFO must be empty; non-zero means we read out of
@@ -877,6 +889,22 @@ proc popup {msg} { \
      ]
    puts $msg
 } ;# popup
+
+# Report an unrecoverable error visibly, then tear down and quit so the
+# tool never lingers in a broken, non-updating state.
+proc fatal {msg} {
+  catch {after cancel $::LH(after,repeat)}
+  popup $msg
+  foreach thd $::LH(threads) {
+    if {[info exists ::LH($thd,stream,h)]} {
+      catch {hal_stream detach $::LH($thd,stream,h)}
+      unset ::LH($thd,stream,h)
+    }
+  }
+  catch {exec pkill glxgears}
+  catch {exec halrun -U}
+  exit 1
+} ;# fatal
 
 proc progress {txt} {
   if !$::LH(verbose) return

--- a/src/hal/components/histobinstream.comp
+++ b/src/hal/components/histobinstream.comp
@@ -121,9 +121,10 @@ EXTRA_SETUP() {
         return -EINVAL;
 
     int err;
-    // The stream buffer should be able to contain one complete set of data:
-    // the negative tail, every bin and the positive tail.
-    if (0 != (err = hal_stream_create(&fifo, comp_id, keys[extra_arg], MAXBINNUMBER + 2, "u")))
+    // One complete set is MAXBINNUMBER+2 records: the negative tail, every
+    // bin and the positive tail. The ring buffer's usable capacity is depth-1
+    // (one slot reserved), so add 1 to fit it.
+    if (0 != (err = hal_stream_create(&fifo, comp_id, keys[extra_arg], MAXBINNUMBER + 2 + 1, "u")))
         return err;
     // The other side should run hal_stream_attach(&fifo, comp_id, key, "u")
     return 0;

--- a/src/hal/components/latencybinstream.comp
+++ b/src/hal/components/latencybinstream.comp
@@ -101,8 +101,9 @@ EXTRA_SETUP() {
 	if (extra_arg < 0 || extra_arg >= MAX_INST || !keys[extra_arg])
 		return -EINVAL;
 	int err;
-	// The stream buffer should be able to contain one complete set of data
-	if (0 != (err = hal_stream_create(&fifo, comp_id, keys[extra_arg], 2*MAXBINNUMBER + 1 + 2, "u")))
+	// One complete set is 2*MAXBINNUMBER+1+2 records. The ring buffer's
+	// usable capacity is depth-1 (one slot reserved), so add 1 to fit it.
+	if (0 != (err = hal_stream_create(&fifo, comp_id, keys[extra_arg], 2*MAXBINNUMBER + 1 + 2 + 1, "u")))
 		return err;
 	// The other side should run hal_stream_attach(&fifo, comp_id, LBSKEY, "u")
 	return 0;


### PR DESCRIPTION
Fixes #4101

## FIFO sizing

The `hal_stream` ring buffer keeps one slot permanently empty to tell full from empty apart, so its usable capacity is `depth - 1`. Both histogram stream components sized their FIFO to exactly one snapshot, so at the maximum bin count the last record overran and the reader waited forever for a depth that never arrived:

| component | FIFO depth | one set | usable | broke at |
|-----------|-----------|---------|--------|----------|
| latencybinstream | `2*MAXBINNUMBER+1+2` = 2003 | 2003 | 2002 | `--sbins 1000` |
| histobinstream | `MAXBINNUMBER+2` = 202 | `nbins+2` = 202 | 201 | `--nbins 200` |

This is why `--sbins 999` worked but `--sbins 1000` failed with:

```
servo: stream timeout (depth 2002 < 2003)
servo: stream-error set (FIFO too small for 2003 records)
```

Each component now allocates one extra slot so a complete set always fits.

## Error handling

Following rodw's note that the tool should not open in a broken state: the stream read loop previously only printed to the console and returned, leaving the window open, blank and non-updating while spamming the console every cycle.

- A hard `stream-error` (FIFO too small) is unrecoverable, so it now pops up a dialog and quits via a new `fatal` proc, matching the existing `availablebins` startup check.
- A plain timeout may be transient, so it now raises a one-shot visible warning after it persists rather than only logging to the console.

Both `latency-histogram` and `hal-histogram` get the matching changes.