### PR TITLE
docs: add four orphan pages to the master books

### DIFF
--- a/docs/po4a.cfg
+++ b/docs/po4a.cfg
@@ -62,6 +62,7 @@
 [type: AsciiDoc_def] src/drivers/hostmot2.adoc $lang:build/adoc/$lang/drivers/hostmot2.adoc
 [type: AsciiDoc_def] src/drivers/hal_gpio.adoc $lang:build/adoc/$lang/drivers/hal_gpio.adoc
 [type: AsciiDoc_def] src/drivers/mb2hal.adoc $lang:build/adoc/$lang/drivers/mb2hal.adoc
+[type: AsciiDoc_def] src/drivers/mesa_modbus.adoc $lang:build/adoc/$lang/drivers/mesa_modbus.adoc
 [type: AsciiDoc_def] src/drivers/mitsub-vfd.adoc $lang:build/adoc/$lang/drivers/mitsub-vfd.adoc
 [type: AsciiDoc_def] src/drivers/motenc.adoc $lang:build/adoc/$lang/drivers/motenc.adoc
 [type: AsciiDoc_def] src/drivers/opto22.adoc $lang:build/adoc/$lang/drivers/opto22.adoc

--- a/docs/src/Master_Developer.adoc
+++ b/docs/src/Master_Developer.adoc
@@ -29,6 +29,8 @@ include::code/adding-configs.adoc[]
 
 include::code/contributing-to-linuxcnc.adoc[]
 
+include::code/writing-tests.adoc[]
+
 include::common/glossary.adoc[]
 
 include::common/gpld-copyright.adoc[]

--- a/docs/src/Master_Documentation.adoc
+++ b/docs/src/Master_Documentation.adoc
@@ -17,6 +17,8 @@ include::getting-started/about-linuxcnc.adoc[]
 
 include::getting-started/system-requirements.adoc[]
 
+include::getting-started/hardware-interface.adoc[]
+
 include::getting-started/getting-linuxcnc.adoc[]
 
 include::getting-started/running-linuxcnc.adoc[]
@@ -132,6 +134,8 @@ include::drivers/hal_gpio.adoc[]
 include::drivers/hostmot2.adoc[]
 
 include::drivers/mb2hal.adoc[]
+
+include::drivers/mesa_modbus.adoc[]
 
 include::drivers/mitsub-vfd.adoc[]
 
@@ -266,6 +270,8 @@ include::gui/pyvcp-examples.adoc[]
 include::gui/gladevcp.adoc[]
 
 include::gui/gladevcp-libraries.adoc[]
+
+include::gui/gladevcp-panels.adoc[]
 
 include::gui/qtvcp.adoc[]
 

--- a/docs/src/getting-started/hardware-interface.adoc
+++ b/docs/src/getting-started/hardware-interface.adoc
@@ -74,7 +74,8 @@ Expatria Technologies PicoBOB-DLX was designed for LinuxCNC Remora.
 Remora docs: https://remora-docs.readthedocs.io
 
 As of March 2024:
-```
+
+----
 STM32 based controller boards
 
     NVEM - an STM32F207 based board with Ethernet PHY chip, originally intended for Mach3. [No longer in production, Legacy Support - no new features]
@@ -92,7 +93,7 @@ RP2040 based controller boards
     WIZnet W5500-EVB-Pico - Raspberry Pi RP2040 based development board with on-board W5500 Ethernet SPI adapter
 
     Expatria Technologies PicoBOB-DLX - Raspberry Pi RP2040 based board with on-board W5500 Ethernet SPI adapter designed for Remora
-```
+----
 
 === Litex-CNC
 This project aims to make a generic CNC firmware and driver for FPGA cards which are supported by LiteX. Configuration of the board and driver is done using json-files. The supported boards are the Colorlight boards 5A-75B and 5A-75E, as these are fully supported with the open source toolchain.


### PR DESCRIPTION
hardware-interface, mesa_modbus, gladevcp-panels and writing-tests are linked from the landing page but missing from every Master_*.adoc, so they appear in neither the PDFs nor the documentation navigation. I include each in its book so both deliveries cover the same pages.