### PR TITLE
latency-test, latency-histogram: add realtime status bar

### DIFF
--- a/docs/src/config/python-lcnc_realtime.adoc
+++ b/docs/src/config/python-lcnc_realtime.adoc
@@ -17,13 +17,20 @@ This is a Python wrapper of the realtime script.
 import lcnc_realtime
 
 print("lcnc_realtime.verify " + str(lcnc_realtime.verify()))
+print("lcnc_realtime.verify_info " + str(lcnc_realtime.verify_info()))
 print("lcnc_realtime.status " + str(lcnc_realtime.status()))
 ----
 
 == methods
 
-hal.verify()::
+lcnc_realtime.verify()::
 Returns a boolean to indicate whether the system is realtime capable.
 
-hal.status()::
+lcnc_realtime.verify_info()::
+Returns a tuple `(capable, type)`, where `capable` is the same boolean as
+`verify()` and `type` is a human-readable string naming the realtime type that
+rtapi is running (for example `Preempt RT`, `RTAI` or `Xenomai`), or
+`No realtime` when none is available.
+
+lcnc_realtime.status()::
 Returns a boolean to indicate whether the realtime backend is running.

--- a/docs/src/install/latency-test.adoc
+++ b/docs/src/install/latency-test.adoc
@@ -193,6 +193,40 @@ Use `--show` to show count for the off-chart [pos|neg] bin.
 image::../config/images/latency-histogram.png["latency-histogram Window"]
 
 
+[[sec:latency-status-bar]]
+=== Realtime status bar
+
+The `latency-test` and `latency-histogram` windows show a status bar along the
+bottom with three fields. A field turns red when it indicates a condition that
+makes the measured latency unrepresentative of a properly configured realtime
+system.
+
+Realtime::
+    The realtime type that rtapi is running, as reported by `realtime verify`,
+    for example `Preempt RT`, `RTAI` or `Xenomai`. It reads `No realtime` (red)
+    when `rtapi_app` cannot obtain realtime scheduling, either because the
+    running kernel is not a realtime kernel (see
+    <<sec:kernel_and_version_requirements,Kernel and Version requirements>>) or
+    because `rtapi_app` lacks the required privileges on a run-in-place build
+    (see <<sub:realtime,Realtime>>, run `sudo make setuid` or
+    `sudo make setcap`). In this state the figures reflect ordinary,
+    non-realtime scheduling and will be far worse than a realtime kernel
+    delivers. For testing only, realtime can be forced with the
+    `LINUXCNC_FORCE_REALTIME=1` environment variable.
+
+CPU governor::
+    The active CPU frequency governor. It is shown in red when it is not
+    `performance`, because frequency scaling lets the CPU drop to a lower clock
+    speed and adds latency spikes. See <<sec:latency-governor,CPU frequency
+    governor>>.
+
+isolcpus::
+    Whether any CPUs are isolated for the exclusive use of LinuxCNC
+    (`isolcpus=...`) or not (`no_isolcpus`). Isolating a CPU keeps other tasks
+    off it and improves latency; see <<sec:tuning-preempt-rt,Tuning Preempt-RT
+    for latency>>.
+
+
 == Latency tuning
 
 LinuxCNC can run on many different hardware platforms and with many
@@ -234,6 +268,23 @@ tuning in the BIOS are:
 * Disable any hardware you do not intend to use.
 
 
+[[sec:latency-governor]]
+=== CPU frequency governor
+
+Frequency scaling lets the CPU lower its clock speed to save power, which adds
+latency while the CPU ramps back up to service a realtime thread. For the best
+latency, set the governor to `performance` on every CPU:
+
+----
+echo performance | sudo tee /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor
+----
+
+This setting does not survive a reboot. To make it permanent, apply it at boot
+with a small systemd service, or with a CPU frequency management tool such as
+`cpupower` (Debian/Ubuntu package `linux-cpupower`) or `tuned`.
+
+
+[[sec:tuning-preempt-rt]]
 === Tuning Preempt-RT for latency
 
 The Preempt-RT kernel may benefit from tuning in order to provide the

--- a/lib/python/lcnc_realtime.py.in
+++ b/lib/python/lcnc_realtime.py.in
@@ -19,13 +19,17 @@ import subprocess
 
 REALTIME="@REALTIME@"
 
-def verify() -> bool:
+def verify_info() -> tuple[bool, str]:
     #Checks if system is realtime compatible
     cmd = [REALTIME, "verify"]
-    ret = subprocess.run(cmd, stdin=subprocess.DEVNULL, stdout=subprocess.DEVNULL)
+    ret = subprocess.run(cmd, stdin=subprocess.DEVNULL, capture_output=True, text=True)
     if ret.returncode != 0 and ret.returncode != 1:
         raise RuntimeError("cmd \"" + " ".join(cmd) + "\" failed with status " + str(ret.returncode))
-    return ret.returncode==0;
+    return ret.returncode==0, ret.stdout.rstrip();
+
+def verify() -> bool:
+    ret, _ = verify_info();
+    return ret;
 
 def status() -> bool:
     #Status: realtime core running (rtapi_app running or kernel modules active)

--- a/scripts/latency-histogram
+++ b/scripts/latency-histogram
@@ -111,6 +111,26 @@ proc which_exe {name} {
   return -code error "$name: executable not found"
 } ;# which_exe
 
+proc check_rt_privileges {} {
+  # Without 'sudo make setuid' (or 'sudo make setcap') rtapi_app runs
+  # unprivileged: realtime threads get no SCHED_FIFO and no locked memory, so
+  # the latency readings are wildly inflated.  Warn rather than mislead.
+  if {![catch {exec id -u} uid] && $uid == 0} return ;# root has every privilege
+  if {[catch {which_exe rtapi_app} rtapi]} return ;# cannot locate, stay quiet
+  if {![catch {file attributes $rtapi -permissions} mode] && ($mode & 04000)} return ;# setuid root
+  if {![catch {exec getcap $rtapi} caps] && [string match *cap_sys_nice* $caps]} return ;# file caps
+  set msg "Warning: rtapi_app is not setuid root and has no realtime capabilities."
+  append msg "\nRealtime threads get no SCHED_FIFO priority or locked memory,"
+  append msg "\nso the latency shown will be far worse than reality."
+  append msg "\nRun 'sudo make setuid' (or 'sudo make setcap') in src/."
+  puts stderr $msg
+  if {$::LH(use_x)} {
+    package require Tk
+    tk_messageBox -parent . -icon warning -type ok \
+        -title "Latency Warning" -message $msg
+  }
+} ;# check_rt_privileges
+
 proc program_check {plist} {
   foreach prog $plist {
     if [catch {
@@ -972,6 +992,7 @@ proc windowToFile { win } {
 if ![info exists ::LH(start)] {
   set_defaults
   config
+  check_rt_privileges
   progress "Loading packages"
   load_packages
   signal trap SIGINT finish

--- a/scripts/latency-histogram
+++ b/scripts/latency-histogram
@@ -115,6 +115,11 @@ proc check_rt_privileges {} {
   # Without 'sudo make setuid' (or 'sudo make setcap') rtapi_app runs
   # unprivileged: realtime threads get no SCHED_FIFO and no locked memory, so
   # the latency readings are wildly inflated.  Warn rather than mislead.
+  # Only meaningful on an RT-capable kernel; stay quiet on non-RT (e.g. dev).
+  set rt 0
+  if {![catch {exec uname -v} kv] && [string match *PREEMPT_RT* $kv]} {set rt 1}
+  if {[string first rtai [string tolower $::tcl_platform(osVersion)]] >= 0} {set rt 1}
+  if {!$rt} return
   if {![catch {exec id -u} uid] && $uid == 0} return ;# root has every privilege
   if {[catch {which_exe rtapi_app} rtapi]} return ;# cannot locate, stay quiet
   if {![catch {file attributes $rtapi -permissions} mode] && ($mode & 04000)} return ;# setuid root

--- a/scripts/latency-histogram
+++ b/scripts/latency-histogram
@@ -112,22 +112,15 @@ proc which_exe {name} {
 } ;# which_exe
 
 proc check_rt_privileges {} {
-  # Without 'sudo make setuid' (or 'sudo make setcap') rtapi_app runs
-  # unprivileged: realtime threads get no SCHED_FIFO and no locked memory, so
-  # the latency readings are wildly inflated.  Warn rather than mislead.
-  # Only meaningful on an RT-capable kernel; stay quiet on non-RT (e.g. dev).
-  set rt 0
-  if {![catch {exec uname -v} kv] && [string match *PREEMPT_RT* $kv]} {set rt 1}
-  if {[string first rtai [string tolower $::tcl_platform(osVersion)]] >= 0} {set rt 1}
-  if {!$rt} return
-  if {![catch {exec id -u} uid] && $uid == 0} return ;# root has every privilege
-  if {[catch {which_exe rtapi_app} rtapi]} return ;# cannot locate, stay quiet
-  if {![catch {file attributes $rtapi -permissions} mode] && ($mode & 04000)} return ;# setuid root
-  if {![catch {exec getcap $rtapi} caps] && [string match *cap_sys_nice* $caps]} return ;# file caps
-  set msg "Warning: rtapi_app is not setuid root and has no realtime capabilities."
-  append msg "\nRealtime threads get no SCHED_FIFO priority or locked memory,"
+  # Ask the realtime layer whether realtime is actually available, via
+  # 'realtime verify' (exits 0 when realtime is up, non-zero otherwise,
+  # usually a missing 'sudo make setuid' or 'sudo make setcap').
+  if {[catch {exec linuxcnc_var REALTIME} rt]} return ;# cannot locate, stay quiet
+  if {![catch {exec $rt verify 2>@1}]} return         ;# realtime available
+  set msg "Warning: realtime is not available."
+  append msg "\nThreads get no SCHED_FIFO priority or locked memory,"
   append msg "\nso the latency shown will be far worse than reality."
-  append msg "\nRun 'sudo make setuid' (or 'sudo make setcap') in src/."
+  append msg "\nOn a run-in-place build, run 'sudo make setuid' (or 'sudo make setcap') in src/."
   puts stderr $msg
   if {$::LH(use_x)} {
     package require Tk
@@ -649,6 +642,7 @@ proc start_collection {} {
     }
   }
   hal start
+  check_rt_privileges
   if {!$::LH(legacy)} {
     # Attach the Tcl hal_stream binding (added in halsh.c) to each
     # thread's latencybinstream FIFO. The handle stays open for the
@@ -997,7 +991,6 @@ proc windowToFile { win } {
 if ![info exists ::LH(start)] {
   set_defaults
   config
-  check_rt_privileges
   progress "Loading packages"
   load_packages
   signal trap SIGINT finish

--- a/scripts/latency-histogram
+++ b/scripts/latency-histogram
@@ -111,24 +111,6 @@ proc which_exe {name} {
   return -code error "$name: executable not found"
 } ;# which_exe
 
-proc check_rt_privileges {} {
-  # Ask the realtime layer whether realtime is actually available, via
-  # 'realtime verify' (exits 0 when realtime is up, non-zero otherwise,
-  # usually a missing 'sudo make setuid' or 'sudo make setcap').
-  if {[catch {exec linuxcnc_var REALTIME} rt]} return ;# cannot locate, stay quiet
-  if {![catch {exec $rt verify 2>@1}]} return         ;# realtime available
-  set msg "Warning: realtime is not available."
-  append msg "\nThreads get no SCHED_FIFO priority or locked memory,"
-  append msg "\nso the latency shown will be far worse than reality."
-  append msg "\nOn a run-in-place build, run 'sudo make setuid' (or 'sudo make setcap') in src/."
-  puts stderr $msg
-  if {$::LH(use_x)} {
-    package require Tk
-    tk_messageBox -parent . -icon warning -type ok \
-        -title "Latency Warning" -message $msg
-  }
-} ;# check_rt_privileges
-
 proc program_check {plist} {
   foreach prog $plist {
     if [catch {
@@ -353,6 +335,44 @@ proc load_packages {} {
   }
 } ;# load_packages
 
+proc rt_status_items {} {
+  # Returns {text color} pairs; color is "" except where it needs attention.
+  set red "#cc4444"
+  set items {}
+
+  # realtime: type from 'realtime verify' stdout, yes/no from its exit status.
+  set rt_text "no realtime"
+  set rt_ok 0
+  if {![catch {exec linuxcnc_var REALTIME} rt]} {
+    if {![catch {open [list | $rt verify 2> /dev/null] r} chan]} {
+      set out [string trim [read $chan]]
+      set rt_ok [expr {![catch {close $chan}]}]
+      if {$out ne ""} {set rt_text $out}
+    }
+  }
+  lappend items [list $rt_text [expr {$rt_ok ? "" : $red}]]
+
+  # cpu governor: red when not 'performance'
+  set gov ""
+  catch {set gov [string trim [exec cat /sys/devices/system/cpu/cpu0/cpufreq/scaling_governor]]}
+  if {$gov eq ""} {set gov "gov?"}
+  if {$gov eq "performance"} {
+    lappend items [list $gov ""]
+  } else {
+    lappend items [list $gov $red]
+  }
+
+  # isolcpus
+  set cmdline ""
+  catch {set cmdline [exec cat /proc/cmdline]}
+  if {[regexp {isolcpus=(\S+)} $cmdline -> iso]} {
+    lappend items [list "isolcpus=$iso" ""]
+  } else {
+    lappend items [list "no_isolcpus" ""]
+  }
+  return $items
+} ;# rt_status_items
+
 proc make_gui { {w .} } {
   set f [frame ${w}fa]
   pack $f -side top -fill x -expand 1
@@ -454,6 +474,28 @@ proc make_gui { {w .} } {
            -command "xaxis $thd"] -side left
     }
 
+  }
+
+  # --- realtime status bar (true footer): one line of axis-style sunken
+  # cells split into equal thirds, left/centre/right aligned ---
+  set sb [frame ${w}statusbar]
+  pack $sb -side bottom -fill x
+  set sbitems [rt_status_items]
+  # Fixed-width sides (chars), elastic middle gets the rest.
+  # Left fits the longest RT label (RT-Xenomai-EVL); right fits isolcpus up to ~4 cpus.
+  set sbwidth  {14 0 18}
+  set sbweight {0  1 0}
+  set sbanch   {w center e}
+  set i 0
+  foreach item $sbitems {
+    lassign $item text color
+    label $sb.s$i -text $text -relief sunken -bd 1 -anchor [lindex $sbanch $i] -padx 6
+    set wdt [lindex $sbwidth $i]
+    if {$wdt > 0} {$sb.s$i configure -width $wdt}
+    if {$color ne ""} {$sb.s$i configure -fg $color}
+    grid $sb.s$i -row 0 -column $i -sticky we
+    grid columnconfigure $sb $i -weight [lindex $sbweight $i]
+    incr i
   }
 
   set f [frame ${w}bot]
@@ -642,7 +684,6 @@ proc start_collection {} {
     }
   }
   hal start
-  check_rt_privileges
   if {!$::LH(legacy)} {
     # Attach the Tcl hal_stream binding (added in halsh.c) to each
     # thread's latencybinstream FIFO. The handle stays open for the

--- a/scripts/latency-test
+++ b/scripts/latency-test
@@ -20,6 +20,11 @@ icalc() { awk "BEGIN { printf \"%.0f\n\", ($1); }" < /dev/null; }
 # unprivileged: realtime threads get no SCHED_FIFO and no locked memory, so the
 # latency readings are wildly inflated.  Warn rather than mislead.
 check_rt_privileges () {
+    # only meaningful on an RT-capable kernel; stay quiet on non-RT (e.g. dev)
+    case "$(uname -v) $(uname -r)" in
+        *PREEMPT_RT*|*rtai*) ;;
+        *) return 0 ;;
+    esac
     [ "$(id -u)" = 0 ] && return 0          # root has every privilege
     rtapi_app=$(command -v rtapi_app) || return 0
     [ -n "$rtapi_app" ] || return 0

--- a/scripts/latency-test
+++ b/scripts/latency-test
@@ -16,30 +16,6 @@ kversion=$(uname -v)
 calc() { awk "BEGIN { print ($1); }" < /dev/null; }
 icalc() { awk "BEGIN { printf \"%.0f\n\", ($1); }" < /dev/null; }
 
-# Without 'sudo make setuid' (or 'sudo make setcap') rtapi_app runs
-# unprivileged: realtime threads get no SCHED_FIFO and no locked memory, so the
-# latency readings are wildly inflated.  Warn rather than mislead.
-check_rt_privileges () {
-    # only meaningful on an RT-capable kernel; stay quiet on non-RT (e.g. dev)
-    case "$(uname -v) $(uname -r)" in
-        *PREEMPT_RT*|*rtai*) ;;
-        *) return 0 ;;
-    esac
-    [ "$(id -u)" = 0 ] && return 0          # root has every privilege
-    rtapi_app=$(command -v rtapi_app) || return 0
-    [ -n "$rtapi_app" ] || return 0
-    [ -u "$rtapi_app" ] && return 0         # setuid root
-    if command -v getcap >/dev/null 2>&1; then
-        case $(getcap "$rtapi_app" 2>/dev/null) in
-            *cap_sys_nice*) return 0 ;;     # file capabilities
-        esac
-    fi
-    echo "Warning: rtapi_app is not setuid root and has no realtime capabilities." >&2
-    echo "         Realtime threads get no SCHED_FIFO priority or locked memory," >&2
-    echo "         so the latency shown will be far worse than reality." >&2
-    echo "         Run 'sudo make setuid' (or 'sudo make setcap') in src/." >&2
-}
-
 parse_time () {
     case $1 in
     -)   echo "0" ;;
@@ -193,7 +169,5 @@ L=\$(($SIGNALS
     ) | sort -n | tail -1)
 echo \$L > "$HOME"/.latency
 EOF
-
-check_rt_privileges
 
 halrun lat.hal

--- a/scripts/latency-test
+++ b/scripts/latency-test
@@ -81,6 +81,23 @@ if [ "$BASE" -eq "$SERVO" ]; then BASE=0; fi
 BASE_HUMAN=$(human_time "$BASE")
 SERVO_HUMAN=$(human_time "$SERVO")
 
+# --- status-bar fields (colour red only when they need attention) ---
+# realtime: type from 'realtime verify'; non-zero exit means none.
+RED="#cc4444"
+if RT_TEXT=$(realtime verify 2>/dev/null); then
+    RT_FG=""
+else
+    RT_FG="foreground=\"$RED\""
+fi
+GOV=$(cat /sys/devices/system/cpu/cpu0/cpufreq/scaling_governor 2>/dev/null)
+[ -z "$GOV" ] && GOV="gov?"
+if [ "$GOV" = performance ]; then GOV_FG=""; else GOV_FG="foreground=\"$RED\""; fi
+if grep -q 'isolcpus=' /proc/cmdline 2>/dev/null; then
+    ISOL_TEXT=$(tr ' ' '\n' < /proc/cmdline | grep '^isolcpus=' | head -1)
+else
+    ISOL_TEXT="no_isolcpus"
+fi
+
 if [ "$BASE" -eq 0 ]; then
 cat > lat.hal <<EOF
 loadrt threads name1=slow period1=$SERVO
@@ -152,6 +169,15 @@ fi
 cat >> lat.xml <<EOF
 <tablerow/>
   <button text="Reset Statistics" halpin="reset" />
+
+<tablerow/><tablesticky sticky="we"/><tablespan columns="5"/>
+<table flexible_columns="[1,2,3]" uniform_columns="aaa">
+<tablesticky sticky="we"/>
+<tablerow/>
+  <label text="$RT_TEXT" $RT_FG relief="sunken" bd="1" anchor="w" padx="6"/>
+  <label text="$GOV" $GOV_FG relief="sunken" bd="1" anchor="center" padx="6"/>
+  <label text="$ISOL_TEXT" relief="sunken" bd="1" anchor="e" padx="6"/>
+</table>
 
 </table>
 </pyvcp>

--- a/scripts/latency-test
+++ b/scripts/latency-test
@@ -16,6 +16,25 @@ kversion=$(uname -v)
 calc() { awk "BEGIN { print ($1); }" < /dev/null; }
 icalc() { awk "BEGIN { printf \"%.0f\n\", ($1); }" < /dev/null; }
 
+# Without 'sudo make setuid' (or 'sudo make setcap') rtapi_app runs
+# unprivileged: realtime threads get no SCHED_FIFO and no locked memory, so the
+# latency readings are wildly inflated.  Warn rather than mislead.
+check_rt_privileges () {
+    [ "$(id -u)" = 0 ] && return 0          # root has every privilege
+    rtapi_app=$(command -v rtapi_app) || return 0
+    [ -n "$rtapi_app" ] || return 0
+    [ -u "$rtapi_app" ] && return 0         # setuid root
+    if command -v getcap >/dev/null 2>&1; then
+        case $(getcap "$rtapi_app" 2>/dev/null) in
+            *cap_sys_nice*) return 0 ;;     # file capabilities
+        esac
+    fi
+    echo "Warning: rtapi_app is not setuid root and has no realtime capabilities." >&2
+    echo "         Realtime threads get no SCHED_FIFO priority or locked memory," >&2
+    echo "         so the latency shown will be far worse than reality." >&2
+    echo "         Run 'sudo make setuid' (or 'sudo make setcap') in src/." >&2
+}
+
 parse_time () {
     case $1 in
     -)   echo "0" ;;
@@ -169,5 +188,7 @@ L=\$(($SIGNALS
     ) | sort -n | tail -1)
 echo \$L > "$HOME"/.latency
 EOF
+
+check_rt_privileges
 
 halrun lat.hal

--- a/scripts/realtime.in
+++ b/scripts/realtime.in
@@ -231,14 +231,13 @@ Verify(){
         rtapi_app check_rt && HAS_REALTIME=true
     ;;
     (*rtai*)
+        echo "RTAI"
         HAS_REALTIME=true
     esac
 
     if [ $HAS_REALTIME = true ]; then
-        echo "realtime detected"
         return 0
     else
-        echo "WARNING: no realtime detected"
         return 1
     fi
 }

--- a/src/rtapi/uspace_rtapi_main.cc
+++ b/src/rtapi/uspace_rtapi_main.cc
@@ -533,7 +533,25 @@ static int do_debug_cmd(const std::string &value) {
     }
 }
 
-static int do_check_rt_cmd(void) {
+// Human-readable name of a realtime type, suitable for display by callers
+// such as 'realtime verify' and the latency tools.
+static const char *realtime_type_name(rtapi_realtime_type_t type) {
+    switch(type) {
+        case REALTIME_TYPE_UNINITIALIZED:   return "Uninitialized";
+        case REALTIME_TYPE_NONE:            return "No realtime";
+        case REALTIME_TYPE_UNKNOWN:         return "Unknown (SCHED_FIFO)";
+        case REALTIME_TYPE_PREEMPT_DYNAMIC: return "Preempt Dynamic";
+        case REALTIME_TYPE_PREEMPT_RT:      return "Preempt RT";
+        case REALTIME_TYPE_RTAI:            return "RTAI";
+        case REALTIME_TYPE_LXRT:            return "LXRT";
+        case REALTIME_TYPE_XENOMAI:         return "Xenomai";
+        case REALTIME_TYPE_XENOMAI_EVL:     return "Xenomai EVL";
+    }
+    return "BUG: unknown realtime type";
+}
+
+static int do_check_rt_cmd(std::string &out) {
+    out = realtime_type_name(rtapi_get_realtime_type());
     return rtapi_is_realtime() == 0;
 }
 
@@ -597,8 +615,8 @@ static ssize_t recv_data(int fd, void *buf, size_t n, int flags) {
  * Protocol:
  * 
  * client->master: std::vector<std::string> args
- * master processes the args and returns result
- * master->client: int result
+ * master processes the args and returns result and stdout string
+ * master->client: int result, std::string out
  *
  * Packing:
  * args are serialized as:
@@ -611,40 +629,11 @@ static ssize_t recv_data(int fd, void *buf, size_t n, int flags) {
  * }
  * 
  * result is serialized as:
- * int
+ * uint16_t size (full package size including the size field)
+ * int result
+ * uint16_t out_size
+ * char[out_size] out
  */
-
-static bool send_result(int fd, int result) {
-    ssize_t res = send_data(fd, &result, sizeof(int), 0);
-    if (res != sizeof(int)) {
-        if (res == -1) {
-            rtapi_print_msg(RTAPI_MSG_ERR, "rtapi_app: send_result failed: %s\n", strerror(errno));
-        } else {
-            rtapi_print_msg(
-                RTAPI_MSG_ERR, "rtapi_app: send_result failed, send only %li of %li bytes\n", res, sizeof(int)
-            );
-        }
-        return false;
-    } else {
-        return true;
-    }
-}
-
-static bool recv_result(int fd, int *result) {
-    ssize_t res = recv_data(fd, result, sizeof(int), 0);
-    if (res != sizeof(int)) {
-        if (res == -1) {
-            rtapi_print_msg(RTAPI_MSG_ERR, "rtapi_app: recv_result failed: %s\n", strerror(errno));
-        } else {
-            rtapi_print_msg(
-                RTAPI_MSG_ERR, "rtapi_app: recv_result failed, recv only %li of %li bytes\n", res, sizeof(int)
-            );
-        }
-        return false;
-    } else {
-        return true;
-    }
-}
 
 static void push_uint16(std::vector<char> &buf, uint16_t value) {
     buf.push_back((char)(0xff & (value >> 0)));
@@ -654,6 +643,121 @@ static void push_uint16(std::vector<char> &buf, uint16_t value) {
 static uint16_t get_uint16(const std::vector<char> &buf, size_t idx) {
     //at() will check index and throw std::out_of_range
     return ((uint16_t)(unsigned char)buf.at(idx)) | ((uint16_t)(unsigned char)buf.at(idx + 1) << 8);
+}
+
+static void push_int(std::vector<char> &buf, int value) {
+    for (size_t i = 0; i < sizeof(int); i++) {
+        buf.push_back((char)(0xff & (value >> i * 8)));
+    }
+}
+
+static int get_int(const std::vector<char> &buf, size_t idx) {
+    //at() will check index and throw std::out_of_range
+    int ret = 0;
+    for (size_t i = 0; i < sizeof(int); i++) {
+        ret |= ((int)(unsigned char)buf.at(idx + i) << i * 8);
+    }
+    return ret;
+}
+
+static bool send_result(int fd, int result, const std::string &out) {
+    //Calculate size
+    size_t buff_size = sizeof(uint16_t) + sizeof(int) + sizeof(uint16_t) + out.size();
+
+    //Check uint16_t conversion of the total size; out.size() is bounded by it
+    if (buff_size > std::numeric_limits<uint16_t>::max()) {
+        rtapi_print_msg(RTAPI_MSG_ERR, "rtapi_app: send_result: result too big, size = %li!\n", buff_size);
+        return false;
+    }
+
+    //Serialize
+    std::vector<char> buf;
+    buf.reserve(buff_size);
+    push_uint16(buf, (uint16_t)buff_size);
+    push_int(buf, result);
+    push_uint16(buf, (uint16_t)out.size());
+    buf.insert(buf.end(), out.begin(), out.end());
+    if (buf.size() != buff_size) {
+        rtapi_print_msg(
+            RTAPI_MSG_ERR, "rtapi_app: Bug send_result: buf.size() %li != buff_size %li\n", buf.size(), buff_size
+        );
+        return false;
+    }
+
+    //Send
+    ssize_t res = send_data(fd, buf.data(), buf.size(), 0);
+    if (res != (ssize_t)buf.size()) {
+        if (res == -1) {
+            rtapi_print_msg(RTAPI_MSG_ERR, "rtapi_app: send_result failed: %s\n", strerror(errno));
+        } else {
+            rtapi_print_msg(
+                RTAPI_MSG_ERR, "rtapi_app: send_result failed, sent only %li of %li bytes\n", res, buf.size()
+            );
+        }
+        return false;
+    }
+    return true;
+}
+
+static bool recv_result(int fd, int *result, std::string &out) {
+    //Get size
+    uint16_t tmp;
+    ssize_t res = recv_data(fd, &tmp, sizeof(uint16_t), 0);
+    if (res != sizeof(uint16_t)) {
+        if (res == -1) {
+            rtapi_print_msg(RTAPI_MSG_ERR, "rtapi_app: recv_result 1 failed: %s\n", strerror(errno));
+        } else {
+            rtapi_print_msg(
+                RTAPI_MSG_ERR, "rtapi_app: recv_result 1 failed, recv only %li of %li bytes\n", res, sizeof(uint16_t)
+            );
+        }
+        return false;
+    }
+    if (tmp < sizeof(uint16_t)) {
+        rtapi_print_msg(RTAPI_MSG_ERR, "rtapi_app: recv_result: bad frame size %u\n", tmp);
+        return false;
+    }
+    size_t buff_size = tmp - sizeof(uint16_t); //Size already consumed
+
+    //Get data
+    std::vector<char> buf(buff_size);
+    res = recv_data(fd, buf.data(), buff_size, 0);
+    if (res != (ssize_t)buff_size) {
+        if (res == -1) {
+            rtapi_print_msg(RTAPI_MSG_ERR, "rtapi_app: recv_result 2 failed: %s\n", strerror(errno));
+        } else {
+            rtapi_print_msg(
+                RTAPI_MSG_ERR, "rtapi_app: recv_result 2 failed, recv only %li of %li bytes\n", res, buff_size
+            );
+        }
+        return false;
+    }
+
+    //Deserialize
+    try {
+        size_t idx = 0;
+        *result = get_int(buf, idx);
+        idx += sizeof(int);
+        size_t out_size = get_uint16(buf, idx);
+        idx += sizeof(uint16_t);
+        //Bound checked, unpack argument
+        auto start = buf.begin() + idx;
+        auto end = start + out_size;
+        if (end > buf.end()) {
+            throw std::out_of_range("recv_result: out size not in buffer range");
+        }
+        out = std::string(start, end);
+        idx += out_size;
+        if (idx != buff_size) {
+            rtapi_print_msg(RTAPI_MSG_ERR, "rtapi_app: Bug recv_result: idx %li != buff_size %li\n", idx, buff_size);
+            return false;
+        }
+    } catch (std::out_of_range &e) {
+        rtapi_print_msg(RTAPI_MSG_ERR, "rtapi_app: Bug recv_result: %s\n", e.what());
+        return false;
+    }
+
+    return true;
 }
 
 static bool recv_args(int fd, std::vector<std::string> &args) {
@@ -668,6 +772,10 @@ static bool recv_args(int fd, std::vector<std::string> &args) {
                 RTAPI_MSG_ERR, "rtapi_app: recv_args 1 failed, recv only %li of %li bytes\n", res, sizeof(uint16_t)
             );
         }
+        return false;
+    }
+    if (tmp < sizeof(uint16_t)) {
+        rtapi_print_msg(RTAPI_MSG_ERR, "rtapi_app: recv_args: bad frame size %u\n", tmp);
         return false;
     }
     size_t buff_size = tmp - sizeof(uint16_t); //Size already consumed
@@ -728,12 +836,12 @@ static bool send_args(int fd, const std::vector<std::string> &args) {
     //Check uint16_t conversions
     //Buffer size is > sum(args[i].size()) so they don't need a separate check
     if (buff_size > std::numeric_limits<uint16_t>::max()) {
-        rtapi_print_msg(RTAPI_MSG_ERR, "rtapi_app: send_args: args to big, size = %li!\n", buff_size);
+        rtapi_print_msg(RTAPI_MSG_ERR, "rtapi_app: send_args: args too big, size = %li!\n", buff_size);
         return false;
     }
     //Edge case: One could in theory send many size zero args
     if (args.size() > std::numeric_limits<uint16_t>::max()) {
-        rtapi_print_msg(RTAPI_MSG_ERR, "rtapi_app: send_args: arg count to big, size = %li!\n", args.size());
+        rtapi_print_msg(RTAPI_MSG_ERR, "rtapi_app: send_args: arg count too big, size = %li!\n", args.size());
         return false;
     }
 
@@ -768,7 +876,7 @@ static bool send_args(int fd, const std::vector<std::string> &args) {
     return true;
 }
 
-static int handle_command(const std::vector<std::string> &args) {
+static int handle_command(const std::vector<std::string> &args, std::string &out) {
     if (args.size() == 0) {
         return 0;
     }
@@ -788,7 +896,7 @@ static int handle_command(const std::vector<std::string> &args) {
     } else if (args.size() == 2 && args[0] == "debug") {
         return do_debug_cmd(args[1]);
     } else if (args.size() == 1 && args[0] == "check_rt") {
-        return do_check_rt_cmd();
+        return do_check_rt_cmd(out);
     } else {
         rtapi_print_msg(RTAPI_MSG_ERR, "Unrecognized command starting with %s\n", args[0].c_str());
         return -1;
@@ -802,10 +910,14 @@ static int slave(int fd, const std::vector<std::string> &args) {
     }
 
     int result = -1;
-    if (!recv_result(fd, &result)) {
+    std::string out;
+    if (!recv_result(fd, &result, out)) {
         rtapi_print_msg(RTAPI_MSG_ERR, "rtapi_app: failed to read from master\n");
         return -1;
     } else {
+        if (out.length() > 0) {
+            printf("%s\n", out.c_str());
+        }
         return result;
     }
 }
@@ -825,6 +937,7 @@ static bool master_process_socket_command(int fd) {
     } else {
         int result;
         std::vector<std::string> args;
+        std::string out;
 
         //Set timeout, so master doesn't hang forever
         struct timeval timeout;
@@ -842,9 +955,9 @@ static bool master_process_socket_command(int fd) {
             return true; //If there is a socket error, just continue
         }
 
-        result = handle_command(args);
+        result = handle_command(args, out);
 
-        if (!send_result(fd1, result)) {
+        if (!send_result(fd1, result, out)) {
             rtapi_print_msg(RTAPI_MSG_ERR, "rtapi_app: failed to write to slave\n");
         }
         close(fd1);
@@ -867,11 +980,15 @@ static int master(int fd, const std::vector<std::string> &args) {
     instance_count = 0;
     App(); // force rtapi_app to be created
     if (args.size()) {
-        result = handle_command(args);
+        std::string out;
+        result = handle_command(args, out);
         if (result != 0)
             goto out;
         if (force_exit || instance_count == 0)
             goto out;
+        if (out.length() > 0) {
+            printf("%s\n", out.c_str());
+        }
     }
     //Process commands as long as master should not exit
     while(master_process_socket_command(fd));
@@ -997,7 +1114,12 @@ become_master:
         //If master is started, this starts up the whole realtime chain
         //and halrun -U is needed to exit again
         if (args.size() == 1 && args[0] == "check_rt") {
-            return do_check_rt_cmd();
+            std::string out;
+            int ret = do_check_rt_cmd(out);
+            if (out.length() > 0) {
+                printf("%s\n", out.c_str());
+            }
+            return ret;
         }
         int result = listen(fd, 10);
         if (result != 0) {


### PR DESCRIPTION
## What

`latency-test` and `latency-histogram` now show a status bar along the bottom with three fields: the running realtime type (or `No realtime`), the CPU frequency governor, and isolcpus. A field is coloured red only when it flags a condition that makes the measured latency unrepresentative, so normal states stay in the theme colour. On a real RT machine it reads e.g. `Preempt RT` / `performance` / `isolcpus=2,3`.

## Why

In #4044 a run-in-place build was used without `sudo make setuid`. `rtapi_app` ran unprivileged, the latency numbers blew up, and it was mistaken for a code regression. A visible realtime indicator surfaces that immediately. The governor and isolcpus fields cover the other two common reasons a latency measurement is misleading.

## How

The realtime type now comes authoritatively from rtapi itself: `realtime verify` returns the type that `rtapi_app` reports for the running backend (`Preempt RT`, `RTAI`, `Xenomai`, ..., or `No realtime`), instead of each tool re-sniffing kernel signals. The governor is read from `/sys` and isolcpus from `/proc/cmdline`. `latency-test` renders the bar as a pyvcp footer; `latency-histogram` as a Tk status bar at the bottom. The histogram's earlier modal `no realtime` popup is replaced by this persistent bar (the console warning is kept for non-X runs).

Docs: `install/latency-test.adoc` gains a status-bar section explaining each field and linking the fixes (realtime kernel, setuid/setcap, isolcpus), plus a CPU frequency governor tuning note.

## rtapi_app change (needs RT/C++ review)

To make the type available without sniffing, this branch carries @hdiethelm's change to `rtapi_app` (`src/rtapi/uspace_rtapi_main.cc`): the `check_rt` socket result is extended to return a string alongside the int status, and the realtime-type enum is mapped to a human-readable name. I added a follow-up commit tidying it: a short-read check in `recv_result()`, a frame-size underflow guard in `recv_result()`/`recv_args()`, an exhaustive type-name switch, and typo fixes. The two commits are kept separate so the tidy delta reads on its own.

## Follow-ups (separate PRs)

- A realtime indicator in the main GUIs (axis, gmoccapy, qtdragon, touchy), showing just the realtime field; cross-GUI placement is #4118.
- A headless `--quiet`/`--seconds` mode for `latency-test` so scripts can capture latency (suggested by @rodw-au).

Depends on #4132 (merged). Closes #4044.