### PR TITLE
gmoccapy: exit on SIGTERM received during startup

### DIFF
--- a/src/emc/usr_intf/gmoccapy/gmoccapy.py
+++ b/src/emc/usr_intf/gmoccapy/gmoccapy.py
@@ -59,10 +59,12 @@ def excepthook(exc_type, exc_obj, exc_tb):
     # caller escalates to SIGKILL.
     if issubclass(exc_type, KeyboardInterrupt):
         LOG.info("gmoccapy interrupted (signal), shutting down")
-        try:
+        if Gtk.main_level() > 0:
             Gtk.main_quit()
-        except Exception:
-            pass
+        else:
+            # No loop yet (startup): the interrupt is swallowed at the GTK
+            # C boundary, so returning resumes startup. Force the exit.
+            os._exit(0)
         return
     try:
         w = app.widgets.window1


### PR DESCRIPTION
Follow-up to #4115. That handler is installed just before Gtk.main(), so a SIGTERM arriving earlier, during construction, is still routed through the excepthook as a KeyboardInterrupt. With no main loop running Gtk.main_quit() asserts, the interrupt is swallowed at the GTK C boundary, and gmoccapy keeps running until the caller escalates to SIGKILL.

This makes the excepthook force the process exit when no main loop is active, so a termination signal during startup takes effect. Verified green against the ui-smoke quit tests in #4054 (289/289).