### PR TITLE
gmoccapy: exit on SIGTERM/SIGINT regardless of main-loop state

### DIFF
--- a/src/emc/usr_intf/gmoccapy/gmoccapy.py
+++ b/src/emc/usr_intf/gmoccapy/gmoccapy.py
@@ -40,6 +40,7 @@ import hal                  # base hal class to react to hal signals
 from common import hal_glib # needed to make our own hal pins
 import sys                 # handle system calls
 import os                  # needed to get the paths and directories
+import signal              # clean shutdown on SIGTERM/SIGINT
 import atexit              # needed to register child's to be closed on closing the GUI
 import subprocess          # to launch onboard and other processes
 import tempfile            # needed only if the user click new in edit mode to open a new empty file
@@ -6593,6 +6594,18 @@ if __name__ == "__main__":
                     LOG.error('postgui command error:{}'.format(res))
                     raise SystemExit(res)
 
+
+    # Exit on SIGTERM/SIGINT whether or not a main loop is running.
+    # Gtk.main_quit() does nothing outside a running loop, so quit the
+    # loop if one is active, otherwise exit the process.
+    def _terminate(signum, frame):
+        LOG.info("gmoccapy received signal {}, shutting down".format(signum))
+        if Gtk.main_level() > 0:
+            Gtk.main_quit()
+        else:
+            sys.exit(0)
+    signal.signal(signal.SIGTERM, _terminate)
+    signal.signal(signal.SIGINT, _terminate)
 
     # start the event loop
     Gtk.main()


### PR DESCRIPTION
gmoccapy did not reliably exit on SIGTERM; callers had to escalate to SIGKILL.

#4076 routed the signal through `excepthook` to `Gtk.main_quit()`, but that only quits while `Gtk.main()` is iterating. A signal arriving during startup, or while a nested dialog is up, hits `gtk_main_quit: assertion 'main_loops != NULL'` and gmoccapy keeps running.

This installs an explicit SIGTERM/SIGINT handler that quits the loop if one is active, otherwise exits the process. Surfaced by the ui-smoke quit-path tests (#4054).
