### PR TITLE
gmoccapy: show "Important changes" as notification instead of dialog

### DIFF
--- a/src/emc/usr_intf/gmoccapy/dialogs.py
+++ b/src/emc/usr_intf/gmoccapy/dialogs.py
@@ -170,7 +170,7 @@ class Dialogs(GObject.GObject):
         dialog.destroy()
         return response == Gtk.ResponseType.YES
 
-    def show_user_message(self, caller, message, title = _("Operator Message"), checkbox = False):
+    def show_user_message(self, caller, message, title = _("Operator Message")):
         dialog = Gtk.MessageDialog(caller.widgets.window1,
                                    Gtk.DialogFlags.DESTROY_WITH_PARENT,
                                    Gtk.MessageType.INFO,
@@ -183,22 +183,13 @@ class Dialogs(GObject.GObject):
         ok_button.connect("clicked",lambda w:dialog.response(Gtk.ResponseType.OK))
         box = Gtk.HButtonBox()
         box.add(ok_button)
-        
-        if checkbox:
-            cb = Gtk.CheckButton(label = _("Don't show this again"))
-            dialog.get_content_area().add(cb)
-        
-        dialog.get_action_area().add(box)
+        dialog.action_area.add(box)
         dialog.set_border_width(5)
         dialog.show_all()
         self.emit("play_sound", "alert")
         response = dialog.run()
         dialog.destroy()
-        
-        if checkbox and response == Gtk.ResponseType.OK:
-            return cb.get_active()
-        else:
-            return response == Gtk.ResponseType.OK
+        return response == Gtk.ResponseType.OK
 
     # dialog for run from line
     def restart_dialog(self, caller):

--- a/src/emc/usr_intf/gmoccapy/gmoccapy.py
+++ b/src/emc/usr_intf/gmoccapy/gmoccapy.py
@@ -552,7 +552,7 @@ class gmoccapy(object):
                     + _("Please check the console output."), ALERT_ICON)
 
     def _startup_message(self):
-        title = _("Important change(s)")
+        title = _("<b>Important change(s)</b>\n\n")
         # This array holds information about new features or things that changed. They can be hidden using the dialog's checkbox.
         # It is important that strings are only appended to this array (not removed), otherwise some messages could get hidden unwanted.
         messages =[ _("<b>3.5.0 (LinuxCNC 2.10.0): Gmoccapy does no longer automatically retain G43 after a toolchange!</b>\n"\
@@ -564,12 +564,12 @@ class gmoccapy(object):
                     ]
         hide_message = self.prefs.getpref("hide_startup_messsage", 0, int)
         if hide_message < len(messages):
-            message = "\n\n".join(messages[hide_message:])
+            message = title + "\n\n".join(messages[hide_message:])
             message += _('\n\nFor more information see the <a href="https://linuxcnc.org/docs/html/gui/gmoccapy_release_notes.txt">release notes</a>.')
+                 
+            self.notification.add_message(message, INFO_ICON, show_checkbox=True)
+            self.num = len(messages)
 
-            dont_show = self.dialogs.show_user_message(self, message, title, checkbox = True)
-            if dont_show:
-                self.prefs.putpref("hide_startup_messsage", len(messages), str)
 
     def _get_ini_data(self):
         self.get_ini_info = getiniinfo.GetIniInfo()
@@ -6222,13 +6222,16 @@ class gmoccapy(object):
                 return
             self.audio.run()
 
-    def _on_message_deleted(self, widget, messages):
+    def _on_message_deleted(self, widget, messages, checkbox_checked):
         number = []
         for message in messages:
             if message[2] == ALERT_ICON:
                 number.append(message[0])
         if len(number) == 0:
             self.halcomp["error"] = False
+        
+        if checkbox_checked:
+            self.prefs.putpref("hide_startup_messsage", self.num, str)
 
     def _del_message_changed(self, pin):
         if pin.get():

--- a/src/emc/usr_intf/gmoccapy/gmoccapy.py
+++ b/src/emc/usr_intf/gmoccapy/gmoccapy.py
@@ -2771,7 +2771,6 @@ class gmoccapy(object):
 
     def _show_error(self, error):
         kind, text = error
-        # print(kind,text)
         if kind in (linuxcnc.NML_ERROR, linuxcnc.OPERATOR_ERROR):
             icon = ALERT_ICON
             self.halcomp["error"] = True
@@ -2813,7 +2812,7 @@ class gmoccapy(object):
             self.stat.poll()
             if self.stat.task_state == linuxcnc.STATE_ESTOP:
                 widget.set_active(True)
-                self._show_error((11, _("External ESTOP is set, could not change state!")))
+                self._show_error((linuxcnc.OPERATOR_ERROR, _("External ESTOP is set, could not change state!")))
 
     # toggle machine on / off button
     def on_tbtn_on_toggled(self, widget, data=None):
@@ -2826,7 +2825,7 @@ class gmoccapy(object):
             self.stat.poll()
             if self.stat.task_state != linuxcnc.STATE_ON:
                 widget.set_active(False)
-                self._show_error((11, _("Could not switch the machine on, is limit switch activated?")))
+                self._show_error((linuxcnc.OPERATOR_DISPLAY, _("Could not switch the machine on, is limit switch activated?")))
                 self._update_widgets(False)
                 return
             self._update_widgets(True)
@@ -3137,7 +3136,7 @@ class gmoccapy(object):
             self.command.abort()
             self.command.mode(linuxcnc.MODE_MANUAL)
             self.command.wait_complete()
-            self._show_error((13, _("It is not possible to change to MDI Mode at the moment")))
+            self._show_error((linuxcnc.OPERATOR_DISPLAY, _("It is not possible to change to MDI Mode at the moment")))
             return
         else:
             # if we are in user tabs, we must reset the button
@@ -3188,7 +3187,7 @@ class gmoccapy(object):
             self.command.abort()
             self.command.mode(linuxcnc.MODE_MANUAL)
             self.command.wait_complete()
-            self._show_error((13, _("It is not possible to change to Auto Mode at the moment")))
+            self._show_error((linuxcnc.OPERATOR_DISPLAY, _("It is not possible to change to Auto Mode at the moment")))
             return
         else:
             # if we are in user tabs, we must reset the button
@@ -3513,7 +3512,7 @@ class gmoccapy(object):
         if keyname == "F3" or keyname == "F5":
             if self.stat.interp_state != linuxcnc.INTERP_IDLE:
                 if signal: # Otherwise the message will be shown twice
-                    self._show_error((13, _("Mode change is only allowed if the interpreter is idle!")))
+                    self._show_error((linuxcnc.OPERATOR_DISPLAY, _("Mode change is only allowed if the interpreter is idle!")))
                 return
             else:
                 # F3 change to manual mode
@@ -4126,7 +4125,7 @@ class gmoccapy(object):
     def on_btn_launch_test_message_pressed(self, widget=None, data=None):
         index = len(self.notification.messages)
         text = _("Halo, welcome to the test message {0}").format(index)
-        self._show_error((13, text))
+        self._show_error((linuxcnc.OPERATOR_DISPLAY, text))
 
     def on_chk_turtle_jog_toggled(self, widget, data=None):
         state = widget.get_active()
@@ -4316,7 +4315,7 @@ class gmoccapy(object):
         self.stat.poll()
         for j in range(self.stat.joints):
             if self.stat.joint[j]["homing"]:
-                self._show_error((13, _("Homing not possible until current homing process is finished.")))
+                self._show_error((linuxcnc.OPERATOR_DISPLAY, _("Homing not possible until current homing process is finished.")))
                 return
         if "axis" in widget.get_property("name"):
             value = widget.get_property("name")[-1]
@@ -6262,7 +6261,7 @@ class gmoccapy(object):
             if self.stat.motion_mode == 1 and pin.get():
                 message = _("Axis jogging is only allowed in world mode, but you are in joint mode!")
                 LOG.debug(message)
-                self._show_error((13, message))
+                self._show_error((linuxcnc.OPERATOR_DISPLAY, message))
                 return
 
         if pin.get():

--- a/src/emc/usr_intf/gmoccapy/notification.py
+++ b/src/emc/usr_intf/gmoccapy/notification.py
@@ -70,7 +70,7 @@ class Notification(Gtk.Window):
     __gproperties = __gproperties__
 
     __gsignals__ = {
-                'message_deleted': (GObject.SignalFlags.RUN_FIRST, GObject.TYPE_NONE, (GObject.TYPE_PYOBJECT,)),
+                'message_deleted': (GObject.SignalFlags.RUN_FIRST, GObject.TYPE_NONE, (GObject.TYPE_PYOBJECT, GObject.TYPE_BOOLEAN)),
                }
 
 
@@ -102,6 +102,7 @@ class Notification(Gtk.Window):
     def _show_message(self, message):
         number = message[0]
         text = message[1]
+        show_checkbox = message[3]
         if self.use_frames:
             frame = Gtk.Frame()
             frame.set_label_widget(None)
@@ -122,6 +123,12 @@ class Notification(Gtk.Window):
         pixbuf = icon_theme_helper.load_symbolic_from_icon_theme(self.icon_theme, icon_name, self.icon_size, default_style)
         icon.set_from_pixbuf(pixbuf)
         hbox.pack_start(icon, False, False, 3)
+        # vbox in the middle with label and checkbox
+        vbox = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=5)
+        vbox.set_margin_top(3)
+        vbox.set_margin_bottom(3)
+        vbox.show()
+        hbox.pack_start(vbox, False, False, 0)
         label = Gtk.Label()
         label.set_line_wrap(True)
         label.set_line_wrap_mode(Pango.WrapMode.WORD_CHAR)
@@ -140,7 +147,12 @@ class Notification(Gtk.Window):
         else:
             label.set_text(text)
         label.set_xalign(0)
-        hbox.pack_start(label, False, False, 0)
+        vbox.pack_start(label, False, False, 0)
+        checkbox = None
+        if show_checkbox:
+            checkbox = Gtk.CheckButton(label="Don't show this again")
+            checkbox.show()
+            vbox.pack_start(checkbox, False, False, 0)
         btn_close = Gtk.Button()
         btn_close.set_name("notification_close")
         image = Gtk.Image()
@@ -148,7 +160,7 @@ class Notification(Gtk.Window):
         image.set_from_pixbuf(pixbuf)
         btn_close.set_image(image)
         btn_close.set_border_width(2)
-        btn_close.connect('clicked', self._on_notification_close_clicked, labelnumber.get_text())
+        btn_close.connect('clicked', self._on_notification_close_clicked, labelnumber.get_text(), checkbox)
         btn_close.set_size_request(48, 48)
         btn_box = Gtk.Box.new(Gtk.Orientation.VERTICAL,0)
         btn_box.set_center_widget(btn_close)
@@ -172,7 +184,7 @@ class Notification(Gtk.Window):
 
     # add a message, the message is a string, it will be line wrapped
     # if to long for the frame
-    def add_message(self, message, icon_name=None):
+    def add_message(self, message, icon_name=None, show_checkbox=False):
         '''Notification.add_message(messagetext, icon_file_name)
 
            messagetext = a string to display
@@ -184,7 +196,7 @@ class Notification(Gtk.Window):
         if number_of_messages == self.max_messages:
             self.del_first()
             number_of_messages = len(self.messages)
-        self.messages.append([number_of_messages, message, icon_name])
+        self.messages.append([number_of_messages, message, icon_name, show_checkbox])
         self._show_message(self.messages[number_of_messages])
         if not self.top_to_bottom:
             self.height = self.popup.get_size()[1]
@@ -200,7 +212,7 @@ class Notification(Gtk.Window):
         if len(self.messages) != 0:
             del self.messages[0]
             self._refill_messages()
-            self.emit("message_deleted", self.messages)
+            self.emit("message_deleted", self.messages, False)
 
     def del_last(self):
         '''del_last()
@@ -209,7 +221,7 @@ class Notification(Gtk.Window):
         if len(self.messages) != 0:
             del self.messages[len(self.messages) - 1]
             self._refill_messages()
-            self.emit("message_deleted", self.messages)
+            self.emit("message_deleted", self.messages, False)
 
     # this will delete a message, if the user gives a valid number it will be deleted,
     # but the user must take care to use the correct number
@@ -221,7 +233,7 @@ class Notification(Gtk.Window):
            messagenumber = integer
                            -1 will erase all messages
         '''
-        self.emit("message_deleted", self.messages)
+        self.emit("message_deleted", self.messages, False)
         if messagenumber == -1:
             self.messages = []
             self._refill_messages()
@@ -238,9 +250,13 @@ class Notification(Gtk.Window):
 
     # this is the recomendet way to delete a message, by clicking the
     # close button of the corresponding frame
-    def _on_notification_close_clicked(self, widget, labelnumber):
+    def _on_notification_close_clicked(self, widget, labelnumber, checkbox):
         del self.messages[int(labelnumber)]
-        self.emit("message_deleted", self.messages)
+        if checkbox is not None:
+            checkbox_state = checkbox.get_active()
+        else:
+            checkbox_state = False
+        self.emit("message_deleted", self.messages, checkbox_state)
         self._refill_messages()
 
     def _refill_messages(self):

--- a/src/emc/usr_intf/gmoccapy/notification.py
+++ b/src/emc/usr_intf/gmoccapy/notification.py
@@ -78,7 +78,7 @@ class Notification(Gtk.Window):
     def __init__(self):
         self.messages = []
         self.popup = Gtk.Window(type = Gtk.WindowType.POPUP)
-        self.vbox = Gtk.VBox()
+        self.vbox = Gtk.Box.new(Gtk.Orientation.VERTICAL, 0)
         self.popup.add(self.vbox)
         self.icon_size = 24
         self.message_width = 200
@@ -104,11 +104,13 @@ class Notification(Gtk.Window):
         text = message[1]
         if self.use_frames:
             frame = Gtk.Frame()
-            frame.set_label("")
-        hbox = Gtk.HBox()
-        hbox.set_property('spacing', 5)
+            frame.set_label_widget(None)
+            frame.set_margin_top(1)
+            frame.set_margin_bottom(1)
+        hbox = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=5)
         if self.use_frames:
             frame.add(hbox)
+        # we do not show the labelnumber, but we use it for handling
         labelnumber = Gtk.Label(label = str(number))
         hbox.pack_start(labelnumber, False, False, 0)
         icon = Gtk.Image()
@@ -129,8 +131,8 @@ class Notification(Gtk.Window):
         # As messages may contain non Pango conform syntax like "vel <= 0" we will have to check that to avoid an error
         Pango_ok = True
         try:
-            # The GError exception is raised if an error occurs while parsing the markup text.
-            Pango.parse_markup(text)
+            # An exception is raised if an error occurs while parsing the markup text.
+            label.set_markup(text)
         except:
             Pango_ok = False
         if Pango_ok:
@@ -146,7 +148,7 @@ class Notification(Gtk.Window):
         image.set_from_pixbuf(pixbuf)
         btn_close.set_image(image)
         btn_close.set_border_width(2)
-        btn_close.connect('clicked', self._on_btn_close_clicked, labelnumber.get_text())
+        btn_close.connect('clicked', self._on_notification_close_clicked, labelnumber.get_text())
         btn_close.set_size_request(48, 48)
         btn_box = Gtk.Box.new(Gtk.Orientation.VERTICAL,0)
         btn_box.set_center_widget(btn_close)
@@ -166,8 +168,6 @@ class Notification(Gtk.Window):
         btn_close.show()
         hbox.show()
         icon.show()
-# we do not show the labelnumber, but we use it for the handling
-        #labelnumber.show()
         self.vbox.show()
 
     # add a message, the message is a string, it will be line wrapped
@@ -238,7 +238,7 @@ class Notification(Gtk.Window):
 
     # this is the recomendet way to delete a message, by clicking the
     # close button of the corresponding frame
-    def _on_btn_close_clicked(self, widget, labelnumber):
+    def _on_notification_close_clicked(self, widget, labelnumber):
         del self.messages[int(labelnumber)]
         self.emit("message_deleted", self.messages)
         self._refill_messages()


### PR DESCRIPTION
This came up in conjunction with https://github.com/LinuxCNC/linuxcnc/issues/4072.

I think this is more handy than the dialog that needed to be confirmed.

<img width="990" height="784" alt="grafik" src="https://github.com/user-attachments/assets/e17185c4-e338-4b57-9279-a95895ba35ff" />


Compare to the dialog before:

<img width="992" height="788" alt="grafik" src="https://github.com/user-attachments/assets/4ebb9a8c-0970-4e68-b6bb-83ff98a3a4ca" />
