### PR TITLE
hm2_eth: don't abort board load when SIOCSARP is denied

### DIFF
--- a/src/hal/drivers/mesa-hostmot2/hm2_eth.c
+++ b/src/hal/drivers/mesa-hostmot2/hm2_eth.c
@@ -759,11 +759,17 @@ static int init_board(hm2_eth_t *board, const char *board_ip) {
         return ret;
     }
 
+    // Pinning the ARP entry needs CAP_NET_ADMIN; rootless without setcap
+    // fails with EPERM.  Best-effort, not fatal: fall back to dynamic ARP
+    // so the board still loads.  Clear ATF_PERM so the SIOCDARP teardown
+    // in close_board() does not try to remove an entry we never set.
     ret = ioctl_siocsarp(board);
     if(ret < 0) {
-        LL_PRINT("ERROR: ioctl SIOCSARP failed: %s\n", strerror(errno));
+        LL_PRINT("WARNING: ioctl SIOCSARP failed: %s; continuing with "
+                 "dynamic ARP.  Install file capabilities (sudo make "
+                 "setcap) or run setuid to pin the board's ARP entry and "
+                 "avoid occasional transmit latency.\n", strerror(errno));
         board->req.arp_flags &= ~ATF_PERM;
-        return -errno;
     }
 
     // install_iptables_board() is a no-op when iptables is unavailable


### PR DESCRIPTION
Follow-up to #3964, addressing a point @jepler raised in that review.

hm2_eth pins a permanent ARP entry for the board with `SIOCSARP`, which needs `CAP_NET_ADMIN`. On a rootless install without `make setcap` the ioctl fails with EPERM, and the old code treated that as fatal: it returned `-errno`, so the board would not load at all.

That is inconsistent with the rest of the rootless work in #3964, where the firewall setup degrades gracefully (skip with a warning) when the capability is missing. This one ioctl made the whole "run without setcap" mode unusable for ethernet boards.

## What changed

* `SIOCSARP` failure is now best-effort instead of fatal. On failure the driver warns, clears `ATF_PERM`, and continues. The kernel falls back to dynamic ARP, which works; the only cost is an occasional transmit delay when the cache entry expires and is refreshed, as @jepler noted.
* The warning points the user at `sudo make setcap` (or setuid) to restore the pinned entry.
* Clearing `ATF_PERM` keeps the `SIOCDARP` teardown in `close_board()` from trying to remove an entry that was never installed.

Installs that run with setcap or setuid are unaffected: the ioctl succeeds as before and the static entry is pinned.

## Tested

Configured `--with-realtime=uspace` and built; hm2_eth compiles and links clean. Not hardware-tested, I do not have a Mesa ethernet card.

cc @jepler, @hdiethelm
