### PR TITLE
qtvcp: fix startup segfault when no notification daemon is present

### DIFF
--- a/lib/python/qtvcp/lib/sys_notify.py
+++ b/lib/python/qtvcp/lib/sys_notify.py
@@ -61,39 +61,29 @@ def init(app_name):
     path = "/org/freedesktop/Notifications"
     interface = "org.freedesktop.Notifications"
 
-    mainloop = None
-    bus = None
     try:
-        if DBusQtMainLoop is not None:
-            mainloop = DBusQtMainLoop(set_as_default=True)
+        # Probe on a throwaway no-mainloop connection first. Wiring the
+        # Qt dbus mainloop before a daemon is confirmed leaves a dangling
+        # QSocketNotifier that segfaults on its next dispatch.
+        probe = dbus.SessionBus(private=True)
+        try:
+            present = probe.name_has_owner(name)
+        finally:
+            probe.close()
+        if not present:
+            raise RuntimeError('no notification daemon')
 
-        bus = dbus.SessionBus(mainloop)
+        mainloop = DBusQtMainLoop(set_as_default=True) if DBusQtMainLoop else None
+        bus = dbus.SessionBus(mainloop=mainloop)
         proxy = bus.get_object(name, path)
         DBUS_IFACE = dbus.Interface(proxy, interface)
 
         if mainloop is not None:
-            # We have a mainloop, so connect callbacks
             DBUS_IFACE.connect_to_signal('ActionInvoked', _onActionInvoked)
             DBUS_IFACE.connect_to_signal('NotificationClosed', _onNotificationClosed)
     except Exception as e:
         LOG.warning('Desktop Notify not available:: {}'.format(e))
-        # When the SessionBus is constructed with a PyQt5/PyQt6 mainloop
-        # integration, dbus-python installs a QSocketNotifier on the
-        # connection fd. If the subsequent get_object/Interface setup
-        # raises (e.g. ServiceUnknown when no notification daemon owns
-        # org.freedesktop.Notifications), the Python-side bus reference
-        # is dropped on exception but the QSocketNotifier keeps the
-        # underlying C connection alive in a half-initialized state.
-        # The next QEventLoop tick dispatches a queued message via
-        # dbus_connection_dispatch() and segfaults inside
-        # _dbus_list_unlink. Close the bus explicitly so the notifier
-        # detaches and the connection is fully released.
         DBUS_IFACE = None
-        if bus is not None:
-            try:
-                bus.close()
-            except Exception:
-                pass
 
 
 def _onActionInvoked(nid, action):


### PR DESCRIPTION
On any system with no desktop notification daemon (headless servers, minimal installs, CI under xvfb), qtvcp segfaults a few seconds after startup. The crash is a use-after-free in `dbus_connection_dispatch()`.

`sys_notify.init()` wires the PyQt dbus mainloop, then the Notifications setup raises `ServiceUnknown` because nothing owns `org.freedesktop.Notifications`. dbus-python has already attached a `QSocketNotifier` to the Qt event loop; the next loop tick dispatches a queued message on the torn-down connection and crashes.

A prior attempt (`d955fc208b`) called `bus.close()` on the failure path, but by then dbus-python had already posted the dispatch to the Qt event loop, so the close came too late. This version probes for the daemon on a throwaway private connection with no mainloop, and only wires the integrated bus once it is confirmed. On the failure path nothing is wired, so nothing dangles.

Backtrace (Ubuntu 24.04, headless, gdb on the core):

```
dbus_connection_dispatch     libdbus-1.so.3
dbus/mainloop/pyqt5.abi3.so
QObject::event
...
QCoreApplication::exec
```
