### PR TITLE
Halscope: Fix setting for AC coupling (2.9)

### DIFF
--- a/src/hal/utils/scope_usr.h
+++ b/src/hal/utils/scope_usr.h
@@ -90,6 +90,7 @@ typedef struct {
     hal_type_t data_type;	/* data type */
     int data_len;		/* data length */
     double vert_offset;		/* offset to be applied */
+    double saved_vert_offset;	/* saved offset when AC coupling is enabled */
     int ac_offset;              /* TRUE if the signal should be AC-coupled */
     int scale_index;		/* scaling (slider setting) */
     int max_index;		/* limits of scale slider */

--- a/src/hal/utils/scope_vert.c
+++ b/src/hal/utils/scope_vert.c
@@ -287,6 +287,7 @@ int set_channel_source(int chan_num, int type, char *name)
     vert->data_offset[chan_num - 1] = -1;
     /* set scale and offset to nominal values */
     chan->vert_offset = 0.0;
+    chan->saved_vert_offset = 0.0;
     chan->scale_index = 0;
     /* return success */
     return 0;
@@ -401,6 +402,8 @@ int set_vert_offset(double setting, int ac_coupled)
     /* set the new offset */
     chan->vert_offset = setting;
     chan->ac_offset = ac_coupled;
+    /* copy the offset to restore when toggling AC coupling */
+    chan->saved_vert_offset = chan->vert_offset;
     /* update the offset display */
     if (chan->data_type == HAL_BIT) {
 	snprintf(buf1, BUFLEN, "----");
@@ -723,7 +726,7 @@ static gboolean dialog_set_offset(int chan_num)
             vert->offset_entry, FALSE, TRUE, 0);
 
     /* update elements */
-    snprintf(data.buf, BUFLEN, "%f", chan->vert_offset);
+    snprintf(data.buf, BUFLEN, "%f", chan->saved_vert_offset);
     /* get AC coupling setting from channel */
     data.ac_coupled = chan->ac_offset;
     gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(vert->offset_ac), data.ac_coupled);
@@ -771,6 +774,14 @@ static void offset_changed(GtkEditable * editable, struct offset_data *data)
     data->ac_coupled =
       gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(ctrl_usr->vert.offset_ac));
     gtk_widget_set_sensitive(ctrl_usr->vert.offset_entry, !data->ac_coupled);
+
+    if (!data->ac_coupled) {
+        /* select all chars, so if the user types the original value goes away */
+        gtk_editable_select_region(
+            GTK_EDITABLE(ctrl_usr->vert.offset_entry), 0, strlen(data->buf));
+        /* make it active so user doesn't have to click on it */
+        gtk_widget_grab_focus(GTK_WIDGET(ctrl_usr->vert.offset_entry));
+    }
 
     /* maybe user typed something, save it in the buffer */
     text = gtk_entry_get_text(GTK_ENTRY(ctrl_usr->vert.offset_entry));

--- a/src/hal/utils/scope_vert.c
+++ b/src/hal/utils/scope_vert.c
@@ -724,14 +724,22 @@ static gboolean dialog_set_offset(int chan_num)
 
     /* update elements */
     snprintf(data.buf, BUFLEN, "%f", chan->vert_offset);
+    /* get AC coupling setting from channel */
+    data.ac_coupled = chan->ac_offset;
+    gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(vert->offset_ac), data.ac_coupled);
+    gtk_widget_set_sensitive(GTK_WIDGET(vert->offset_entry), !data.ac_coupled);
+
     gtk_entry_set_text(GTK_ENTRY(vert->offset_entry), data.buf);
     gtk_entry_set_max_length(GTK_ENTRY(vert->offset_entry), BUFLEN-1);
-    /* point at first char */
-    gtk_editable_set_position(GTK_EDITABLE(vert->offset_entry), 0);
-    /* select all chars, so if the user types the original value goes away */
-    gtk_editable_select_region(GTK_EDITABLE(vert->offset_entry), 0, strlen(data.buf));
-    /* make it active so user doesn't have to click on it */
-    gtk_widget_grab_focus(GTK_WIDGET(vert->offset_entry));
+    
+    if (!data.ac_coupled) {
+        /* point at first char */
+        gtk_editable_set_position(GTK_EDITABLE(vert->offset_entry), 0);
+        /* select all chars, so if the user types the original value goes away */
+        gtk_editable_select_region(GTK_EDITABLE(vert->offset_entry), 0, strlen(data.buf));
+        /* make it active so user doesn't have to click on it */
+        gtk_widget_grab_focus(GTK_WIDGET(vert->offset_entry));
+    }
 
     /* signals */
     g_signal_connect(vert->offset_ac, "toggled",


### PR DESCRIPTION
Steps to reproduce:

1. Set a channel to "AC Coupled" via the offset button, confirm.
2. Click the offset button again: The checkbox "AC Coupled" is disabled but AC coupling is still active. You need to select and unselect the checkbox in order to disable AC coupling.


https://github.com/user-attachments/assets/dc8ce1c4-3bad-43f7-a69a-49620a5a8079



Further:
The offset was reset to zero when AC coupling was enabled.
This adds a data field to restore the previous offset value when disabling AC coupling.