### PR TITLE
docs: copy click-to-enlarge images, not just displayed ones

### DIFF
--- a/docs/src/Submakefile
+++ b/docs/src/Submakefile
@@ -944,13 +944,17 @@ $(foreach L,$(LANGUAGES),$(eval $(call HTML_COPY_RULE,$(L))))
 # $(DOC_OUT_HTML)/<lang>/<topic>/X.html.  The source images are in
 # $(DOC_SRCDIR)/<topic>/ regardless of language (translations are
 # image-symlinked to English originals via the sed below).
+#
+# src="..." covers displayed images; href="...png" covers click-to-enlarge
+# targets from image:thumb[link=...] (which would otherwise 404).  The
+# extension filter keeps page/anchor hrefs out.
 .html-images-stamp: $(DOC_TARGETS_HTML)
 	set -e; for HTML_FILE in $^; do \
 		HTML_REL=$$(echo $$HTML_FILE | sed 's%^$(DOC_OUT_HTML)/%%'); \
 		LANG=$$(echo $$HTML_REL | cut -d/ -f1); \
 		REST=$$(echo $$HTML_REL | cut -d/ -f2-); \
 		HTML_DIR=$$(dirname $$REST | cut -d/ -f1); \
-		for IMAGE_FILE in $$(grep -oE 'src="[^"]+"' $$HTML_FILE | sed 's/src="//;s/"$$//' | grep -vE '^https?:|^data:|^/'); do \
+		for IMAGE_FILE in $$(grep -oE '(src|href)="[^"]+"' $$HTML_FILE | sed -E 's/^(src|href)="//;s/"$$//' | grep -vE '^https?:|^data:|^/' | grep -iE '\.(png|jpe?g|gif|svg|webp)$$'); do \
 			IMAGE_DIR=$$(dirname $$IMAGE_FILE); \
 			IMAGE_PATH=$(DOC_SRCDIR)/$$HTML_DIR/$$IMAGE_FILE; \
 			mkdir -p $(DOC_OUT_HTML)/$$LANG/$$HTML_DIR/$$IMAGE_DIR; \


### PR DESCRIPTION
The HTML image-copy step (`.html-images-stamp`) scanned only `src="..."` attributes when deciding which images to copy into `docs/html`. Images referenced solely as a link target, `image:thumb[link="images/full.png"]`, which asciidoctor renders as `<a href="images/full.png"><img src="thumb"></a>`, were never copied, so clicking the thumbnail to enlarge gave a 404. `gui/gmoccapy` (7 images) and `gui/gstat` (2) were affected.

The fix also scans `href="..."`, filtered to image extensions so page and anchor links are left out.

Surfaced by the now-working link checker (#4104), which reports these as missing-file 404s.

Verified with a full English `make htmldocs`: build completes cleanly, all 9 images are now copied, and both pages report 0 missing-file 404s.