### PR TITLE
2.9 gremlin: Initialize preview interpreter with active modal gcodes

### DIFF
--- a/src/emc/usr_intf/gremlin/gremlin.py
+++ b/src/emc/usr_intf/gremlin/gremlin.py
@@ -328,6 +328,13 @@ class Gremlin(Gtk.DrawingArea,rs274.glcanon.GlCanonDraw,glnav.GlNavBase):
 
             unitcode = "G%d" % (20 + (s.linear_units == 1))
             initcode = ""
+            # To guard against incorrect preview with incomplete preambles in the gcode program
+            # we initialize with active gcodes for modal groups 2,3,4,5,6,7,8,9,10,11,12,13,14,15
+            # sorting is not necessary but helps in debugging
+            active_gcodes = s.gcodes
+            for i in (3,6,14,7,5,4,9,12,10,16,8,11,13,15):
+                if active_gcodes[i] > -1:
+                    initcode = initcode + 'G' + str(active_gcodes[i]/10) + ' '
             result, seq = self.load_preview(filename, canon, unitcode, initcode)
             if result > gcode.MIN_ERROR:
                 self.report_gcode_error(result, seq, filename)


### PR DESCRIPTION
fixes  #4121 and improves preview for gcode with incomplete preambles.

No regression on https://github.com/LinuxCNC/linuxcnc/issues/2753