### PR TITLE
CI: Fail on cppcheck.sh error

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,15 +128,29 @@ jobs:
       run: |
         set -x
         sudo apt-get -q update
-        sudo apt-get --yes install cppcheck shellcheck
+        sudo apt-get --yes install cppcheck
     - name: Cppcheck
-      continue-on-error: true
       run: |
         set -x
         scripts/cppcheck.sh
+
+  shellcheck:
+    runs-on: ubuntu-24.04
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v6
+      with:
+        submodules: false
+        fetch-depth: 1
+    - name: Install dependencies
+      run: |
+        set -x
+        sudo apt-get -q update
+        sudo apt-get --yes install shellcheck
     - name: Shellcheck
       continue-on-error: true
       run: |
+        set -x
         scripts/shellcheck.sh
 
   htmldocs:

--- a/scripts/cppcheck.sh
+++ b/scripts/cppcheck.sh
@@ -16,6 +16,7 @@ EXHAUSTIVE=$(cppcheck --check-level=exhaustive --version > /dev/null 2>&1 && ech
 CPPCHKOPT=( -j "$nproc" --force "$EXHAUSTIVE" --inline-suppr )
 CPPCHKOPT+=( "--enable=warning,performance,portability" )
 CPPCHKOPT+=( "-I$(realpath "$(dirname "$0")/../include")" )
+CPPCHKOPT+=( --error-exitcode=1 )
 
 if [ -n "$CPPCHECK_OPTS" ]; then
     read -r -a OPTS <<< "$CPPCHECK_OPTS"
@@ -107,5 +108,11 @@ do
     echo "I (4/4): checking $d"
     docheck "$d" || result=1
 done < <(find rtapi/ -type d -not -name "*__pycache__" -print0)
+
+if [ $result -gt 0 ]; then
+    echo "ERROR: Issues found"
+else
+    echo "No issues found"
+fi
 
 exit $result


### PR DESCRIPTION
Fix issue in cppcheck.sh and make CI fail on cppcheck error

~Additionally, make shellckeck.sh failing except for files that need yet to be fixed.~