### PR TITLE
docs(build): filter checklink's Perl noise in checkref

### DIFF
--- a/docs/src/checkref
+++ b/docs/src/checkref
@@ -25,7 +25,11 @@ for F in "$@"; do
     # --follow-file-links is required: recent w3c-linkchecker refuses file://
     # URIs by default, so without it checklink never inspects the local file
     # and validates nothing.
-    linuxcnc-checklink --quiet --follow-file-links --exclude "(http|https|irc)://" "$F"  2>&1 | tee "$OUT"
+    #
+    # Drop checklink's own "uninitialized value ... checklink line N" Perl
+    # noise (not link results).  checklink stays first, so PIPESTATUS[0] holds.
+    linuxcnc-checklink --quiet --follow-file-links --exclude "(http|https|irc)://" "$F" 2>&1 \
+        | grep -vE 'Use of uninitialized value .* at .*checklink line [0-9]+' | tee "$OUT"
     STATUS=${PIPESTATUS[0]}
     # Distinguish "checklink never inspected the file" from "checklink ran and
     # found problems".  It exits 64 when it reports broken links, so a nonzero


### PR DESCRIPTION
Now that link checking actually runs (#4104), the build and CI logs are flooded with Perl warnings from `linuxcnc-checklink` (w3c-linkchecker) itself:

```
Use of uninitialized value $_ in pattern match (m//) at /usr/bin/checklink line 1296.
```

These come from the W3C tool, not from any of our links, so they add only noise. Reported by @hansu on the #4081 CI run.

This drops those lines from the output `checkref` captures and prints. `linuxcnc-checklink` stays first in the pipe, so `PIPESTATUS[0]` (checked right after to distinguish "could not validate" from "found broken links") is unchanged, and the `Access to 'file' URIs has been disabled` sentinel that `checkref` greps for is preserved.

One-line change, no behavior change beyond suppressing the noise.