### PR TITLE
docs: fix malformed and dangling cross-references

### DIFF
--- a/docs/src/config/pncconf.adoc
+++ b/docs/src/config/pncconf.adoc
@@ -66,7 +66,7 @@ Just like a railroad, LinuxCNC requires everything on a very tight and consisten
 LinuxCNC requires and uses a 'real-time' operating system, which just means it has a low-latency (lateness) response time.
 When LinuxCNC requires and is performing calculations, it cannot be interrupted by lower priority requests (such as user input to screen buttons or drawing etc).
 
-Testing the latency is crucial and a key thing to check before proceeding further. Please follow the directions on the <<sub:install:sec:latency-test,Latency Test>> page before proceeding further.
+Testing the latency is crucial and a key thing to check before proceeding further. Please follow the directions on the <<sec:latency-test,Latency Test>> page before proceeding further.
 
 Now we are happy with the latency and must pick a servo period.
 In most cases a servo period of 1000000 ns is fine (that gives a 1 kHz servo calculation rate - 1000 calculations a second).

--- a/docs/src/gcode/o-code.adoc
+++ b/docs/src/gcode/o-code.adoc
@@ -17,6 +17,7 @@ O-codes are also sometimes called o-words and these terms are interchangeable.
 Using the lower case 'o' makes it easier to distinguish from a 0 that might have been mistyped.
 For example 'o100' is easier to see than 'O100' that it is not a '0'.
 
+[[ocode:numbering]]
 == Numbering
 
 There are two categories of o-codes with different scoping rules:
@@ -80,7 +81,7 @@ change in the future.
 The behavior is undefined if:
 
 * The same number is used for more than one block within the same scope
-  (see <<Numbering>> for scoping rules).
+  (see <<ocode:numbering>> for scoping rules).
 * Other words are used on a line with an o-word.
 * Comments are used on a line with an o-word.
 

--- a/docs/src/gui/qtvcp-widgets.adoc
+++ b/docs/src/gui/qtvcp-widgets.adoc
@@ -425,7 +425,7 @@ This widget allows a user to *set a HAL pin true or false* with the push of a bu
 
 As an option it can be a _toggle button_.
 
-For  a _LED Indicator Option_, see <<sub:qtvcp:widgets:indicatedpushbutton>>[IndicatedPushButton] below for more info.
+For  a _LED Indicator Option_, see <<sub:qtvcp:widgets:indicatedpushbutton,IndicatedPushButton>> below for more info.
 
 It also has other options.
 
@@ -649,7 +649,7 @@ MDI_COMMAND_MACRO1 = G53 G0 Z0;G53 G0 X0 Y0, Goto\nMachn\nZero
 
 //FIXME add link to Indicated_PushButton section
 Action buttons are subclassed from
-<<sub:qtvcp:widgets:indicatedpushbutton>>[`IndicatedPushButton`].
+<<sub:qtvcp:widgets:indicatedpushbutton,`IndicatedPushButton`>>.
 See the following sections for more information about:
 
 * <<sub:qtvcp:widgets:indicatedpushbutton:led,LED Indicator option>>

--- a/docs/src/plasma/qtplasmac.adoc
+++ b/docs/src/plasma/qtplasmac.adoc
@@ -2590,7 +2590,7 @@ If SLOW jogging is already active, the axis will jog at the displayed jog speed.
 === MDI
 
 In addition to the typical G and M codes that are allowed by LinuxCNC in MDI mode, the MDI in QtPlasmaC can be used to access several other handy features.
-The following link outlines the features and their use: <<sub:qtvcp:widgets:mdiline>>[MDILine Widget]
+The following link outlines the features and their use: <<sub:qtvcp:widgets:mdiline,MDILine Widget>>
 
 [NOTE]
 M3, M4, and M5 are not allowed in the QtPlasmaC MDI.

--- a/docs/src/remap/remap.adoc
+++ b/docs/src/remap/remap.adoc
@@ -172,7 +172,6 @@ When done, redefine the existing code to use your remapping setup.
 Let's assume the new code will be defined by an NGC procedure, and needs some parameters, some of which might be required, others might be optional.
 We have the following options to feed values to the procedure:
 
-// . <<remap:extracting-words,extracting words from the current block>>
 . Extracting words from the current block and pass them to the procedure as parameters (like `X22.34` or `P47`),
 . referring to <<gcode:ini-hal-params,INI file variables>>,
 . referring to global variables (like `#2200 = 47.11` or `#<_global_param> = 315.2`).


### PR DESCRIPTION
Five source-level cross-reference bugs found while auditing the doc links. Independent of the resolver (#4100); these are wrong in the source regardless.

- **qtvcp-widgets.adoc** (x2), **qtplasmac.adoc**: `<<id>>[Label]` is malformed. The `[Label]` leaked as literal text after the link instead of being the link text. Fixed to `<<id,Label>>`.
- **o-code.adoc**: `<<Numbering>>` had no matching anchor (the section's auto id is `_numbering`), so it rendered as literal `[Numbering]`. Added an explicit `[[ocode:numbering]]` anchor, matching the file's convention.
- **pncconf.adoc**: `<<sub:install:sec:latency-test,...>>` used a stale prefix; the real anchor is `sec:latency-test`.
- **remap.adoc**: dropped a commented-out line carrying a dangling `<<remap:extracting-words>>` ref (a stale duplicate of the line below it), so nobody copies the broken form.

Verified with a full English `make htmldocs`: checkref reports "all links are good!" and the four rendered links now resolve correctly.