### PR TITLE
docs: fix two broken cross-reference targets

### DIFF
--- a/docs/src/gui/qtvcp-widgets.adoc
+++ b/docs/src/gui/qtvcp-widgets.adoc
@@ -1537,7 +1537,7 @@ Enter any of these _case sensitive_ commands to load the respective program or a
 *`CLEAR HISTORY`*::
   _Clears the MDI History_.
 *`net`*::
-  See link:../man/man1/halcmd.1.html#COMMANDS[`halcmd net` commands]. +
+  See link:../man/man1/halcmd.1.html#_commands[`halcmd net` commands]. +
   An error will result if the command is unsuccessful.
   * _Syntax_: `net <signal name> <pin name>`
   * __Example__: `net plasmac:jog-inhibit motion.jog-stop`

--- a/docs/src/man/man1/linuxcncrsh.1.adoc
+++ b/docs/src/man/man1/linuxcncrsh.1.adoc
@@ -146,12 +146,12 @@ The supported commands are as follows:
 
 *get* _<subcommand>_ [_<parameters>_]::
   The 'GET' command takes one of the LinuxCNC sub-commands
-  (see link:#_linuxcnc_subcommands[*SUBCOMMANDS*] below) and zero or
+  (see link:#_subcommands[*SUBCOMMANDS*] below) and zero or
   more additional subcommand-specific parameters.
 
 *set* _<subcommand>_ [_<parameters>_]::
   The 'SET' command takes one of the LinuxCNC sub-commands
-  (see link:#_linuxcnc_subcommands[*SUBCOMMANDS*] below) and zero or
+  (see link:#_subcommands[*SUBCOMMANDS*] below) and zero or
   more additional parameters.
 
 *quit*::
@@ -164,7 +164,7 @@ The supported commands are as follows:
   The 'SHUTDOWN' command tells LinuxCNC to shutdown and disconnect the
   session. This command may only be issued if the 'HELLO' has been
   successfully negotiated and the connection has control of the CNC
-  (see 'SET ENABLE' sub-command in the link:#_linuxcnc_subcommands[*SUBCOMMANDS*]
+  (see 'SET ENABLE' sub-command in the link:#_subcommands[*SUBCOMMANDS*]
   section below).
   +
   Note that LinuxCNC will only shutdown automatically if *linuxcncrsh*


### PR DESCRIPTION
Two broken links surfaced once HTML link checking actually runs (companion to the checkref fix, #4104). Both are stale fragment ids: the generated ids are `_commands` (halcmd.1) and `_subcommands` (linuxcncrsh.1).