### PR TITLE
docs(build): symlink docs/html -> build/html for the website sync

### DIFF
--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -4,6 +4,9 @@
 # Rendered output: HTML, PDF, and po4a-translated .adoc all land under build/.
 build/
 
+# Legacy publish path: a symlink to build/html for the website sync (Submakefile).
+/html
+
 # Intermediate .html asciidoctor writes beside each source .adoc before the
 # copy step moves it into build/html/.
 src/*/*.html

--- a/docs/src/Submakefile
+++ b/docs/src/Submakefile
@@ -418,6 +418,7 @@ endif
 docs: manpages
 
 clean: clean-manpages clean-translated
+	-rm -f $(DOC_DIR)/html
 clean-manpages:
 	-rm -f $(GENERATED_MANPAGES)
 	# Remove generated alias man pages too.
@@ -436,7 +437,14 @@ endif
 ifeq ($(BUILD_DOCS_HTML),yes)
 docs: htmldocs
 install-doc: install-doc-html
+docs: $(DOC_DIR)/html
 endif
+
+# Legacy publish path: the website sync uploads docs/html/, which the unified
+# build moved to docs/build/html/.  Expose docs/html as a symlink to the new
+# tree so the (dereferencing) sync keeps publishing.  git-ignored, clean'd.
+$(DOC_DIR)/html:
+	$(Q)ln -sfn build/html $@
 
 # debian/linuxcnc-doc-en.docs installs docs/build/html/en/gcode.html, so the
 # English gcode reference must land in the build tree even when only PDF docs


### PR DESCRIPTION
The unified docs build moved rendered HTML to docs/build/html/, but the website sync still uploads docs/html/, so the dev-docs link on linuxcnc.org/documents/ returns 404.

This re-exposes docs/html as a symlink to build/html during the HTML build (git-ignored, removed by make clean), so the sync keeps publishing from the old path with no buildbot or cron change.

Caveat: this only helps if the sync dereferences symlinks (rsync -L, a trailing-slash source on the symlinked dir, or cp -rL). If it copies the link verbatim it will not resolve on the server. This is the first thing to try per the mailing-list thread.

@BsAtHome @andypugh