### PR TITLE
Touchy gtk3 conversion

### DIFF
--- a/src/emc/usr_intf/touchy/touchy.glade
+++ b/src/emc/usr_intf/touchy/touchy.glade
@@ -481,98 +481,91 @@
                             <property name="border-width">5</property>
                             <property name="label-xalign">0</property>
                             <child>
-                              <object class="GtkAlignment" id="alignment2">
+                              <object class="GtkTable" id="table6">
                                 <property name="visible">True</property>
                                 <property name="can-focus">False</property>
-                                <property name="left-padding">12</property>
+                                <property name="border-width">5</property>
+                                <property name="n-rows">2</property>
+                                <property name="n-columns">3</property>
+                                <property name="column-spacing">15</property>
+                                <property name="homogeneous">True</property>
                                 <child>
-                                  <object class="GtkTable" id="table6">
+                                  <placeholder/>
+                                </child>
+                                <child>
+                                  <object class="GtkToggleButton" id="estop_reset">
+                                    <property name="label" translatable="yes">Estop Reset</property>
                                     <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
-                                    <property name="border-width">5</property>
-                                    <property name="n-rows">2</property>
-                                    <property name="n-columns">3</property>
-                                    <property name="column-spacing">15</property>
-                                    <property name="homogeneous">True</property>
-                                    <child>
-                                      <placeholder/>
-                                    </child>
-                                    <child>
-                                      <object class="GtkToggleButton" id="estop_reset">
-                                        <property name="label" translatable="yes">Estop Reset</property>
-                                        <property name="visible">True</property>
-                                        <property name="can-focus">True</property>
-                                        <property name="focus-on-click">False</property>
-                                        <property name="receives-default">False</property>
-                                        <property name="use-underline">True</property>
-                                        <signal name="clicked" handler="on_estop_reset_clicked" swapped="no"/>
-                                      </object>
-                                    </child>
-                                    <child>
-                                      <object class="GtkToggleButton" id="estop">
-                                        <property name="label" translatable="yes">Estop</property>
-                                        <property name="visible">True</property>
-                                        <property name="can-focus">True</property>
-                                        <property name="focus-on-click">False</property>
-                                        <property name="receives-default">False</property>
-                                        <property name="use-underline">True</property>
-                                        <property name="active">True</property>
-                                        <signal name="clicked" handler="on_estop_clicked" swapped="no"/>
-                                      </object>
-                                      <packing>
-                                        <property name="top-attach">1</property>
-                                        <property name="bottom-attach">2</property>
-                                      </packing>
-                                    </child>
-                                    <child>
-                                      <object class="GtkToggleButton" id="machine_on">
-                                        <property name="label" translatable="yes">Machine On</property>
-                                        <property name="visible">True</property>
-                                        <property name="can-focus">True</property>
-                                        <property name="focus-on-click">False</property>
-                                        <property name="receives-default">False</property>
-                                        <property name="use-underline">True</property>
-                                        <signal name="clicked" handler="on_machine_on_clicked" swapped="no"/>
-                                      </object>
-                                      <packing>
-                                        <property name="left-attach">1</property>
-                                        <property name="right-attach">2</property>
-                                      </packing>
-                                    </child>
-                                    <child>
-                                      <object class="GtkToggleButton" id="machine_off">
-                                        <property name="label" translatable="yes">Machine Off</property>
-                                        <property name="visible">True</property>
-                                        <property name="can-focus">True</property>
-                                        <property name="focus-on-click">False</property>
-                                        <property name="receives-default">False</property>
-                                        <property name="use-underline">True</property>
-                                        <property name="active">True</property>
-                                        <signal name="clicked" handler="on_machine_off_clicked" swapped="no"/>
-                                      </object>
-                                      <packing>
-                                        <property name="left-attach">1</property>
-                                        <property name="right-attach">2</property>
-                                        <property name="top-attach">1</property>
-                                        <property name="bottom-attach">2</property>
-                                      </packing>
-                                    </child>
-                                    <child>
-                                      <object class="GtkToggleButton" id="override_limits">
-                                        <property name="label" translatable="yes">Override Limits</property>
-                                        <property name="visible">True</property>
-                                        <property name="can-focus">True</property>
-                                        <property name="focus-on-click">False</property>
-                                        <property name="receives-default">False</property>
-                                        <property name="use-underline">True</property>
-                                        <signal name="clicked" handler="on_override_limits_clicked" swapped="no"/>
-                                      </object>
-                                      <packing>
-                                        <property name="left-attach">2</property>
-                                        <property name="right-attach">3</property>
-                                      </packing>
-                                    </child>
+                                    <property name="can-focus">True</property>
+                                    <property name="focus-on-click">False</property>
+                                    <property name="receives-default">False</property>
+                                    <property name="use-underline">True</property>
+                                    <signal name="clicked" handler="on_estop_reset_clicked" swapped="no"/>
                                   </object>
+                                </child>
+                                <child>
+                                  <object class="GtkToggleButton" id="estop">
+                                    <property name="label" translatable="yes">Estop</property>
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">True</property>
+                                    <property name="focus-on-click">False</property>
+                                    <property name="receives-default">False</property>
+                                    <property name="use-underline">True</property>
+                                    <property name="active">True</property>
+                                    <signal name="clicked" handler="on_estop_clicked" swapped="no"/>
+                                  </object>
+                                  <packing>
+                                    <property name="top-attach">1</property>
+                                    <property name="bottom-attach">2</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkToggleButton" id="machine_on">
+                                    <property name="label" translatable="yes">Machine On</property>
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">True</property>
+                                    <property name="focus-on-click">False</property>
+                                    <property name="receives-default">False</property>
+                                    <property name="use-underline">True</property>
+                                    <signal name="clicked" handler="on_machine_on_clicked" swapped="no"/>
+                                  </object>
+                                  <packing>
+                                    <property name="left-attach">1</property>
+                                    <property name="right-attach">2</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkToggleButton" id="machine_off">
+                                    <property name="label" translatable="yes">Machine Off</property>
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">True</property>
+                                    <property name="focus-on-click">False</property>
+                                    <property name="receives-default">False</property>
+                                    <property name="use-underline">True</property>
+                                    <property name="active">True</property>
+                                    <signal name="clicked" handler="on_machine_off_clicked" swapped="no"/>
+                                  </object>
+                                  <packing>
+                                    <property name="left-attach">1</property>
+                                    <property name="right-attach">2</property>
+                                    <property name="top-attach">1</property>
+                                    <property name="bottom-attach">2</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkToggleButton" id="override_limits">
+                                    <property name="label" translatable="yes">Override Limits</property>
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">True</property>
+                                    <property name="focus-on-click">False</property>
+                                    <property name="receives-default">False</property>
+                                    <property name="use-underline">True</property>
+                                    <signal name="clicked" handler="on_override_limits_clicked" swapped="no"/>
+                                  </object>
+                                  <packing>
+                                    <property name="left-attach">2</property>
+                                    <property name="right-attach">3</property>
+                                  </packing>
                                 </child>
                               </object>
                             </child>
@@ -598,78 +591,71 @@
                             <property name="border-width">5</property>
                             <property name="label-xalign">0</property>
                             <child>
-                              <object class="GtkAlignment" id="alignment1">
+                              <object class="GtkTable" id="table5">
                                 <property name="visible">True</property>
                                 <property name="can-focus">False</property>
-                                <property name="left-padding">12</property>
+                                <property name="border-width">5</property>
+                                <property name="n-rows">2</property>
+                                <property name="n-columns">2</property>
+                                <property name="column-spacing">15</property>
+                                <property name="homogeneous">True</property>
                                 <child>
-                                  <object class="GtkTable" id="table5">
+                                  <object class="GtkButton" id="unhome_all">
+                                    <property name="label" translatable="yes">Unhome All</property>
                                     <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
-                                    <property name="border-width">5</property>
-                                    <property name="n-rows">2</property>
-                                    <property name="n-columns">2</property>
-                                    <property name="column-spacing">15</property>
-                                    <property name="homogeneous">True</property>
-                                    <child>
-                                      <object class="GtkButton" id="unhome_all">
-                                        <property name="label" translatable="yes">Unhome All</property>
-                                        <property name="visible">True</property>
-                                        <property name="can-focus">True</property>
-                                        <property name="focus-on-click">False</property>
-                                        <property name="receives-default">False</property>
-                                        <property name="use-underline">True</property>
-                                        <signal name="clicked" handler="on_unhome_all_clicked" swapped="no"/>
-                                      </object>
-                                      <packing>
-                                        <property name="top-attach">1</property>
-                                        <property name="bottom-attach">2</property>
-                                      </packing>
-                                    </child>
-                                    <child>
-                                      <object class="GtkButton" id="home_all">
-                                        <property name="label" translatable="yes">Home All</property>
-                                        <property name="visible">True</property>
-                                        <property name="can-focus">True</property>
-                                        <property name="focus-on-click">False</property>
-                                        <property name="receives-default">False</property>
-                                        <property name="use-underline">True</property>
-                                        <signal name="clicked" handler="on_home_all_clicked" swapped="no"/>
-                                      </object>
-                                    </child>
-                                    <child>
-                                      <object class="GtkButton" id="home_selected">
-                                        <property name="label" translatable="yes">Home Selected</property>
-                                        <property name="visible">True</property>
-                                        <property name="can-focus">True</property>
-                                        <property name="focus-on-click">False</property>
-                                        <property name="receives-default">False</property>
-                                        <property name="use-underline">True</property>
-                                        <signal name="clicked" handler="on_home_selected_clicked" swapped="no"/>
-                                      </object>
-                                      <packing>
-                                        <property name="left-attach">1</property>
-                                        <property name="right-attach">2</property>
-                                      </packing>
-                                    </child>
-                                    <child>
-                                      <object class="GtkButton" id="unhome_selected">
-                                        <property name="label" translatable="yes">Unhome Selected</property>
-                                        <property name="visible">True</property>
-                                        <property name="can-focus">True</property>
-                                        <property name="focus-on-click">False</property>
-                                        <property name="receives-default">False</property>
-                                        <property name="use-underline">True</property>
-                                        <signal name="clicked" handler="on_unhome_selected_clicked" swapped="no"/>
-                                      </object>
-                                      <packing>
-                                        <property name="left-attach">1</property>
-                                        <property name="right-attach">2</property>
-                                        <property name="top-attach">1</property>
-                                        <property name="bottom-attach">2</property>
-                                      </packing>
-                                    </child>
+                                    <property name="can-focus">True</property>
+                                    <property name="focus-on-click">False</property>
+                                    <property name="receives-default">False</property>
+                                    <property name="use-underline">True</property>
+                                    <signal name="clicked" handler="on_unhome_all_clicked" swapped="no"/>
                                   </object>
+                                  <packing>
+                                    <property name="top-attach">1</property>
+                                    <property name="bottom-attach">2</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkButton" id="home_all">
+                                    <property name="label" translatable="yes">Home All</property>
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">True</property>
+                                    <property name="focus-on-click">False</property>
+                                    <property name="receives-default">False</property>
+                                    <property name="use-underline">True</property>
+                                    <signal name="clicked" handler="on_home_all_clicked" swapped="no"/>
+                                  </object>
+                                </child>
+                                <child>
+                                  <object class="GtkButton" id="home_selected">
+                                    <property name="label" translatable="yes">Home Selected</property>
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">True</property>
+                                    <property name="focus-on-click">False</property>
+                                    <property name="receives-default">False</property>
+                                    <property name="use-underline">True</property>
+                                    <signal name="clicked" handler="on_home_selected_clicked" swapped="no"/>
+                                  </object>
+                                  <packing>
+                                    <property name="left-attach">1</property>
+                                    <property name="right-attach">2</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkButton" id="unhome_selected">
+                                    <property name="label" translatable="yes">Unhome Selected</property>
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">True</property>
+                                    <property name="focus-on-click">False</property>
+                                    <property name="receives-default">False</property>
+                                    <property name="use-underline">True</property>
+                                    <signal name="clicked" handler="on_unhome_selected_clicked" swapped="no"/>
+                                  </object>
+                                  <packing>
+                                    <property name="left-attach">1</property>
+                                    <property name="right-attach">2</property>
+                                    <property name="top-attach">1</property>
+                                    <property name="bottom-attach">2</property>
+                                  </packing>
                                 </child>
                               </object>
                             </child>
@@ -687,6 +673,9 @@
                             <property name="fill">True</property>
                             <property name="position">1</property>
                           </packing>
+                        </child>
+                        <child>
+                          <placeholder/>
                         </child>
                       </object>
                     </child>
@@ -2690,13 +2679,11 @@
                       </packing>
                     </child>
                     <child>
-                      <object class="GtkTable" id="table8">
+                      <!-- n-columns=2 n-rows=18 -->
+                      <object class="GtkGrid" id="table8">
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
-                        <property name="n-rows">18</property>
-                        <property name="n-columns">2</property>
-                        <property name="column-spacing">10</property>
-                        <property name="row-spacing">3</property>
+                        <property name="column-spacing">5</property>
                         <child>
                           <object class="GtkLabel" id="label3">
                             <property name="visible">True</property>
@@ -2705,8 +2692,20 @@
                             <property name="xalign">1</property>
                           </object>
                           <packing>
-                            <property name="x-options">GTK_FILL</property>
-                            <property name="y-options"/>
+                            <property name="left-attach">0</property>
+                            <property name="top-attach">0</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkLabel" id="label2">
+                            <property name="visible">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="label" translatable="yes">Loaded file lines:</property>
+                            <property name="xalign">1</property>
+                          </object>
+                          <packing>
+                            <property name="left-attach">0</property>
+                            <property name="top-attach">1</property>
                           </packing>
                         </child>
                         <child>
@@ -2718,280 +2717,8 @@
                             <property name="xalign">1</property>
                           </object>
                           <packing>
+                            <property name="left-attach">0</property>
                             <property name="top-attach">2</property>
-                            <property name="bottom-attach">3</property>
-                            <property name="x-options">GTK_FILL</property>
-                            <property name="y-options"/>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkLabel" id="label12">
-                            <property name="visible">True</property>
-                            <property name="can-focus">False</property>
-                            <property name="label" translatable="yes">Distance:</property>
-                            <property name="xalign">1</property>
-                          </object>
-                          <packing>
-                            <property name="top-attach">7</property>
-                            <property name="bottom-attach">8</property>
-                            <property name="x-options">GTK_FILL</property>
-                            <property name="y-options"/>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkLabel" id="label13">
-                            <property name="visible">True</property>
-                            <property name="can-focus">False</property>
-                            <property name="label" translatable="yes">Velocity:</property>
-                            <property name="xalign">1</property>
-                          </object>
-                          <packing>
-                            <property name="top-attach">8</property>
-                            <property name="bottom-attach">9</property>
-                            <property name="x-options">GTK_FILL</property>
-                            <property name="y-options"/>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkLabel" id="label14">
-                            <property name="visible">True</property>
-                            <property name="can-focus">False</property>
-                            <property name="label" translatable="yes">Delay:</property>
-                            <property name="xalign">1</property>
-                          </object>
-                          <packing>
-                            <property name="top-attach">9</property>
-                            <property name="bottom-attach">10</property>
-                            <property name="x-options">GTK_FILL</property>
-                            <property name="y-options"/>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkLabel" id="label15">
-                            <property name="visible">True</property>
-                            <property name="can-focus">False</property>
-                            <property name="label" translatable="yes">On limit switch:</property>
-                            <property name="xalign">1</property>
-                          </object>
-                          <packing>
-                            <property name="top-attach">10</property>
-                            <property name="bottom-attach">11</property>
-                            <property name="x-options">GTK_FILL</property>
-                            <property name="y-options"/>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkLabel" id="label16">
-                            <property name="visible">True</property>
-                            <property name="can-focus">False</property>
-                            <property name="label" translatable="yes">Spindle direction:</property>
-                            <property name="xalign">1</property>
-                          </object>
-                          <packing>
-                            <property name="top-attach">11</property>
-                            <property name="bottom-attach">12</property>
-                            <property name="x-options">GTK_FILL</property>
-                            <property name="y-options"/>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkLabel" id="label17">
-                            <property name="visible">True</property>
-                            <property name="can-focus">False</property>
-                            <property name="label" translatable="yes">Spindle speed:</property>
-                            <property name="xalign">1</property>
-                          </object>
-                          <packing>
-                            <property name="top-attach">12</property>
-                            <property name="bottom-attach">13</property>
-                            <property name="x-options">GTK_FILL</property>
-                            <property name="y-options"/>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkLabel" id="label18">
-                            <property name="visible">True</property>
-                            <property name="can-focus">False</property>
-                            <property name="label" translatable="yes">Loaded tool:</property>
-                            <property name="xalign">1</property>
-                          </object>
-                          <packing>
-                            <property name="top-attach">14</property>
-                            <property name="bottom-attach">15</property>
-                            <property name="x-options">GTK_FILL</property>
-                            <property name="y-options"/>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkLabel" id="status_file">
-                            <property name="visible">True</property>
-                            <property name="can-focus">False</property>
-                            <property name="label" translatable="yes">label19</property>
-                            <property name="xalign">0</property>
-                          </object>
-                          <packing>
-                            <property name="left-attach">1</property>
-                            <property name="right-attach">2</property>
-                            <property name="x-options">GTK_FILL</property>
-                            <property name="y-options"/>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkLabel" id="status_dtg">
-                            <property name="visible">True</property>
-                            <property name="can-focus">False</property>
-                            <property name="label" translatable="yes">label20</property>
-                            <property name="xalign">0</property>
-                          </object>
-                          <packing>
-                            <property name="left-attach">1</property>
-                            <property name="right-attach">2</property>
-                            <property name="top-attach">7</property>
-                            <property name="bottom-attach">8</property>
-                            <property name="x-options">GTK_FILL</property>
-                            <property name="y-options"/>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkLabel" id="status_line">
-                            <property name="visible">True</property>
-                            <property name="can-focus">False</property>
-                            <property name="label" translatable="yes">label21</property>
-                            <property name="xalign">0</property>
-                          </object>
-                          <packing>
-                            <property name="left-attach">1</property>
-                            <property name="right-attach">2</property>
-                            <property name="top-attach">2</property>
-                            <property name="bottom-attach">3</property>
-                            <property name="x-options">GTK_FILL</property>
-                            <property name="y-options"/>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkLabel" id="status_delay">
-                            <property name="visible">True</property>
-                            <property name="can-focus">False</property>
-                            <property name="label" translatable="yes">label22</property>
-                            <property name="xalign">0</property>
-                          </object>
-                          <packing>
-                            <property name="left-attach">1</property>
-                            <property name="right-attach">2</property>
-                            <property name="top-attach">9</property>
-                            <property name="bottom-attach">10</property>
-                            <property name="x-options">GTK_FILL</property>
-                            <property name="y-options"/>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkLabel" id="status_velocity">
-                            <property name="visible">True</property>
-                            <property name="can-focus">False</property>
-                            <property name="label" translatable="yes">label23</property>
-                            <property name="xalign">0</property>
-                          </object>
-                          <packing>
-                            <property name="left-attach">1</property>
-                            <property name="right-attach">2</property>
-                            <property name="top-attach">8</property>
-                            <property name="bottom-attach">9</property>
-                            <property name="x-options">GTK_FILL</property>
-                            <property name="y-options"/>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkLabel" id="status_onlimit">
-                            <property name="visible">True</property>
-                            <property name="can-focus">False</property>
-                            <property name="label" translatable="yes">label24</property>
-                            <property name="xalign">0</property>
-                          </object>
-                          <packing>
-                            <property name="left-attach">1</property>
-                            <property name="right-attach">2</property>
-                            <property name="top-attach">10</property>
-                            <property name="bottom-attach">11</property>
-                            <property name="x-options">GTK_FILL</property>
-                            <property name="y-options"/>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkLabel" id="status_spindledir">
-                            <property name="visible">True</property>
-                            <property name="can-focus">False</property>
-                            <property name="label" translatable="yes">label25</property>
-                            <property name="xalign">0</property>
-                          </object>
-                          <packing>
-                            <property name="left-attach">1</property>
-                            <property name="right-attach">2</property>
-                            <property name="top-attach">11</property>
-                            <property name="bottom-attach">12</property>
-                            <property name="x-options">GTK_FILL</property>
-                            <property name="y-options"/>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkLabel" id="status_spindlespeed">
-                            <property name="visible">True</property>
-                            <property name="can-focus">False</property>
-                            <property name="label" translatable="yes">label26</property>
-                            <property name="xalign">0</property>
-                          </object>
-                          <packing>
-                            <property name="left-attach">1</property>
-                            <property name="right-attach">2</property>
-                            <property name="top-attach">12</property>
-                            <property name="bottom-attach">13</property>
-                            <property name="x-options">GTK_FILL</property>
-                            <property name="y-options"/>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkLabel" id="status_loadedtool">
-                            <property name="visible">True</property>
-                            <property name="can-focus">False</property>
-                            <property name="label" translatable="yes">label27</property>
-                            <property name="xalign">0</property>
-                          </object>
-                          <packing>
-                            <property name="left-attach">1</property>
-                            <property name="right-attach">2</property>
-                            <property name="top-attach">14</property>
-                            <property name="bottom-attach">15</property>
-                            <property name="x-options">GTK_FILL</property>
-                            <property name="y-options"/>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkLabel" id="label28">
-                            <property name="visible">True</property>
-                            <property name="can-focus">False</property>
-                            <property name="label" translatable="yes">Prepped tool:</property>
-                            <property name="xalign">1</property>
-                          </object>
-                          <packing>
-                            <property name="top-attach">15</property>
-                            <property name="bottom-attach">16</property>
-                            <property name="x-options">GTK_FILL</property>
-                            <property name="y-options"/>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkLabel" id="status_preppedtool">
-                            <property name="visible">True</property>
-                            <property name="can-focus">False</property>
-                            <property name="label" translatable="yes">label28</property>
-                            <property name="xalign">0</property>
-                          </object>
-                          <packing>
-                            <property name="left-attach">1</property>
-                            <property name="right-attach">2</property>
-                            <property name="top-attach">15</property>
-                            <property name="bottom-attach">16</property>
-                            <property name="x-options">GTK_FILL</property>
-                            <property name="y-options"/>
                           </packing>
                         </child>
                         <child>
@@ -3003,26 +2730,8 @@
                             <property name="xalign">1</property>
                           </object>
                           <packing>
+                            <property name="left-attach">0</property>
                             <property name="top-attach">3</property>
-                            <property name="bottom-attach">4</property>
-                            <property name="x-options">GTK_FILL</property>
-                            <property name="y-options"/>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkLabel" id="status_id">
-                            <property name="visible">True</property>
-                            <property name="can-focus">False</property>
-                            <property name="label" translatable="yes">label21</property>
-                            <property name="xalign">0</property>
-                          </object>
-                          <packing>
-                            <property name="left-attach">1</property>
-                            <property name="right-attach">2</property>
-                            <property name="top-attach">3</property>
-                            <property name="bottom-attach">4</property>
-                            <property name="x-options">GTK_FILL</property>
-                            <property name="y-options"/>
                           </packing>
                         </child>
                         <child>
@@ -3034,10 +2743,217 @@
                             <property name="xalign">1</property>
                           </object>
                           <packing>
+                            <property name="left-attach">0</property>
                             <property name="top-attach">4</property>
-                            <property name="bottom-attach">5</property>
-                            <property name="x-options">GTK_FILL</property>
-                            <property name="y-options"/>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkLabel" id="status_label_g5xoffset">
+                            <property name="visible">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="label" translatable="yes">G5x Offset:</property>
+                            <property name="use-markup">True</property>
+                            <property name="justify">right</property>
+                            <property name="xalign">1</property>
+                          </object>
+                          <packing>
+                            <property name="left-attach">0</property>
+                            <property name="top-attach">5</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkLabel" id="label5">
+                            <property name="visible">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="label" translatable="yes">G92 Offset:</property>
+                            <property name="justify">right</property>
+                            <property name="xalign">1</property>
+                          </object>
+                          <packing>
+                            <property name="left-attach">0</property>
+                            <property name="top-attach">6</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkLabel" id="label12">
+                            <property name="visible">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="label" translatable="yes">Distance:</property>
+                            <property name="xalign">1</property>
+                          </object>
+                          <packing>
+                            <property name="left-attach">0</property>
+                            <property name="top-attach">7</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkLabel" id="label13">
+                            <property name="visible">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="label" translatable="yes">Velocity:</property>
+                            <property name="xalign">1</property>
+                          </object>
+                          <packing>
+                            <property name="left-attach">0</property>
+                            <property name="top-attach">8</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkLabel" id="label14">
+                            <property name="visible">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="label" translatable="yes">Delay:</property>
+                            <property name="xalign">1</property>
+                          </object>
+                          <packing>
+                            <property name="left-attach">0</property>
+                            <property name="top-attach">9</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkLabel" id="label15">
+                            <property name="visible">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="label" translatable="yes">On limit switch:</property>
+                            <property name="xalign">1</property>
+                          </object>
+                          <packing>
+                            <property name="left-attach">0</property>
+                            <property name="top-attach">10</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkLabel" id="label16">
+                            <property name="visible">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="label" translatable="yes">Spindle direction:</property>
+                            <property name="xalign">1</property>
+                          </object>
+                          <packing>
+                            <property name="left-attach">0</property>
+                            <property name="top-attach">11</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkLabel" id="label17">
+                            <property name="visible">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="label" translatable="yes">Spindle speed:</property>
+                            <property name="xalign">1</property>
+                          </object>
+                          <packing>
+                            <property name="left-attach">0</property>
+                            <property name="top-attach">12</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkLabel" id="label6">
+                            <property name="visible">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="label" translatable="yes">Pockets:</property>
+                            <property name="xalign">1</property>
+                            <property name="yalign">0</property>
+                          </object>
+                          <packing>
+                            <property name="left-attach">0</property>
+                            <property name="top-attach">13</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkLabel" id="label18">
+                            <property name="visible">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="label" translatable="yes">Loaded tool:</property>
+                            <property name="xalign">1</property>
+                          </object>
+                          <packing>
+                            <property name="left-attach">0</property>
+                            <property name="top-attach">14</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkLabel" id="label28">
+                            <property name="visible">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="label" translatable="yes">Prepped tool:</property>
+                            <property name="xalign">1</property>
+                          </object>
+                          <packing>
+                            <property name="left-attach">0</property>
+                            <property name="top-attach">15</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkLabel" id="label51">
+                            <property name="visible">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="label" translatable="yes">Tool length:</property>
+                            <property name="xalign">1</property>
+                          </object>
+                          <packing>
+                            <property name="left-attach">0</property>
+                            <property name="top-attach">16</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkLabel" id="label53">
+                            <property name="visible">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="label" translatable="yes">Active codes:</property>
+                            <property name="xalign">1</property>
+                            <property name="yalign">0</property>
+                          </object>
+                          <packing>
+                            <property name="left-attach">0</property>
+                            <property name="top-attach">17</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkLabel" id="status_file">
+                            <property name="visible">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="label" translatable="yes">label19</property>
+                            <property name="xalign">0</property>
+                          </object>
+                          <packing>
+                            <property name="left-attach">1</property>
+                            <property name="top-attach">0</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkLabel" id="status_file_lines">
+                            <property name="visible">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="label" translatable="yes">label19</property>
+                            <property name="xalign">0</property>
+                          </object>
+                          <packing>
+                            <property name="left-attach">1</property>
+                            <property name="top-attach">1</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkLabel" id="status_line">
+                            <property name="visible">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="label" translatable="yes">label21</property>
+                            <property name="xalign">0</property>
+                          </object>
+                          <packing>
+                            <property name="left-attach">1</property>
+                            <property name="top-attach">2</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkLabel" id="status_id">
+                            <property name="visible">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="label" translatable="yes">label21</property>
+                            <property name="xalign">0</property>
+                          </object>
+                          <packing>
+                            <property name="left-attach">1</property>
+                            <property name="top-attach">3</property>
                           </packing>
                         </child>
                         <child>
@@ -3049,25 +2965,144 @@
                           </object>
                           <packing>
                             <property name="left-attach">1</property>
-                            <property name="right-attach">2</property>
                             <property name="top-attach">4</property>
-                            <property name="bottom-attach">5</property>
-                            <property name="x-options">GTK_FILL</property>
-                            <property name="y-options"/>
                           </packing>
                         </child>
                         <child>
-                          <object class="GtkLabel" id="label51">
+                          <object class="GtkLabel" id="status_g5xoffset">
                             <property name="visible">True</property>
                             <property name="can-focus">False</property>
-                            <property name="label" translatable="yes">Tool length:</property>
-                            <property name="xalign">1</property>
+                            <property name="label" translatable="yes">label21</property>
+                            <property name="xalign">0</property>
                           </object>
                           <packing>
-                            <property name="top-attach">16</property>
-                            <property name="bottom-attach">17</property>
-                            <property name="x-options">GTK_FILL</property>
-                            <property name="y-options"/>
+                            <property name="left-attach">1</property>
+                            <property name="top-attach">5</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkLabel" id="status_g92offset">
+                            <property name="visible">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="label" translatable="yes">label21</property>
+                            <property name="xalign">0</property>
+                          </object>
+                          <packing>
+                            <property name="left-attach">1</property>
+                            <property name="top-attach">6</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkLabel" id="status_dtg">
+                            <property name="visible">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="label" translatable="yes">label20</property>
+                            <property name="xalign">0</property>
+                          </object>
+                          <packing>
+                            <property name="left-attach">1</property>
+                            <property name="top-attach">7</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkLabel" id="status_velocity">
+                            <property name="visible">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="label" translatable="yes">label23</property>
+                            <property name="xalign">0</property>
+                          </object>
+                          <packing>
+                            <property name="left-attach">1</property>
+                            <property name="top-attach">8</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkLabel" id="status_delay">
+                            <property name="visible">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="label" translatable="yes">label22</property>
+                            <property name="xalign">0</property>
+                          </object>
+                          <packing>
+                            <property name="left-attach">1</property>
+                            <property name="top-attach">9</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkLabel" id="status_onlimit">
+                            <property name="visible">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="label" translatable="yes">label24</property>
+                            <property name="xalign">0</property>
+                          </object>
+                          <packing>
+                            <property name="left-attach">1</property>
+                            <property name="top-attach">10</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkLabel" id="status_spindledir">
+                            <property name="visible">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="label" translatable="yes">label25</property>
+                            <property name="xalign">0</property>
+                          </object>
+                          <packing>
+                            <property name="left-attach">1</property>
+                            <property name="top-attach">11</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkLabel" id="status_spindlespeed">
+                            <property name="visible">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="label" translatable="yes">label26</property>
+                            <property name="xalign">0</property>
+                          </object>
+                          <packing>
+                            <property name="left-attach">1</property>
+                            <property name="top-attach">12</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkLabel" id="status_tooltable">
+                            <property name="visible">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="valign">start</property>
+                            <property name="label" translatable="yes">&lt;b&gt;1&lt;/b&gt;
+2
+3</property>
+                            <property name="use-markup">True</property>
+                            <property name="wrap">True</property>
+                            <property name="xalign">0</property>
+                          </object>
+                          <packing>
+                            <property name="left-attach">1</property>
+                            <property name="top-attach">13</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkLabel" id="status_loadedtool">
+                            <property name="visible">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="label" translatable="yes">label27</property>
+                            <property name="xalign">0</property>
+                          </object>
+                          <packing>
+                            <property name="left-attach">1</property>
+                            <property name="top-attach">14</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkLabel" id="status_preppedtool">
+                            <property name="visible">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="label" translatable="yes">label28</property>
+                            <property name="xalign">0</property>
+                          </object>
+                          <packing>
+                            <property name="left-attach">1</property>
+                            <property name="top-attach">15</property>
                           </packing>
                         </child>
                         <child>
@@ -3079,11 +3114,7 @@
                           </object>
                           <packing>
                             <property name="left-attach">1</property>
-                            <property name="right-attach">2</property>
                             <property name="top-attach">16</property>
-                            <property name="bottom-attach">17</property>
-                            <property name="x-options">GTK_FILL</property>
-                            <property name="y-options"/>
                           </packing>
                         </child>
                         <child>
@@ -3101,155 +3132,7 @@ F1 S1</property>
                           </object>
                           <packing>
                             <property name="left-attach">1</property>
-                            <property name="right-attach">2</property>
                             <property name="top-attach">17</property>
-                            <property name="bottom-attach">18</property>
-                            <property name="x-options">GTK_FILL</property>
-                            <property name="y-options"/>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkLabel" id="label53">
-                            <property name="visible">True</property>
-                            <property name="can-focus">False</property>
-                            <property name="label" translatable="yes">Active codes:</property>
-                            <property name="xalign">1</property>
-                            <property name="yalign">0</property>
-                          </object>
-                          <packing>
-                            <property name="top-attach">17</property>
-                            <property name="bottom-attach">18</property>
-                            <property name="x-options">GTK_FILL</property>
-                            <property name="y-options">GTK_FILL</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkLabel" id="status_label_g5xoffset">
-                            <property name="visible">True</property>
-                            <property name="can-focus">False</property>
-                            <property name="label" translatable="yes">G5x Offset:</property>
-                            <property name="use-markup">True</property>
-                            <property name="justify">right</property>
-                            <property name="xalign">1</property>
-                          </object>
-                          <packing>
-                            <property name="top-attach">5</property>
-                            <property name="bottom-attach">6</property>
-                            <property name="x-options">GTK_FILL</property>
-                            <property name="y-options"/>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkLabel" id="label5">
-                            <property name="visible">True</property>
-                            <property name="can-focus">False</property>
-                            <property name="label" translatable="yes">G92 Offset:</property>
-                            <property name="justify">right</property>
-                            <property name="xalign">1</property>
-                          </object>
-                          <packing>
-                            <property name="top-attach">6</property>
-                            <property name="bottom-attach">7</property>
-                            <property name="x-options">GTK_FILL</property>
-                            <property name="y-options"/>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkLabel" id="status_g5xoffset">
-                            <property name="visible">True</property>
-                            <property name="can-focus">False</property>
-                            <property name="label" translatable="yes">label21</property>
-                            <property name="xalign">0</property>
-                          </object>
-                          <packing>
-                            <property name="left-attach">1</property>
-                            <property name="right-attach">2</property>
-                            <property name="top-attach">5</property>
-                            <property name="bottom-attach">6</property>
-                            <property name="x-options">GTK_FILL</property>
-                            <property name="y-options"/>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkLabel" id="status_g92offset">
-                            <property name="visible">True</property>
-                            <property name="can-focus">False</property>
-                            <property name="label" translatable="yes">label21</property>
-                            <property name="xalign">0</property>
-                          </object>
-                          <packing>
-                            <property name="left-attach">1</property>
-                            <property name="right-attach">2</property>
-                            <property name="top-attach">6</property>
-                            <property name="bottom-attach">7</property>
-                            <property name="x-options">GTK_FILL</property>
-                            <property name="y-options"/>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkLabel" id="label2">
-                            <property name="visible">True</property>
-                            <property name="can-focus">False</property>
-                            <property name="label" translatable="yes">Loaded file lines:</property>
-                            <property name="xalign">1</property>
-                          </object>
-                          <packing>
-                            <property name="top-attach">1</property>
-                            <property name="bottom-attach">2</property>
-                            <property name="x-options">GTK_FILL</property>
-                            <property name="y-options"/>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkLabel" id="status_file_lines">
-                            <property name="visible">True</property>
-                            <property name="can-focus">False</property>
-                            <property name="label" translatable="yes">label19</property>
-                            <property name="xalign">0</property>
-                          </object>
-                          <packing>
-                            <property name="left-attach">1</property>
-                            <property name="right-attach">2</property>
-                            <property name="top-attach">1</property>
-                            <property name="bottom-attach">2</property>
-                            <property name="x-options">GTK_FILL</property>
-                            <property name="y-options"/>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkLabel" id="label6">
-                            <property name="visible">True</property>
-                            <property name="can-focus">False</property>
-                            <property name="label" translatable="yes">Pockets:</property>
-                            <property name="xalign">1</property>
-                            <property name="yalign">0</property>
-                          </object>
-                          <packing>
-                            <property name="top-attach">13</property>
-                            <property name="bottom-attach">14</property>
-                            <property name="x-options">GTK_FILL</property>
-                            <property name="y-options">GTK_FILL</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkLabel" id="status_tooltable">
-                            <property name="visible">True</property>
-                            <property name="can-focus">False</property>
-                            <property name="valign">start</property>
-                            <property name="label" translatable="yes">&lt;b&gt;1&lt;/b&gt;
-2
-3</property>
-                            <property name="use-markup">True</property>
-                            <property name="wrap">True</property>
-                            <property name="xalign">0</property>
-                          </object>
-                          <packing>
-                            <property name="left-attach">1</property>
-                            <property name="right-attach">2</property>
-                            <property name="top-attach">13</property>
-                            <property name="bottom-attach">14</property>
-                            <property name="x-options">GTK_FILL</property>
-                            <property name="y-options"/>
                           </packing>
                         </child>
                       </object>
@@ -3807,6 +3690,9 @@ F1 S1</property>
                             <property name="position">1</property>
                           </packing>
                         </child>
+                        <child>
+                          <placeholder/>
+                        </child>
                       </object>
                       <packing>
                         <property name="position">5</property>
@@ -3846,100 +3732,157 @@ F1 S1</property>
                 <property name="border-width">5</property>
                 <property name="label-xalign">0</property>
                 <child>
-                  <object class="GtkAlignment" id="alignment3">
+                  <object class="GtkBox" id="vbox4">
                     <property name="visible">True</property>
                     <property name="can-focus">False</property>
-                    <property name="left-padding">12</property>
+                    <property name="orientation">vertical</property>
                     <child>
-                      <object class="GtkBox" id="vbox4">
+                      <object class="GtkBox" id="vbox3">
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
+                        <property name="border-width">5</property>
                         <property name="orientation">vertical</property>
                         <child>
-                          <object class="GtkBox" id="vbox3">
+                          <object class="GtkToggleButton" id="fo">
+                            <property name="label" translatable="yes">FO: 100%</property>
+                            <property name="visible">True</property>
+                            <property name="can-focus">True</property>
+                            <property name="focus-on-click">False</property>
+                            <property name="receives-default">False</property>
+                            <property name="use-underline">True</property>
+                            <property name="active">True</property>
+                            <signal name="clicked" handler="on_fo_clicked" swapped="no"/>
+                          </object>
+                          <packing>
+                            <property name="expand">True</property>
+                            <property name="fill">True</property>
+                            <property name="position">0</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkToggleButton" id="so">
+                            <property name="label" translatable="yes">SO: 100%</property>
+                            <property name="visible">True</property>
+                            <property name="can-focus">True</property>
+                            <property name="focus-on-click">False</property>
+                            <property name="receives-default">False</property>
+                            <property name="use-underline">True</property>
+                            <signal name="clicked" handler="on_so_clicked" swapped="no"/>
+                          </object>
+                          <packing>
+                            <property name="expand">True</property>
+                            <property name="fill">True</property>
+                            <property name="position">1</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkToggleButton" id="mv">
+                            <property name="label" translatable="yes">MV: 100</property>
+                            <property name="visible">True</property>
+                            <property name="can-focus">True</property>
+                            <property name="focus-on-click">False</property>
+                            <property name="receives-default">False</property>
+                            <property name="use-underline">True</property>
+                            <signal name="clicked" handler="on_mv_clicked" swapped="no"/>
+                          </object>
+                          <packing>
+                            <property name="expand">True</property>
+                            <property name="fill">True</property>
+                            <property name="position">2</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkToggleButton" id="jogging">
+                            <property name="label" translatable="yes">Jogging</property>
+                            <property name="visible">True</property>
+                            <property name="can-focus">True</property>
+                            <property name="focus-on-click">False</property>
+                            <property name="receives-default">False</property>
+                            <property name="use-underline">True</property>
+                            <signal name="clicked" handler="on_jogging_clicked" swapped="no"/>
+                          </object>
+                          <packing>
+                            <property name="expand">True</property>
+                            <property name="fill">True</property>
+                            <property name="position">3</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkToggleButton" id="scrolling">
+                            <property name="label" translatable="yes">Start Point</property>
+                            <property name="visible">True</property>
+                            <property name="can-focus">True</property>
+                            <property name="focus-on-click">False</property>
+                            <property name="receives-default">False</property>
+                            <property name="use-underline">True</property>
+                            <signal name="clicked" handler="on_scrolling_clicked" swapped="no"/>
+                          </object>
+                          <packing>
+                            <property name="expand">True</property>
+                            <property name="fill">True</property>
+                            <property name="position">4</property>
+                          </packing>
+                        </child>
+                      </object>
+                      <packing>
+                        <property name="expand">True</property>
+                        <property name="fill">True</property>
+                        <property name="position">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkBox" id="wheel_hbox">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <child>
+                          <object class="GtkTable" id="table24">
                             <property name="visible">True</property>
                             <property name="can-focus">False</property>
                             <property name="border-width">5</property>
-                            <property name="orientation">vertical</property>
+                            <property name="n-rows">3</property>
                             <child>
-                              <object class="GtkToggleButton" id="fo">
-                                <property name="label" translatable="yes">FO: 100%</property>
+                              <object class="GtkToggleButton" id="wheelinc1">
+                                <property name="label" translatable="yes">.01</property>
                                 <property name="visible">True</property>
+                                <property name="sensitive">False</property>
                                 <property name="can-focus">True</property>
                                 <property name="focus-on-click">False</property>
                                 <property name="receives-default">False</property>
                                 <property name="use-underline">True</property>
                                 <property name="active">True</property>
-                                <signal name="clicked" handler="on_fo_clicked" swapped="no"/>
+                                <signal name="clicked" handler="on_wheelinc1_clicked" swapped="no"/>
                               </object>
-                              <packing>
-                                <property name="expand">True</property>
-                                <property name="fill">True</property>
-                                <property name="position">0</property>
-                              </packing>
                             </child>
                             <child>
-                              <object class="GtkToggleButton" id="so">
-                                <property name="label" translatable="yes">SO: 100%</property>
+                              <object class="GtkToggleButton" id="wheelinc2">
+                                <property name="label" translatable="yes">.001</property>
                                 <property name="visible">True</property>
+                                <property name="sensitive">False</property>
                                 <property name="can-focus">True</property>
                                 <property name="focus-on-click">False</property>
                                 <property name="receives-default">False</property>
                                 <property name="use-underline">True</property>
-                                <signal name="clicked" handler="on_so_clicked" swapped="no"/>
+                                <signal name="clicked" handler="on_wheelinc2_clicked" swapped="no"/>
                               </object>
                               <packing>
-                                <property name="expand">True</property>
-                                <property name="fill">True</property>
-                                <property name="position">1</property>
+                                <property name="top-attach">1</property>
+                                <property name="bottom-attach">2</property>
                               </packing>
                             </child>
                             <child>
-                              <object class="GtkToggleButton" id="mv">
-                                <property name="label" translatable="yes">MV: 100</property>
+                              <object class="GtkToggleButton" id="wheelinc3">
+                                <property name="label" translatable="yes">.0001</property>
                                 <property name="visible">True</property>
+                                <property name="sensitive">False</property>
                                 <property name="can-focus">True</property>
                                 <property name="focus-on-click">False</property>
                                 <property name="receives-default">False</property>
                                 <property name="use-underline">True</property>
-                                <signal name="clicked" handler="on_mv_clicked" swapped="no"/>
+                                <signal name="clicked" handler="on_wheelinc3_clicked" swapped="no"/>
                               </object>
                               <packing>
-                                <property name="expand">True</property>
-                                <property name="fill">True</property>
-                                <property name="position">2</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkToggleButton" id="jogging">
-                                <property name="label" translatable="yes">Jogging</property>
-                                <property name="visible">True</property>
-                                <property name="can-focus">True</property>
-                                <property name="focus-on-click">False</property>
-                                <property name="receives-default">False</property>
-                                <property name="use-underline">True</property>
-                                <signal name="clicked" handler="on_jogging_clicked" swapped="no"/>
-                              </object>
-                              <packing>
-                                <property name="expand">True</property>
-                                <property name="fill">True</property>
-                                <property name="position">3</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkToggleButton" id="scrolling">
-                                <property name="label" translatable="yes">Start Point</property>
-                                <property name="visible">True</property>
-                                <property name="can-focus">True</property>
-                                <property name="focus-on-click">False</property>
-                                <property name="receives-default">False</property>
-                                <property name="use-underline">True</property>
-                                <signal name="clicked" handler="on_scrolling_clicked" swapped="no"/>
-                              </object>
-                              <packing>
-                                <property name="expand">True</property>
-                                <property name="fill">True</property>
-                                <property name="position">4</property>
+                                <property name="top-attach">2</property>
+                                <property name="bottom-attach">3</property>
                               </packing>
                             </child>
                           </object>
@@ -3950,226 +3893,157 @@ F1 S1</property>
                           </packing>
                         </child>
                         <child>
-                          <object class="GtkBox" id="wheel_hbox">
+                          <object class="GtkTable" id="axis_table">
                             <property name="visible">True</property>
                             <property name="can-focus">False</property>
+                            <property name="border-width">5</property>
+                            <property name="n-rows">3</property>
+                            <property name="n-columns">3</property>
+                            <property name="homogeneous">True</property>
                             <child>
-                              <object class="GtkTable" id="table24">
+                              <object class="GtkToggleButton" id="wheelx">
+                                <property name="label" translatable="yes">  X  </property>
                                 <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                                <property name="border-width">5</property>
-                                <property name="n-rows">3</property>
-                                <child>
-                                  <object class="GtkToggleButton" id="wheelinc1">
-                                    <property name="label" translatable="yes">.01</property>
-                                    <property name="visible">True</property>
-                                    <property name="sensitive">False</property>
-                                    <property name="can-focus">True</property>
-                                    <property name="focus-on-click">False</property>
-                                    <property name="receives-default">False</property>
-                                    <property name="use-underline">True</property>
-                                    <property name="active">True</property>
-                                    <signal name="clicked" handler="on_wheelinc1_clicked" swapped="no"/>
-                                  </object>
-                                </child>
-                                <child>
-                                  <object class="GtkToggleButton" id="wheelinc2">
-                                    <property name="label" translatable="yes">.001</property>
-                                    <property name="visible">True</property>
-                                    <property name="sensitive">False</property>
-                                    <property name="can-focus">True</property>
-                                    <property name="focus-on-click">False</property>
-                                    <property name="receives-default">False</property>
-                                    <property name="use-underline">True</property>
-                                    <signal name="clicked" handler="on_wheelinc2_clicked" swapped="no"/>
-                                  </object>
-                                  <packing>
-                                    <property name="top-attach">1</property>
-                                    <property name="bottom-attach">2</property>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <object class="GtkToggleButton" id="wheelinc3">
-                                    <property name="label" translatable="yes">.0001</property>
-                                    <property name="visible">True</property>
-                                    <property name="sensitive">False</property>
-                                    <property name="can-focus">True</property>
-                                    <property name="focus-on-click">False</property>
-                                    <property name="receives-default">False</property>
-                                    <property name="use-underline">True</property>
-                                    <signal name="clicked" handler="on_wheelinc3_clicked" swapped="no"/>
-                                  </object>
-                                  <packing>
-                                    <property name="top-attach">2</property>
-                                    <property name="bottom-attach">3</property>
-                                  </packing>
-                                </child>
+                                <property name="can-focus">True</property>
+                                <property name="focus-on-click">False</property>
+                                <property name="receives-default">False</property>
+                                <property name="use-underline">True</property>
+                                <property name="active">True</property>
+                                <signal name="clicked" handler="on_wheelx_clicked" swapped="no"/>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="GtkToggleButton" id="wheely">
+                                <property name="label" translatable="yes">  Y  </property>
+                                <property name="visible">True</property>
+                                <property name="can-focus">True</property>
+                                <property name="focus-on-click">False</property>
+                                <property name="receives-default">False</property>
+                                <property name="use-underline">True</property>
+                                <signal name="clicked" handler="on_wheely_clicked" swapped="no"/>
                               </object>
                               <packing>
-                                <property name="expand">True</property>
-                                <property name="fill">True</property>
-                                <property name="position">0</property>
+                                <property name="top-attach">1</property>
+                                <property name="bottom-attach">2</property>
                               </packing>
                             </child>
                             <child>
-                              <object class="GtkTable" id="axis_table">
+                              <object class="GtkToggleButton" id="wheelz">
+                                <property name="label" translatable="yes">  Z  </property>
                                 <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                                <property name="border-width">5</property>
-                                <property name="n-rows">3</property>
-                                <property name="n-columns">3</property>
-                                <property name="homogeneous">True</property>
-                                <child>
-                                  <object class="GtkToggleButton" id="wheelx">
-                                    <property name="label" translatable="yes">  X  </property>
-                                    <property name="visible">True</property>
-                                    <property name="can-focus">True</property>
-                                    <property name="focus-on-click">False</property>
-                                    <property name="receives-default">False</property>
-                                    <property name="use-underline">True</property>
-                                    <property name="active">True</property>
-                                    <signal name="clicked" handler="on_wheelx_clicked" swapped="no"/>
-                                  </object>
-                                </child>
-                                <child>
-                                  <object class="GtkToggleButton" id="wheely">
-                                    <property name="label" translatable="yes">  Y  </property>
-                                    <property name="visible">True</property>
-                                    <property name="can-focus">True</property>
-                                    <property name="focus-on-click">False</property>
-                                    <property name="receives-default">False</property>
-                                    <property name="use-underline">True</property>
-                                    <signal name="clicked" handler="on_wheely_clicked" swapped="no"/>
-                                  </object>
-                                  <packing>
-                                    <property name="top-attach">1</property>
-                                    <property name="bottom-attach">2</property>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <object class="GtkToggleButton" id="wheelz">
-                                    <property name="label" translatable="yes">  Z  </property>
-                                    <property name="visible">True</property>
-                                    <property name="can-focus">True</property>
-                                    <property name="focus-on-click">False</property>
-                                    <property name="receives-default">False</property>
-                                    <property name="use-underline">True</property>
-                                    <signal name="clicked" handler="on_wheelz_clicked" swapped="no"/>
-                                  </object>
-                                  <packing>
-                                    <property name="top-attach">2</property>
-                                    <property name="bottom-attach">3</property>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <object class="GtkToggleButton" id="wheela">
-                                    <property name="label" translatable="yes">  A  </property>
-                                    <property name="visible">True</property>
-                                    <property name="can-focus">True</property>
-                                    <property name="focus-on-click">False</property>
-                                    <property name="receives-default">False</property>
-                                    <property name="use-underline">True</property>
-                                    <property name="active">True</property>
-                                    <signal name="clicked" handler="on_wheela_clicked" swapped="no"/>
-                                  </object>
-                                  <packing>
-                                    <property name="left-attach">1</property>
-                                    <property name="right-attach">2</property>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <object class="GtkToggleButton" id="wheelb">
-                                    <property name="label" translatable="yes">  B  </property>
-                                    <property name="visible">True</property>
-                                    <property name="can-focus">True</property>
-                                    <property name="focus-on-click">False</property>
-                                    <property name="receives-default">False</property>
-                                    <property name="use-underline">True</property>
-                                    <property name="active">True</property>
-                                    <signal name="clicked" handler="on_wheelb_clicked" swapped="no"/>
-                                  </object>
-                                  <packing>
-                                    <property name="left-attach">1</property>
-                                    <property name="right-attach">2</property>
-                                    <property name="top-attach">1</property>
-                                    <property name="bottom-attach">2</property>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <object class="GtkToggleButton" id="wheelc">
-                                    <property name="label" translatable="yes">  C  </property>
-                                    <property name="visible">True</property>
-                                    <property name="can-focus">True</property>
-                                    <property name="focus-on-click">False</property>
-                                    <property name="receives-default">False</property>
-                                    <property name="use-underline">True</property>
-                                    <property name="active">True</property>
-                                    <signal name="clicked" handler="on_wheelc_clicked" swapped="no"/>
-                                  </object>
-                                  <packing>
-                                    <property name="left-attach">1</property>
-                                    <property name="right-attach">2</property>
-                                    <property name="top-attach">2</property>
-                                    <property name="bottom-attach">3</property>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <object class="GtkToggleButton" id="wheelu">
-                                    <property name="label" translatable="yes">  U  </property>
-                                    <property name="visible">True</property>
-                                    <property name="can-focus">True</property>
-                                    <property name="focus-on-click">False</property>
-                                    <property name="receives-default">False</property>
-                                    <property name="use-underline">True</property>
-                                    <property name="active">True</property>
-                                    <signal name="clicked" handler="on_wheelu_clicked" swapped="no"/>
-                                  </object>
-                                  <packing>
-                                    <property name="left-attach">2</property>
-                                    <property name="right-attach">3</property>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <object class="GtkToggleButton" id="wheelv">
-                                    <property name="label" translatable="yes">  V  </property>
-                                    <property name="visible">True</property>
-                                    <property name="can-focus">True</property>
-                                    <property name="focus-on-click">False</property>
-                                    <property name="receives-default">False</property>
-                                    <property name="use-underline">True</property>
-                                    <property name="active">True</property>
-                                    <signal name="clicked" handler="on_wheelv_clicked" swapped="no"/>
-                                  </object>
-                                  <packing>
-                                    <property name="left-attach">2</property>
-                                    <property name="right-attach">3</property>
-                                    <property name="top-attach">1</property>
-                                    <property name="bottom-attach">2</property>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <object class="GtkToggleButton" id="wheelw">
-                                    <property name="label" translatable="yes">  W  </property>
-                                    <property name="visible">True</property>
-                                    <property name="can-focus">True</property>
-                                    <property name="focus-on-click">False</property>
-                                    <property name="receives-default">False</property>
-                                    <property name="use-underline">True</property>
-                                    <property name="active">True</property>
-                                    <signal name="clicked" handler="on_wheelw_clicked" swapped="no"/>
-                                  </object>
-                                  <packing>
-                                    <property name="left-attach">2</property>
-                                    <property name="right-attach">3</property>
-                                    <property name="top-attach">2</property>
-                                    <property name="bottom-attach">3</property>
-                                  </packing>
-                                </child>
+                                <property name="can-focus">True</property>
+                                <property name="focus-on-click">False</property>
+                                <property name="receives-default">False</property>
+                                <property name="use-underline">True</property>
+                                <signal name="clicked" handler="on_wheelz_clicked" swapped="no"/>
                               </object>
                               <packing>
-                                <property name="expand">True</property>
-                                <property name="fill">True</property>
-                                <property name="position">1</property>
+                                <property name="top-attach">2</property>
+                                <property name="bottom-attach">3</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkToggleButton" id="wheela">
+                                <property name="label" translatable="yes">  A  </property>
+                                <property name="visible">True</property>
+                                <property name="can-focus">True</property>
+                                <property name="focus-on-click">False</property>
+                                <property name="receives-default">False</property>
+                                <property name="use-underline">True</property>
+                                <property name="active">True</property>
+                                <signal name="clicked" handler="on_wheela_clicked" swapped="no"/>
+                              </object>
+                              <packing>
+                                <property name="left-attach">1</property>
+                                <property name="right-attach">2</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkToggleButton" id="wheelb">
+                                <property name="label" translatable="yes">  B  </property>
+                                <property name="visible">True</property>
+                                <property name="can-focus">True</property>
+                                <property name="focus-on-click">False</property>
+                                <property name="receives-default">False</property>
+                                <property name="use-underline">True</property>
+                                <property name="active">True</property>
+                                <signal name="clicked" handler="on_wheelb_clicked" swapped="no"/>
+                              </object>
+                              <packing>
+                                <property name="left-attach">1</property>
+                                <property name="right-attach">2</property>
+                                <property name="top-attach">1</property>
+                                <property name="bottom-attach">2</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkToggleButton" id="wheelc">
+                                <property name="label" translatable="yes">  C  </property>
+                                <property name="visible">True</property>
+                                <property name="can-focus">True</property>
+                                <property name="focus-on-click">False</property>
+                                <property name="receives-default">False</property>
+                                <property name="use-underline">True</property>
+                                <property name="active">True</property>
+                                <signal name="clicked" handler="on_wheelc_clicked" swapped="no"/>
+                              </object>
+                              <packing>
+                                <property name="left-attach">1</property>
+                                <property name="right-attach">2</property>
+                                <property name="top-attach">2</property>
+                                <property name="bottom-attach">3</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkToggleButton" id="wheelu">
+                                <property name="label" translatable="yes">  U  </property>
+                                <property name="visible">True</property>
+                                <property name="can-focus">True</property>
+                                <property name="focus-on-click">False</property>
+                                <property name="receives-default">False</property>
+                                <property name="use-underline">True</property>
+                                <property name="active">True</property>
+                                <signal name="clicked" handler="on_wheelu_clicked" swapped="no"/>
+                              </object>
+                              <packing>
+                                <property name="left-attach">2</property>
+                                <property name="right-attach">3</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkToggleButton" id="wheelv">
+                                <property name="label" translatable="yes">  V  </property>
+                                <property name="visible">True</property>
+                                <property name="can-focus">True</property>
+                                <property name="focus-on-click">False</property>
+                                <property name="receives-default">False</property>
+                                <property name="use-underline">True</property>
+                                <property name="active">True</property>
+                                <signal name="clicked" handler="on_wheelv_clicked" swapped="no"/>
+                              </object>
+                              <packing>
+                                <property name="left-attach">2</property>
+                                <property name="right-attach">3</property>
+                                <property name="top-attach">1</property>
+                                <property name="bottom-attach">2</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkToggleButton" id="wheelw">
+                                <property name="label" translatable="yes">  W  </property>
+                                <property name="visible">True</property>
+                                <property name="can-focus">True</property>
+                                <property name="focus-on-click">False</property>
+                                <property name="receives-default">False</property>
+                                <property name="use-underline">True</property>
+                                <property name="active">True</property>
+                                <signal name="clicked" handler="on_wheelw_clicked" swapped="no"/>
+                              </object>
+                              <packing>
+                                <property name="left-attach">2</property>
+                                <property name="right-attach">3</property>
+                                <property name="top-attach">2</property>
+                                <property name="bottom-attach">3</property>
                               </packing>
                             </child>
                           </object>
@@ -4179,7 +4053,15 @@ F1 S1</property>
                             <property name="position">1</property>
                           </packing>
                         </child>
+                        <child>
+                          <placeholder/>
+                        </child>
                       </object>
+                      <packing>
+                        <property name="expand">True</property>
+                        <property name="fill">True</property>
+                        <property name="position">1</property>
+                      </packing>
                     </child>
                   </object>
                 </child>

--- a/src/emc/usr_intf/touchy/touchy.glade
+++ b/src/emc/usr_intf/touchy/touchy.glade
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Generated with glade 3.40.0 -->
 <interface>
-  <requires lib="gtk+" version="3.0"/>
+  <requires lib="gtk+" version="3.20"/>
   <object class="GtkListStore" id="model1">
     <columns>
       <!-- column-name gchararray -->
@@ -21,17 +21,19 @@
     <property name="default-height">600</property>
     <signal name="destroy" handler="quit" swapped="no"/>
     <child>
-      <object class="GtkVBox" id="vbox5">
+      <object class="GtkBox" id="vbox5">
         <property name="visible">True</property>
         <property name="can-focus">False</property>
+        <property name="orientation">vertical</property>
         <child>
-          <object class="GtkHBox" id="hbox5">
+          <object class="GtkBox" id="hbox5">
             <property name="visible">True</property>
             <property name="can-focus">False</property>
             <child>
-              <object class="GtkVBox" id="vbox1">
+              <object class="GtkBox" id="vbox1">
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
+                <property name="orientation">vertical</property>
                 <child>
                   <object class="GtkTable" id="dro_table">
                     <property name="visible">True</property>
@@ -468,9 +470,10 @@
                     <property name="tab-pos">bottom</property>
                     <signal name="switch-page" handler="on_notebook1_switch_page" swapped="no"/>
                     <child>
-                      <object class="GtkVBox" id="vbox6">
+                      <object class="GtkBox" id="vbox6">
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
+                        <property name="orientation">vertical</property>
                         <child>
                           <object class="GtkFrame" id="frame2">
                             <property name="visible">True</property>
@@ -700,11 +703,12 @@
                       </packing>
                     </child>
                     <child>
-                      <object class="GtkVBox" id="vbox12">
+                      <object class="GtkBox" id="vbox12">
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
+                        <property name="orientation">vertical</property>
                         <child>
-                          <object class="GtkHBox" id="hbox9">
+                          <object class="GtkBox" id="hbox9">
                             <property name="visible">True</property>
                             <property name="can-focus">False</property>
                             <property name="homogeneous">True</property>
@@ -767,14 +771,15 @@
                           </packing>
                         </child>
                         <child>
-                          <object class="GtkHBox" id="hbox8">
+                          <object class="GtkBox" id="hbox8">
                             <property name="visible">True</property>
                             <property name="can-focus">False</property>
                             <property name="border-width">10</property>
                             <child>
-                              <object class="GtkVBox" id="vbox11">
+                              <object class="GtkBox" id="vbox11">
                                 <property name="visible">True</property>
                                 <property name="can-focus">False</property>
+                                <property name="orientation">vertical</property>
                                 <property name="homogeneous">True</property>
                                 <child>
                                   <object class="GtkEventBox" id="eventbox_mdi0">
@@ -1266,9 +1271,10 @@
                                   </packing>
                                 </child>
                                 <child>
-                                  <object class="GtkVBox" id="vbox2">
+                                  <object class="GtkBox" id="vbox2">
                                     <property name="visible">True</property>
                                     <property name="can-focus">False</property>
+                                    <property name="orientation">vertical</property>
                                     <property name="homogeneous">True</property>
                                     <child>
                                       <object class="GtkButton" id="g">
@@ -1392,11 +1398,12 @@
                       </packing>
                     </child>
                     <child>
-                      <object class="GtkVBox" id="vbox7">
+                      <object class="GtkBox" id="vbox7">
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
+                        <property name="orientation">vertical</property>
                         <child>
-                          <object class="GtkHBox" id="hbox10">
+                          <object class="GtkBox" id="hbox10">
                             <property name="visible">True</property>
                             <property name="can-focus">False</property>
                             <child>
@@ -1625,7 +1632,7 @@
                                       </packing>
                                     </child>
                                     <child>
-                                      <object class="GtkHBox" id="hbox12">
+                                      <object class="GtkBox" id="hbox12">
                                         <property name="visible">True</property>
                                         <property name="can-focus">False</property>
                                         <child>
@@ -2607,7 +2614,7 @@
                                         <property name="xscale">0</property>
                                         <property name="yscale">0</property>
                                         <child>
-                                          <object class="GtkHBox" id="hbox7">
+                                          <object class="GtkBox" id="hbox7">
                                             <property name="visible">True</property>
                                             <property name="can-focus">False</property>
                                             <property name="spacing">2</property>
@@ -3264,9 +3271,10 @@ F1 S1</property>
                       </packing>
                     </child>
                     <child>
-                      <object class="GtkVBox" id="vbox10">
+                      <object class="GtkBox" id="vbox10">
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
+                        <property name="orientation">vertical</property>
                         <child>
                           <object class="GtkFrame" id="frame11">
                             <property name="visible">True</property>
@@ -3531,7 +3539,7 @@ F1 S1</property>
                           </packing>
                         </child>
                         <child>
-                          <object class="GtkHBox" id="hbox11">
+                          <object class="GtkBox" id="hbox11">
                             <property name="visible">True</property>
                             <property name="can-focus">False</property>
                             <child>
@@ -3843,14 +3851,16 @@ F1 S1</property>
                     <property name="can-focus">False</property>
                     <property name="left-padding">12</property>
                     <child>
-                      <object class="GtkVBox" id="vbox4">
+                      <object class="GtkBox" id="vbox4">
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
+                        <property name="orientation">vertical</property>
                         <child>
-                          <object class="GtkVBox" id="vbox3">
+                          <object class="GtkBox" id="vbox3">
                             <property name="visible">True</property>
                             <property name="can-focus">False</property>
                             <property name="border-width">5</property>
+                            <property name="orientation">vertical</property>
                             <child>
                               <object class="GtkToggleButton" id="fo">
                                 <property name="label" translatable="yes">FO: 100%</property>
@@ -3940,7 +3950,7 @@ F1 S1</property>
                           </packing>
                         </child>
                         <child>
-                          <object class="GtkHBox" id="wheel_hbox">
+                          <object class="GtkBox" id="wheel_hbox">
                             <property name="visible">True</property>
                             <property name="can-focus">False</property>
                             <child>

--- a/src/emc/usr_intf/touchy/touchy.glade
+++ b/src/emc/usr_intf/touchy/touchy.glade
@@ -1,7 +1,10 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.40.0 -->
 <interface>
+  <requires lib="gtk+" version="3.0"/>
   <object class="GtkListStore" id="model1">
     <columns>
+      <!-- column-name gchararray -->
       <column type="gchararray"/>
     </columns>
     <data>
@@ -10,526 +13,561 @@
       </row>
     </data>
   </object>
-  <!-- interface-requires gtk+ 2.6 -->
-  <!-- interface-naming-policy toplevel-contextual -->
   <object class="GtkWindow" id="MainWindow">
     <property name="visible">True</property>
+    <property name="can-focus">False</property>
     <property name="title" translatable="yes">LinuxCNC/Touchy</property>
-    <property name="default_width">800</property>
-    <property name="default_height">600</property>
-    <accessibility>
-      
-    </accessibility>
-    <signal name="destroy" handler="quit"/>
+    <property name="default-width">800</property>
+    <property name="default-height">600</property>
+    <signal name="destroy" handler="quit" swapped="no"/>
     <child>
       <object class="GtkVBox" id="vbox5">
         <property name="visible">True</property>
+        <property name="can-focus">False</property>
         <child>
           <object class="GtkHBox" id="hbox5">
             <property name="visible">True</property>
+            <property name="can-focus">False</property>
             <child>
               <object class="GtkVBox" id="vbox1">
                 <property name="visible">True</property>
+                <property name="can-focus">False</property>
                 <child>
                   <object class="GtkTable" id="dro_table">
                     <property name="visible">True</property>
-                    <property name="n_rows">10</property>
-                    <property name="n_columns">3</property>
+                    <property name="can-focus">False</property>
+                    <property name="n-rows">10</property>
+                    <property name="n-columns">3</property>
                     <child>
                       <object class="GtkLabel" id="xa">
                         <property name="visible">True</property>
+                        <property name="can-focus">False</property>
                         <property name="label" translatable="yes">xa</property>
                       </object>
                       <packing>
-                        <property name="left_attach">1</property>
-                        <property name="right_attach">2</property>
-                        <property name="top_attach">1</property>
-                        <property name="bottom_attach">2</property>
-                        <property name="y_options"/>
+                        <property name="left-attach">1</property>
+                        <property name="right-attach">2</property>
+                        <property name="top-attach">1</property>
+                        <property name="bottom-attach">2</property>
+                        <property name="y-options"/>
                       </packing>
                     </child>
                     <child>
                       <object class="GtkLabel" id="xd">
                         <property name="visible">True</property>
+                        <property name="can-focus">False</property>
                         <property name="label" translatable="yes">xd</property>
                       </object>
                       <packing>
-                        <property name="left_attach">2</property>
-                        <property name="right_attach">3</property>
-                        <property name="top_attach">1</property>
-                        <property name="bottom_attach">2</property>
-                        <property name="y_options"/>
+                        <property name="left-attach">2</property>
+                        <property name="right-attach">3</property>
+                        <property name="top-attach">1</property>
+                        <property name="bottom-attach">2</property>
+                        <property name="y-options"/>
                       </packing>
                     </child>
                     <child>
                       <object class="GtkLabel" id="yr">
                         <property name="visible">True</property>
+                        <property name="can-focus">False</property>
                         <property name="label" translatable="yes">yr</property>
                       </object>
                       <packing>
-                        <property name="top_attach">2</property>
-                        <property name="bottom_attach">3</property>
-                        <property name="y_options"/>
+                        <property name="top-attach">2</property>
+                        <property name="bottom-attach">3</property>
+                        <property name="y-options"/>
                       </packing>
                     </child>
                     <child>
                       <object class="GtkLabel" id="ya">
                         <property name="visible">True</property>
+                        <property name="can-focus">False</property>
                         <property name="label" translatable="yes">ya</property>
                       </object>
                       <packing>
-                        <property name="left_attach">1</property>
-                        <property name="right_attach">2</property>
-                        <property name="top_attach">2</property>
-                        <property name="bottom_attach">3</property>
-                        <property name="y_options"/>
+                        <property name="left-attach">1</property>
+                        <property name="right-attach">2</property>
+                        <property name="top-attach">2</property>
+                        <property name="bottom-attach">3</property>
+                        <property name="y-options"/>
                       </packing>
                     </child>
                     <child>
                       <object class="GtkLabel" id="yd">
                         <property name="visible">True</property>
+                        <property name="can-focus">False</property>
                         <property name="label" translatable="yes">yd</property>
                       </object>
                       <packing>
-                        <property name="left_attach">2</property>
-                        <property name="right_attach">3</property>
-                        <property name="top_attach">2</property>
-                        <property name="bottom_attach">3</property>
-                        <property name="y_options"/>
+                        <property name="left-attach">2</property>
+                        <property name="right-attach">3</property>
+                        <property name="top-attach">2</property>
+                        <property name="bottom-attach">3</property>
+                        <property name="y-options"/>
                       </packing>
                     </child>
                     <child>
                       <object class="GtkLabel" id="zr">
                         <property name="visible">True</property>
+                        <property name="can-focus">False</property>
                         <property name="label" translatable="yes">zr</property>
                       </object>
                       <packing>
-                        <property name="top_attach">3</property>
-                        <property name="bottom_attach">4</property>
-                        <property name="y_options"/>
+                        <property name="top-attach">3</property>
+                        <property name="bottom-attach">4</property>
+                        <property name="y-options"/>
                       </packing>
                     </child>
                     <child>
                       <object class="GtkLabel" id="za">
                         <property name="visible">True</property>
+                        <property name="can-focus">False</property>
                         <property name="label" translatable="yes">za</property>
                       </object>
                       <packing>
-                        <property name="left_attach">1</property>
-                        <property name="right_attach">2</property>
-                        <property name="top_attach">3</property>
-                        <property name="bottom_attach">4</property>
-                        <property name="y_options"/>
+                        <property name="left-attach">1</property>
+                        <property name="right-attach">2</property>
+                        <property name="top-attach">3</property>
+                        <property name="bottom-attach">4</property>
+                        <property name="y-options"/>
                       </packing>
                     </child>
                     <child>
                       <object class="GtkLabel" id="zd">
                         <property name="visible">True</property>
+                        <property name="can-focus">False</property>
                         <property name="label" translatable="yes">zd</property>
                       </object>
                       <packing>
-                        <property name="left_attach">2</property>
-                        <property name="right_attach">3</property>
-                        <property name="top_attach">3</property>
-                        <property name="bottom_attach">4</property>
-                        <property name="y_options"/>
+                        <property name="left-attach">2</property>
+                        <property name="right-attach">3</property>
+                        <property name="top-attach">3</property>
+                        <property name="bottom-attach">4</property>
+                        <property name="y-options"/>
                       </packing>
                     </child>
                     <child>
                       <object class="GtkLabel" id="dtg">
                         <property name="visible">True</property>
+                        <property name="can-focus">False</property>
                         <property name="label" translatable="yes">DTG</property>
                         <property name="justify">right</property>
                       </object>
                       <packing>
-                        <property name="left_attach">2</property>
-                        <property name="right_attach">3</property>
-                        <property name="y_options"/>
+                        <property name="left-attach">2</property>
+                        <property name="right-attach">3</property>
+                        <property name="y-options"/>
                       </packing>
                     </child>
                     <child>
                       <object class="GtkLabel" id="absolute">
                         <property name="visible">True</property>
+                        <property name="can-focus">False</property>
                         <property name="label" translatable="yes">Absolute</property>
                         <property name="justify">right</property>
                       </object>
                       <packing>
-                        <property name="left_attach">1</property>
-                        <property name="right_attach">2</property>
-                        <property name="y_options"/>
+                        <property name="left-attach">1</property>
+                        <property name="right-attach">2</property>
+                        <property name="y-options"/>
                       </packing>
                     </child>
                     <child>
                       <object class="GtkLabel" id="relative">
                         <property name="visible">True</property>
+                        <property name="can-focus">False</property>
                         <property name="label" translatable="yes">Relative</property>
                         <property name="justify">right</property>
                       </object>
                       <packing>
-                        <property name="y_options"/>
+                        <property name="y-options"/>
                       </packing>
                     </child>
                     <child>
                       <object class="GtkLabel" id="xr">
                         <property name="visible">True</property>
+                        <property name="can-focus">False</property>
                         <property name="label" translatable="yes">xr</property>
                       </object>
                       <packing>
-                        <property name="top_attach">1</property>
-                        <property name="bottom_attach">2</property>
-                        <property name="y_options"/>
+                        <property name="top-attach">1</property>
+                        <property name="bottom-attach">2</property>
+                        <property name="y-options"/>
                       </packing>
                     </child>
                     <child>
                       <object class="GtkLabel" id="ar">
                         <property name="visible">True</property>
+                        <property name="can-focus">False</property>
                         <property name="label" translatable="yes">ar</property>
                       </object>
                       <packing>
-                        <property name="top_attach">4</property>
-                        <property name="bottom_attach">5</property>
-                        <property name="x_options">GTK_FILL</property>
-                        <property name="y_options"/>
+                        <property name="top-attach">4</property>
+                        <property name="bottom-attach">5</property>
+                        <property name="x-options">GTK_FILL</property>
+                        <property name="y-options"/>
                       </packing>
                     </child>
                     <child>
                       <object class="GtkLabel" id="br">
                         <property name="visible">True</property>
+                        <property name="can-focus">False</property>
                         <property name="label" translatable="yes">br</property>
                       </object>
                       <packing>
-                        <property name="top_attach">5</property>
-                        <property name="bottom_attach">6</property>
-                        <property name="x_options">GTK_FILL</property>
-                        <property name="y_options"/>
+                        <property name="top-attach">5</property>
+                        <property name="bottom-attach">6</property>
+                        <property name="x-options">GTK_FILL</property>
+                        <property name="y-options"/>
                       </packing>
                     </child>
                     <child>
                       <object class="GtkLabel" id="cr">
                         <property name="visible">True</property>
+                        <property name="can-focus">False</property>
                         <property name="label" translatable="yes">cr</property>
                       </object>
                       <packing>
-                        <property name="top_attach">6</property>
-                        <property name="bottom_attach">7</property>
-                        <property name="x_options">GTK_FILL</property>
-                        <property name="y_options"/>
+                        <property name="top-attach">6</property>
+                        <property name="bottom-attach">7</property>
+                        <property name="x-options">GTK_FILL</property>
+                        <property name="y-options"/>
                       </packing>
                     </child>
                     <child>
                       <object class="GtkLabel" id="ur">
                         <property name="visible">True</property>
+                        <property name="can-focus">False</property>
                         <property name="label" translatable="yes">ur</property>
                       </object>
                       <packing>
-                        <property name="top_attach">7</property>
-                        <property name="bottom_attach">8</property>
-                        <property name="x_options">GTK_FILL</property>
-                        <property name="y_options"/>
+                        <property name="top-attach">7</property>
+                        <property name="bottom-attach">8</property>
+                        <property name="x-options">GTK_FILL</property>
+                        <property name="y-options"/>
                       </packing>
                     </child>
                     <child>
                       <object class="GtkLabel" id="vr">
                         <property name="visible">True</property>
+                        <property name="can-focus">False</property>
                         <property name="label" translatable="yes">vr</property>
                       </object>
                       <packing>
-                        <property name="top_attach">8</property>
-                        <property name="bottom_attach">9</property>
-                        <property name="x_options">GTK_FILL</property>
-                        <property name="y_options"/>
+                        <property name="top-attach">8</property>
+                        <property name="bottom-attach">9</property>
+                        <property name="x-options">GTK_FILL</property>
+                        <property name="y-options"/>
                       </packing>
                     </child>
                     <child>
                       <object class="GtkLabel" id="wr">
                         <property name="visible">True</property>
+                        <property name="can-focus">False</property>
                         <property name="label" translatable="yes">wr</property>
                       </object>
                       <packing>
-                        <property name="top_attach">9</property>
-                        <property name="bottom_attach">10</property>
-                        <property name="x_options">GTK_FILL</property>
-                        <property name="y_options"/>
+                        <property name="top-attach">9</property>
+                        <property name="bottom-attach">10</property>
+                        <property name="x-options">GTK_FILL</property>
+                        <property name="y-options"/>
                       </packing>
                     </child>
                     <child>
                       <object class="GtkLabel" id="aa">
                         <property name="visible">True</property>
+                        <property name="can-focus">False</property>
                         <property name="label" translatable="yes">aa</property>
                       </object>
                       <packing>
-                        <property name="left_attach">1</property>
-                        <property name="right_attach">2</property>
-                        <property name="top_attach">4</property>
-                        <property name="bottom_attach">5</property>
-                        <property name="x_options">GTK_FILL</property>
-                        <property name="y_options"/>
+                        <property name="left-attach">1</property>
+                        <property name="right-attach">2</property>
+                        <property name="top-attach">4</property>
+                        <property name="bottom-attach">5</property>
+                        <property name="x-options">GTK_FILL</property>
+                        <property name="y-options"/>
                       </packing>
                     </child>
                     <child>
                       <object class="GtkLabel" id="ba">
                         <property name="visible">True</property>
+                        <property name="can-focus">False</property>
                         <property name="label" translatable="yes">ba</property>
                       </object>
                       <packing>
-                        <property name="left_attach">1</property>
-                        <property name="right_attach">2</property>
-                        <property name="top_attach">5</property>
-                        <property name="bottom_attach">6</property>
-                        <property name="x_options">GTK_FILL</property>
-                        <property name="y_options"/>
+                        <property name="left-attach">1</property>
+                        <property name="right-attach">2</property>
+                        <property name="top-attach">5</property>
+                        <property name="bottom-attach">6</property>
+                        <property name="x-options">GTK_FILL</property>
+                        <property name="y-options"/>
                       </packing>
                     </child>
                     <child>
                       <object class="GtkLabel" id="ca">
                         <property name="visible">True</property>
+                        <property name="can-focus">False</property>
                         <property name="label" translatable="yes">ca</property>
                       </object>
                       <packing>
-                        <property name="left_attach">1</property>
-                        <property name="right_attach">2</property>
-                        <property name="top_attach">6</property>
-                        <property name="bottom_attach">7</property>
-                        <property name="x_options">GTK_FILL</property>
-                        <property name="y_options"/>
+                        <property name="left-attach">1</property>
+                        <property name="right-attach">2</property>
+                        <property name="top-attach">6</property>
+                        <property name="bottom-attach">7</property>
+                        <property name="x-options">GTK_FILL</property>
+                        <property name="y-options"/>
                       </packing>
                     </child>
                     <child>
                       <object class="GtkLabel" id="ua">
                         <property name="visible">True</property>
+                        <property name="can-focus">False</property>
                         <property name="label" translatable="yes">ua</property>
                       </object>
                       <packing>
-                        <property name="left_attach">1</property>
-                        <property name="right_attach">2</property>
-                        <property name="top_attach">7</property>
-                        <property name="bottom_attach">8</property>
-                        <property name="x_options">GTK_FILL</property>
-                        <property name="y_options"/>
+                        <property name="left-attach">1</property>
+                        <property name="right-attach">2</property>
+                        <property name="top-attach">7</property>
+                        <property name="bottom-attach">8</property>
+                        <property name="x-options">GTK_FILL</property>
+                        <property name="y-options"/>
                       </packing>
                     </child>
                     <child>
                       <object class="GtkLabel" id="va">
                         <property name="visible">True</property>
+                        <property name="can-focus">False</property>
                         <property name="label" translatable="yes">va</property>
                       </object>
                       <packing>
-                        <property name="left_attach">1</property>
-                        <property name="right_attach">2</property>
-                        <property name="top_attach">8</property>
-                        <property name="bottom_attach">9</property>
-                        <property name="x_options">GTK_FILL</property>
-                        <property name="y_options"/>
+                        <property name="left-attach">1</property>
+                        <property name="right-attach">2</property>
+                        <property name="top-attach">8</property>
+                        <property name="bottom-attach">9</property>
+                        <property name="x-options">GTK_FILL</property>
+                        <property name="y-options"/>
                       </packing>
                     </child>
                     <child>
                       <object class="GtkLabel" id="wa">
                         <property name="visible">True</property>
+                        <property name="can-focus">False</property>
                         <property name="label" translatable="yes">wa</property>
                       </object>
                       <packing>
-                        <property name="left_attach">1</property>
-                        <property name="right_attach">2</property>
-                        <property name="top_attach">9</property>
-                        <property name="bottom_attach">10</property>
-                        <property name="x_options">GTK_FILL</property>
-                        <property name="y_options"/>
+                        <property name="left-attach">1</property>
+                        <property name="right-attach">2</property>
+                        <property name="top-attach">9</property>
+                        <property name="bottom-attach">10</property>
+                        <property name="x-options">GTK_FILL</property>
+                        <property name="y-options"/>
                       </packing>
                     </child>
                     <child>
                       <object class="GtkLabel" id="ad">
                         <property name="visible">True</property>
+                        <property name="can-focus">False</property>
                         <property name="label" translatable="yes">ad</property>
                       </object>
                       <packing>
-                        <property name="left_attach">2</property>
-                        <property name="right_attach">3</property>
-                        <property name="top_attach">4</property>
-                        <property name="bottom_attach">5</property>
-                        <property name="x_options">GTK_FILL</property>
-                        <property name="y_options"/>
+                        <property name="left-attach">2</property>
+                        <property name="right-attach">3</property>
+                        <property name="top-attach">4</property>
+                        <property name="bottom-attach">5</property>
+                        <property name="x-options">GTK_FILL</property>
+                        <property name="y-options"/>
                       </packing>
                     </child>
                     <child>
                       <object class="GtkLabel" id="bd">
                         <property name="visible">True</property>
+                        <property name="can-focus">False</property>
                         <property name="label" translatable="yes">bd</property>
                       </object>
                       <packing>
-                        <property name="left_attach">2</property>
-                        <property name="right_attach">3</property>
-                        <property name="top_attach">5</property>
-                        <property name="bottom_attach">6</property>
-                        <property name="x_options">GTK_FILL</property>
-                        <property name="y_options"/>
+                        <property name="left-attach">2</property>
+                        <property name="right-attach">3</property>
+                        <property name="top-attach">5</property>
+                        <property name="bottom-attach">6</property>
+                        <property name="x-options">GTK_FILL</property>
+                        <property name="y-options"/>
                       </packing>
                     </child>
                     <child>
                       <object class="GtkLabel" id="cd">
                         <property name="visible">True</property>
+                        <property name="can-focus">False</property>
                         <property name="label" translatable="yes">cd</property>
                       </object>
                       <packing>
-                        <property name="left_attach">2</property>
-                        <property name="right_attach">3</property>
-                        <property name="top_attach">6</property>
-                        <property name="bottom_attach">7</property>
-                        <property name="x_options">GTK_FILL</property>
-                        <property name="y_options"/>
+                        <property name="left-attach">2</property>
+                        <property name="right-attach">3</property>
+                        <property name="top-attach">6</property>
+                        <property name="bottom-attach">7</property>
+                        <property name="x-options">GTK_FILL</property>
+                        <property name="y-options"/>
                       </packing>
                     </child>
                     <child>
                       <object class="GtkLabel" id="ud">
                         <property name="visible">True</property>
+                        <property name="can-focus">False</property>
                         <property name="label" translatable="yes">ud</property>
                       </object>
                       <packing>
-                        <property name="left_attach">2</property>
-                        <property name="right_attach">3</property>
-                        <property name="top_attach">7</property>
-                        <property name="bottom_attach">8</property>
-                        <property name="x_options">GTK_FILL</property>
-                        <property name="y_options"/>
+                        <property name="left-attach">2</property>
+                        <property name="right-attach">3</property>
+                        <property name="top-attach">7</property>
+                        <property name="bottom-attach">8</property>
+                        <property name="x-options">GTK_FILL</property>
+                        <property name="y-options"/>
                       </packing>
                     </child>
                     <child>
                       <object class="GtkLabel" id="vd">
                         <property name="visible">True</property>
+                        <property name="can-focus">False</property>
                         <property name="label" translatable="yes">vd</property>
                       </object>
                       <packing>
-                        <property name="left_attach">2</property>
-                        <property name="right_attach">3</property>
-                        <property name="top_attach">8</property>
-                        <property name="bottom_attach">9</property>
-                        <property name="x_options">GTK_FILL</property>
-                        <property name="y_options"/>
+                        <property name="left-attach">2</property>
+                        <property name="right-attach">3</property>
+                        <property name="top-attach">8</property>
+                        <property name="bottom-attach">9</property>
+                        <property name="x-options">GTK_FILL</property>
+                        <property name="y-options"/>
                       </packing>
                     </child>
                     <child>
                       <object class="GtkLabel" id="wd">
                         <property name="visible">True</property>
+                        <property name="can-focus">False</property>
                         <property name="label" translatable="yes">wd</property>
                       </object>
                       <packing>
-                        <property name="left_attach">2</property>
-                        <property name="right_attach">3</property>
-                        <property name="top_attach">9</property>
-                        <property name="bottom_attach">10</property>
-                        <property name="x_options">GTK_FILL</property>
-                        <property name="y_options"/>
+                        <property name="left-attach">2</property>
+                        <property name="right-attach">3</property>
+                        <property name="top-attach">9</property>
+                        <property name="bottom-attach">10</property>
+                        <property name="x-options">GTK_FILL</property>
+                        <property name="y-options"/>
                       </packing>
                     </child>
                   </object>
                   <packing>
                     <property name="expand">False</property>
+                    <property name="fill">True</property>
                     <property name="position">0</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkNotebook" id="notebook1">
                     <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="border_width">5</property>
-                    <property name="tab_pos">bottom</property>
-                    <signal name="switch_page" handler="on_notebook1_switch_page"/>
+                    <property name="can-focus">True</property>
+                    <property name="border-width">5</property>
+                    <property name="tab-pos">bottom</property>
+                    <signal name="switch-page" handler="on_notebook1_switch_page" swapped="no"/>
                     <child>
                       <object class="GtkVBox" id="vbox6">
                         <property name="visible">True</property>
+                        <property name="can-focus">False</property>
                         <child>
                           <object class="GtkFrame" id="frame2">
                             <property name="visible">True</property>
-                            <property name="border_width">5</property>
-                            <property name="label_xalign">0</property>
+                            <property name="can-focus">False</property>
+                            <property name="border-width">5</property>
+                            <property name="label-xalign">0</property>
                             <child>
                               <object class="GtkAlignment" id="alignment2">
                                 <property name="visible">True</property>
-                                <property name="left_padding">12</property>
+                                <property name="can-focus">False</property>
+                                <property name="left-padding">12</property>
                                 <child>
                                   <object class="GtkTable" id="table6">
                                     <property name="visible">True</property>
-                                    <property name="border_width">5</property>
-                                    <property name="n_rows">2</property>
-                                    <property name="n_columns">3</property>
-                                    <property name="column_spacing">15</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="border-width">5</property>
+                                    <property name="n-rows">2</property>
+                                    <property name="n-columns">3</property>
+                                    <property name="column-spacing">15</property>
                                     <property name="homogeneous">True</property>
+                                    <child>
+                                      <placeholder/>
+                                    </child>
                                     <child>
                                       <object class="GtkToggleButton" id="estop_reset">
                                         <property name="label" translatable="yes">Estop Reset</property>
                                         <property name="visible">True</property>
-                                        <property name="can_focus">True</property>
-                                        <property name="receives_default">False</property>
-                                        <property name="use_underline">True</property>
-                                        <property name="focus_on_click">False</property>
-                                        <signal name="clicked" handler="on_estop_reset_clicked"/>
+                                        <property name="can-focus">True</property>
+                                        <property name="focus-on-click">False</property>
+                                        <property name="receives-default">False</property>
+                                        <property name="use-underline">True</property>
+                                        <signal name="clicked" handler="on_estop_reset_clicked" swapped="no"/>
                                       </object>
                                     </child>
                                     <child>
                                       <object class="GtkToggleButton" id="estop">
                                         <property name="label" translatable="yes">Estop</property>
                                         <property name="visible">True</property>
-                                        <property name="can_focus">True</property>
-                                        <property name="receives_default">False</property>
-                                        <property name="use_underline">True</property>
-                                        <property name="focus_on_click">False</property>
+                                        <property name="can-focus">True</property>
+                                        <property name="focus-on-click">False</property>
+                                        <property name="receives-default">False</property>
+                                        <property name="use-underline">True</property>
                                         <property name="active">True</property>
-                                        <signal name="clicked" handler="on_estop_clicked"/>
+                                        <signal name="clicked" handler="on_estop_clicked" swapped="no"/>
                                       </object>
                                       <packing>
-                                        <property name="top_attach">1</property>
-                                        <property name="bottom_attach">2</property>
+                                        <property name="top-attach">1</property>
+                                        <property name="bottom-attach">2</property>
                                       </packing>
                                     </child>
                                     <child>
                                       <object class="GtkToggleButton" id="machine_on">
                                         <property name="label" translatable="yes">Machine On</property>
                                         <property name="visible">True</property>
-                                        <property name="can_focus">True</property>
-                                        <property name="receives_default">False</property>
-                                        <property name="use_underline">True</property>
-                                        <property name="focus_on_click">False</property>
-                                        <signal name="clicked" handler="on_machine_on_clicked"/>
+                                        <property name="can-focus">True</property>
+                                        <property name="focus-on-click">False</property>
+                                        <property name="receives-default">False</property>
+                                        <property name="use-underline">True</property>
+                                        <signal name="clicked" handler="on_machine_on_clicked" swapped="no"/>
                                       </object>
                                       <packing>
-                                        <property name="left_attach">1</property>
-                                        <property name="right_attach">2</property>
+                                        <property name="left-attach">1</property>
+                                        <property name="right-attach">2</property>
                                       </packing>
                                     </child>
                                     <child>
                                       <object class="GtkToggleButton" id="machine_off">
                                         <property name="label" translatable="yes">Machine Off</property>
                                         <property name="visible">True</property>
-                                        <property name="can_focus">True</property>
-                                        <property name="receives_default">False</property>
-                                        <property name="use_underline">True</property>
-                                        <property name="focus_on_click">False</property>
+                                        <property name="can-focus">True</property>
+                                        <property name="focus-on-click">False</property>
+                                        <property name="receives-default">False</property>
+                                        <property name="use-underline">True</property>
                                         <property name="active">True</property>
-                                        <signal name="clicked" handler="on_machine_off_clicked"/>
+                                        <signal name="clicked" handler="on_machine_off_clicked" swapped="no"/>
                                       </object>
                                       <packing>
-                                        <property name="left_attach">1</property>
-                                        <property name="right_attach">2</property>
-                                        <property name="top_attach">1</property>
-                                        <property name="bottom_attach">2</property>
+                                        <property name="left-attach">1</property>
+                                        <property name="right-attach">2</property>
+                                        <property name="top-attach">1</property>
+                                        <property name="bottom-attach">2</property>
                                       </packing>
                                     </child>
                                     <child>
                                       <object class="GtkToggleButton" id="override_limits">
                                         <property name="label" translatable="yes">Override Limits</property>
                                         <property name="visible">True</property>
-                                        <property name="can_focus">True</property>
-                                        <property name="receives_default">False</property>
-                                        <property name="use_underline">True</property>
-                                        <property name="focus_on_click">False</property>
-                                        <signal name="clicked" handler="on_override_limits_clicked"/>
+                                        <property name="can-focus">True</property>
+                                        <property name="focus-on-click">False</property>
+                                        <property name="receives-default">False</property>
+                                        <property name="use-underline">True</property>
+                                        <signal name="clicked" handler="on_override_limits_clicked" swapped="no"/>
                                       </object>
                                       <packing>
-                                        <property name="left_attach">2</property>
-                                        <property name="right_attach">3</property>
+                                        <property name="left-attach">2</property>
+                                        <property name="right-attach">3</property>
                                       </packing>
-                                    </child>
-                                    <child>
-                                      <placeholder/>
                                     </child>
                                   </object>
                                 </child>
@@ -538,88 +576,94 @@
                             <child type="label">
                               <object class="GtkLabel" id="frame1">
                                 <property name="visible">True</property>
+                                <property name="can-focus">False</property>
                                 <property name="label" translatable="yes">&lt;b&gt;Power&lt;/b&gt;</property>
-                                <property name="use_markup">True</property>
+                                <property name="use-markup">True</property>
                               </object>
                             </child>
                           </object>
                           <packing>
+                            <property name="expand">True</property>
+                            <property name="fill">True</property>
                             <property name="position">0</property>
                           </packing>
                         </child>
                         <child>
                           <object class="GtkFrame" id="frame3">
                             <property name="visible">True</property>
-                            <property name="border_width">5</property>
-                            <property name="label_xalign">0</property>
+                            <property name="can-focus">False</property>
+                            <property name="border-width">5</property>
+                            <property name="label-xalign">0</property>
                             <child>
                               <object class="GtkAlignment" id="alignment1">
                                 <property name="visible">True</property>
-                                <property name="left_padding">12</property>
+                                <property name="can-focus">False</property>
+                                <property name="left-padding">12</property>
                                 <child>
                                   <object class="GtkTable" id="table5">
                                     <property name="visible">True</property>
-                                    <property name="border_width">5</property>
-                                    <property name="n_rows">2</property>
-                                    <property name="n_columns">2</property>
-                                    <property name="column_spacing">15</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="border-width">5</property>
+                                    <property name="n-rows">2</property>
+                                    <property name="n-columns">2</property>
+                                    <property name="column-spacing">15</property>
                                     <property name="homogeneous">True</property>
                                     <child>
                                       <object class="GtkButton" id="unhome_all">
                                         <property name="label" translatable="yes">Unhome All</property>
                                         <property name="visible">True</property>
-                                        <property name="can_focus">True</property>
-                                        <property name="receives_default">False</property>
-                                        <property name="use_underline">True</property>
-                                        <property name="focus_on_click">False</property>
-                                        <signal name="clicked" handler="on_unhome_all_clicked"/>
+                                        <property name="can-focus">True</property>
+                                        <property name="focus-on-click">False</property>
+                                        <property name="receives-default">False</property>
+                                        <property name="use-underline">True</property>
+                                        <signal name="clicked" handler="on_unhome_all_clicked" swapped="no"/>
                                       </object>
                                       <packing>
-                                        <property name="top_attach">1</property>
-                                        <property name="bottom_attach">2</property>
+                                        <property name="top-attach">1</property>
+                                        <property name="bottom-attach">2</property>
                                       </packing>
                                     </child>
                                     <child>
                                       <object class="GtkButton" id="home_all">
                                         <property name="label" translatable="yes">Home All</property>
                                         <property name="visible">True</property>
-                                        <property name="can_focus">True</property>
-                                        <property name="receives_default">False</property>
-                                        <property name="use_underline">True</property>
-                                        <property name="focus_on_click">False</property>
-                                        <signal name="clicked" handler="on_home_all_clicked"/>
+                                        <property name="can-focus">True</property>
+                                        <property name="focus-on-click">False</property>
+                                        <property name="receives-default">False</property>
+                                        <property name="use-underline">True</property>
+                                        <signal name="clicked" handler="on_home_all_clicked" swapped="no"/>
                                       </object>
                                     </child>
                                     <child>
                                       <object class="GtkButton" id="home_selected">
                                         <property name="label" translatable="yes">Home Selected</property>
                                         <property name="visible">True</property>
-                                        <property name="can_focus">True</property>
-                                        <property name="receives_default">False</property>
-                                        <property name="use_underline">True</property>
-                                        <property name="focus_on_click">False</property>
-                                        <signal name="clicked" handler="on_home_selected_clicked"/>
+                                        <property name="can-focus">True</property>
+                                        <property name="focus-on-click">False</property>
+                                        <property name="receives-default">False</property>
+                                        <property name="use-underline">True</property>
+                                        <signal name="clicked" handler="on_home_selected_clicked" swapped="no"/>
                                       </object>
                                       <packing>
-                                        <property name="left_attach">1</property>
-                                        <property name="right_attach">2</property>
+                                        <property name="left-attach">1</property>
+                                        <property name="right-attach">2</property>
                                       </packing>
                                     </child>
                                     <child>
                                       <object class="GtkButton" id="unhome_selected">
                                         <property name="label" translatable="yes">Unhome Selected</property>
                                         <property name="visible">True</property>
-                                        <property name="can_focus">True</property>
-                                        <property name="receives_default">False</property>
-                                        <property name="use_underline">True</property>
-                                        <property name="focus_on_click">False</property>
-                                        <signal name="clicked" handler="on_unhome_selected_clicked"/>
+                                        <property name="can-focus">True</property>
+                                        <property name="focus-on-click">False</property>
+                                        <property name="receives-default">False</property>
+                                        <property name="use-underline">True</property>
+                                        <signal name="clicked" handler="on_unhome_selected_clicked" swapped="no"/>
                                       </object>
                                       <packing>
-                                        <property name="left_attach">1</property>
-                                        <property name="right_attach">2</property>
-                                        <property name="top_attach">1</property>
-                                        <property name="bottom_attach">2</property>
+                                        <property name="left-attach">1</property>
+                                        <property name="right-attach">2</property>
+                                        <property name="top-attach">1</property>
+                                        <property name="bottom-attach">2</property>
                                       </packing>
                                     </child>
                                   </object>
@@ -629,12 +673,15 @@
                             <child type="label">
                               <object class="GtkLabel" id="frame4">
                                 <property name="visible">True</property>
+                                <property name="can-focus">False</property>
                                 <property name="label" translatable="yes">&lt;b&gt;Homing&lt;/b&gt;</property>
-                                <property name="use_markup">True</property>
+                                <property name="use-markup">True</property>
                               </object>
                             </child>
                           </object>
                           <packing>
+                            <property name="expand">True</property>
+                            <property name="fill">True</property>
                             <property name="position">1</property>
                           </packing>
                         </child>
@@ -643,33 +690,38 @@
                     <child type="tab">
                       <object class="GtkLabel" id="startup">
                         <property name="visible">True</property>
+                        <property name="can-focus">False</property>
                         <property name="xpad">10</property>
                         <property name="ypad">15</property>
                         <property name="label" translatable="yes">Startup</property>
                       </object>
                       <packing>
-                        <property name="tab_fill">False</property>
+                        <property name="tab-fill">False</property>
                       </packing>
                     </child>
                     <child>
                       <object class="GtkVBox" id="vbox12">
                         <property name="visible">True</property>
+                        <property name="can-focus">False</property>
                         <child>
                           <object class="GtkHBox" id="hbox9">
                             <property name="visible">True</property>
+                            <property name="can-focus">False</property>
                             <property name="homogeneous">True</property>
                             <child>
                               <object class="GtkButton" id="set_tool">
                                 <property name="label" translatable="yes">Set Tool</property>
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="receives_default">False</property>
-                                <property name="border_width">11</property>
-                                <property name="use_underline">True</property>
-                                <property name="focus_on_click">False</property>
-                                <signal name="clicked" handler="on_mdi_set_tool_clicked"/>
+                                <property name="can-focus">False</property>
+                                <property name="focus-on-click">False</property>
+                                <property name="receives-default">False</property>
+                                <property name="border-width">11</property>
+                                <property name="use-underline">True</property>
+                                <signal name="clicked" handler="on_mdi_set_tool_clicked" swapped="no"/>
                               </object>
                               <packing>
+                                <property name="expand">True</property>
+                                <property name="fill">True</property>
                                 <property name="position">0</property>
                               </packing>
                             </child>
@@ -677,14 +729,16 @@
                               <object class="GtkButton" id="set_origin">
                                 <property name="label" translatable="yes">Set Origin</property>
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="receives_default">False</property>
-                                <property name="border_width">11</property>
-                                <property name="use_underline">True</property>
-                                <property name="focus_on_click">False</property>
-                                <signal name="clicked" handler="on_mdi_set_origin_clicked"/>
+                                <property name="can-focus">False</property>
+                                <property name="focus-on-click">False</property>
+                                <property name="receives-default">False</property>
+                                <property name="border-width">11</property>
+                                <property name="use-underline">True</property>
+                                <signal name="clicked" handler="on_mdi_set_origin_clicked" swapped="no"/>
                               </object>
                               <packing>
+                                <property name="expand">True</property>
+                                <property name="fill">True</property>
                                 <property name="position">1</property>
                               </packing>
                             </child>
@@ -692,502 +746,559 @@
                               <object class="GtkButton" id="macro">
                                 <property name="label" translatable="yes">Macro</property>
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="receives_default">False</property>
-                                <property name="border_width">11</property>
-                                <property name="use_underline">True</property>
-                                <property name="focus_on_click">False</property>
-                                <signal name="clicked" handler="on_mdi_macro_clicked"/>
+                                <property name="can-focus">False</property>
+                                <property name="focus-on-click">False</property>
+                                <property name="receives-default">False</property>
+                                <property name="border-width">11</property>
+                                <property name="use-underline">True</property>
+                                <signal name="clicked" handler="on_mdi_macro_clicked" swapped="no"/>
                               </object>
                               <packing>
+                                <property name="expand">True</property>
+                                <property name="fill">True</property>
                                 <property name="position">2</property>
                               </packing>
                             </child>
                           </object>
                           <packing>
                             <property name="expand">False</property>
+                            <property name="fill">True</property>
                             <property name="position">0</property>
                           </packing>
                         </child>
                         <child>
                           <object class="GtkHBox" id="hbox8">
                             <property name="visible">True</property>
-                            <property name="border_width">10</property>
+                            <property name="can-focus">False</property>
+                            <property name="border-width">10</property>
                             <child>
                               <object class="GtkVBox" id="vbox11">
                                 <property name="visible">True</property>
+                                <property name="can-focus">False</property>
                                 <property name="homogeneous">True</property>
                                 <child>
                                   <object class="GtkEventBox" id="eventbox_mdi0">
                                     <property name="visible">True</property>
-                                    <signal name="button_release_event" handler="on_mdi_select"/>
+                                    <property name="can-focus">False</property>
+                                    <signal name="button-release-event" handler="on_mdi_select" swapped="no"/>
                                     <child>
                                       <object class="GtkLabel" id="mdi0">
-                                        <property name="width_request">60</property>
+                                        <property name="width-request">60</property>
                                         <property name="visible">True</property>
-                                        <property name="xalign">0</property>
+                                        <property name="can-focus">False</property>
                                         <property name="xpad">6</property>
                                         <property name="label" translatable="yes">G</property>
-                                        <property name="single_line_mode">True</property>
+                                        <property name="single-line-mode">True</property>
+                                        <property name="xalign">0</property>
                                       </object>
                                     </child>
                                   </object>
                                   <packing>
+                                    <property name="expand">True</property>
+                                    <property name="fill">True</property>
                                     <property name="position">0</property>
                                   </packing>
                                 </child>
                                 <child>
                                   <object class="GtkEventBox" id="eventbox_mdi1">
                                     <property name="visible">True</property>
-                                    <signal name="button_release_event" handler="on_mdi_select"/>
+                                    <property name="can-focus">False</property>
+                                    <signal name="button-release-event" handler="on_mdi_select" swapped="no"/>
                                     <child>
                                       <object class="GtkLabel" id="mdi1">
-                                        <property name="width_request">60</property>
+                                        <property name="width-request">60</property>
                                         <property name="visible">True</property>
-                                        <property name="xalign">0</property>
+                                        <property name="can-focus">False</property>
                                         <property name="xpad">6</property>
-                                        <property name="single_line_mode">True</property>
+                                        <property name="single-line-mode">True</property>
+                                        <property name="xalign">0</property>
                                       </object>
                                     </child>
                                   </object>
                                   <packing>
+                                    <property name="expand">True</property>
+                                    <property name="fill">True</property>
                                     <property name="position">1</property>
                                   </packing>
                                 </child>
                                 <child>
                                   <object class="GtkEventBox" id="eventbox_mdi2">
                                     <property name="visible">True</property>
-                                    <signal name="button_release_event" handler="on_mdi_select"/>
+                                    <property name="can-focus">False</property>
+                                    <signal name="button-release-event" handler="on_mdi_select" swapped="no"/>
                                     <child>
                                       <object class="GtkLabel" id="mdi2">
-                                        <property name="width_request">60</property>
+                                        <property name="width-request">60</property>
                                         <property name="visible">True</property>
-                                        <property name="xalign">0</property>
+                                        <property name="can-focus">False</property>
                                         <property name="xpad">6</property>
-                                        <property name="single_line_mode">True</property>
+                                        <property name="single-line-mode">True</property>
+                                        <property name="xalign">0</property>
                                       </object>
                                     </child>
                                   </object>
                                   <packing>
+                                    <property name="expand">True</property>
+                                    <property name="fill">True</property>
                                     <property name="position">2</property>
                                   </packing>
                                 </child>
                                 <child>
                                   <object class="GtkEventBox" id="eventbox_mdi3">
                                     <property name="visible">True</property>
-                                    <signal name="button_release_event" handler="on_mdi_select"/>
+                                    <property name="can-focus">False</property>
+                                    <signal name="button-release-event" handler="on_mdi_select" swapped="no"/>
                                     <child>
                                       <object class="GtkLabel" id="mdi3">
-                                        <property name="width_request">60</property>
+                                        <property name="width-request">60</property>
                                         <property name="visible">True</property>
-                                        <property name="xalign">0</property>
+                                        <property name="can-focus">False</property>
                                         <property name="xpad">6</property>
-                                        <property name="single_line_mode">True</property>
+                                        <property name="single-line-mode">True</property>
+                                        <property name="xalign">0</property>
                                       </object>
                                     </child>
                                   </object>
                                   <packing>
+                                    <property name="expand">True</property>
+                                    <property name="fill">True</property>
                                     <property name="position">3</property>
                                   </packing>
                                 </child>
                                 <child>
                                   <object class="GtkEventBox" id="eventbox_mdi4">
                                     <property name="visible">True</property>
-                                    <signal name="button_release_event" handler="on_mdi_select"/>
+                                    <property name="can-focus">False</property>
+                                    <signal name="button-release-event" handler="on_mdi_select" swapped="no"/>
                                     <child>
                                       <object class="GtkLabel" id="mdi4">
-                                        <property name="width_request">60</property>
+                                        <property name="width-request">60</property>
                                         <property name="visible">True</property>
-                                        <property name="xalign">0</property>
+                                        <property name="can-focus">False</property>
                                         <property name="xpad">6</property>
-                                        <property name="single_line_mode">True</property>
+                                        <property name="single-line-mode">True</property>
+                                        <property name="xalign">0</property>
                                       </object>
                                     </child>
                                   </object>
                                   <packing>
+                                    <property name="expand">True</property>
+                                    <property name="fill">True</property>
                                     <property name="position">4</property>
                                   </packing>
                                 </child>
                                 <child>
                                   <object class="GtkEventBox" id="eventbox_mdi5">
                                     <property name="visible">True</property>
-                                    <signal name="button_release_event" handler="on_mdi_select"/>
+                                    <property name="can-focus">False</property>
+                                    <signal name="button-release-event" handler="on_mdi_select" swapped="no"/>
                                     <child>
                                       <object class="GtkLabel" id="mdi5">
-                                        <property name="width_request">60</property>
+                                        <property name="width-request">60</property>
                                         <property name="visible">True</property>
-                                        <property name="xalign">0</property>
+                                        <property name="can-focus">False</property>
                                         <property name="xpad">6</property>
-                                        <property name="single_line_mode">True</property>
+                                        <property name="single-line-mode">True</property>
+                                        <property name="xalign">0</property>
                                       </object>
                                     </child>
                                   </object>
                                   <packing>
+                                    <property name="expand">True</property>
+                                    <property name="fill">True</property>
                                     <property name="position">5</property>
                                   </packing>
                                 </child>
                                 <child>
                                   <object class="GtkEventBox" id="eventbox_mdi6">
                                     <property name="visible">True</property>
-                                    <signal name="button_release_event" handler="on_mdi_select"/>
+                                    <property name="can-focus">False</property>
+                                    <signal name="button-release-event" handler="on_mdi_select" swapped="no"/>
                                     <child>
                                       <object class="GtkLabel" id="mdi6">
-                                        <property name="width_request">60</property>
+                                        <property name="width-request">60</property>
                                         <property name="visible">True</property>
-                                        <property name="xalign">0</property>
+                                        <property name="can-focus">False</property>
                                         <property name="xpad">6</property>
-                                        <property name="single_line_mode">True</property>
+                                        <property name="single-line-mode">True</property>
+                                        <property name="xalign">0</property>
                                       </object>
                                     </child>
                                   </object>
                                   <packing>
+                                    <property name="expand">True</property>
+                                    <property name="fill">True</property>
                                     <property name="position">6</property>
                                   </packing>
                                 </child>
                                 <child>
                                   <object class="GtkEventBox" id="eventbox_mdi7">
                                     <property name="visible">True</property>
-                                    <signal name="button_release_event" handler="on_mdi_select"/>
+                                    <property name="can-focus">False</property>
+                                    <signal name="button-release-event" handler="on_mdi_select" swapped="no"/>
                                     <child>
                                       <object class="GtkLabel" id="mdi7">
-                                        <property name="width_request">60</property>
+                                        <property name="width-request">60</property>
                                         <property name="visible">True</property>
-                                        <property name="xalign">0</property>
+                                        <property name="can-focus">False</property>
                                         <property name="xpad">6</property>
-                                        <property name="single_line_mode">True</property>
+                                        <property name="single-line-mode">True</property>
+                                        <property name="xalign">0</property>
                                       </object>
                                     </child>
                                   </object>
                                   <packing>
+                                    <property name="expand">True</property>
+                                    <property name="fill">True</property>
                                     <property name="position">7</property>
                                   </packing>
                                 </child>
                                 <child>
                                   <object class="GtkEventBox" id="eventbox_mdi8">
                                     <property name="visible">True</property>
-                                    <signal name="button_release_event" handler="on_mdi_select"/>
+                                    <property name="can-focus">False</property>
+                                    <signal name="button-release-event" handler="on_mdi_select" swapped="no"/>
                                     <child>
                                       <object class="GtkLabel" id="mdi8">
-                                        <property name="width_request">60</property>
+                                        <property name="width-request">60</property>
                                         <property name="visible">True</property>
-                                        <property name="xalign">0</property>
+                                        <property name="can-focus">False</property>
                                         <property name="xpad">6</property>
-                                        <property name="single_line_mode">True</property>
+                                        <property name="single-line-mode">True</property>
+                                        <property name="xalign">0</property>
                                       </object>
                                     </child>
                                   </object>
                                   <packing>
+                                    <property name="expand">True</property>
+                                    <property name="fill">True</property>
                                     <property name="position">8</property>
                                   </packing>
                                 </child>
                                 <child>
                                   <object class="GtkEventBox" id="eventbox_mdi9">
                                     <property name="visible">True</property>
-                                    <signal name="button_release_event" handler="on_mdi_select"/>
+                                    <property name="can-focus">False</property>
+                                    <signal name="button-release-event" handler="on_mdi_select" swapped="no"/>
                                     <child>
                                       <object class="GtkLabel" id="mdi9">
-                                        <property name="width_request">60</property>
+                                        <property name="width-request">60</property>
                                         <property name="visible">True</property>
-                                        <property name="xalign">0</property>
+                                        <property name="can-focus">False</property>
                                         <property name="xpad">6</property>
-                                        <property name="single_line_mode">True</property>
+                                        <property name="single-line-mode">True</property>
+                                        <property name="xalign">0</property>
                                       </object>
                                     </child>
                                   </object>
                                   <packing>
+                                    <property name="expand">True</property>
+                                    <property name="fill">True</property>
                                     <property name="position">9</property>
                                   </packing>
                                 </child>
                                 <child>
                                   <object class="GtkEventBox" id="eventbox_mdi10">
                                     <property name="visible">True</property>
-                                    <signal name="button_release_event" handler="on_mdi_select"/>
+                                    <property name="can-focus">False</property>
+                                    <signal name="button-release-event" handler="on_mdi_select" swapped="no"/>
                                     <child>
                                       <object class="GtkLabel" id="mdi10">
-                                        <property name="width_request">60</property>
+                                        <property name="width-request">60</property>
                                         <property name="visible">True</property>
-                                        <property name="xalign">0</property>
+                                        <property name="can-focus">False</property>
                                         <property name="xpad">6</property>
-                                        <property name="single_line_mode">True</property>
+                                        <property name="single-line-mode">True</property>
+                                        <property name="xalign">0</property>
                                       </object>
                                     </child>
                                   </object>
                                   <packing>
+                                    <property name="expand">True</property>
+                                    <property name="fill">True</property>
                                     <property name="position">10</property>
                                   </packing>
                                 </child>
                               </object>
                               <packing>
+                                <property name="expand">True</property>
+                                <property name="fill">True</property>
                                 <property name="position">0</property>
                               </packing>
                             </child>
                             <child>
                               <object class="GtkTable" id="table14">
                                 <property name="visible">True</property>
-                                <property name="n_rows">4</property>
-                                <property name="n_columns">5</property>
+                                <property name="can-focus">False</property>
+                                <property name="n-rows">4</property>
+                                <property name="n-columns">5</property>
                                 <property name="homogeneous">True</property>
                                 <child>
                                   <object class="GtkButton" id="decimal">
                                     <property name="label" translatable="yes">.</property>
                                     <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="receives_default">False</property>
-                                    <property name="use_underline">True</property>
-                                    <property name="focus_on_click">False</property>
-                                    <signal name="clicked" handler="on_mdi_decimal_clicked"/>
+                                    <property name="can-focus">True</property>
+                                    <property name="focus-on-click">False</property>
+                                    <property name="receives-default">False</property>
+                                    <property name="use-underline">True</property>
+                                    <signal name="clicked" handler="on_mdi_decimal_clicked" swapped="no"/>
                                   </object>
                                   <packing>
-                                    <property name="left_attach">3</property>
-                                    <property name="right_attach">4</property>
-                                    <property name="top_attach">3</property>
-                                    <property name="bottom_attach">4</property>
+                                    <property name="left-attach">3</property>
+                                    <property name="right-attach">4</property>
+                                    <property name="top-attach">3</property>
+                                    <property name="bottom-attach">4</property>
                                   </packing>
                                 </child>
                                 <child>
                                   <object class="GtkButton" id="minus">
                                     <property name="label" translatable="yes">-</property>
                                     <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="receives_default">False</property>
-                                    <property name="use_underline">True</property>
-                                    <property name="focus_on_click">False</property>
-                                    <signal name="clicked" handler="on_mdi_minus_clicked"/>
+                                    <property name="can-focus">True</property>
+                                    <property name="focus-on-click">False</property>
+                                    <property name="receives-default">False</property>
+                                    <property name="use-underline">True</property>
+                                    <signal name="clicked" handler="on_mdi_minus_clicked" swapped="no"/>
                                   </object>
                                   <packing>
-                                    <property name="left_attach">1</property>
-                                    <property name="right_attach">2</property>
-                                    <property name="top_attach">3</property>
-                                    <property name="bottom_attach">4</property>
+                                    <property name="left-attach">1</property>
+                                    <property name="right-attach">2</property>
+                                    <property name="top-attach">3</property>
+                                    <property name="bottom-attach">4</property>
                                   </packing>
                                 </child>
                                 <child>
                                   <object class="GtkButton" id="0">
                                     <property name="label" translatable="yes">0</property>
                                     <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="receives_default">False</property>
-                                    <property name="use_underline">True</property>
-                                    <property name="focus_on_click">False</property>
-                                    <signal name="clicked" handler="on_mdi_keypad_clicked"/>
+                                    <property name="can-focus">True</property>
+                                    <property name="focus-on-click">False</property>
+                                    <property name="receives-default">False</property>
+                                    <property name="use-underline">True</property>
+                                    <signal name="clicked" handler="on_mdi_keypad_clicked" swapped="no"/>
                                   </object>
                                   <packing>
-                                    <property name="left_attach">2</property>
-                                    <property name="right_attach">3</property>
-                                    <property name="top_attach">3</property>
-                                    <property name="bottom_attach">4</property>
+                                    <property name="left-attach">2</property>
+                                    <property name="right-attach">3</property>
+                                    <property name="top-attach">3</property>
+                                    <property name="bottom-attach">4</property>
                                   </packing>
                                 </child>
                                 <child>
                                   <object class="GtkButton" id="3">
                                     <property name="label" translatable="yes">3</property>
                                     <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="receives_default">False</property>
-                                    <property name="use_underline">True</property>
-                                    <property name="focus_on_click">False</property>
-                                    <signal name="clicked" handler="on_mdi_keypad_clicked"/>
+                                    <property name="can-focus">True</property>
+                                    <property name="focus-on-click">False</property>
+                                    <property name="receives-default">False</property>
+                                    <property name="use-underline">True</property>
+                                    <signal name="clicked" handler="on_mdi_keypad_clicked" swapped="no"/>
                                   </object>
                                   <packing>
-                                    <property name="left_attach">3</property>
-                                    <property name="right_attach">4</property>
-                                    <property name="top_attach">2</property>
-                                    <property name="bottom_attach">3</property>
+                                    <property name="left-attach">3</property>
+                                    <property name="right-attach">4</property>
+                                    <property name="top-attach">2</property>
+                                    <property name="bottom-attach">3</property>
                                   </packing>
                                 </child>
                                 <child>
                                   <object class="GtkButton" id="2">
                                     <property name="label" translatable="yes">2</property>
                                     <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="receives_default">False</property>
-                                    <property name="use_underline">True</property>
-                                    <property name="focus_on_click">False</property>
-                                    <signal name="clicked" handler="on_mdi_keypad_clicked"/>
+                                    <property name="can-focus">True</property>
+                                    <property name="focus-on-click">False</property>
+                                    <property name="receives-default">False</property>
+                                    <property name="use-underline">True</property>
+                                    <signal name="clicked" handler="on_mdi_keypad_clicked" swapped="no"/>
                                   </object>
                                   <packing>
-                                    <property name="left_attach">2</property>
-                                    <property name="right_attach">3</property>
-                                    <property name="top_attach">2</property>
-                                    <property name="bottom_attach">3</property>
+                                    <property name="left-attach">2</property>
+                                    <property name="right-attach">3</property>
+                                    <property name="top-attach">2</property>
+                                    <property name="bottom-attach">3</property>
                                   </packing>
                                 </child>
                                 <child>
                                   <object class="GtkButton" id="1">
                                     <property name="label" translatable="yes">1</property>
                                     <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="receives_default">False</property>
-                                    <property name="use_underline">True</property>
-                                    <property name="focus_on_click">False</property>
-                                    <signal name="clicked" handler="on_mdi_keypad_clicked"/>
+                                    <property name="can-focus">True</property>
+                                    <property name="focus-on-click">False</property>
+                                    <property name="receives-default">False</property>
+                                    <property name="use-underline">True</property>
+                                    <signal name="clicked" handler="on_mdi_keypad_clicked" swapped="no"/>
                                   </object>
                                   <packing>
-                                    <property name="left_attach">1</property>
-                                    <property name="right_attach">2</property>
-                                    <property name="top_attach">2</property>
-                                    <property name="bottom_attach">3</property>
+                                    <property name="left-attach">1</property>
+                                    <property name="right-attach">2</property>
+                                    <property name="top-attach">2</property>
+                                    <property name="bottom-attach">3</property>
                                   </packing>
                                 </child>
                                 <child>
                                   <object class="GtkButton" id="6">
                                     <property name="label" translatable="yes">6</property>
                                     <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="receives_default">False</property>
-                                    <property name="use_underline">True</property>
-                                    <property name="focus_on_click">False</property>
-                                    <signal name="clicked" handler="on_mdi_keypad_clicked"/>
+                                    <property name="can-focus">True</property>
+                                    <property name="focus-on-click">False</property>
+                                    <property name="receives-default">False</property>
+                                    <property name="use-underline">True</property>
+                                    <signal name="clicked" handler="on_mdi_keypad_clicked" swapped="no"/>
                                   </object>
                                   <packing>
-                                    <property name="left_attach">3</property>
-                                    <property name="right_attach">4</property>
-                                    <property name="top_attach">1</property>
-                                    <property name="bottom_attach">2</property>
+                                    <property name="left-attach">3</property>
+                                    <property name="right-attach">4</property>
+                                    <property name="top-attach">1</property>
+                                    <property name="bottom-attach">2</property>
                                   </packing>
                                 </child>
                                 <child>
                                   <object class="GtkButton" id="5">
                                     <property name="label" translatable="yes">5</property>
                                     <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="receives_default">False</property>
-                                    <property name="use_underline">True</property>
-                                    <property name="focus_on_click">False</property>
-                                    <signal name="clicked" handler="on_mdi_keypad_clicked"/>
+                                    <property name="can-focus">True</property>
+                                    <property name="focus-on-click">False</property>
+                                    <property name="receives-default">False</property>
+                                    <property name="use-underline">True</property>
+                                    <signal name="clicked" handler="on_mdi_keypad_clicked" swapped="no"/>
                                   </object>
                                   <packing>
-                                    <property name="left_attach">2</property>
-                                    <property name="right_attach">3</property>
-                                    <property name="top_attach">1</property>
-                                    <property name="bottom_attach">2</property>
+                                    <property name="left-attach">2</property>
+                                    <property name="right-attach">3</property>
+                                    <property name="top-attach">1</property>
+                                    <property name="bottom-attach">2</property>
                                   </packing>
                                 </child>
                                 <child>
                                   <object class="GtkButton" id="4">
                                     <property name="label" translatable="yes">4</property>
                                     <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="receives_default">False</property>
-                                    <property name="use_underline">True</property>
-                                    <property name="focus_on_click">False</property>
-                                    <signal name="clicked" handler="on_mdi_keypad_clicked"/>
+                                    <property name="can-focus">True</property>
+                                    <property name="focus-on-click">False</property>
+                                    <property name="receives-default">False</property>
+                                    <property name="use-underline">True</property>
+                                    <signal name="clicked" handler="on_mdi_keypad_clicked" swapped="no"/>
                                   </object>
                                   <packing>
-                                    <property name="left_attach">1</property>
-                                    <property name="right_attach">2</property>
-                                    <property name="top_attach">1</property>
-                                    <property name="bottom_attach">2</property>
+                                    <property name="left-attach">1</property>
+                                    <property name="right-attach">2</property>
+                                    <property name="top-attach">1</property>
+                                    <property name="bottom-attach">2</property>
                                   </packing>
                                 </child>
                                 <child>
                                   <object class="GtkButton" id="9">
                                     <property name="label" translatable="yes">9</property>
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="receives_default">False</property>
-                                    <property name="use_underline">True</property>
-                                    <property name="focus_on_click">False</property>
-                                    <signal name="clicked" handler="on_mdi_keypad_clicked"/>
+                                    <property name="can-focus">False</property>
+                                    <property name="focus-on-click">False</property>
+                                    <property name="receives-default">False</property>
+                                    <property name="use-underline">True</property>
+                                    <signal name="clicked" handler="on_mdi_keypad_clicked" swapped="no"/>
                                   </object>
                                   <packing>
-                                    <property name="left_attach">3</property>
-                                    <property name="right_attach">4</property>
+                                    <property name="left-attach">3</property>
+                                    <property name="right-attach">4</property>
                                   </packing>
                                 </child>
                                 <child>
                                   <object class="GtkButton" id="8">
                                     <property name="label" translatable="yes">8</property>
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="receives_default">False</property>
-                                    <property name="use_underline">True</property>
-                                    <property name="focus_on_click">False</property>
-                                    <signal name="clicked" handler="on_mdi_keypad_clicked"/>
+                                    <property name="can-focus">False</property>
+                                    <property name="focus-on-click">False</property>
+                                    <property name="receives-default">False</property>
+                                    <property name="use-underline">True</property>
+                                    <signal name="clicked" handler="on_mdi_keypad_clicked" swapped="no"/>
                                   </object>
                                   <packing>
-                                    <property name="left_attach">2</property>
-                                    <property name="right_attach">3</property>
+                                    <property name="left-attach">2</property>
+                                    <property name="right-attach">3</property>
                                   </packing>
                                 </child>
                                 <child>
                                   <object class="GtkButton" id="7">
                                     <property name="label" translatable="yes">7</property>
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="receives_default">False</property>
-                                    <property name="use_underline">True</property>
-                                    <property name="focus_on_click">False</property>
-                                    <signal name="clicked" handler="on_mdi_keypad_clicked"/>
+                                    <property name="can-focus">False</property>
+                                    <property name="focus-on-click">False</property>
+                                    <property name="receives-default">False</property>
+                                    <property name="use-underline">True</property>
+                                    <signal name="clicked" handler="on_mdi_keypad_clicked" swapped="no"/>
                                   </object>
                                   <packing>
-                                    <property name="left_attach">1</property>
-                                    <property name="right_attach">2</property>
+                                    <property name="left-attach">1</property>
+                                    <property name="right-attach">2</property>
                                   </packing>
                                 </child>
                                 <child>
                                   <object class="GtkButton" id="button15">
                                     <property name="label">gtk-go-back</property>
                                     <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="receives_default">False</property>
-                                    <property name="use_stock">True</property>
-                                    <property name="focus_on_click">False</property>
-                                    <signal name="clicked" handler="on_mdi_back_clicked"/>
+                                    <property name="can-focus">True</property>
+                                    <property name="focus-on-click">False</property>
+                                    <property name="receives-default">False</property>
+                                    <property name="use-stock">True</property>
+                                    <signal name="clicked" handler="on_mdi_back_clicked" swapped="no"/>
                                   </object>
                                   <packing>
-                                    <property name="left_attach">4</property>
-                                    <property name="right_attach">5</property>
-                                    <property name="top_attach">1</property>
-                                    <property name="bottom_attach">2</property>
-                                    <property name="x_padding">8</property>
+                                    <property name="left-attach">4</property>
+                                    <property name="right-attach">5</property>
+                                    <property name="top-attach">1</property>
+                                    <property name="bottom-attach">2</property>
+                                    <property name="x-padding">8</property>
                                   </packing>
                                 </child>
                                 <child>
                                   <object class="GtkButton" id="button16">
                                     <property name="label">gtk-clear</property>
                                     <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="receives_default">False</property>
-                                    <property name="use_stock">True</property>
-                                    <property name="focus_on_click">False</property>
-                                    <signal name="clicked" handler="on_mdi_clear_clicked"/>
+                                    <property name="can-focus">True</property>
+                                    <property name="focus-on-click">False</property>
+                                    <property name="receives-default">False</property>
+                                    <property name="use-stock">True</property>
+                                    <signal name="clicked" handler="on_mdi_clear_clicked" swapped="no"/>
                                   </object>
                                   <packing>
-                                    <property name="left_attach">4</property>
-                                    <property name="right_attach">5</property>
-                                    <property name="x_padding">8</property>
+                                    <property name="left-attach">4</property>
+                                    <property name="right-attach">5</property>
+                                    <property name="x-padding">8</property>
                                   </packing>
                                 </child>
                                 <child>
                                   <object class="GtkVBox" id="vbox2">
                                     <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
                                     <property name="homogeneous">True</property>
                                     <child>
                                       <object class="GtkButton" id="g">
                                         <property name="label">G/XY</property>
                                         <property name="visible">True</property>
-                                        <property name="can_focus">True</property>
-                                        <property name="receives_default">False</property>
-                                        <property name="use_underline">True</property>
-                                        <property name="focus_on_click">False</property>
-                                        <signal name="clicked" handler="on_mdi_g_clicked"/>
+                                        <property name="can-focus">True</property>
+                                        <property name="focus-on-click">False</property>
+                                        <property name="receives-default">False</property>
+                                        <property name="use-underline">True</property>
+                                        <signal name="clicked" handler="on_mdi_g_clicked" swapped="no"/>
                                       </object>
                                       <packing>
+                                        <property name="expand">True</property>
+                                        <property name="fill">True</property>
                                         <property name="position">0</property>
                                       </packing>
                                     </child>
                                     <child>
                                       <object class="GtkButton" id="gp">
-                                        <property name="label">G/R&#x3B8;</property>
+                                        <property name="label">G/Rθ</property>
                                         <property name="visible">True</property>
-                                        <property name="can_focus">True</property>
-                                        <property name="receives_default">False</property>
-                                        <property name="use_underline">True</property>
-                                        <property name="focus_on_click">False</property>
-                                        <signal name="clicked" handler="on_mdi_gp_clicked"/>
+                                        <property name="can-focus">True</property>
+                                        <property name="focus-on-click">False</property>
+                                        <property name="receives-default">False</property>
+                                        <property name="use-underline">True</property>
+                                        <signal name="clicked" handler="on_mdi_gp_clicked" swapped="no"/>
                                       </object>
                                       <packing>
+                                        <property name="expand">True</property>
+                                        <property name="fill">True</property>
                                         <property name="position">1</property>
                                       </packing>
                                     </child>
@@ -1195,13 +1306,15 @@
                                       <object class="GtkButton" id="m">
                                         <property name="label">M</property>
                                         <property name="visible">True</property>
-                                        <property name="can_focus">True</property>
-                                        <property name="receives_default">False</property>
-                                        <property name="use_underline">True</property>
-                                        <property name="focus_on_click">False</property>
-                                        <signal name="clicked" handler="on_mdi_m_clicked"/>
+                                        <property name="can-focus">True</property>
+                                        <property name="focus-on-click">False</property>
+                                        <property name="receives-default">False</property>
+                                        <property name="use-underline">True</property>
+                                        <signal name="clicked" handler="on_mdi_m_clicked" swapped="no"/>
                                       </object>
                                       <packing>
+                                        <property name="expand">True</property>
+                                        <property name="fill">True</property>
                                         <property name="position">2</property>
                                       </packing>
                                     </child>
@@ -1209,146 +1322,161 @@
                                       <object class="GtkButton" id="t">
                                         <property name="label">T</property>
                                         <property name="visible">True</property>
-                                        <property name="can_focus">True</property>
-                                        <property name="receives_default">False</property>
-                                        <property name="use_underline">True</property>
-                                        <property name="focus_on_click">False</property>
-                                        <signal name="clicked" handler="on_mdi_t_clicked"/>
+                                        <property name="can-focus">True</property>
+                                        <property name="focus-on-click">False</property>
+                                        <property name="receives-default">False</property>
+                                        <property name="use-underline">True</property>
+                                        <signal name="clicked" handler="on_mdi_t_clicked" swapped="no"/>
                                       </object>
                                       <packing>
+                                        <property name="expand">True</property>
+                                        <property name="fill">True</property>
                                         <property name="position">3</property>
                                       </packing>
                                     </child>
                                   </object>
                                   <packing>
-                                    <property name="bottom_attach">4</property>
-                                    <property name="y_options">GTK_FILL</property>
-                                    <property name="x_padding">8</property>
+                                    <property name="bottom-attach">4</property>
+                                    <property name="y-options">GTK_FILL</property>
+                                    <property name="x-padding">8</property>
                                   </packing>
                                 </child>
                                 <child>
                                   <object class="GtkButton" id="button13">
                                     <property name="label">gtk-media-next</property>
                                     <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="receives_default">False</property>
-                                    <property name="use_stock">True</property>
-                                    <property name="focus_on_click">False</property>
-                                    <signal name="clicked" handler="on_mdi_next_clicked"/>
+                                    <property name="can-focus">True</property>
+                                    <property name="focus-on-click">False</property>
+                                    <property name="receives-default">False</property>
+                                    <property name="use-stock">True</property>
+                                    <signal name="clicked" handler="on_mdi_next_clicked" swapped="no"/>
                                   </object>
                                   <packing>
-                                    <property name="left_attach">4</property>
-                                    <property name="right_attach">5</property>
-                                    <property name="top_attach">2</property>
-                                    <property name="bottom_attach">4</property>
-                                    <property name="x_padding">8</property>
+                                    <property name="left-attach">4</property>
+                                    <property name="right-attach">5</property>
+                                    <property name="top-attach">2</property>
+                                    <property name="bottom-attach">4</property>
+                                    <property name="x-padding">8</property>
                                   </packing>
                                 </child>
                               </object>
                               <packing>
+                                <property name="expand">True</property>
+                                <property name="fill">True</property>
                                 <property name="position">1</property>
                               </packing>
                             </child>
                           </object>
                           <packing>
+                            <property name="expand">True</property>
+                            <property name="fill">True</property>
                             <property name="position">1</property>
                           </packing>
                         </child>
                       </object>
+                      <packing>
+                        <property name="position">1</property>
+                      </packing>
                     </child>
                     <child type="tab">
                       <object class="GtkLabel" id="mdi">
                         <property name="visible">True</property>
+                        <property name="can-focus">False</property>
                         <property name="xpad">10</property>
                         <property name="ypad">15</property>
                         <property name="label" translatable="yes">MDI</property>
                       </object>
                       <packing>
                         <property name="position">1</property>
-                        <property name="tab_fill">False</property>
+                        <property name="tab-fill">False</property>
                       </packing>
                     </child>
                     <child>
                       <object class="GtkVBox" id="vbox7">
                         <property name="visible">True</property>
+                        <property name="can-focus">False</property>
                         <child>
                           <object class="GtkHBox" id="hbox10">
                             <property name="visible">True</property>
+                            <property name="can-focus">False</property>
                             <child>
                               <object class="GtkFrame" id="frame5">
                                 <property name="visible">True</property>
-                                <property name="border_width">5</property>
-                                <property name="label_xalign">0</property>
+                                <property name="can-focus">False</property>
+                                <property name="border-width">5</property>
+                                <property name="label-xalign">0</property>
                                 <child>
                                   <object class="GtkAlignment" id="alignment4">
                                     <property name="visible">True</property>
-                                    <property name="left_padding">12</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="left-padding">12</property>
                                     <child>
                                       <object class="GtkTable" id="table9">
                                         <property name="visible">True</property>
-                                        <property name="border_width">5</property>
-                                        <property name="n_rows">2</property>
-                                        <property name="n_columns">2</property>
-                                        <property name="column_spacing">15</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="border-width">5</property>
+                                        <property name="n-rows">2</property>
+                                        <property name="n-columns">2</property>
+                                        <property name="column-spacing">15</property>
                                         <property name="homogeneous">True</property>
                                         <child>
                                           <object class="GtkToggleButton" id="flood_on">
                                             <property name="label" translatable="yes">Flood On</property>
                                             <property name="visible">True</property>
-                                            <property name="can_focus">True</property>
-                                            <property name="receives_default">False</property>
-                                            <property name="use_underline">True</property>
-                                            <property name="focus_on_click">False</property>
-                                            <signal name="clicked" handler="on_flood_on_clicked"/>
+                                            <property name="can-focus">True</property>
+                                            <property name="focus-on-click">False</property>
+                                            <property name="receives-default">False</property>
+                                            <property name="use-underline">True</property>
+                                            <signal name="clicked" handler="on_flood_on_clicked" swapped="no"/>
                                           </object>
                                         </child>
                                         <child>
                                           <object class="GtkToggleButton" id="flood_off">
                                             <property name="label" translatable="yes">Flood Off</property>
                                             <property name="visible">True</property>
-                                            <property name="can_focus">True</property>
-                                            <property name="receives_default">False</property>
-                                            <property name="use_underline">True</property>
-                                            <property name="focus_on_click">False</property>
+                                            <property name="can-focus">True</property>
+                                            <property name="focus-on-click">False</property>
+                                            <property name="receives-default">False</property>
+                                            <property name="use-underline">True</property>
                                             <property name="active">True</property>
-                                            <signal name="clicked" handler="on_flood_off_clicked"/>
+                                            <signal name="clicked" handler="on_flood_off_clicked" swapped="no"/>
                                           </object>
                                           <packing>
-                                            <property name="top_attach">1</property>
-                                            <property name="bottom_attach">2</property>
+                                            <property name="top-attach">1</property>
+                                            <property name="bottom-attach">2</property>
                                           </packing>
                                         </child>
                                         <child>
                                           <object class="GtkToggleButton" id="mist_on">
                                             <property name="label" translatable="yes">Mist On</property>
                                             <property name="visible">True</property>
-                                            <property name="can_focus">True</property>
-                                            <property name="receives_default">False</property>
-                                            <property name="use_underline">True</property>
-                                            <property name="focus_on_click">False</property>
-                                            <signal name="clicked" handler="on_mist_on_clicked"/>
+                                            <property name="can-focus">True</property>
+                                            <property name="focus-on-click">False</property>
+                                            <property name="receives-default">False</property>
+                                            <property name="use-underline">True</property>
+                                            <signal name="clicked" handler="on_mist_on_clicked" swapped="no"/>
                                           </object>
                                           <packing>
-                                            <property name="left_attach">1</property>
-                                            <property name="right_attach">2</property>
+                                            <property name="left-attach">1</property>
+                                            <property name="right-attach">2</property>
                                           </packing>
                                         </child>
                                         <child>
                                           <object class="GtkToggleButton" id="mist_off">
                                             <property name="label" translatable="yes">Mist Off</property>
                                             <property name="visible">True</property>
-                                            <property name="can_focus">True</property>
-                                            <property name="receives_default">False</property>
-                                            <property name="use_underline">True</property>
-                                            <property name="focus_on_click">False</property>
+                                            <property name="can-focus">True</property>
+                                            <property name="focus-on-click">False</property>
+                                            <property name="receives-default">False</property>
+                                            <property name="use-underline">True</property>
                                             <property name="active">True</property>
-                                            <signal name="clicked" handler="on_mist_off_clicked"/>
+                                            <signal name="clicked" handler="on_mist_off_clicked" swapped="no"/>
                                           </object>
                                           <packing>
-                                            <property name="left_attach">1</property>
-                                            <property name="right_attach">2</property>
-                                            <property name="top_attach">1</property>
-                                            <property name="bottom_attach">2</property>
+                                            <property name="left-attach">1</property>
+                                            <property name="right-attach">2</property>
+                                            <property name="top-attach">1</property>
+                                            <property name="bottom-attach">2</property>
                                           </packing>
                                         </child>
                                       </object>
@@ -1358,30 +1486,34 @@
                                 <child type="label">
                                   <object class="GtkLabel" id="label29">
                                     <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">&lt;b&gt;Coolant&lt;/b&gt;</property>
-                                    <property name="use_markup">True</property>
+                                    <property name="use-markup">True</property>
                                   </object>
                                 </child>
                               </object>
                               <packing>
+                                <property name="expand">True</property>
+                                <property name="fill">True</property>
                                 <property name="position">0</property>
                               </packing>
                             </child>
                             <child>
                               <object class="GtkAlignment" id="alignment12">
                                 <property name="visible">True</property>
-                                <property name="top_padding">11</property>
-                                <property name="bottom_padding">5</property>
-                                <property name="left_padding">5</property>
-                                <property name="right_padding">6</property>
+                                <property name="can-focus">False</property>
+                                <property name="top-padding">11</property>
+                                <property name="bottom-padding">5</property>
+                                <property name="left-padding">5</property>
+                                <property name="right-padding">6</property>
                                 <child>
                                   <object class="GtkButton" id="reload_tooltable">
                                     <property name="label" translatable="yes">Reload Tool Table</property>
                                     <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="receives_default">False</property>
-                                    <property name="use_underline">True</property>
-                                    <signal name="clicked" handler="on_reload_tooltable_clicked"/>
+                                    <property name="can-focus">True</property>
+                                    <property name="receives-default">False</property>
+                                    <property name="use-underline">True</property>
+                                    <signal name="clicked" handler="on_reload_tooltable_clicked" swapped="no"/>
                                   </object>
                                 </child>
                               </object>
@@ -1393,108 +1525,115 @@
                             </child>
                           </object>
                           <packing>
+                            <property name="expand">True</property>
+                            <property name="fill">True</property>
                             <property name="position">0</property>
                           </packing>
                         </child>
                         <child>
                           <object class="GtkFrame" id="frame6">
                             <property name="visible">True</property>
-                            <property name="border_width">5</property>
-                            <property name="label_xalign">0</property>
+                            <property name="can-focus">False</property>
+                            <property name="border-width">5</property>
+                            <property name="label-xalign">0</property>
                             <child>
                               <object class="GtkAlignment" id="alignment5">
                                 <property name="visible">True</property>
-                                <property name="left_padding">12</property>
+                                <property name="can-focus">False</property>
+                                <property name="left-padding">12</property>
                                 <child>
                                   <object class="GtkTable" id="table10">
                                     <property name="visible">True</property>
-                                    <property name="border_width">5</property>
-                                    <property name="n_rows">3</property>
-                                    <property name="n_columns">2</property>
-                                    <property name="column_spacing">15</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="border-width">5</property>
+                                    <property name="n-rows">3</property>
+                                    <property name="n-columns">2</property>
+                                    <property name="column-spacing">15</property>
                                     <property name="homogeneous">True</property>
                                     <child>
                                       <object class="GtkToggleButton" id="spindle_forward">
                                         <property name="label" translatable="yes">Spindle Forward</property>
                                         <property name="visible">True</property>
-                                        <property name="can_focus">True</property>
-                                        <property name="receives_default">False</property>
-                                        <property name="use_underline">True</property>
-                                        <property name="focus_on_click">False</property>
-                                        <signal name="clicked" handler="on_spindle_forward_clicked"/>
+                                        <property name="can-focus">True</property>
+                                        <property name="focus-on-click">False</property>
+                                        <property name="receives-default">False</property>
+                                        <property name="use-underline">True</property>
+                                        <signal name="clicked" handler="on_spindle_forward_clicked" swapped="no"/>
                                       </object>
                                     </child>
                                     <child>
                                       <object class="GtkToggleButton" id="spindle_reverse">
                                         <property name="label" translatable="yes">Spindle Reverse</property>
                                         <property name="visible">True</property>
-                                        <property name="can_focus">True</property>
-                                        <property name="receives_default">False</property>
-                                        <property name="use_underline">True</property>
-                                        <property name="focus_on_click">False</property>
-                                        <signal name="clicked" handler="on_spindle_reverse_clicked"/>
+                                        <property name="can-focus">True</property>
+                                        <property name="focus-on-click">False</property>
+                                        <property name="receives-default">False</property>
+                                        <property name="use-underline">True</property>
+                                        <signal name="clicked" handler="on_spindle_reverse_clicked" swapped="no"/>
                                       </object>
                                       <packing>
-                                        <property name="top_attach">2</property>
-                                        <property name="bottom_attach">3</property>
+                                        <property name="top-attach">2</property>
+                                        <property name="bottom-attach">3</property>
                                       </packing>
                                     </child>
                                     <child>
                                       <object class="GtkToggleButton" id="spindle_off">
                                         <property name="label" translatable="yes">Spindle Off</property>
                                         <property name="visible">True</property>
-                                        <property name="can_focus">True</property>
-                                        <property name="receives_default">False</property>
-                                        <property name="use_underline">True</property>
-                                        <property name="focus_on_click">False</property>
+                                        <property name="can-focus">True</property>
+                                        <property name="focus-on-click">False</property>
+                                        <property name="receives-default">False</property>
+                                        <property name="use-underline">True</property>
                                         <property name="active">True</property>
-                                        <signal name="clicked" handler="on_spindle_off_clicked"/>
+                                        <signal name="clicked" handler="on_spindle_off_clicked" swapped="no"/>
                                       </object>
                                       <packing>
-                                        <property name="top_attach">1</property>
-                                        <property name="bottom_attach">2</property>
+                                        <property name="top-attach">1</property>
+                                        <property name="bottom-attach">2</property>
                                       </packing>
                                     </child>
                                     <child>
                                       <object class="GtkButton" id="spindle_faster">
                                         <property name="label" translatable="yes">Spindle Faster</property>
                                         <property name="visible">True</property>
-                                        <property name="can_focus">True</property>
-                                        <property name="receives_default">False</property>
-                                        <property name="use_underline">True</property>
-                                        <property name="focus_on_click">False</property>
-                                        <signal name="clicked" handler="on_spindle_faster_clicked"/>
+                                        <property name="can-focus">True</property>
+                                        <property name="focus-on-click">False</property>
+                                        <property name="receives-default">False</property>
+                                        <property name="use-underline">True</property>
+                                        <signal name="clicked" handler="on_spindle_faster_clicked" swapped="no"/>
                                       </object>
                                       <packing>
-                                        <property name="left_attach">1</property>
-                                        <property name="right_attach">2</property>
+                                        <property name="left-attach">1</property>
+                                        <property name="right-attach">2</property>
                                       </packing>
                                     </child>
                                     <child>
                                       <object class="GtkButton" id="spindle_slower">
                                         <property name="label" translatable="yes">Spindle Slower</property>
                                         <property name="visible">True</property>
-                                        <property name="can_focus">True</property>
-                                        <property name="receives_default">False</property>
-                                        <property name="use_underline">True</property>
-                                        <property name="focus_on_click">False</property>
-                                        <signal name="clicked" handler="on_spindle_slower_clicked"/>
+                                        <property name="can-focus">True</property>
+                                        <property name="focus-on-click">False</property>
+                                        <property name="receives-default">False</property>
+                                        <property name="use-underline">True</property>
+                                        <signal name="clicked" handler="on_spindle_slower_clicked" swapped="no"/>
                                       </object>
                                       <packing>
-                                        <property name="left_attach">1</property>
-                                        <property name="right_attach">2</property>
-                                        <property name="top_attach">2</property>
-                                        <property name="bottom_attach">3</property>
+                                        <property name="left-attach">1</property>
+                                        <property name="right-attach">2</property>
+                                        <property name="top-attach">2</property>
+                                        <property name="bottom-attach">3</property>
                                       </packing>
                                     </child>
                                     <child>
                                       <object class="GtkHBox" id="hbox12">
                                         <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
                                         <child>
                                           <object class="GtkLabel" id="ss2label">
                                             <property name="visible">True</property>
-                                            <property name="xalign">1</property>
+                                            <property name="can-focus">False</property>
                                             <property name="label" translatable="yes">Spindle speed:</property>
+                                            <property name="xalign">1</property>
                                           </object>
                                           <packing>
                                             <property name="expand">False</property>
@@ -1505,8 +1644,9 @@
                                         <child>
                                           <object class="GtkLabel" id="status_spindlespeed2">
                                             <property name="visible">True</property>
-                                            <property name="xalign">0</property>
+                                            <property name="can-focus">False</property>
                                             <property name="label" translatable="yes">label26</property>
+                                            <property name="xalign">0</property>
                                           </object>
                                           <packing>
                                             <property name="expand">False</property>
@@ -1517,12 +1657,12 @@
                                         </child>
                                       </object>
                                       <packing>
-                                        <property name="left_attach">1</property>
-                                        <property name="right_attach">2</property>
-                                        <property name="top_attach">1</property>
-                                        <property name="bottom_attach">2</property>
-                                        <property name="x_options">GTK_FILL</property>
-                                        <property name="y_options">GTK_FILL</property>
+                                        <property name="left-attach">1</property>
+                                        <property name="right-attach">2</property>
+                                        <property name="top-attach">1</property>
+                                        <property name="bottom-attach">2</property>
+                                        <property name="x-options">GTK_FILL</property>
+                                        <property name="y-options">GTK_FILL</property>
                                       </packing>
                                     </child>
                                   </object>
@@ -1532,60 +1672,73 @@
                             <child type="label">
                               <object class="GtkLabel" id="label30">
                                 <property name="visible">True</property>
+                                <property name="can-focus">False</property>
                                 <property name="label" translatable="yes">&lt;b&gt;Spindle&lt;/b&gt;</property>
-                                <property name="use_markup">True</property>
+                                <property name="use-markup">True</property>
                               </object>
                             </child>
                           </object>
                           <packing>
+                            <property name="expand">True</property>
+                            <property name="fill">True</property>
                             <property name="position">1</property>
                           </packing>
                         </child>
                       </object>
+                      <packing>
+                        <property name="position">2</property>
+                      </packing>
                     </child>
                     <child type="tab">
                       <object class="GtkLabel" id="manual">
                         <property name="visible">True</property>
+                        <property name="can-focus">False</property>
                         <property name="xpad">10</property>
                         <property name="ypad">15</property>
                         <property name="label" translatable="yes">Manual</property>
                       </object>
                       <packing>
                         <property name="position">2</property>
-                        <property name="tab_fill">False</property>
+                        <property name="tab-fill">False</property>
                       </packing>
                     </child>
                     <child>
                       <object class="GtkFrame" id="frame7">
                         <property name="visible">True</property>
-                        <property name="border_width">5</property>
-                        <property name="label_xalign">0</property>
+                        <property name="can-focus">False</property>
+                        <property name="border-width">5</property>
+                        <property name="label-xalign">0</property>
                         <child>
                           <object class="GtkAlignment" id="alignment6">
                             <property name="visible">True</property>
-                            <property name="left_padding">12</property>
+                            <property name="can-focus">False</property>
+                            <property name="left-padding">12</property>
                             <child>
                               <object class="GtkTable" id="table21">
                                 <property name="visible">True</property>
-                                <property name="border_width">5</property>
-                                <property name="n_rows">4</property>
-                                <property name="n_columns">4</property>
-                                <property name="column_spacing">10</property>
+                                <property name="can-focus">False</property>
+                                <property name="border-width">5</property>
+                                <property name="n-rows">4</property>
+                                <property name="n-columns">4</property>
+                                <property name="column-spacing">10</property>
                                 <child>
                                   <object class="GtkTable" id="table17">
                                     <property name="visible">True</property>
-                                    <property name="n_rows">11</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="n-rows">11</property>
                                     <child>
                                       <object class="GtkEventBox" id="eventbox_filechooser0">
                                         <property name="visible">True</property>
-                                        <signal name="button_release_event" handler="on_filechooser_select"/>
+                                        <property name="can-focus">False</property>
+                                        <signal name="button-release-event" handler="on_filechooser_select" swapped="no"/>
                                         <child>
                                           <object class="GtkLabel" id="filechooser0">
                                             <property name="visible">True</property>
-                                            <property name="xalign">0</property>
+                                            <property name="can-focus">False</property>
                                             <property name="label" translatable="yes">file.ngc</property>
-                                            <property name="width_chars">8</property>
-                                            <property name="single_line_mode">True</property>
+                                            <property name="width-chars">8</property>
+                                            <property name="single-line-mode">True</property>
+                                            <property name="xalign">0</property>
                                           </object>
                                         </child>
                                       </object>
@@ -1593,214 +1746,237 @@
                                     <child>
                                       <object class="GtkEventBox" id="eventbox_filechooser1">
                                         <property name="visible">True</property>
-                                        <signal name="button_release_event" handler="on_filechooser_select"/>
+                                        <property name="can-focus">False</property>
+                                        <signal name="button-release-event" handler="on_filechooser_select" swapped="no"/>
                                         <child>
                                           <object class="GtkLabel" id="filechooser1">
                                             <property name="visible">True</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="width-chars">8</property>
+                                            <property name="single-line-mode">True</property>
                                             <property name="xalign">0</property>
-                                            <property name="width_chars">8</property>
-                                            <property name="single_line_mode">True</property>
                                           </object>
                                         </child>
                                       </object>
                                       <packing>
-                                        <property name="top_attach">1</property>
-                                        <property name="bottom_attach">2</property>
-                                        <property name="x_options">GTK_FILL</property>
+                                        <property name="top-attach">1</property>
+                                        <property name="bottom-attach">2</property>
+                                        <property name="x-options">GTK_FILL</property>
                                       </packing>
                                     </child>
                                     <child>
                                       <object class="GtkEventBox" id="eventbox_filechooser2">
                                         <property name="visible">True</property>
-                                        <signal name="button_release_event" handler="on_filechooser_select"/>
+                                        <property name="can-focus">False</property>
+                                        <signal name="button-release-event" handler="on_filechooser_select" swapped="no"/>
                                         <child>
                                           <object class="GtkLabel" id="filechooser2">
                                             <property name="visible">True</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="width-chars">8</property>
+                                            <property name="single-line-mode">True</property>
                                             <property name="xalign">0</property>
-                                            <property name="width_chars">8</property>
-                                            <property name="single_line_mode">True</property>
                                           </object>
                                         </child>
                                       </object>
                                       <packing>
-                                        <property name="top_attach">2</property>
-                                        <property name="bottom_attach">3</property>
-                                        <property name="x_options">GTK_FILL</property>
+                                        <property name="top-attach">2</property>
+                                        <property name="bottom-attach">3</property>
+                                        <property name="x-options">GTK_FILL</property>
                                       </packing>
                                     </child>
                                     <child>
                                       <object class="GtkEventBox" id="eventbox_filechooser3">
                                         <property name="visible">True</property>
-                                        <signal name="button_release_event" handler="on_filechooser_select"/>
+                                        <property name="can-focus">False</property>
+                                        <signal name="button-release-event" handler="on_filechooser_select" swapped="no"/>
                                         <child>
                                           <object class="GtkLabel" id="filechooser3">
                                             <property name="visible">True</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="width-chars">8</property>
+                                            <property name="single-line-mode">True</property>
                                             <property name="xalign">0</property>
-                                            <property name="width_chars">8</property>
-                                            <property name="single_line_mode">True</property>
                                           </object>
                                         </child>
                                       </object>
                                       <packing>
-                                        <property name="top_attach">3</property>
-                                        <property name="bottom_attach">4</property>
-                                        <property name="x_options">GTK_FILL</property>
+                                        <property name="top-attach">3</property>
+                                        <property name="bottom-attach">4</property>
+                                        <property name="x-options">GTK_FILL</property>
                                       </packing>
                                     </child>
                                     <child>
                                       <object class="GtkEventBox" id="eventbox_filechooser4">
                                         <property name="visible">True</property>
-                                        <signal name="button_release_event" handler="on_filechooser_select"/>
+                                        <property name="can-focus">False</property>
+                                        <signal name="button-release-event" handler="on_filechooser_select" swapped="no"/>
                                         <child>
                                           <object class="GtkLabel" id="filechooser4">
                                             <property name="visible">True</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="width-chars">8</property>
+                                            <property name="single-line-mode">True</property>
                                             <property name="xalign">0</property>
-                                            <property name="width_chars">8</property>
-                                            <property name="single_line_mode">True</property>
                                           </object>
                                         </child>
                                       </object>
                                       <packing>
-                                        <property name="top_attach">4</property>
-                                        <property name="bottom_attach">5</property>
-                                        <property name="x_options">GTK_FILL</property>
+                                        <property name="top-attach">4</property>
+                                        <property name="bottom-attach">5</property>
+                                        <property name="x-options">GTK_FILL</property>
                                       </packing>
                                     </child>
                                     <child>
                                       <object class="GtkEventBox" id="eventbox_filechooser5">
                                         <property name="visible">True</property>
-                                        <signal name="button_release_event" handler="on_filechooser_select"/>
+                                        <property name="can-focus">False</property>
+                                        <signal name="button-release-event" handler="on_filechooser_select" swapped="no"/>
                                         <child>
                                           <object class="GtkLabel" id="filechooser5">
                                             <property name="visible">True</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="width-chars">8</property>
+                                            <property name="single-line-mode">True</property>
                                             <property name="xalign">0</property>
-                                            <property name="width_chars">8</property>
-                                            <property name="single_line_mode">True</property>
                                           </object>
                                         </child>
                                       </object>
                                       <packing>
-                                        <property name="top_attach">5</property>
-                                        <property name="bottom_attach">6</property>
-                                        <property name="x_options">GTK_FILL</property>
+                                        <property name="top-attach">5</property>
+                                        <property name="bottom-attach">6</property>
+                                        <property name="x-options">GTK_FILL</property>
                                       </packing>
                                     </child>
                                     <child>
                                       <object class="GtkEventBox" id="eventbox_filechooser6">
                                         <property name="visible">True</property>
-                                        <signal name="button_release_event" handler="on_filechooser_select"/>
+                                        <property name="can-focus">False</property>
+                                        <signal name="button-release-event" handler="on_filechooser_select" swapped="no"/>
                                         <child>
                                           <object class="GtkLabel" id="filechooser6">
                                             <property name="visible">True</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="width-chars">8</property>
+                                            <property name="single-line-mode">True</property>
                                             <property name="xalign">0</property>
-                                            <property name="width_chars">8</property>
-                                            <property name="single_line_mode">True</property>
                                           </object>
                                         </child>
                                       </object>
                                       <packing>
-                                        <property name="top_attach">6</property>
-                                        <property name="bottom_attach">7</property>
-                                        <property name="x_options">GTK_FILL</property>
+                                        <property name="top-attach">6</property>
+                                        <property name="bottom-attach">7</property>
+                                        <property name="x-options">GTK_FILL</property>
                                       </packing>
                                     </child>
                                     <child>
                                       <object class="GtkEventBox" id="eventbox_filechooser7">
                                         <property name="visible">True</property>
-                                        <signal name="button_release_event" handler="on_filechooser_select"/>
+                                        <property name="can-focus">False</property>
+                                        <signal name="button-release-event" handler="on_filechooser_select" swapped="no"/>
                                         <child>
                                           <object class="GtkLabel" id="filechooser7">
                                             <property name="visible">True</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="width-chars">8</property>
+                                            <property name="single-line-mode">True</property>
                                             <property name="xalign">0</property>
-                                            <property name="width_chars">8</property>
-                                            <property name="single_line_mode">True</property>
                                           </object>
                                         </child>
                                       </object>
                                       <packing>
-                                        <property name="top_attach">7</property>
-                                        <property name="bottom_attach">8</property>
-                                        <property name="x_options">GTK_FILL</property>
+                                        <property name="top-attach">7</property>
+                                        <property name="bottom-attach">8</property>
+                                        <property name="x-options">GTK_FILL</property>
                                       </packing>
                                     </child>
                                     <child>
                                       <object class="GtkEventBox" id="eventbox_filechooser8">
                                         <property name="visible">True</property>
-                                        <signal name="button_release_event" handler="on_filechooser_select"/>
+                                        <property name="can-focus">False</property>
+                                        <signal name="button-release-event" handler="on_filechooser_select" swapped="no"/>
                                         <child>
                                           <object class="GtkLabel" id="filechooser8">
                                             <property name="visible">True</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="width-chars">8</property>
+                                            <property name="single-line-mode">True</property>
                                             <property name="xalign">0</property>
-                                            <property name="width_chars">8</property>
-                                            <property name="single_line_mode">True</property>
                                           </object>
                                         </child>
                                       </object>
                                       <packing>
-                                        <property name="top_attach">8</property>
-                                        <property name="bottom_attach">9</property>
-                                        <property name="x_options">GTK_FILL</property>
+                                        <property name="top-attach">8</property>
+                                        <property name="bottom-attach">9</property>
+                                        <property name="x-options">GTK_FILL</property>
                                       </packing>
                                     </child>
                                     <child>
                                       <object class="GtkEventBox" id="eventbox_filechooser9">
                                         <property name="visible">True</property>
-                                        <signal name="button_release_event" handler="on_filechooser_select"/>
+                                        <property name="can-focus">False</property>
+                                        <signal name="button-release-event" handler="on_filechooser_select" swapped="no"/>
                                         <child>
                                           <object class="GtkLabel" id="filechooser9">
                                             <property name="visible">True</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="width-chars">8</property>
+                                            <property name="single-line-mode">True</property>
                                             <property name="xalign">0</property>
-                                            <property name="width_chars">8</property>
-                                            <property name="single_line_mode">True</property>
                                           </object>
                                         </child>
                                       </object>
                                       <packing>
-                                        <property name="top_attach">9</property>
-                                        <property name="bottom_attach">10</property>
-                                        <property name="x_options">GTK_FILL</property>
+                                        <property name="top-attach">9</property>
+                                        <property name="bottom-attach">10</property>
+                                        <property name="x-options">GTK_FILL</property>
                                       </packing>
                                     </child>
                                     <child>
                                       <object class="GtkEventBox" id="eventbox_filechooser10">
                                         <property name="visible">True</property>
-                                        <signal name="button_release_event" handler="on_filechooser_select"/>
+                                        <property name="can-focus">False</property>
+                                        <signal name="button-release-event" handler="on_filechooser_select" swapped="no"/>
                                         <child>
                                           <object class="GtkLabel" id="filechooser10">
                                             <property name="visible">True</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="width-chars">8</property>
+                                            <property name="single-line-mode">True</property>
                                             <property name="xalign">0</property>
-                                            <property name="width_chars">8</property>
-                                            <property name="single_line_mode">True</property>
                                           </object>
                                         </child>
                                       </object>
                                       <packing>
-                                        <property name="top_attach">10</property>
-                                        <property name="bottom_attach">11</property>
-                                        <property name="x_options">GTK_FILL</property>
+                                        <property name="top-attach">10</property>
+                                        <property name="bottom-attach">11</property>
+                                        <property name="x-options">GTK_FILL</property>
                                       </packing>
                                     </child>
                                   </object>
                                   <packing>
-                                    <property name="bottom_attach">4</property>
+                                    <property name="bottom-attach">4</property>
                                   </packing>
                                 </child>
                                 <child>
                                   <object class="GtkTable" id="table16">
                                     <property name="visible">True</property>
-                                    <property name="n_rows">20</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="n-rows">20</property>
                                     <property name="homogeneous">True</property>
                                     <child>
                                       <object class="GtkEventBox" id="eventbox_listing0">
                                         <property name="visible">True</property>
-                                        <signal name="button_release_event" handler="on_listing_select"/>
+                                        <property name="can-focus">False</property>
+                                        <signal name="button-release-event" handler="on_listing_select" swapped="no"/>
                                         <child>
                                           <object class="GtkLabel" id="listing0">
                                             <property name="visible">True</property>
-                                            <property name="xalign">0</property>
+                                            <property name="can-focus">False</property>
                                             <property name="label" translatable="yes">M2</property>
-                                            <property name="width_chars">20</property>
-                                            <property name="single_line_mode">True</property>
+                                            <property name="width-chars">20</property>
+                                            <property name="single-line-mode">True</property>
+                                            <property name="xalign">0</property>
                                           </object>
                                         </child>
                                       </object>
@@ -1808,419 +1984,460 @@
                                     <child>
                                       <object class="GtkEventBox" id="eventbox_listing1">
                                         <property name="visible">True</property>
-                                        <signal name="button_release_event" handler="on_listing_select"/>
+                                        <property name="can-focus">False</property>
+                                        <signal name="button-release-event" handler="on_listing_select" swapped="no"/>
                                         <child>
                                           <object class="GtkLabel" id="listing1">
                                             <property name="visible">True</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="width-chars">8</property>
+                                            <property name="single-line-mode">True</property>
                                             <property name="xalign">0</property>
-                                            <property name="width_chars">8</property>
-                                            <property name="single_line_mode">True</property>
                                           </object>
                                         </child>
                                       </object>
                                       <packing>
-                                        <property name="top_attach">1</property>
-                                        <property name="bottom_attach">2</property>
-                                        <property name="x_options">GTK_FILL</property>
+                                        <property name="top-attach">1</property>
+                                        <property name="bottom-attach">2</property>
+                                        <property name="x-options">GTK_FILL</property>
                                       </packing>
                                     </child>
                                     <child>
                                       <object class="GtkEventBox" id="eventbox_listing2">
                                         <property name="visible">True</property>
-                                        <signal name="button_release_event" handler="on_listing_select"/>
+                                        <property name="can-focus">False</property>
+                                        <signal name="button-release-event" handler="on_listing_select" swapped="no"/>
                                         <child>
                                           <object class="GtkLabel" id="listing2">
                                             <property name="visible">True</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="width-chars">8</property>
+                                            <property name="single-line-mode">True</property>
                                             <property name="xalign">0</property>
-                                            <property name="width_chars">8</property>
-                                            <property name="single_line_mode">True</property>
                                           </object>
                                         </child>
                                       </object>
                                       <packing>
-                                        <property name="top_attach">2</property>
-                                        <property name="bottom_attach">3</property>
-                                        <property name="x_options">GTK_FILL</property>
+                                        <property name="top-attach">2</property>
+                                        <property name="bottom-attach">3</property>
+                                        <property name="x-options">GTK_FILL</property>
                                       </packing>
                                     </child>
                                     <child>
                                       <object class="GtkEventBox" id="eventbox_listing3">
                                         <property name="visible">True</property>
-                                        <signal name="button_release_event" handler="on_listing_select"/>
+                                        <property name="can-focus">False</property>
+                                        <signal name="button-release-event" handler="on_listing_select" swapped="no"/>
                                         <child>
                                           <object class="GtkLabel" id="listing3">
                                             <property name="visible">True</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="width-chars">8</property>
+                                            <property name="single-line-mode">True</property>
                                             <property name="xalign">0</property>
-                                            <property name="width_chars">8</property>
-                                            <property name="single_line_mode">True</property>
                                           </object>
                                         </child>
                                       </object>
                                       <packing>
-                                        <property name="top_attach">3</property>
-                                        <property name="bottom_attach">4</property>
-                                        <property name="x_options">GTK_FILL</property>
+                                        <property name="top-attach">3</property>
+                                        <property name="bottom-attach">4</property>
+                                        <property name="x-options">GTK_FILL</property>
                                       </packing>
                                     </child>
                                     <child>
                                       <object class="GtkEventBox" id="eventbox_listing4">
                                         <property name="visible">True</property>
-                                        <signal name="button_release_event" handler="on_listing_select"/>
+                                        <property name="can-focus">False</property>
+                                        <signal name="button-release-event" handler="on_listing_select" swapped="no"/>
                                         <child>
                                           <object class="GtkLabel" id="listing4">
                                             <property name="visible">True</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="width-chars">8</property>
+                                            <property name="single-line-mode">True</property>
                                             <property name="xalign">0</property>
-                                            <property name="width_chars">8</property>
-                                            <property name="single_line_mode">True</property>
                                           </object>
                                         </child>
                                       </object>
                                       <packing>
-                                        <property name="top_attach">4</property>
-                                        <property name="bottom_attach">5</property>
-                                        <property name="x_options">GTK_FILL</property>
+                                        <property name="top-attach">4</property>
+                                        <property name="bottom-attach">5</property>
+                                        <property name="x-options">GTK_FILL</property>
                                       </packing>
                                     </child>
                                     <child>
                                       <object class="GtkEventBox" id="eventbox_listing5">
                                         <property name="visible">True</property>
-                                        <signal name="button_release_event" handler="on_listing_select"/>
+                                        <property name="can-focus">False</property>
+                                        <signal name="button-release-event" handler="on_listing_select" swapped="no"/>
                                         <child>
                                           <object class="GtkLabel" id="listing5">
                                             <property name="visible">True</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="width-chars">8</property>
+                                            <property name="single-line-mode">True</property>
                                             <property name="xalign">0</property>
-                                            <property name="width_chars">8</property>
-                                            <property name="single_line_mode">True</property>
                                           </object>
                                         </child>
                                       </object>
                                       <packing>
-                                        <property name="top_attach">5</property>
-                                        <property name="bottom_attach">6</property>
-                                        <property name="x_options">GTK_FILL</property>
+                                        <property name="top-attach">5</property>
+                                        <property name="bottom-attach">6</property>
+                                        <property name="x-options">GTK_FILL</property>
                                       </packing>
                                     </child>
                                     <child>
                                       <object class="GtkEventBox" id="eventbox_listing6">
                                         <property name="visible">True</property>
-                                        <signal name="button_release_event" handler="on_listing_select"/>
+                                        <property name="can-focus">False</property>
+                                        <signal name="button-release-event" handler="on_listing_select" swapped="no"/>
                                         <child>
                                           <object class="GtkLabel" id="listing6">
                                             <property name="visible">True</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="width-chars">8</property>
+                                            <property name="single-line-mode">True</property>
                                             <property name="xalign">0</property>
-                                            <property name="width_chars">8</property>
-                                            <property name="single_line_mode">True</property>
                                           </object>
                                         </child>
                                       </object>
                                       <packing>
-                                        <property name="top_attach">6</property>
-                                        <property name="bottom_attach">7</property>
-                                        <property name="x_options">GTK_FILL</property>
+                                        <property name="top-attach">6</property>
+                                        <property name="bottom-attach">7</property>
+                                        <property name="x-options">GTK_FILL</property>
                                       </packing>
                                     </child>
                                     <child>
                                       <object class="GtkEventBox" id="eventbox_listing7">
                                         <property name="visible">True</property>
-                                        <signal name="button_release_event" handler="on_listing_select"/>
+                                        <property name="can-focus">False</property>
+                                        <signal name="button-release-event" handler="on_listing_select" swapped="no"/>
                                         <child>
                                           <object class="GtkLabel" id="listing7">
                                             <property name="visible">True</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="width-chars">8</property>
+                                            <property name="single-line-mode">True</property>
                                             <property name="xalign">0</property>
-                                            <property name="width_chars">8</property>
-                                            <property name="single_line_mode">True</property>
                                           </object>
                                         </child>
                                       </object>
                                       <packing>
-                                        <property name="top_attach">7</property>
-                                        <property name="bottom_attach">8</property>
-                                        <property name="x_options">GTK_FILL</property>
+                                        <property name="top-attach">7</property>
+                                        <property name="bottom-attach">8</property>
+                                        <property name="x-options">GTK_FILL</property>
                                       </packing>
                                     </child>
                                     <child>
                                       <object class="GtkEventBox" id="eventbox_listing8">
                                         <property name="visible">True</property>
-                                        <signal name="button_release_event" handler="on_listing_select"/>
+                                        <property name="can-focus">False</property>
+                                        <signal name="button-release-event" handler="on_listing_select" swapped="no"/>
                                         <child>
                                           <object class="GtkLabel" id="listing8">
                                             <property name="visible">True</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="width-chars">8</property>
+                                            <property name="single-line-mode">True</property>
                                             <property name="xalign">0</property>
-                                            <property name="width_chars">8</property>
-                                            <property name="single_line_mode">True</property>
                                           </object>
                                         </child>
                                       </object>
                                       <packing>
-                                        <property name="top_attach">8</property>
-                                        <property name="bottom_attach">9</property>
-                                        <property name="x_options">GTK_FILL</property>
+                                        <property name="top-attach">8</property>
+                                        <property name="bottom-attach">9</property>
+                                        <property name="x-options">GTK_FILL</property>
                                       </packing>
                                     </child>
                                     <child>
                                       <object class="GtkEventBox" id="eventbox_listing9">
                                         <property name="visible">True</property>
-                                        <signal name="button_release_event" handler="on_listing_select"/>
+                                        <property name="can-focus">False</property>
+                                        <signal name="button-release-event" handler="on_listing_select" swapped="no"/>
                                         <child>
                                           <object class="GtkLabel" id="listing9">
                                             <property name="visible">True</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="width-chars">8</property>
+                                            <property name="single-line-mode">True</property>
                                             <property name="xalign">0</property>
-                                            <property name="width_chars">8</property>
-                                            <property name="single_line_mode">True</property>
                                           </object>
                                         </child>
                                       </object>
                                       <packing>
-                                        <property name="top_attach">9</property>
-                                        <property name="bottom_attach">10</property>
-                                        <property name="x_options">GTK_FILL</property>
+                                        <property name="top-attach">9</property>
+                                        <property name="bottom-attach">10</property>
+                                        <property name="x-options">GTK_FILL</property>
                                       </packing>
                                     </child>
                                     <child>
                                       <object class="GtkEventBox" id="eventbox_listing10">
                                         <property name="visible">True</property>
-                                        <signal name="button_release_event" handler="on_listing_select"/>
+                                        <property name="can-focus">False</property>
+                                        <signal name="button-release-event" handler="on_listing_select" swapped="no"/>
                                         <child>
                                           <object class="GtkLabel" id="listing10">
                                             <property name="visible">True</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="width-chars">8</property>
+                                            <property name="single-line-mode">True</property>
                                             <property name="xalign">0</property>
-                                            <property name="width_chars">8</property>
-                                            <property name="single_line_mode">True</property>
                                           </object>
                                         </child>
                                       </object>
                                       <packing>
-                                        <property name="top_attach">10</property>
-                                        <property name="bottom_attach">11</property>
-                                        <property name="x_options">GTK_FILL</property>
+                                        <property name="top-attach">10</property>
+                                        <property name="bottom-attach">11</property>
+                                        <property name="x-options">GTK_FILL</property>
                                       </packing>
                                     </child>
                                     <child>
                                       <object class="GtkEventBox" id="eventbox_listing11">
                                         <property name="visible">True</property>
-                                        <signal name="button_release_event" handler="on_listing_select"/>
+                                        <property name="can-focus">False</property>
+                                        <signal name="button-release-event" handler="on_listing_select" swapped="no"/>
                                         <child>
                                           <object class="GtkLabel" id="listing11">
                                             <property name="visible">True</property>
-                                            <property name="xalign">0</property>
+                                            <property name="can-focus">False</property>
                                             <property name="label" translatable="yes">M2</property>
-                                            <property name="width_chars">8</property>
-                                            <property name="single_line_mode">True</property>
+                                            <property name="width-chars">8</property>
+                                            <property name="single-line-mode">True</property>
+                                            <property name="xalign">0</property>
                                           </object>
                                         </child>
                                       </object>
                                       <packing>
-                                        <property name="top_attach">11</property>
-                                        <property name="bottom_attach">12</property>
-                                        <property name="x_options">GTK_FILL</property>
+                                        <property name="top-attach">11</property>
+                                        <property name="bottom-attach">12</property>
+                                        <property name="x-options">GTK_FILL</property>
                                       </packing>
                                     </child>
                                     <child>
                                       <object class="GtkEventBox" id="eventbox_listing12">
                                         <property name="visible">True</property>
-                                        <signal name="button_release_event" handler="on_listing_select"/>
+                                        <property name="can-focus">False</property>
+                                        <signal name="button-release-event" handler="on_listing_select" swapped="no"/>
                                         <child>
                                           <object class="GtkLabel" id="listing12">
                                             <property name="visible">True</property>
-                                            <property name="xalign">0</property>
+                                            <property name="can-focus">False</property>
                                             <property name="label" translatable="yes">M2</property>
-                                            <property name="width_chars">8</property>
-                                            <property name="single_line_mode">True</property>
+                                            <property name="width-chars">8</property>
+                                            <property name="single-line-mode">True</property>
+                                            <property name="xalign">0</property>
                                           </object>
                                         </child>
                                       </object>
                                       <packing>
-                                        <property name="top_attach">12</property>
-                                        <property name="bottom_attach">13</property>
-                                        <property name="x_options">GTK_FILL</property>
+                                        <property name="top-attach">12</property>
+                                        <property name="bottom-attach">13</property>
+                                        <property name="x-options">GTK_FILL</property>
                                       </packing>
                                     </child>
                                     <child>
                                       <object class="GtkEventBox" id="eventbox_listing13">
                                         <property name="visible">True</property>
-                                        <signal name="button_release_event" handler="on_listing_select"/>
+                                        <property name="can-focus">False</property>
+                                        <signal name="button-release-event" handler="on_listing_select" swapped="no"/>
                                         <child>
                                           <object class="GtkLabel" id="listing13">
                                             <property name="visible">True</property>
-                                            <property name="xalign">0</property>
+                                            <property name="can-focus">False</property>
                                             <property name="label" translatable="yes">M2</property>
-                                            <property name="width_chars">8</property>
-                                            <property name="single_line_mode">True</property>
+                                            <property name="width-chars">8</property>
+                                            <property name="single-line-mode">True</property>
+                                            <property name="xalign">0</property>
                                           </object>
                                         </child>
                                       </object>
                                       <packing>
-                                        <property name="top_attach">13</property>
-                                        <property name="bottom_attach">14</property>
-                                        <property name="x_options">GTK_FILL</property>
+                                        <property name="top-attach">13</property>
+                                        <property name="bottom-attach">14</property>
+                                        <property name="x-options">GTK_FILL</property>
                                       </packing>
                                     </child>
                                     <child>
                                       <object class="GtkEventBox" id="eventbox_listing14">
                                         <property name="visible">True</property>
-                                        <signal name="button_release_event" handler="on_listing_select"/>
+                                        <property name="can-focus">False</property>
+                                        <signal name="button-release-event" handler="on_listing_select" swapped="no"/>
                                         <child>
                                           <object class="GtkLabel" id="listing14">
                                             <property name="visible">True</property>
-                                            <property name="xalign">0</property>
+                                            <property name="can-focus">False</property>
                                             <property name="label" translatable="yes">M2</property>
-                                            <property name="width_chars">8</property>
-                                            <property name="single_line_mode">True</property>
+                                            <property name="width-chars">8</property>
+                                            <property name="single-line-mode">True</property>
+                                            <property name="xalign">0</property>
                                           </object>
                                         </child>
                                       </object>
                                       <packing>
-                                        <property name="top_attach">14</property>
-                                        <property name="bottom_attach">15</property>
-                                        <property name="x_options">GTK_FILL</property>
+                                        <property name="top-attach">14</property>
+                                        <property name="bottom-attach">15</property>
+                                        <property name="x-options">GTK_FILL</property>
                                       </packing>
                                     </child>
                                     <child>
                                       <object class="GtkEventBox" id="eventbox_listing15">
                                         <property name="visible">True</property>
-                                        <signal name="button_release_event" handler="on_listing_select"/>
+                                        <property name="can-focus">False</property>
+                                        <signal name="button-release-event" handler="on_listing_select" swapped="no"/>
                                         <child>
                                           <object class="GtkLabel" id="listing15">
                                             <property name="visible">True</property>
-                                            <property name="xalign">0</property>
+                                            <property name="can-focus">False</property>
                                             <property name="label" translatable="yes">M2</property>
-                                            <property name="width_chars">8</property>
-                                            <property name="single_line_mode">True</property>
+                                            <property name="width-chars">8</property>
+                                            <property name="single-line-mode">True</property>
+                                            <property name="xalign">0</property>
                                           </object>
                                         </child>
                                       </object>
                                       <packing>
-                                        <property name="top_attach">15</property>
-                                        <property name="bottom_attach">16</property>
-                                        <property name="x_options">GTK_FILL</property>
+                                        <property name="top-attach">15</property>
+                                        <property name="bottom-attach">16</property>
+                                        <property name="x-options">GTK_FILL</property>
                                       </packing>
                                     </child>
                                     <child>
                                       <object class="GtkEventBox" id="eventbox_listing16">
                                         <property name="visible">True</property>
-                                        <signal name="button_release_event" handler="on_listing_select"/>
+                                        <property name="can-focus">False</property>
+                                        <signal name="button-release-event" handler="on_listing_select" swapped="no"/>
                                         <child>
                                           <object class="GtkLabel" id="listing16">
                                             <property name="visible">True</property>
-                                            <property name="xalign">0</property>
+                                            <property name="can-focus">False</property>
                                             <property name="label" translatable="yes">M2</property>
-                                            <property name="width_chars">8</property>
-                                            <property name="single_line_mode">True</property>
+                                            <property name="width-chars">8</property>
+                                            <property name="single-line-mode">True</property>
+                                            <property name="xalign">0</property>
                                           </object>
                                         </child>
                                       </object>
                                       <packing>
-                                        <property name="top_attach">16</property>
-                                        <property name="bottom_attach">17</property>
-                                        <property name="x_options">GTK_FILL</property>
+                                        <property name="top-attach">16</property>
+                                        <property name="bottom-attach">17</property>
+                                        <property name="x-options">GTK_FILL</property>
                                       </packing>
                                     </child>
                                     <child>
                                       <object class="GtkEventBox" id="eventbox_listing17">
                                         <property name="visible">True</property>
-                                        <signal name="button_release_event" handler="on_listing_select"/>
+                                        <property name="can-focus">False</property>
+                                        <signal name="button-release-event" handler="on_listing_select" swapped="no"/>
                                         <child>
                                           <object class="GtkLabel" id="listing17">
                                             <property name="visible">True</property>
-                                            <property name="xalign">0</property>
+                                            <property name="can-focus">False</property>
                                             <property name="label" translatable="yes">M2</property>
-                                            <property name="width_chars">8</property>
-                                            <property name="single_line_mode">True</property>
+                                            <property name="width-chars">8</property>
+                                            <property name="single-line-mode">True</property>
+                                            <property name="xalign">0</property>
                                           </object>
                                         </child>
                                       </object>
                                       <packing>
-                                        <property name="top_attach">17</property>
-                                        <property name="bottom_attach">18</property>
-                                        <property name="x_options">GTK_FILL</property>
+                                        <property name="top-attach">17</property>
+                                        <property name="bottom-attach">18</property>
+                                        <property name="x-options">GTK_FILL</property>
                                       </packing>
                                     </child>
                                     <child>
                                       <object class="GtkEventBox" id="eventbox_listing18">
                                         <property name="visible">True</property>
-                                        <signal name="button_release_event" handler="on_listing_select"/>
+                                        <property name="can-focus">False</property>
+                                        <signal name="button-release-event" handler="on_listing_select" swapped="no"/>
                                         <child>
                                           <object class="GtkLabel" id="listing18">
                                             <property name="visible">True</property>
-                                            <property name="xalign">0</property>
+                                            <property name="can-focus">False</property>
                                             <property name="label" translatable="yes">M2</property>
-                                            <property name="width_chars">8</property>
-                                            <property name="single_line_mode">True</property>
+                                            <property name="width-chars">8</property>
+                                            <property name="single-line-mode">True</property>
+                                            <property name="xalign">0</property>
                                           </object>
                                         </child>
                                       </object>
                                       <packing>
-                                        <property name="top_attach">18</property>
-                                        <property name="bottom_attach">19</property>
-                                        <property name="x_options">GTK_FILL</property>
+                                        <property name="top-attach">18</property>
+                                        <property name="bottom-attach">19</property>
+                                        <property name="x-options">GTK_FILL</property>
                                       </packing>
                                     </child>
                                     <child>
                                       <object class="GtkEventBox" id="eventbox_listing19">
                                         <property name="visible">True</property>
-                                        <signal name="button_release_event" handler="on_listing_select"/>
+                                        <property name="can-focus">False</property>
+                                        <signal name="button-release-event" handler="on_listing_select" swapped="no"/>
                                         <child>
                                           <object class="GtkLabel" id="listing19">
                                             <property name="visible">True</property>
-                                            <property name="xalign">0</property>
+                                            <property name="can-focus">False</property>
                                             <property name="label" translatable="yes">M2</property>
-                                            <property name="width_chars">8</property>
-                                            <property name="single_line_mode">True</property>
+                                            <property name="width-chars">8</property>
+                                            <property name="single-line-mode">True</property>
+                                            <property name="xalign">0</property>
                                           </object>
                                         </child>
                                       </object>
                                       <packing>
-                                        <property name="top_attach">19</property>
-                                        <property name="bottom_attach">20</property>
-                                        <property name="x_options">GTK_FILL</property>
+                                        <property name="top-attach">19</property>
+                                        <property name="bottom-attach">20</property>
+                                        <property name="x-options">GTK_FILL</property>
                                       </packing>
                                     </child>
                                   </object>
                                   <packing>
-                                    <property name="left_attach">2</property>
-                                    <property name="right_attach">3</property>
-                                    <property name="bottom_attach">4</property>
+                                    <property name="left-attach">2</property>
+                                    <property name="right-attach">3</property>
+                                    <property name="bottom-attach">4</property>
                                   </packing>
                                 </child>
                                 <child>
                                   <object class="GtkFrame" id="frame8">
                                     <property name="visible">True</property>
-                                    <property name="border_width">1</property>
-                                    <property name="label_xalign">0</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="border-width">1</property>
+                                    <property name="label-xalign">0</property>
                                     <child>
                                       <object class="GtkAlignment" id="alignment10">
                                         <property name="visible">True</property>
-                                        <property name="bottom_padding">5</property>
-                                        <property name="left_padding">5</property>
-                                        <property name="right_padding">5</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="bottom-padding">5</property>
+                                        <property name="left-padding">5</property>
+                                        <property name="right-padding">5</property>
                                         <child>
                                           <object class="GtkTable" id="table19">
                                             <property name="visible">True</property>
-                                            <property name="n_rows">2</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="n-rows">2</property>
                                             <child>
                                               <object class="GtkButton" id="button17">
                                                 <property name="label">gtk-go-up</property>
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">True</property>
-                                                <property name="receives_default">False</property>
-                                                <property name="use_stock">True</property>
-                                                <property name="focus_on_click">False</property>
-                                                <signal name="clicked" handler="on_listing_up_clicked"/>
+                                                <property name="can-focus">True</property>
+                                                <property name="focus-on-click">False</property>
+                                                <property name="receives-default">False</property>
+                                                <property name="use-stock">True</property>
+                                                <signal name="clicked" handler="on_listing_up_clicked" swapped="no"/>
                                               </object>
                                             </child>
                                             <child>
                                               <object class="GtkButton" id="button18">
                                                 <property name="label">gtk-go-down</property>
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">True</property>
-                                                <property name="receives_default">False</property>
-                                                <property name="use_stock">True</property>
-                                                <property name="focus_on_click">False</property>
-                                                <signal name="clicked" handler="on_listing_down_clicked"/>
+                                                <property name="can-focus">True</property>
+                                                <property name="focus-on-click">False</property>
+                                                <property name="receives-default">False</property>
+                                                <property name="use-stock">True</property>
+                                                <signal name="clicked" handler="on_listing_down_clicked" swapped="no"/>
                                               </object>
                                               <packing>
-                                                <property name="top_attach">1</property>
-                                                <property name="bottom_attach">2</property>
+                                                <property name="top-attach">1</property>
+                                                <property name="bottom-attach">2</property>
                                               </packing>
                                             </child>
                                           </object>
@@ -2230,58 +2447,62 @@
                                     <child type="label">
                                       <object class="GtkLabel" id="label48">
                                         <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
                                         <property name="label" translatable="yes">&lt;b&gt;Page&lt;/b&gt;</property>
-                                        <property name="use_markup">True</property>
+                                        <property name="use-markup">True</property>
                                       </object>
                                     </child>
                                   </object>
                                   <packing>
-                                    <property name="left_attach">3</property>
-                                    <property name="right_attach">4</property>
-                                    <property name="bottom_attach">2</property>
-                                    <property name="x_options">GTK_FILL</property>
-                                    <property name="y_options">GTK_FILL</property>
+                                    <property name="left-attach">3</property>
+                                    <property name="right-attach">4</property>
+                                    <property name="bottom-attach">2</property>
+                                    <property name="x-options">GTK_FILL</property>
+                                    <property name="y-options">GTK_FILL</property>
                                   </packing>
                                 </child>
                                 <child>
                                   <object class="GtkFrame" id="frame9">
                                     <property name="visible">True</property>
-                                    <property name="border_width">1</property>
-                                    <property name="label_xalign">0</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="border-width">1</property>
+                                    <property name="label-xalign">0</property>
                                     <child>
                                       <object class="GtkAlignment" id="alignment9">
                                         <property name="visible">True</property>
-                                        <property name="bottom_padding">5</property>
-                                        <property name="left_padding">5</property>
-                                        <property name="right_padding">5</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="bottom-padding">5</property>
+                                        <property name="left-padding">5</property>
+                                        <property name="right-padding">5</property>
                                         <child>
                                           <object class="GtkTable" id="table18">
                                             <property name="visible">True</property>
-                                            <property name="n_rows">2</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="n-rows">2</property>
                                             <child>
                                               <object class="GtkButton" id="button21">
                                                 <property name="label">gtk-media-previous</property>
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">True</property>
-                                                <property name="receives_default">False</property>
-                                                <property name="use_stock">True</property>
-                                                <property name="focus_on_click">False</property>
-                                                <signal name="clicked" handler="on_listing_previous_clicked"/>
+                                                <property name="can-focus">True</property>
+                                                <property name="focus-on-click">False</property>
+                                                <property name="receives-default">False</property>
+                                                <property name="use-stock">True</property>
+                                                <signal name="clicked" handler="on_listing_previous_clicked" swapped="no"/>
                                               </object>
                                             </child>
                                             <child>
                                               <object class="GtkButton" id="button20">
                                                 <property name="label">gtk-media-next</property>
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">True</property>
-                                                <property name="receives_default">False</property>
-                                                <property name="use_stock">True</property>
-                                                <property name="focus_on_click">False</property>
-                                                <signal name="clicked" handler="on_listing_next_clicked"/>
+                                                <property name="can-focus">True</property>
+                                                <property name="focus-on-click">False</property>
+                                                <property name="receives-default">False</property>
+                                                <property name="use-stock">True</property>
+                                                <signal name="clicked" handler="on_listing_next_clicked" swapped="no"/>
                                               </object>
                                               <packing>
-                                                <property name="top_attach">1</property>
-                                                <property name="bottom_attach">2</property>
+                                                <property name="top-attach">1</property>
+                                                <property name="bottom-attach">2</property>
                                               </packing>
                                             </child>
                                           </object>
@@ -2291,60 +2512,64 @@
                                     <child type="label">
                                       <object class="GtkLabel" id="label47">
                                         <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
                                         <property name="label" translatable="yes">&lt;span foreground="blue" weight="bold"&gt;Start Point&lt;/span&gt;</property>
-                                        <property name="use_markup">True</property>
-                                        <property name="single_line_mode">True</property>
+                                        <property name="use-markup">True</property>
+                                        <property name="single-line-mode">True</property>
                                       </object>
                                     </child>
                                   </object>
                                   <packing>
-                                    <property name="left_attach">3</property>
-                                    <property name="right_attach">4</property>
-                                    <property name="top_attach">2</property>
-                                    <property name="bottom_attach">4</property>
-                                    <property name="x_options">GTK_FILL</property>
-                                    <property name="y_options">GTK_FILL</property>
+                                    <property name="left-attach">3</property>
+                                    <property name="right-attach">4</property>
+                                    <property name="top-attach">2</property>
+                                    <property name="bottom-attach">4</property>
+                                    <property name="x-options">GTK_FILL</property>
+                                    <property name="y-options">GTK_FILL</property>
                                   </packing>
                                 </child>
                                 <child>
                                   <object class="GtkFrame" id="frame10">
                                     <property name="visible">True</property>
-                                    <property name="border_width">1</property>
-                                    <property name="label_xalign">0</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="border-width">1</property>
+                                    <property name="label-xalign">0</property>
                                     <child>
                                       <object class="GtkAlignment" id="alignment11">
                                         <property name="visible">True</property>
-                                        <property name="bottom_padding">5</property>
-                                        <property name="left_padding">5</property>
-                                        <property name="right_padding">5</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="bottom-padding">5</property>
+                                        <property name="left-padding">5</property>
+                                        <property name="right-padding">5</property>
                                         <child>
                                           <object class="GtkTable" id="table20">
                                             <property name="visible">True</property>
-                                            <property name="n_rows">2</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="n-rows">2</property>
                                             <child>
                                               <object class="GtkButton" id="filechooser_up">
                                                 <property name="label">gtk-go-up</property>
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">True</property>
-                                                <property name="receives_default">False</property>
-                                                <property name="use_stock">True</property>
-                                                <property name="focus_on_click">False</property>
-                                                <signal name="clicked" handler="on_filechooser_up_clicked"/>
+                                                <property name="can-focus">True</property>
+                                                <property name="focus-on-click">False</property>
+                                                <property name="receives-default">False</property>
+                                                <property name="use-stock">True</property>
+                                                <signal name="clicked" handler="on_filechooser_up_clicked" swapped="no"/>
                                               </object>
                                             </child>
                                             <child>
                                               <object class="GtkButton" id="filechooser_down">
                                                 <property name="label">gtk-go-down</property>
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">True</property>
-                                                <property name="receives_default">False</property>
-                                                <property name="use_stock">True</property>
-                                                <property name="focus_on_click">False</property>
-                                                <signal name="clicked" handler="on_filechooser_down_clicked"/>
+                                                <property name="can-focus">True</property>
+                                                <property name="focus-on-click">False</property>
+                                                <property name="receives-default">False</property>
+                                                <property name="use-stock">True</property>
+                                                <signal name="clicked" handler="on_filechooser_down_clicked" swapped="no"/>
                                               </object>
                                               <packing>
-                                                <property name="top_attach">1</property>
-                                                <property name="bottom_attach">2</property>
+                                                <property name="top-attach">1</property>
+                                                <property name="bottom-attach">2</property>
                                               </packing>
                                             </child>
                                           </object>
@@ -2354,38 +2579,42 @@
                                     <child type="label">
                                       <object class="GtkLabel" id="label49">
                                         <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
                                         <property name="label" translatable="yes">&lt;b&gt;Page&lt;/b&gt;</property>
-                                        <property name="use_markup">True</property>
+                                        <property name="use-markup">True</property>
                                       </object>
                                     </child>
                                   </object>
                                   <packing>
-                                    <property name="left_attach">1</property>
-                                    <property name="right_attach">2</property>
-                                    <property name="bottom_attach">2</property>
-                                    <property name="x_options">GTK_FILL</property>
-                                    <property name="y_options">GTK_FILL</property>
+                                    <property name="left-attach">1</property>
+                                    <property name="right-attach">2</property>
+                                    <property name="bottom-attach">2</property>
+                                    <property name="x-options">GTK_FILL</property>
+                                    <property name="y-options">GTK_FILL</property>
                                   </packing>
                                 </child>
                                 <child>
                                   <object class="GtkButton" id="filechooser_reload">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="receives_default">False</property>
-                                    <property name="focus_on_click">False</property>
-                                    <signal name="clicked" handler="on_filechooser_reload_clicked"/>
+                                    <property name="can-focus">True</property>
+                                    <property name="focus-on-click">False</property>
+                                    <property name="receives-default">False</property>
+                                    <signal name="clicked" handler="on_filechooser_reload_clicked" swapped="no"/>
                                     <child>
                                       <object class="GtkAlignment" id="alignment7">
                                         <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
                                         <property name="xscale">0</property>
                                         <property name="yscale">0</property>
                                         <child>
                                           <object class="GtkHBox" id="hbox7">
                                             <property name="visible">True</property>
+                                            <property name="can-focus">False</property>
                                             <property name="spacing">2</property>
                                             <child>
                                               <object class="GtkImage" id="image1">
                                                 <property name="visible">True</property>
+                                                <property name="can-focus">False</property>
                                                 <property name="stock">gtk-refresh</property>
                                               </object>
                                               <packing>
@@ -2397,8 +2626,9 @@
                                             <child>
                                               <object class="GtkLabel" id="label31">
                                                 <property name="visible">True</property>
+                                                <property name="can-focus">False</property>
                                                 <property name="label" translatable="yes">Refresh</property>
-                                                <property name="use_underline">True</property>
+                                                <property name="use-underline">True</property>
                                               </object>
                                               <packing>
                                                 <property name="expand">False</property>
@@ -2412,14 +2642,14 @@
                                     </child>
                                   </object>
                                   <packing>
-                                    <property name="left_attach">1</property>
-                                    <property name="right_attach">2</property>
-                                    <property name="top_attach">2</property>
-                                    <property name="bottom_attach">4</property>
-                                    <property name="x_options">GTK_FILL</property>
-                                    <property name="y_options">GTK_FILL</property>
-                                    <property name="x_padding">8</property>
-                                    <property name="y_padding">10</property>
+                                    <property name="left-attach">1</property>
+                                    <property name="right-attach">2</property>
+                                    <property name="top-attach">2</property>
+                                    <property name="bottom-attach">4</property>
+                                    <property name="x-options">GTK_FILL</property>
+                                    <property name="y-options">GTK_FILL</property>
+                                    <property name="x-padding">8</property>
+                                    <property name="y-padding">10</property>
                                   </packing>
                                 </child>
                               </object>
@@ -2429,777 +2659,841 @@
                         <child type="label">
                           <object class="GtkLabel" id="loaded_file">
                             <property name="visible">True</property>
+                            <property name="can-focus">False</property>
                             <property name="label" translatable="yes">&lt;b&gt;Loaded File&lt;/b&gt;</property>
-                            <property name="use_markup">True</property>
+                            <property name="use-markup">True</property>
                           </object>
                         </child>
                       </object>
+                      <packing>
+                        <property name="position">3</property>
+                      </packing>
                     </child>
                     <child type="tab">
                       <object class="GtkLabel" id="auto">
                         <property name="visible">True</property>
+                        <property name="can-focus">False</property>
                         <property name="xpad">10</property>
                         <property name="ypad">15</property>
                         <property name="label" translatable="yes">Auto</property>
                       </object>
                       <packing>
                         <property name="position">3</property>
-                        <property name="tab_fill">False</property>
+                        <property name="tab-fill">False</property>
                       </packing>
                     </child>
                     <child>
                       <object class="GtkTable" id="table8">
                         <property name="visible">True</property>
-                        <property name="n_rows">18</property>
-                        <property name="n_columns">2</property>
-                        <property name="column_spacing">10</property>
-                        <property name="row_spacing">3</property>
+                        <property name="can-focus">False</property>
+                        <property name="n-rows">18</property>
+                        <property name="n-columns">2</property>
+                        <property name="column-spacing">10</property>
+                        <property name="row-spacing">3</property>
                         <child>
                           <object class="GtkLabel" id="label3">
                             <property name="visible">True</property>
-                            <property name="xalign">1</property>
+                            <property name="can-focus">False</property>
                             <property name="label" translatable="yes">Loaded file:</property>
+                            <property name="xalign">1</property>
                           </object>
                           <packing>
-                            <property name="x_options">GTK_FILL</property>
-                            <property name="y_options"/>
+                            <property name="x-options">GTK_FILL</property>
+                            <property name="y-options"/>
                           </packing>
                         </child>
                         <child>
                           <object class="GtkLabel" id="label4">
                             <property name="visible">True</property>
-                            <property name="xalign">1</property>
+                            <property name="can-focus">False</property>
                             <property name="label" translatable="yes">Interpreted line:</property>
                             <property name="justify">right</property>
+                            <property name="xalign">1</property>
                           </object>
                           <packing>
-                            <property name="top_attach">2</property>
-                            <property name="bottom_attach">3</property>
-                            <property name="x_options">GTK_FILL</property>
-                            <property name="y_options"/>
+                            <property name="top-attach">2</property>
+                            <property name="bottom-attach">3</property>
+                            <property name="x-options">GTK_FILL</property>
+                            <property name="y-options"/>
                           </packing>
                         </child>
                         <child>
                           <object class="GtkLabel" id="label12">
                             <property name="visible">True</property>
-                            <property name="xalign">1</property>
+                            <property name="can-focus">False</property>
                             <property name="label" translatable="yes">Distance:</property>
+                            <property name="xalign">1</property>
                           </object>
                           <packing>
-                            <property name="top_attach">7</property>
-                            <property name="bottom_attach">8</property>
-                            <property name="x_options">GTK_FILL</property>
-                            <property name="y_options"/>
+                            <property name="top-attach">7</property>
+                            <property name="bottom-attach">8</property>
+                            <property name="x-options">GTK_FILL</property>
+                            <property name="y-options"/>
                           </packing>
                         </child>
                         <child>
                           <object class="GtkLabel" id="label13">
                             <property name="visible">True</property>
-                            <property name="xalign">1</property>
+                            <property name="can-focus">False</property>
                             <property name="label" translatable="yes">Velocity:</property>
+                            <property name="xalign">1</property>
                           </object>
                           <packing>
-                            <property name="top_attach">8</property>
-                            <property name="bottom_attach">9</property>
-                            <property name="x_options">GTK_FILL</property>
-                            <property name="y_options"/>
+                            <property name="top-attach">8</property>
+                            <property name="bottom-attach">9</property>
+                            <property name="x-options">GTK_FILL</property>
+                            <property name="y-options"/>
                           </packing>
                         </child>
                         <child>
                           <object class="GtkLabel" id="label14">
                             <property name="visible">True</property>
-                            <property name="xalign">1</property>
+                            <property name="can-focus">False</property>
                             <property name="label" translatable="yes">Delay:</property>
+                            <property name="xalign">1</property>
                           </object>
                           <packing>
-                            <property name="top_attach">9</property>
-                            <property name="bottom_attach">10</property>
-                            <property name="x_options">GTK_FILL</property>
-                            <property name="y_options"/>
+                            <property name="top-attach">9</property>
+                            <property name="bottom-attach">10</property>
+                            <property name="x-options">GTK_FILL</property>
+                            <property name="y-options"/>
                           </packing>
                         </child>
                         <child>
                           <object class="GtkLabel" id="label15">
                             <property name="visible">True</property>
-                            <property name="xalign">1</property>
+                            <property name="can-focus">False</property>
                             <property name="label" translatable="yes">On limit switch:</property>
+                            <property name="xalign">1</property>
                           </object>
                           <packing>
-                            <property name="top_attach">10</property>
-                            <property name="bottom_attach">11</property>
-                            <property name="x_options">GTK_FILL</property>
-                            <property name="y_options"/>
+                            <property name="top-attach">10</property>
+                            <property name="bottom-attach">11</property>
+                            <property name="x-options">GTK_FILL</property>
+                            <property name="y-options"/>
                           </packing>
                         </child>
                         <child>
                           <object class="GtkLabel" id="label16">
                             <property name="visible">True</property>
-                            <property name="xalign">1</property>
+                            <property name="can-focus">False</property>
                             <property name="label" translatable="yes">Spindle direction:</property>
+                            <property name="xalign">1</property>
                           </object>
                           <packing>
-                            <property name="top_attach">11</property>
-                            <property name="bottom_attach">12</property>
-                            <property name="x_options">GTK_FILL</property>
-                            <property name="y_options"/>
+                            <property name="top-attach">11</property>
+                            <property name="bottom-attach">12</property>
+                            <property name="x-options">GTK_FILL</property>
+                            <property name="y-options"/>
                           </packing>
                         </child>
                         <child>
                           <object class="GtkLabel" id="label17">
                             <property name="visible">True</property>
-                            <property name="xalign">1</property>
+                            <property name="can-focus">False</property>
                             <property name="label" translatable="yes">Spindle speed:</property>
+                            <property name="xalign">1</property>
                           </object>
                           <packing>
-                            <property name="top_attach">12</property>
-                            <property name="bottom_attach">13</property>
-                            <property name="x_options">GTK_FILL</property>
-                            <property name="y_options"/>
+                            <property name="top-attach">12</property>
+                            <property name="bottom-attach">13</property>
+                            <property name="x-options">GTK_FILL</property>
+                            <property name="y-options"/>
                           </packing>
                         </child>
                         <child>
                           <object class="GtkLabel" id="label18">
                             <property name="visible">True</property>
-                            <property name="xalign">1</property>
+                            <property name="can-focus">False</property>
                             <property name="label" translatable="yes">Loaded tool:</property>
+                            <property name="xalign">1</property>
                           </object>
                           <packing>
-                            <property name="top_attach">14</property>
-                            <property name="bottom_attach">15</property>
-                            <property name="x_options">GTK_FILL</property>
-                            <property name="y_options"/>
+                            <property name="top-attach">14</property>
+                            <property name="bottom-attach">15</property>
+                            <property name="x-options">GTK_FILL</property>
+                            <property name="y-options"/>
                           </packing>
                         </child>
                         <child>
                           <object class="GtkLabel" id="status_file">
                             <property name="visible">True</property>
-                            <property name="xalign">0</property>
+                            <property name="can-focus">False</property>
                             <property name="label" translatable="yes">label19</property>
+                            <property name="xalign">0</property>
                           </object>
                           <packing>
-                            <property name="left_attach">1</property>
-                            <property name="right_attach">2</property>
-                            <property name="x_options">GTK_FILL</property>
-                            <property name="y_options"/>
+                            <property name="left-attach">1</property>
+                            <property name="right-attach">2</property>
+                            <property name="x-options">GTK_FILL</property>
+                            <property name="y-options"/>
                           </packing>
                         </child>
                         <child>
                           <object class="GtkLabel" id="status_dtg">
                             <property name="visible">True</property>
-                            <property name="xalign">0</property>
+                            <property name="can-focus">False</property>
                             <property name="label" translatable="yes">label20</property>
+                            <property name="xalign">0</property>
                           </object>
                           <packing>
-                            <property name="left_attach">1</property>
-                            <property name="right_attach">2</property>
-                            <property name="top_attach">7</property>
-                            <property name="bottom_attach">8</property>
-                            <property name="x_options">GTK_FILL</property>
-                            <property name="y_options"/>
+                            <property name="left-attach">1</property>
+                            <property name="right-attach">2</property>
+                            <property name="top-attach">7</property>
+                            <property name="bottom-attach">8</property>
+                            <property name="x-options">GTK_FILL</property>
+                            <property name="y-options"/>
                           </packing>
                         </child>
                         <child>
                           <object class="GtkLabel" id="status_line">
                             <property name="visible">True</property>
-                            <property name="xalign">0</property>
+                            <property name="can-focus">False</property>
                             <property name="label" translatable="yes">label21</property>
+                            <property name="xalign">0</property>
                           </object>
                           <packing>
-                            <property name="left_attach">1</property>
-                            <property name="right_attach">2</property>
-                            <property name="top_attach">2</property>
-                            <property name="bottom_attach">3</property>
-                            <property name="x_options">GTK_FILL</property>
-                            <property name="y_options"/>
+                            <property name="left-attach">1</property>
+                            <property name="right-attach">2</property>
+                            <property name="top-attach">2</property>
+                            <property name="bottom-attach">3</property>
+                            <property name="x-options">GTK_FILL</property>
+                            <property name="y-options"/>
                           </packing>
                         </child>
                         <child>
                           <object class="GtkLabel" id="status_delay">
                             <property name="visible">True</property>
-                            <property name="xalign">0</property>
+                            <property name="can-focus">False</property>
                             <property name="label" translatable="yes">label22</property>
+                            <property name="xalign">0</property>
                           </object>
                           <packing>
-                            <property name="left_attach">1</property>
-                            <property name="right_attach">2</property>
-                            <property name="top_attach">9</property>
-                            <property name="bottom_attach">10</property>
-                            <property name="x_options">GTK_FILL</property>
-                            <property name="y_options"/>
+                            <property name="left-attach">1</property>
+                            <property name="right-attach">2</property>
+                            <property name="top-attach">9</property>
+                            <property name="bottom-attach">10</property>
+                            <property name="x-options">GTK_FILL</property>
+                            <property name="y-options"/>
                           </packing>
                         </child>
                         <child>
                           <object class="GtkLabel" id="status_velocity">
                             <property name="visible">True</property>
-                            <property name="xalign">0</property>
+                            <property name="can-focus">False</property>
                             <property name="label" translatable="yes">label23</property>
+                            <property name="xalign">0</property>
                           </object>
                           <packing>
-                            <property name="left_attach">1</property>
-                            <property name="right_attach">2</property>
-                            <property name="top_attach">8</property>
-                            <property name="bottom_attach">9</property>
-                            <property name="x_options">GTK_FILL</property>
-                            <property name="y_options"/>
+                            <property name="left-attach">1</property>
+                            <property name="right-attach">2</property>
+                            <property name="top-attach">8</property>
+                            <property name="bottom-attach">9</property>
+                            <property name="x-options">GTK_FILL</property>
+                            <property name="y-options"/>
                           </packing>
                         </child>
                         <child>
                           <object class="GtkLabel" id="status_onlimit">
                             <property name="visible">True</property>
-                            <property name="xalign">0</property>
+                            <property name="can-focus">False</property>
                             <property name="label" translatable="yes">label24</property>
+                            <property name="xalign">0</property>
                           </object>
                           <packing>
-                            <property name="left_attach">1</property>
-                            <property name="right_attach">2</property>
-                            <property name="top_attach">10</property>
-                            <property name="bottom_attach">11</property>
-                            <property name="x_options">GTK_FILL</property>
-                            <property name="y_options"/>
+                            <property name="left-attach">1</property>
+                            <property name="right-attach">2</property>
+                            <property name="top-attach">10</property>
+                            <property name="bottom-attach">11</property>
+                            <property name="x-options">GTK_FILL</property>
+                            <property name="y-options"/>
                           </packing>
                         </child>
                         <child>
                           <object class="GtkLabel" id="status_spindledir">
                             <property name="visible">True</property>
-                            <property name="xalign">0</property>
+                            <property name="can-focus">False</property>
                             <property name="label" translatable="yes">label25</property>
+                            <property name="xalign">0</property>
                           </object>
                           <packing>
-                            <property name="left_attach">1</property>
-                            <property name="right_attach">2</property>
-                            <property name="top_attach">11</property>
-                            <property name="bottom_attach">12</property>
-                            <property name="x_options">GTK_FILL</property>
-                            <property name="y_options"/>
+                            <property name="left-attach">1</property>
+                            <property name="right-attach">2</property>
+                            <property name="top-attach">11</property>
+                            <property name="bottom-attach">12</property>
+                            <property name="x-options">GTK_FILL</property>
+                            <property name="y-options"/>
                           </packing>
                         </child>
                         <child>
                           <object class="GtkLabel" id="status_spindlespeed">
                             <property name="visible">True</property>
-                            <property name="xalign">0</property>
+                            <property name="can-focus">False</property>
                             <property name="label" translatable="yes">label26</property>
+                            <property name="xalign">0</property>
                           </object>
                           <packing>
-                            <property name="left_attach">1</property>
-                            <property name="right_attach">2</property>
-                            <property name="top_attach">12</property>
-                            <property name="bottom_attach">13</property>
-                            <property name="x_options">GTK_FILL</property>
-                            <property name="y_options"/>
+                            <property name="left-attach">1</property>
+                            <property name="right-attach">2</property>
+                            <property name="top-attach">12</property>
+                            <property name="bottom-attach">13</property>
+                            <property name="x-options">GTK_FILL</property>
+                            <property name="y-options"/>
                           </packing>
                         </child>
                         <child>
                           <object class="GtkLabel" id="status_loadedtool">
                             <property name="visible">True</property>
-                            <property name="xalign">0</property>
+                            <property name="can-focus">False</property>
                             <property name="label" translatable="yes">label27</property>
+                            <property name="xalign">0</property>
                           </object>
                           <packing>
-                            <property name="left_attach">1</property>
-                            <property name="right_attach">2</property>
-                            <property name="top_attach">14</property>
-                            <property name="bottom_attach">15</property>
-                            <property name="x_options">GTK_FILL</property>
-                            <property name="y_options"/>
+                            <property name="left-attach">1</property>
+                            <property name="right-attach">2</property>
+                            <property name="top-attach">14</property>
+                            <property name="bottom-attach">15</property>
+                            <property name="x-options">GTK_FILL</property>
+                            <property name="y-options"/>
                           </packing>
                         </child>
                         <child>
                           <object class="GtkLabel" id="label28">
                             <property name="visible">True</property>
-                            <property name="xalign">1</property>
+                            <property name="can-focus">False</property>
                             <property name="label" translatable="yes">Prepped tool:</property>
+                            <property name="xalign">1</property>
                           </object>
                           <packing>
-                            <property name="top_attach">15</property>
-                            <property name="bottom_attach">16</property>
-                            <property name="x_options">GTK_FILL</property>
-                            <property name="y_options"/>
+                            <property name="top-attach">15</property>
+                            <property name="bottom-attach">16</property>
+                            <property name="x-options">GTK_FILL</property>
+                            <property name="y-options"/>
                           </packing>
                         </child>
                         <child>
                           <object class="GtkLabel" id="status_preppedtool">
                             <property name="visible">True</property>
-                            <property name="xalign">0</property>
+                            <property name="can-focus">False</property>
                             <property name="label" translatable="yes">label28</property>
+                            <property name="xalign">0</property>
                           </object>
                           <packing>
-                            <property name="left_attach">1</property>
-                            <property name="right_attach">2</property>
-                            <property name="top_attach">15</property>
-                            <property name="bottom_attach">16</property>
-                            <property name="x_options">GTK_FILL</property>
-                            <property name="y_options"/>
+                            <property name="left-attach">1</property>
+                            <property name="right-attach">2</property>
+                            <property name="top-attach">15</property>
+                            <property name="bottom-attach">16</property>
+                            <property name="x-options">GTK_FILL</property>
+                            <property name="y-options"/>
                           </packing>
                         </child>
                         <child>
                           <object class="GtkLabel" id="label33">
                             <property name="visible">True</property>
-                            <property name="xalign">1</property>
+                            <property name="can-focus">False</property>
                             <property name="label" translatable="yes">Running line:</property>
                             <property name="justify">right</property>
+                            <property name="xalign">1</property>
                           </object>
                           <packing>
-                            <property name="top_attach">3</property>
-                            <property name="bottom_attach">4</property>
-                            <property name="x_options">GTK_FILL</property>
-                            <property name="y_options"/>
+                            <property name="top-attach">3</property>
+                            <property name="bottom-attach">4</property>
+                            <property name="x-options">GTK_FILL</property>
+                            <property name="y-options"/>
                           </packing>
                         </child>
                         <child>
                           <object class="GtkLabel" id="status_id">
                             <property name="visible">True</property>
-                            <property name="xalign">0</property>
+                            <property name="can-focus">False</property>
                             <property name="label" translatable="yes">label21</property>
+                            <property name="xalign">0</property>
                           </object>
                           <packing>
-                            <property name="left_attach">1</property>
-                            <property name="right_attach">2</property>
-                            <property name="top_attach">3</property>
-                            <property name="bottom_attach">4</property>
-                            <property name="x_options">GTK_FILL</property>
-                            <property name="y_options"/>
+                            <property name="left-attach">1</property>
+                            <property name="right-attach">2</property>
+                            <property name="top-attach">3</property>
+                            <property name="bottom-attach">4</property>
+                            <property name="x-options">GTK_FILL</property>
+                            <property name="y-options"/>
                           </packing>
                         </child>
                         <child>
                           <object class="GtkLabel" id="label50">
                             <property name="visible">True</property>
-                            <property name="xalign">1</property>
+                            <property name="can-focus">False</property>
                             <property name="label" translatable="yes">XY Rotation:</property>
                             <property name="justify">right</property>
+                            <property name="xalign">1</property>
                           </object>
                           <packing>
-                            <property name="top_attach">4</property>
-                            <property name="bottom_attach">5</property>
-                            <property name="x_options">GTK_FILL</property>
-                            <property name="y_options"/>
+                            <property name="top-attach">4</property>
+                            <property name="bottom-attach">5</property>
+                            <property name="x-options">GTK_FILL</property>
+                            <property name="y-options"/>
                           </packing>
                         </child>
                         <child>
                           <object class="GtkLabel" id="status_xyrotation">
                             <property name="visible">True</property>
-                            <property name="xalign">0</property>
+                            <property name="can-focus">False</property>
                             <property name="label" translatable="yes">label21</property>
+                            <property name="xalign">0</property>
                           </object>
                           <packing>
-                            <property name="left_attach">1</property>
-                            <property name="right_attach">2</property>
-                            <property name="top_attach">4</property>
-                            <property name="bottom_attach">5</property>
-                            <property name="x_options">GTK_FILL</property>
-                            <property name="y_options"/>
+                            <property name="left-attach">1</property>
+                            <property name="right-attach">2</property>
+                            <property name="top-attach">4</property>
+                            <property name="bottom-attach">5</property>
+                            <property name="x-options">GTK_FILL</property>
+                            <property name="y-options"/>
                           </packing>
                         </child>
                         <child>
                           <object class="GtkLabel" id="label51">
                             <property name="visible">True</property>
-                            <property name="xalign">1</property>
+                            <property name="can-focus">False</property>
                             <property name="label" translatable="yes">Tool length:</property>
+                            <property name="xalign">1</property>
                           </object>
                           <packing>
-                            <property name="top_attach">16</property>
-                            <property name="bottom_attach">17</property>
-                            <property name="x_options">GTK_FILL</property>
-                            <property name="y_options"/>
+                            <property name="top-attach">16</property>
+                            <property name="bottom-attach">17</property>
+                            <property name="x-options">GTK_FILL</property>
+                            <property name="y-options"/>
                           </packing>
                         </child>
                         <child>
                           <object class="GtkLabel" id="status_tlo">
                             <property name="visible">True</property>
-                            <property name="xalign">0</property>
+                            <property name="can-focus">False</property>
                             <property name="label" translatable="yes">label52</property>
+                            <property name="xalign">0</property>
                           </object>
                           <packing>
-                            <property name="left_attach">1</property>
-                            <property name="right_attach">2</property>
-                            <property name="top_attach">16</property>
-                            <property name="bottom_attach">17</property>
-                            <property name="x_options">GTK_FILL</property>
-                            <property name="y_options"/>
+                            <property name="left-attach">1</property>
+                            <property name="right-attach">2</property>
+                            <property name="top-attach">16</property>
+                            <property name="bottom-attach">17</property>
+                            <property name="x-options">GTK_FILL</property>
+                            <property name="y-options"/>
                           </packing>
                         </child>
                         <child>
                           <object class="GtkLabel" id="status_activecodes">
                             <property name="visible">True</property>
-                            <property name="xalign">0</property>
+                            <property name="can-focus">False</property>
                             <property name="valign">start</property>
                             <property name="label" translatable="yes">G1 G2 G3
 M1 M2 M3
 F1 S1</property>
-			    <property name="max-width-chars">40</property>
-			    <property name="width-chars">40</property>
                             <property name="wrap">True</property>
+                            <property name="width-chars">40</property>
+                            <property name="max-width-chars">40</property>
+                            <property name="xalign">0</property>
                           </object>
                           <packing>
-                            <property name="left_attach">1</property>
-                            <property name="right_attach">2</property>
-                            <property name="top_attach">17</property>
-                            <property name="bottom_attach">18</property>
-                            <property name="x_options">GTK_FILL</property>
-                            <property name="y_options"/>
+                            <property name="left-attach">1</property>
+                            <property name="right-attach">2</property>
+                            <property name="top-attach">17</property>
+                            <property name="bottom-attach">18</property>
+                            <property name="x-options">GTK_FILL</property>
+                            <property name="y-options"/>
                           </packing>
                         </child>
                         <child>
                           <object class="GtkLabel" id="label53">
                             <property name="visible">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="label" translatable="yes">Active codes:</property>
                             <property name="xalign">1</property>
                             <property name="yalign">0</property>
-                            <property name="label" translatable="yes">Active codes:</property>
                           </object>
                           <packing>
-                            <property name="top_attach">17</property>
-                            <property name="bottom_attach">18</property>
-                            <property name="x_options">GTK_FILL</property>
-                            <property name="y_options">GTK_FILL</property>
+                            <property name="top-attach">17</property>
+                            <property name="bottom-attach">18</property>
+                            <property name="x-options">GTK_FILL</property>
+                            <property name="y-options">GTK_FILL</property>
                           </packing>
                         </child>
                         <child>
                           <object class="GtkLabel" id="status_label_g5xoffset">
                             <property name="visible">True</property>
-                            <property name="xalign">1</property>
+                            <property name="can-focus">False</property>
                             <property name="label" translatable="yes">G5x Offset:</property>
-                            <property name="use_markup">True</property>
+                            <property name="use-markup">True</property>
                             <property name="justify">right</property>
+                            <property name="xalign">1</property>
                           </object>
                           <packing>
-                            <property name="top_attach">5</property>
-                            <property name="bottom_attach">6</property>
-                            <property name="x_options">GTK_FILL</property>
-                            <property name="y_options"/>
+                            <property name="top-attach">5</property>
+                            <property name="bottom-attach">6</property>
+                            <property name="x-options">GTK_FILL</property>
+                            <property name="y-options"/>
                           </packing>
                         </child>
                         <child>
                           <object class="GtkLabel" id="label5">
                             <property name="visible">True</property>
-                            <property name="xalign">1</property>
+                            <property name="can-focus">False</property>
                             <property name="label" translatable="yes">G92 Offset:</property>
                             <property name="justify">right</property>
+                            <property name="xalign">1</property>
                           </object>
                           <packing>
-                            <property name="top_attach">6</property>
-                            <property name="bottom_attach">7</property>
-                            <property name="x_options">GTK_FILL</property>
-                            <property name="y_options"/>
+                            <property name="top-attach">6</property>
+                            <property name="bottom-attach">7</property>
+                            <property name="x-options">GTK_FILL</property>
+                            <property name="y-options"/>
                           </packing>
                         </child>
                         <child>
                           <object class="GtkLabel" id="status_g5xoffset">
                             <property name="visible">True</property>
-                            <property name="xalign">0</property>
+                            <property name="can-focus">False</property>
                             <property name="label" translatable="yes">label21</property>
+                            <property name="xalign">0</property>
                           </object>
                           <packing>
-                            <property name="left_attach">1</property>
-                            <property name="right_attach">2</property>
-                            <property name="top_attach">5</property>
-                            <property name="bottom_attach">6</property>
-                            <property name="x_options">GTK_FILL</property>
-                            <property name="y_options"/>
+                            <property name="left-attach">1</property>
+                            <property name="right-attach">2</property>
+                            <property name="top-attach">5</property>
+                            <property name="bottom-attach">6</property>
+                            <property name="x-options">GTK_FILL</property>
+                            <property name="y-options"/>
                           </packing>
                         </child>
                         <child>
                           <object class="GtkLabel" id="status_g92offset">
                             <property name="visible">True</property>
-                            <property name="xalign">0</property>
+                            <property name="can-focus">False</property>
                             <property name="label" translatable="yes">label21</property>
+                            <property name="xalign">0</property>
                           </object>
                           <packing>
-                            <property name="left_attach">1</property>
-                            <property name="right_attach">2</property>
-                            <property name="top_attach">6</property>
-                            <property name="bottom_attach">7</property>
-                            <property name="x_options">GTK_FILL</property>
-                            <property name="y_options"/>
+                            <property name="left-attach">1</property>
+                            <property name="right-attach">2</property>
+                            <property name="top-attach">6</property>
+                            <property name="bottom-attach">7</property>
+                            <property name="x-options">GTK_FILL</property>
+                            <property name="y-options"/>
                           </packing>
                         </child>
                         <child>
                           <object class="GtkLabel" id="label2">
                             <property name="visible">True</property>
-                            <property name="xalign">1</property>
+                            <property name="can-focus">False</property>
                             <property name="label" translatable="yes">Loaded file lines:</property>
+                            <property name="xalign">1</property>
                           </object>
                           <packing>
-                            <property name="top_attach">1</property>
-                            <property name="bottom_attach">2</property>
-                            <property name="x_options">GTK_FILL</property>
-                            <property name="y_options"/>
+                            <property name="top-attach">1</property>
+                            <property name="bottom-attach">2</property>
+                            <property name="x-options">GTK_FILL</property>
+                            <property name="y-options"/>
                           </packing>
                         </child>
                         <child>
                           <object class="GtkLabel" id="status_file_lines">
                             <property name="visible">True</property>
-                            <property name="xalign">0</property>
+                            <property name="can-focus">False</property>
                             <property name="label" translatable="yes">label19</property>
+                            <property name="xalign">0</property>
                           </object>
                           <packing>
-                            <property name="left_attach">1</property>
-                            <property name="right_attach">2</property>
-                            <property name="top_attach">1</property>
-                            <property name="bottom_attach">2</property>
-                            <property name="x_options">GTK_FILL</property>
-                            <property name="y_options"/>
+                            <property name="left-attach">1</property>
+                            <property name="right-attach">2</property>
+                            <property name="top-attach">1</property>
+                            <property name="bottom-attach">2</property>
+                            <property name="x-options">GTK_FILL</property>
+                            <property name="y-options"/>
                           </packing>
                         </child>
                         <child>
                           <object class="GtkLabel" id="label6">
                             <property name="visible">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="label" translatable="yes">Pockets:</property>
                             <property name="xalign">1</property>
                             <property name="yalign">0</property>
-                            <property name="label" translatable="yes">Pockets:</property>
                           </object>
                           <packing>
-                            <property name="top_attach">13</property>
-                            <property name="bottom_attach">14</property>
-                            <property name="x_options">GTK_FILL</property>
-                            <property name="y_options">GTK_FILL</property>
+                            <property name="top-attach">13</property>
+                            <property name="bottom-attach">14</property>
+                            <property name="x-options">GTK_FILL</property>
+                            <property name="y-options">GTK_FILL</property>
                           </packing>
                         </child>
                         <child>
                           <object class="GtkLabel" id="status_tooltable">
                             <property name="visible">True</property>
-                            <property name="xalign">0</property>
+                            <property name="can-focus">False</property>
                             <property name="valign">start</property>
                             <property name="label" translatable="yes">&lt;b&gt;1&lt;/b&gt;
 2
 3</property>
-                            <property name="use_markup">True</property>
+                            <property name="use-markup">True</property>
                             <property name="wrap">True</property>
+                            <property name="xalign">0</property>
                           </object>
                           <packing>
-                            <property name="left_attach">1</property>
-                            <property name="right_attach">2</property>
-                            <property name="top_attach">13</property>
-                            <property name="bottom_attach">14</property>
-                            <property name="x_options">GTK_FILL</property>
-                            <property name="y_options"/>
+                            <property name="left-attach">1</property>
+                            <property name="right-attach">2</property>
+                            <property name="top-attach">13</property>
+                            <property name="bottom-attach">14</property>
+                            <property name="x-options">GTK_FILL</property>
+                            <property name="y-options"/>
                           </packing>
                         </child>
                       </object>
+                      <packing>
+                        <property name="position">4</property>
+                      </packing>
                     </child>
                     <child type="tab">
                       <object class="GtkLabel" id="status">
                         <property name="visible">True</property>
+                        <property name="can-focus">False</property>
                         <property name="xpad">10</property>
                         <property name="ypad">15</property>
                         <property name="label" translatable="yes">Status</property>
                       </object>
                       <packing>
                         <property name="position">4</property>
-                        <property name="tab_fill">False</property>
+                        <property name="tab-fill">False</property>
                       </packing>
                     </child>
                     <child>
                       <object class="GtkVBox" id="vbox10">
                         <property name="visible">True</property>
+                        <property name="can-focus">False</property>
                         <child>
                           <object class="GtkFrame" id="frame11">
                             <property name="visible">True</property>
-                            <property name="border_width">5</property>
-                            <property name="label_xalign">0</property>
+                            <property name="can-focus">False</property>
+                            <property name="border-width">5</property>
+                            <property name="label-xalign">0</property>
                             <child>
                               <object class="GtkAlignment" id="alignment14">
                                 <property name="visible">True</property>
-                                <property name="left_padding">12</property>
+                                <property name="can-focus">False</property>
+                                <property name="left-padding">12</property>
                                 <child>
                                   <object class="GtkTable" id="table3">
                                     <property name="visible">True</property>
-                                    <property name="n_rows">5</property>
-                                    <property name="n_columns">3</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="n-rows">5</property>
+                                    <property name="n-columns">3</property>
+                                    <child>
+                                      <placeholder/>
+                                    </child>
                                     <child>
                                       <object class="GtkLabel" id="controlfont">
                                         <property name="visible">True</property>
-                                        <property name="xalign">1</property>
+                                        <property name="can-focus">False</property>
                                         <property name="label" translatable="yes">Control Font:</property>
                                         <property name="justify">right</property>
+                                        <property name="xalign">1</property>
                                       </object>
                                       <packing>
-                                        <property name="x_options">GTK_FILL</property>
-                                        <property name="y_options"/>
+                                        <property name="x-options">GTK_FILL</property>
+                                        <property name="y-options"/>
                                       </packing>
                                     </child>
                                     <child>
                                       <object class="GtkLabel" id="drofont">
                                         <property name="visible">True</property>
-                                        <property name="xalign">1</property>
+                                        <property name="can-focus">False</property>
                                         <property name="label" translatable="yes">DRO Font:</property>
                                         <property name="justify">right</property>
+                                        <property name="xalign">1</property>
                                       </object>
                                       <packing>
-                                        <property name="top_attach">1</property>
-                                        <property name="bottom_attach">2</property>
-                                        <property name="x_options">GTK_FILL</property>
-                                        <property name="y_options"/>
+                                        <property name="top-attach">1</property>
+                                        <property name="bottom-attach">2</property>
+                                        <property name="x-options">GTK_FILL</property>
+                                        <property name="y-options"/>
                                       </packing>
                                     </child>
                                     <child>
                                       <object class="GtkLabel" id="errorfont">
                                         <property name="visible">True</property>
-                                        <property name="xalign">1</property>
+                                        <property name="can-focus">False</property>
                                         <property name="label" translatable="yes">Error Font:</property>
                                         <property name="justify">right</property>
+                                        <property name="xalign">1</property>
                                       </object>
                                       <packing>
-                                        <property name="top_attach">2</property>
-                                        <property name="bottom_attach">3</property>
-                                        <property name="x_options">GTK_FILL</property>
-                                        <property name="y_options"/>
+                                        <property name="top-attach">2</property>
+                                        <property name="bottom-attach">3</property>
+                                        <property name="x-options">GTK_FILL</property>
+                                        <property name="y-options"/>
                                       </packing>
                                     </child>
                                     <child>
                                       <object class="GtkFontButton" id="controlfontbutton">
                                         <property name="visible">True</property>
-                                        <property name="can_focus">True</property>
-                                        <property name="receives_default">False</property>
-                                        <property name="border_width">10</property>
-                                        <property name="focus_on_click">False</property>
+                                        <property name="can-focus">True</property>
+                                        <property name="focus-on-click">False</property>
+                                        <property name="receives-default">False</property>
+                                        <property name="border-width">10</property>
+                                        <property name="font">Sans 12</property>
                                         <property name="title" translatable="yes">ControlFont</property>
-                                        <property name="use_font">True</property>
-                                        <property name="use_size">True</property>
-                                        <signal name="font_set" handler="on_controlfontbutton_font_set"/>
+                                        <property name="use-font">True</property>
+                                        <property name="use-size">True</property>
+                                        <signal name="font-set" handler="on_controlfontbutton_font_set" swapped="no"/>
                                       </object>
                                       <packing>
-                                        <property name="left_attach">1</property>
-                                        <property name="right_attach">2</property>
-                                        <property name="x_options">GTK_FILL</property>
-                                        <property name="y_options"/>
+                                        <property name="left-attach">1</property>
+                                        <property name="right-attach">2</property>
+                                        <property name="x-options">GTK_FILL</property>
+                                        <property name="y-options"/>
                                       </packing>
                                     </child>
                                     <child>
                                       <object class="GtkFontButton" id="drofontbutton">
                                         <property name="visible">True</property>
-                                        <property name="can_focus">True</property>
-                                        <property name="receives_default">False</property>
-                                        <property name="border_width">10</property>
-                                        <property name="focus_on_click">False</property>
+                                        <property name="can-focus">True</property>
+                                        <property name="focus-on-click">False</property>
+                                        <property name="receives-default">False</property>
+                                        <property name="border-width">10</property>
+                                        <property name="font">Sans 12</property>
                                         <property name="title" translatable="yes">DRO Font</property>
-                                        <property name="use_font">True</property>
-                                        <property name="use_size">True</property>
-                                        <signal name="font_set" handler="on_drofontbutton_font_set"/>
+                                        <property name="use-font">True</property>
+                                        <property name="use-size">True</property>
+                                        <signal name="font-set" handler="on_drofontbutton_font_set" swapped="no"/>
                                       </object>
                                       <packing>
-                                        <property name="left_attach">1</property>
-                                        <property name="right_attach">2</property>
-                                        <property name="top_attach">1</property>
-                                        <property name="bottom_attach">2</property>
-                                        <property name="x_options">GTK_FILL</property>
-                                        <property name="y_options"/>
+                                        <property name="left-attach">1</property>
+                                        <property name="right-attach">2</property>
+                                        <property name="top-attach">1</property>
+                                        <property name="bottom-attach">2</property>
+                                        <property name="x-options">GTK_FILL</property>
+                                        <property name="y-options"/>
                                       </packing>
                                     </child>
                                     <child>
                                       <object class="GtkFontButton" id="errorfontbutton">
                                         <property name="visible">True</property>
-                                        <property name="can_focus">True</property>
-                                        <property name="receives_default">False</property>
-                                        <property name="border_width">10</property>
-                                        <property name="focus_on_click">False</property>
+                                        <property name="can-focus">True</property>
+                                        <property name="focus-on-click">False</property>
+                                        <property name="receives-default">False</property>
+                                        <property name="border-width">10</property>
+                                        <property name="font">Sans 12</property>
                                         <property name="title" translatable="yes">Error Font</property>
-                                        <property name="use_font">True</property>
-                                        <property name="use_size">True</property>
-                                        <signal name="font_set" handler="on_errorfontbutton_font_set"/>
+                                        <property name="use-font">True</property>
+                                        <property name="use-size">True</property>
+                                        <signal name="font-set" handler="on_errorfontbutton_font_set" swapped="no"/>
                                       </object>
                                       <packing>
-                                        <property name="left_attach">1</property>
-                                        <property name="right_attach">2</property>
-                                        <property name="top_attach">2</property>
-                                        <property name="bottom_attach">3</property>
-                                        <property name="x_options">GTK_FILL</property>
-                                        <property name="y_options"/>
+                                        <property name="left-attach">1</property>
+                                        <property name="right-attach">2</property>
+                                        <property name="top-attach">2</property>
+                                        <property name="bottom-attach">3</property>
+                                        <property name="x-options">GTK_FILL</property>
+                                        <property name="y-options"/>
                                       </packing>
                                     </child>
                                     <child>
                                       <object class="GtkLabel" id="label46">
                                         <property name="visible">True</property>
-                                        <property name="xalign">1</property>
+                                        <property name="can-focus">False</property>
                                         <property name="label" translatable="yes">Listing Font:</property>
                                         <property name="justify">right</property>
+                                        <property name="xalign">1</property>
                                       </object>
                                       <packing>
-                                        <property name="top_attach">3</property>
-                                        <property name="bottom_attach">4</property>
-                                        <property name="x_options">GTK_FILL</property>
-                                        <property name="y_options"/>
+                                        <property name="top-attach">3</property>
+                                        <property name="bottom-attach">4</property>
+                                        <property name="x-options">GTK_FILL</property>
+                                        <property name="y-options"/>
                                       </packing>
                                     </child>
                                     <child>
                                       <object class="GtkFontButton" id="listingfontbutton">
                                         <property name="visible">True</property>
-                                        <property name="can_focus">True</property>
-                                        <property name="receives_default">False</property>
-                                        <property name="border_width">10</property>
-                                        <property name="focus_on_click">False</property>
+                                        <property name="can-focus">True</property>
+                                        <property name="focus-on-click">False</property>
+                                        <property name="receives-default">False</property>
+                                        <property name="border-width">10</property>
+                                        <property name="font">Sans 12</property>
                                         <property name="title" translatable="yes">Listing Font</property>
-                                        <property name="use_font">True</property>
-                                        <property name="use_size">True</property>
-                                        <signal name="font_set" handler="on_listingfontbutton_font_set"/>
+                                        <property name="use-font">True</property>
+                                        <property name="use-size">True</property>
+                                        <signal name="font-set" handler="on_listingfontbutton_font_set" swapped="no"/>
                                       </object>
                                       <packing>
-                                        <property name="left_attach">1</property>
-                                        <property name="right_attach">2</property>
-                                        <property name="top_attach">3</property>
-                                        <property name="bottom_attach">4</property>
-                                        <property name="x_options">GTK_FILL</property>
-                                        <property name="y_options"/>
+                                        <property name="left-attach">1</property>
+                                        <property name="right-attach">2</property>
+                                        <property name="top-attach">3</property>
+                                        <property name="bottom-attach">4</property>
+                                        <property name="x-options">GTK_FILL</property>
+                                        <property name="y-options"/>
                                       </packing>
                                     </child>
                                     <child>
                                       <object class="GtkTable" id="table23">
                                         <property name="visible">True</property>
-                                        <property name="n_rows">2</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="n-rows">2</property>
                                         <child>
                                           <object class="GtkToggleButton" id="pointer_hide">
                                             <property name="label" translatable="yes">Hide pointer</property>
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
-                                            <property name="receives_default">False</property>
-                                            <property name="use_underline">True</property>
-                                            <property name="focus_on_click">False</property>
-                                            <signal name="clicked" handler="on_pointer_hide_clicked"/>
+                                            <property name="can-focus">False</property>
+                                            <property name="focus-on-click">False</property>
+                                            <property name="receives-default">False</property>
+                                            <property name="use-underline">True</property>
+                                            <signal name="clicked" handler="on_pointer_hide_clicked" swapped="no"/>
                                           </object>
                                         </child>
                                         <child>
                                           <object class="GtkToggleButton" id="pointer_show">
                                             <property name="label" translatable="yes">Show pointer</property>
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
-                                            <property name="receives_default">False</property>
-                                            <property name="use_underline">True</property>
-                                            <property name="focus_on_click">False</property>
-                                            <signal name="clicked" handler="on_pointer_show_clicked"/>
+                                            <property name="can-focus">False</property>
+                                            <property name="focus-on-click">False</property>
+                                            <property name="receives-default">False</property>
+                                            <property name="use-underline">True</property>
+                                            <signal name="clicked" handler="on_pointer_show_clicked" swapped="no"/>
                                           </object>
                                           <packing>
-                                            <property name="top_attach">1</property>
-                                            <property name="bottom_attach">2</property>
+                                            <property name="top-attach">1</property>
+                                            <property name="bottom-attach">2</property>
                                           </packing>
                                         </child>
                                       </object>
                                       <packing>
-                                        <property name="left_attach">2</property>
-                                        <property name="right_attach">3</property>
-                                        <property name="bottom_attach">4</property>
-                                        <property name="y_options">GTK_FILL</property>
-                                        <property name="x_padding">10</property>
-                                        <property name="y_padding">10</property>
+                                        <property name="left-attach">2</property>
+                                        <property name="right-attach">3</property>
+                                        <property name="bottom-attach">4</property>
+                                        <property name="y-options">GTK_FILL</property>
+                                        <property name="x-padding">10</property>
+                                        <property name="y-padding">10</property>
                                       </packing>
                                     </child>
                                     <child>
                                       <object class="GtkLabel" id="label8">
                                         <property name="visible">True</property>
-                                        <property name="xalign">1</property>
+                                        <property name="can-focus">False</property>
                                         <property name="label" translatable="yes">Theme:</property>
                                         <property name="justify">right</property>
+                                        <property name="xalign">1</property>
                                       </object>
                                       <packing>
-                                        <property name="top_attach">4</property>
-                                        <property name="bottom_attach">5</property>
-                                        <property name="x_options">GTK_FILL</property>
-                                        <property name="y_options"/>
+                                        <property name="top-attach">4</property>
+                                        <property name="bottom-attach">5</property>
+                                        <property name="x-options">GTK_FILL</property>
+                                        <property name="y-options"/>
                                       </packing>
                                     </child>
                                     <child>
                                       <object class="GtkComboBox" id="theme_choice">
                                         <property name="visible">True</property>
-                                        <property name="button_sensitivity">on</property>
-                                        <signal name="changed" handler="on_changetheme_clicked"/>
+                                        <property name="can-focus">False</property>
                                         <property name="model">model1</property>
+                                        <property name="button-sensitivity">on</property>
+                                        <signal name="changed" handler="on_changetheme_clicked" swapped="no"/>
                                         <child>
                                           <object class="GtkCellRendererText" id="renderer1"/>
                                           <attributes>
@@ -3208,17 +3502,14 @@ F1 S1</property>
                                         </child>
                                       </object>
                                       <packing>
-                                        <property name="left_attach">1</property>
-                                        <property name="right_attach">2</property>
-                                        <property name="top_attach">4</property>
-                                        <property name="bottom_attach">5</property>
-                                        <property name="x_options">GTK_FILL</property>
-                                        <property name="y_options"/>
-                                        <property name="x_padding">10</property>
+                                        <property name="left-attach">1</property>
+                                        <property name="right-attach">2</property>
+                                        <property name="top-attach">4</property>
+                                        <property name="bottom-attach">5</property>
+                                        <property name="x-options">GTK_FILL</property>
+                                        <property name="y-options"/>
+                                        <property name="x-padding">10</property>
                                       </packing>
-                                    </child>
-                                    <child>
-                                      <placeholder/>
                                     </child>
                                   </object>
                                 </child>
@@ -3227,91 +3518,98 @@ F1 S1</property>
                             <child type="label">
                               <object class="GtkLabel" id="label54">
                                 <property name="visible">True</property>
+                                <property name="can-focus">False</property>
                                 <property name="label" translatable="yes">&lt;b&gt;Display Options&lt;/b&gt;</property>
-                                <property name="use_markup">True</property>
+                                <property name="use-markup">True</property>
                               </object>
                             </child>
                           </object>
                           <packing>
+                            <property name="expand">True</property>
+                            <property name="fill">True</property>
                             <property name="position">0</property>
                           </packing>
                         </child>
                         <child>
                           <object class="GtkHBox" id="hbox11">
                             <property name="visible">True</property>
+                            <property name="can-focus">False</property>
                             <child>
                               <object class="GtkFrame" id="frame12">
                                 <property name="visible">True</property>
-                                <property name="border_width">5</property>
-                                <property name="label_xalign">0</property>
+                                <property name="can-focus">False</property>
+                                <property name="border-width">5</property>
+                                <property name="label-xalign">0</property>
                                 <child>
                                   <object class="GtkAlignment" id="alignment8">
                                     <property name="visible">True</property>
-                                    <property name="left_padding">12</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="left-padding">12</property>
                                     <child>
                                       <object class="GtkTable" id="table12">
                                         <property name="visible">True</property>
-                                        <property name="border_width">5</property>
-                                        <property name="n_rows">2</property>
-                                        <property name="n_columns">2</property>
-                                        <property name="column_spacing">15</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="border-width">5</property>
+                                        <property name="n-rows">2</property>
+                                        <property name="n-columns">2</property>
+                                        <property name="column-spacing">15</property>
                                         <property name="homogeneous">True</property>
                                         <child>
                                           <object class="GtkToggleButton" id="dro_inch">
                                             <property name="label" translatable="yes">Inch</property>
                                             <property name="visible">True</property>
-                                            <property name="can_focus">True</property>
-                                            <property name="receives_default">False</property>
-                                            <property name="use_underline">True</property>
-                                            <property name="focus_on_click">False</property>
-                                            <signal name="clicked" handler="on_dro_inch_clicked"/>
+                                            <property name="can-focus">True</property>
+                                            <property name="focus-on-click">False</property>
+                                            <property name="receives-default">False</property>
+                                            <property name="use-underline">True</property>
+                                            <signal name="clicked" handler="on_dro_inch_clicked" swapped="no"/>
                                           </object>
                                           <packing>
-                                            <property name="left_attach">1</property>
-                                            <property name="right_attach">2</property>
+                                            <property name="left-attach">1</property>
+                                            <property name="right-attach">2</property>
                                           </packing>
                                         </child>
                                         <child>
                                           <object class="GtkToggleButton" id="dro_mm">
                                             <property name="label" translatable="yes">mm</property>
                                             <property name="visible">True</property>
-                                            <property name="can_focus">True</property>
-                                            <property name="receives_default">False</property>
-                                            <property name="use_underline">True</property>
-                                            <property name="focus_on_click">False</property>
-                                            <signal name="clicked" handler="on_dro_mm_clicked"/>
+                                            <property name="can-focus">True</property>
+                                            <property name="focus-on-click">False</property>
+                                            <property name="receives-default">False</property>
+                                            <property name="use-underline">True</property>
+                                            <signal name="clicked" handler="on_dro_mm_clicked" swapped="no"/>
                                           </object>
                                           <packing>
-                                            <property name="left_attach">1</property>
-                                            <property name="right_attach">2</property>
-                                            <property name="top_attach">1</property>
-                                            <property name="bottom_attach">2</property>
+                                            <property name="left-attach">1</property>
+                                            <property name="right-attach">2</property>
+                                            <property name="top-attach">1</property>
+                                            <property name="bottom-attach">2</property>
                                           </packing>
                                         </child>
                                         <child>
                                           <object class="GtkToggleButton" id="dro_commanded">
                                             <property name="label" translatable="yes">Commanded</property>
                                             <property name="visible">True</property>
-                                            <property name="can_focus">True</property>
-                                            <property name="receives_default">False</property>
-                                            <property name="use_underline">True</property>
-                                            <property name="focus_on_click">False</property>
-                                            <signal name="clicked" handler="on_dro_commanded_clicked"/>
+                                            <property name="can-focus">True</property>
+                                            <property name="focus-on-click">False</property>
+                                            <property name="receives-default">False</property>
+                                            <property name="use-underline">True</property>
+                                            <signal name="clicked" handler="on_dro_commanded_clicked" swapped="no"/>
                                           </object>
                                         </child>
                                         <child>
                                           <object class="GtkToggleButton" id="dro_actual">
                                             <property name="label" translatable="yes">Actual</property>
                                             <property name="visible">True</property>
-                                            <property name="can_focus">True</property>
-                                            <property name="receives_default">False</property>
-                                            <property name="use_underline">True</property>
-                                            <property name="focus_on_click">False</property>
-                                            <signal name="clicked" handler="on_dro_actual_clicked"/>
+                                            <property name="can-focus">True</property>
+                                            <property name="focus-on-click">False</property>
+                                            <property name="receives-default">False</property>
+                                            <property name="use-underline">True</property>
+                                            <signal name="clicked" handler="on_dro_actual_clicked" swapped="no"/>
                                           </object>
                                           <packing>
-                                            <property name="top_attach">1</property>
-                                            <property name="bottom_attach">2</property>
+                                            <property name="top-attach">1</property>
+                                            <property name="bottom-attach">2</property>
                                           </packing>
                                         </child>
                                       </object>
@@ -3321,55 +3619,61 @@ F1 S1</property>
                                 <child type="label">
                                   <object class="GtkLabel" id="label32">
                                     <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">&lt;b&gt;Position Readout&lt;/b&gt;</property>
-                                    <property name="use_markup">True</property>
+                                    <property name="use-markup">True</property>
                                   </object>
                                 </child>
                               </object>
                               <packing>
+                                <property name="expand">True</property>
+                                <property name="fill">True</property>
                                 <property name="position">0</property>
                               </packing>
                             </child>
                             <child>
                               <object class="GtkFrame" id="frame14">
                                 <property name="visible">True</property>
-                                <property name="border_width">5</property>
-                                <property name="label_xalign">0</property>
+                                <property name="can-focus">False</property>
+                                <property name="border-width">5</property>
+                                <property name="label-xalign">0</property>
                                 <child>
                                   <object class="GtkAlignment" id="alignment15">
                                     <property name="visible">True</property>
-                                    <property name="left_padding">12</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="left-padding">12</property>
                                     <child>
                                       <object class="GtkTable" id="table1">
                                         <property name="visible">True</property>
-                                        <property name="border_width">5</property>
-                                        <property name="n_rows">2</property>
-                                        <property name="column_spacing">15</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="border-width">5</property>
+                                        <property name="n-rows">2</property>
+                                        <property name="column-spacing">15</property>
                                         <property name="homogeneous">True</property>
                                         <child>
                                           <object class="GtkToggleButton" id="toolset_workpiece">
                                             <property name="label" translatable="yes">Workpiece</property>
                                             <property name="visible">True</property>
-                                            <property name="can_focus">True</property>
-                                            <property name="receives_default">True</property>
-                                            <property name="use_underline">True</property>
-                                            <property name="focus_on_click">False</property>
-                                            <signal name="clicked" handler="on_toolset_workpiece_clicked"/>
+                                            <property name="can-focus">True</property>
+                                            <property name="focus-on-click">False</property>
+                                            <property name="receives-default">True</property>
+                                            <property name="use-underline">True</property>
+                                            <signal name="clicked" handler="on_toolset_workpiece_clicked" swapped="no"/>
                                           </object>
                                         </child>
                                         <child>
                                           <object class="GtkToggleButton" id="toolset_fixture">
                                             <property name="label" translatable="yes">Fixture</property>
                                             <property name="visible">True</property>
-                                            <property name="can_focus">True</property>
-                                            <property name="receives_default">True</property>
-                                            <property name="use_underline">True</property>
-                                            <property name="focus_on_click">False</property>
-                                            <signal name="clicked" handler="on_toolset_fixture_clicked"/>
+                                            <property name="can-focus">True</property>
+                                            <property name="focus-on-click">False</property>
+                                            <property name="receives-default">True</property>
+                                            <property name="use-underline">True</property>
+                                            <signal name="clicked" handler="on_toolset_fixture_clicked" swapped="no"/>
                                           </object>
                                           <packing>
-                                            <property name="top_attach">1</property>
-                                            <property name="bottom_attach">2</property>
+                                            <property name="top-attach">1</property>
+                                            <property name="bottom-attach">2</property>
                                           </packing>
                                         </child>
                                       </object>
@@ -3379,88 +3683,94 @@ F1 S1</property>
                                 <child type="label">
                                   <object class="GtkLabel" id="label7">
                                     <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">&lt;b&gt;Tool Setting&lt;/b&gt;</property>
-                                    <property name="use_markup">True</property>
+                                    <property name="use-markup">True</property>
                                   </object>
                                 </child>
                               </object>
                               <packing>
+                                <property name="expand">True</property>
+                                <property name="fill">True</property>
                                 <property name="position">1</property>
                               </packing>
                             </child>
                             <child>
                               <object class="GtkFrame" id="frame13">
                                 <property name="visible">True</property>
-                                <property name="border_width">5</property>
-                                <property name="label_xalign">0</property>
+                                <property name="can-focus">False</property>
+                                <property name="border-width">5</property>
+                                <property name="label-xalign">0</property>
                                 <child>
                                   <object class="GtkAlignment" id="alignment13">
                                     <property name="visible">True</property>
-                                    <property name="left_padding">12</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="left-padding">12</property>
                                     <child>
                                       <object class="GtkTable" id="table22">
                                         <property name="visible">True</property>
-                                        <property name="border_width">5</property>
-                                        <property name="n_rows">2</property>
-                                        <property name="n_columns">2</property>
-                                        <property name="column_spacing">15</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="border-width">5</property>
+                                        <property name="n-rows">2</property>
+                                        <property name="n-columns">2</property>
+                                        <property name="column-spacing">15</property>
                                         <property name="homogeneous">True</property>
                                         <child>
                                           <object class="GtkToggleButton" id="blockdel_on">
                                             <property name="label" translatable="yes">Delete / lines</property>
                                             <property name="visible">True</property>
-                                            <property name="can_focus">True</property>
-                                            <property name="receives_default">False</property>
-                                            <property name="use_underline">True</property>
-                                            <property name="focus_on_click">False</property>
-                                            <signal name="clicked" handler="on_blockdel_on_clicked"/>
+                                            <property name="can-focus">True</property>
+                                            <property name="focus-on-click">False</property>
+                                            <property name="receives-default">False</property>
+                                            <property name="use-underline">True</property>
+                                            <signal name="clicked" handler="on_blockdel_on_clicked" swapped="no"/>
                                           </object>
                                           <packing>
-                                            <property name="left_attach">1</property>
-                                            <property name="right_attach">2</property>
+                                            <property name="left-attach">1</property>
+                                            <property name="right-attach">2</property>
                                           </packing>
                                         </child>
                                         <child>
                                           <object class="GtkToggleButton" id="blockdel_off">
                                             <property name="label" translatable="yes">Keep / lines</property>
                                             <property name="visible">True</property>
-                                            <property name="can_focus">True</property>
-                                            <property name="receives_default">False</property>
-                                            <property name="use_underline">True</property>
-                                            <property name="focus_on_click">False</property>
-                                            <signal name="clicked" handler="on_blockdel_off_clicked"/>
+                                            <property name="can-focus">True</property>
+                                            <property name="focus-on-click">False</property>
+                                            <property name="receives-default">False</property>
+                                            <property name="use-underline">True</property>
+                                            <signal name="clicked" handler="on_blockdel_off_clicked" swapped="no"/>
                                           </object>
                                           <packing>
-                                            <property name="left_attach">1</property>
-                                            <property name="right_attach">2</property>
-                                            <property name="top_attach">1</property>
-                                            <property name="bottom_attach">2</property>
+                                            <property name="left-attach">1</property>
+                                            <property name="right-attach">2</property>
+                                            <property name="top-attach">1</property>
+                                            <property name="bottom-attach">2</property>
                                           </packing>
                                         </child>
                                         <child>
                                           <object class="GtkToggleButton" id="opstop_on">
                                             <property name="label" translatable="yes">Pause on M1</property>
                                             <property name="visible">True</property>
-                                            <property name="can_focus">True</property>
-                                            <property name="receives_default">False</property>
-                                            <property name="use_underline">True</property>
-                                            <property name="focus_on_click">False</property>
-                                            <signal name="clicked" handler="on_opstop_on_clicked"/>
+                                            <property name="can-focus">True</property>
+                                            <property name="focus-on-click">False</property>
+                                            <property name="receives-default">False</property>
+                                            <property name="use-underline">True</property>
+                                            <signal name="clicked" handler="on_opstop_on_clicked" swapped="no"/>
                                           </object>
                                         </child>
                                         <child>
                                           <object class="GtkToggleButton" id="opstop_off">
                                             <property name="label" translatable="yes">Ignore M1</property>
                                             <property name="visible">True</property>
-                                            <property name="can_focus">True</property>
-                                            <property name="receives_default">False</property>
-                                            <property name="use_underline">True</property>
-                                            <property name="focus_on_click">False</property>
-                                            <signal name="clicked" handler="on_opstop_off_clicked"/>
+                                            <property name="can-focus">True</property>
+                                            <property name="focus-on-click">False</property>
+                                            <property name="receives-default">False</property>
+                                            <property name="use-underline">True</property>
+                                            <signal name="clicked" handler="on_opstop_off_clicked" swapped="no"/>
                                           </object>
                                           <packing>
-                                            <property name="top_attach">1</property>
-                                            <property name="bottom_attach">2</property>
+                                            <property name="top-attach">1</property>
+                                            <property name="bottom-attach">2</property>
                                           </packing>
                                         </child>
                                       </object>
@@ -3470,72 +3780,91 @@ F1 S1</property>
                                 <child type="label">
                                   <object class="GtkLabel" id="label52">
                                     <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">&lt;b&gt;Program Options&lt;/b&gt;</property>
-                                    <property name="use_markup">True</property>
+                                    <property name="use-markup">True</property>
                                   </object>
                                 </child>
                               </object>
                               <packing>
+                                <property name="expand">True</property>
+                                <property name="fill">True</property>
                                 <property name="position">2</property>
                               </packing>
                             </child>
                           </object>
                           <packing>
+                            <property name="expand">True</property>
+                            <property name="fill">True</property>
                             <property name="position">1</property>
                           </packing>
                         </child>
                       </object>
+                      <packing>
+                        <property name="position">5</property>
+                      </packing>
                     </child>
                     <child type="tab">
                       <object class="GtkLabel" id="preferences">
                         <property name="visible">True</property>
+                        <property name="can-focus">False</property>
                         <property name="xpad">10</property>
                         <property name="ypad">15</property>
                         <property name="label" translatable="yes">Preferences</property>
                       </object>
                       <packing>
                         <property name="position">5</property>
-                        <property name="tab_fill">False</property>
+                        <property name="tab-fill">False</property>
                       </packing>
                     </child>
                   </object>
                   <packing>
+                    <property name="expand">True</property>
+                    <property name="fill">True</property>
                     <property name="position">1</property>
                   </packing>
                 </child>
               </object>
               <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
                 <property name="position">0</property>
               </packing>
             </child>
             <child>
               <object class="GtkFrame" id="wheel">
                 <property name="visible">True</property>
-                <property name="border_width">5</property>
-                <property name="label_xalign">0</property>
+                <property name="can-focus">False</property>
+                <property name="border-width">5</property>
+                <property name="label-xalign">0</property>
                 <child>
                   <object class="GtkAlignment" id="alignment3">
                     <property name="visible">True</property>
-                    <property name="left_padding">12</property>
+                    <property name="can-focus">False</property>
+                    <property name="left-padding">12</property>
                     <child>
                       <object class="GtkVBox" id="vbox4">
                         <property name="visible">True</property>
+                        <property name="can-focus">False</property>
                         <child>
                           <object class="GtkVBox" id="vbox3">
                             <property name="visible">True</property>
-                            <property name="border_width">5</property>
+                            <property name="can-focus">False</property>
+                            <property name="border-width">5</property>
                             <child>
                               <object class="GtkToggleButton" id="fo">
                                 <property name="label" translatable="yes">FO: 100%</property>
                                 <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="receives_default">False</property>
-                                <property name="use_underline">True</property>
-                                <property name="focus_on_click">False</property>
+                                <property name="can-focus">True</property>
+                                <property name="focus-on-click">False</property>
+                                <property name="receives-default">False</property>
+                                <property name="use-underline">True</property>
                                 <property name="active">True</property>
-                                <signal name="clicked" handler="on_fo_clicked"/>
+                                <signal name="clicked" handler="on_fo_clicked" swapped="no"/>
                               </object>
                               <packing>
+                                <property name="expand">True</property>
+                                <property name="fill">True</property>
                                 <property name="position">0</property>
                               </packing>
                             </child>
@@ -3543,13 +3872,15 @@ F1 S1</property>
                               <object class="GtkToggleButton" id="so">
                                 <property name="label" translatable="yes">SO: 100%</property>
                                 <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="receives_default">False</property>
-                                <property name="use_underline">True</property>
-                                <property name="focus_on_click">False</property>
-                                <signal name="clicked" handler="on_so_clicked"/>
+                                <property name="can-focus">True</property>
+                                <property name="focus-on-click">False</property>
+                                <property name="receives-default">False</property>
+                                <property name="use-underline">True</property>
+                                <signal name="clicked" handler="on_so_clicked" swapped="no"/>
                               </object>
                               <packing>
+                                <property name="expand">True</property>
+                                <property name="fill">True</property>
                                 <property name="position">1</property>
                               </packing>
                             </child>
@@ -3557,13 +3888,15 @@ F1 S1</property>
                               <object class="GtkToggleButton" id="mv">
                                 <property name="label" translatable="yes">MV: 100</property>
                                 <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="receives_default">False</property>
-                                <property name="use_underline">True</property>
-                                <property name="focus_on_click">False</property>
-                                <signal name="clicked" handler="on_mv_clicked"/>
+                                <property name="can-focus">True</property>
+                                <property name="focus-on-click">False</property>
+                                <property name="receives-default">False</property>
+                                <property name="use-underline">True</property>
+                                <signal name="clicked" handler="on_mv_clicked" swapped="no"/>
                               </object>
                               <packing>
+                                <property name="expand">True</property>
+                                <property name="fill">True</property>
                                 <property name="position">2</property>
                               </packing>
                             </child>
@@ -3571,13 +3904,15 @@ F1 S1</property>
                               <object class="GtkToggleButton" id="jogging">
                                 <property name="label" translatable="yes">Jogging</property>
                                 <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="receives_default">False</property>
-                                <property name="use_underline">True</property>
-                                <property name="focus_on_click">False</property>
-                                <signal name="clicked" handler="on_jogging_clicked"/>
+                                <property name="can-focus">True</property>
+                                <property name="focus-on-click">False</property>
+                                <property name="receives-default">False</property>
+                                <property name="use-underline">True</property>
+                                <signal name="clicked" handler="on_jogging_clicked" swapped="no"/>
                               </object>
                               <packing>
+                                <property name="expand">True</property>
+                                <property name="fill">True</property>
                                 <property name="position">3</property>
                               </packing>
                             </child>
@@ -3585,40 +3920,46 @@ F1 S1</property>
                               <object class="GtkToggleButton" id="scrolling">
                                 <property name="label" translatable="yes">Start Point</property>
                                 <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="receives_default">False</property>
-                                <property name="use_underline">True</property>
-                                <property name="focus_on_click">False</property>
-                                <signal name="clicked" handler="on_scrolling_clicked"/>
+                                <property name="can-focus">True</property>
+                                <property name="focus-on-click">False</property>
+                                <property name="receives-default">False</property>
+                                <property name="use-underline">True</property>
+                                <signal name="clicked" handler="on_scrolling_clicked" swapped="no"/>
                               </object>
                               <packing>
+                                <property name="expand">True</property>
+                                <property name="fill">True</property>
                                 <property name="position">4</property>
                               </packing>
                             </child>
                           </object>
                           <packing>
+                            <property name="expand">True</property>
+                            <property name="fill">True</property>
                             <property name="position">0</property>
                           </packing>
                         </child>
                         <child>
                           <object class="GtkHBox" id="wheel_hbox">
                             <property name="visible">True</property>
+                            <property name="can-focus">False</property>
                             <child>
                               <object class="GtkTable" id="table24">
                                 <property name="visible">True</property>
-                                <property name="border_width">5</property>
-                                <property name="n_rows">3</property>
+                                <property name="can-focus">False</property>
+                                <property name="border-width">5</property>
+                                <property name="n-rows">3</property>
                                 <child>
                                   <object class="GtkToggleButton" id="wheelinc1">
                                     <property name="label" translatable="yes">.01</property>
                                     <property name="visible">True</property>
                                     <property name="sensitive">False</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="receives_default">False</property>
-                                    <property name="use_underline">True</property>
-                                    <property name="focus_on_click">False</property>
+                                    <property name="can-focus">True</property>
+                                    <property name="focus-on-click">False</property>
+                                    <property name="receives-default">False</property>
+                                    <property name="use-underline">True</property>
                                     <property name="active">True</property>
-                                    <signal name="clicked" handler="on_wheelinc1_clicked"/>
+                                    <signal name="clicked" handler="on_wheelinc1_clicked" swapped="no"/>
                                   </object>
                                 </child>
                                 <child>
@@ -3626,15 +3967,15 @@ F1 S1</property>
                                     <property name="label" translatable="yes">.001</property>
                                     <property name="visible">True</property>
                                     <property name="sensitive">False</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="receives_default">False</property>
-                                    <property name="use_underline">True</property>
-                                    <property name="focus_on_click">False</property>
-                                    <signal name="clicked" handler="on_wheelinc2_clicked"/>
+                                    <property name="can-focus">True</property>
+                                    <property name="focus-on-click">False</property>
+                                    <property name="receives-default">False</property>
+                                    <property name="use-underline">True</property>
+                                    <signal name="clicked" handler="on_wheelinc2_clicked" swapped="no"/>
                                   </object>
                                   <packing>
-                                    <property name="top_attach">1</property>
-                                    <property name="bottom_attach">2</property>
+                                    <property name="top-attach">1</property>
+                                    <property name="bottom-attach">2</property>
                                   </packing>
                                 </child>
                                 <child>
@@ -3642,182 +3983,189 @@ F1 S1</property>
                                     <property name="label" translatable="yes">.0001</property>
                                     <property name="visible">True</property>
                                     <property name="sensitive">False</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="receives_default">False</property>
-                                    <property name="use_underline">True</property>
-                                    <property name="focus_on_click">False</property>
-                                    <signal name="clicked" handler="on_wheelinc3_clicked"/>
+                                    <property name="can-focus">True</property>
+                                    <property name="focus-on-click">False</property>
+                                    <property name="receives-default">False</property>
+                                    <property name="use-underline">True</property>
+                                    <signal name="clicked" handler="on_wheelinc3_clicked" swapped="no"/>
                                   </object>
                                   <packing>
-                                    <property name="top_attach">2</property>
-                                    <property name="bottom_attach">3</property>
+                                    <property name="top-attach">2</property>
+                                    <property name="bottom-attach">3</property>
                                   </packing>
                                 </child>
                               </object>
                               <packing>
+                                <property name="expand">True</property>
+                                <property name="fill">True</property>
                                 <property name="position">0</property>
                               </packing>
                             </child>
                             <child>
                               <object class="GtkTable" id="axis_table">
                                 <property name="visible">True</property>
-                                <property name="border_width">5</property>
-                                <property name="n_rows">3</property>
-                                <property name="n_columns">3</property>
+                                <property name="can-focus">False</property>
+                                <property name="border-width">5</property>
+                                <property name="n-rows">3</property>
+                                <property name="n-columns">3</property>
                                 <property name="homogeneous">True</property>
                                 <child>
                                   <object class="GtkToggleButton" id="wheelx">
                                     <property name="label" translatable="yes">  X  </property>
                                     <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="receives_default">False</property>
-                                    <property name="use_underline">True</property>
-                                    <property name="focus_on_click">False</property>
+                                    <property name="can-focus">True</property>
+                                    <property name="focus-on-click">False</property>
+                                    <property name="receives-default">False</property>
+                                    <property name="use-underline">True</property>
                                     <property name="active">True</property>
-                                    <signal name="clicked" handler="on_wheelx_clicked"/>
+                                    <signal name="clicked" handler="on_wheelx_clicked" swapped="no"/>
                                   </object>
                                 </child>
                                 <child>
                                   <object class="GtkToggleButton" id="wheely">
                                     <property name="label" translatable="yes">  Y  </property>
                                     <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="receives_default">False</property>
-                                    <property name="use_underline">True</property>
-                                    <property name="focus_on_click">False</property>
-                                    <signal name="clicked" handler="on_wheely_clicked"/>
+                                    <property name="can-focus">True</property>
+                                    <property name="focus-on-click">False</property>
+                                    <property name="receives-default">False</property>
+                                    <property name="use-underline">True</property>
+                                    <signal name="clicked" handler="on_wheely_clicked" swapped="no"/>
                                   </object>
                                   <packing>
-                                    <property name="top_attach">1</property>
-                                    <property name="bottom_attach">2</property>
+                                    <property name="top-attach">1</property>
+                                    <property name="bottom-attach">2</property>
                                   </packing>
                                 </child>
                                 <child>
                                   <object class="GtkToggleButton" id="wheelz">
                                     <property name="label" translatable="yes">  Z  </property>
                                     <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="receives_default">False</property>
-                                    <property name="use_underline">True</property>
-                                    <property name="focus_on_click">False</property>
-                                    <signal name="clicked" handler="on_wheelz_clicked"/>
+                                    <property name="can-focus">True</property>
+                                    <property name="focus-on-click">False</property>
+                                    <property name="receives-default">False</property>
+                                    <property name="use-underline">True</property>
+                                    <signal name="clicked" handler="on_wheelz_clicked" swapped="no"/>
                                   </object>
                                   <packing>
-                                    <property name="top_attach">2</property>
-                                    <property name="bottom_attach">3</property>
+                                    <property name="top-attach">2</property>
+                                    <property name="bottom-attach">3</property>
                                   </packing>
                                 </child>
                                 <child>
                                   <object class="GtkToggleButton" id="wheela">
                                     <property name="label" translatable="yes">  A  </property>
                                     <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="receives_default">False</property>
-                                    <property name="use_underline">True</property>
-                                    <property name="focus_on_click">False</property>
+                                    <property name="can-focus">True</property>
+                                    <property name="focus-on-click">False</property>
+                                    <property name="receives-default">False</property>
+                                    <property name="use-underline">True</property>
                                     <property name="active">True</property>
-                                    <signal name="clicked" handler="on_wheela_clicked"/>
+                                    <signal name="clicked" handler="on_wheela_clicked" swapped="no"/>
                                   </object>
                                   <packing>
-                                    <property name="left_attach">1</property>
-                                    <property name="right_attach">2</property>
+                                    <property name="left-attach">1</property>
+                                    <property name="right-attach">2</property>
                                   </packing>
                                 </child>
                                 <child>
                                   <object class="GtkToggleButton" id="wheelb">
                                     <property name="label" translatable="yes">  B  </property>
                                     <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="receives_default">False</property>
-                                    <property name="use_underline">True</property>
-                                    <property name="focus_on_click">False</property>
+                                    <property name="can-focus">True</property>
+                                    <property name="focus-on-click">False</property>
+                                    <property name="receives-default">False</property>
+                                    <property name="use-underline">True</property>
                                     <property name="active">True</property>
-                                    <signal name="clicked" handler="on_wheelb_clicked"/>
+                                    <signal name="clicked" handler="on_wheelb_clicked" swapped="no"/>
                                   </object>
                                   <packing>
-                                    <property name="left_attach">1</property>
-                                    <property name="right_attach">2</property>
-                                    <property name="top_attach">1</property>
-                                    <property name="bottom_attach">2</property>
+                                    <property name="left-attach">1</property>
+                                    <property name="right-attach">2</property>
+                                    <property name="top-attach">1</property>
+                                    <property name="bottom-attach">2</property>
                                   </packing>
                                 </child>
                                 <child>
                                   <object class="GtkToggleButton" id="wheelc">
                                     <property name="label" translatable="yes">  C  </property>
                                     <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="receives_default">False</property>
-                                    <property name="use_underline">True</property>
-                                    <property name="focus_on_click">False</property>
+                                    <property name="can-focus">True</property>
+                                    <property name="focus-on-click">False</property>
+                                    <property name="receives-default">False</property>
+                                    <property name="use-underline">True</property>
                                     <property name="active">True</property>
-                                    <signal name="clicked" handler="on_wheelc_clicked"/>
+                                    <signal name="clicked" handler="on_wheelc_clicked" swapped="no"/>
                                   </object>
                                   <packing>
-                                    <property name="left_attach">1</property>
-                                    <property name="right_attach">2</property>
-                                    <property name="top_attach">2</property>
-                                    <property name="bottom_attach">3</property>
+                                    <property name="left-attach">1</property>
+                                    <property name="right-attach">2</property>
+                                    <property name="top-attach">2</property>
+                                    <property name="bottom-attach">3</property>
                                   </packing>
                                 </child>
                                 <child>
                                   <object class="GtkToggleButton" id="wheelu">
                                     <property name="label" translatable="yes">  U  </property>
                                     <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="receives_default">False</property>
-                                    <property name="use_underline">True</property>
-                                    <property name="focus_on_click">False</property>
+                                    <property name="can-focus">True</property>
+                                    <property name="focus-on-click">False</property>
+                                    <property name="receives-default">False</property>
+                                    <property name="use-underline">True</property>
                                     <property name="active">True</property>
-                                    <signal name="clicked" handler="on_wheelu_clicked"/>
+                                    <signal name="clicked" handler="on_wheelu_clicked" swapped="no"/>
                                   </object>
                                   <packing>
-                                    <property name="left_attach">2</property>
-                                    <property name="right_attach">3</property>
+                                    <property name="left-attach">2</property>
+                                    <property name="right-attach">3</property>
                                   </packing>
                                 </child>
                                 <child>
                                   <object class="GtkToggleButton" id="wheelv">
                                     <property name="label" translatable="yes">  V  </property>
                                     <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="receives_default">False</property>
-                                    <property name="use_underline">True</property>
-                                    <property name="focus_on_click">False</property>
+                                    <property name="can-focus">True</property>
+                                    <property name="focus-on-click">False</property>
+                                    <property name="receives-default">False</property>
+                                    <property name="use-underline">True</property>
                                     <property name="active">True</property>
-                                    <signal name="clicked" handler="on_wheelv_clicked"/>
+                                    <signal name="clicked" handler="on_wheelv_clicked" swapped="no"/>
                                   </object>
                                   <packing>
-                                    <property name="left_attach">2</property>
-                                    <property name="right_attach">3</property>
-                                    <property name="top_attach">1</property>
-                                    <property name="bottom_attach">2</property>
+                                    <property name="left-attach">2</property>
+                                    <property name="right-attach">3</property>
+                                    <property name="top-attach">1</property>
+                                    <property name="bottom-attach">2</property>
                                   </packing>
                                 </child>
                                 <child>
                                   <object class="GtkToggleButton" id="wheelw">
                                     <property name="label" translatable="yes">  W  </property>
                                     <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="receives_default">False</property>
-                                    <property name="use_underline">True</property>
-                                    <property name="focus_on_click">False</property>
+                                    <property name="can-focus">True</property>
+                                    <property name="focus-on-click">False</property>
+                                    <property name="receives-default">False</property>
+                                    <property name="use-underline">True</property>
                                     <property name="active">True</property>
-                                    <signal name="clicked" handler="on_wheelw_clicked"/>
+                                    <signal name="clicked" handler="on_wheelw_clicked" swapped="no"/>
                                   </object>
                                   <packing>
-                                    <property name="left_attach">2</property>
-                                    <property name="right_attach">3</property>
-                                    <property name="top_attach">2</property>
-                                    <property name="bottom_attach">3</property>
+                                    <property name="left-attach">2</property>
+                                    <property name="right-attach">3</property>
+                                    <property name="top-attach">2</property>
+                                    <property name="bottom-attach">3</property>
                                   </packing>
                                 </child>
                               </object>
                               <packing>
+                                <property name="expand">True</property>
+                                <property name="fill">True</property>
                                 <property name="position">1</property>
                               </packing>
                             </child>
                           </object>
                           <packing>
+                            <property name="expand">True</property>
+                            <property name="fill">True</property>
                             <property name="position">1</property>
                           </packing>
                         </child>
@@ -3828,28 +4176,34 @@ F1 S1</property>
                 <child type="label">
                   <object class="GtkLabel" id="label1">
                     <property name="visible">True</property>
+                    <property name="can-focus">False</property>
                     <property name="label" translatable="yes">&lt;b&gt;Handwheel&lt;/b&gt;</property>
-                    <property name="use_markup">True</property>
+                    <property name="use-markup">True</property>
                   </object>
                 </child>
               </object>
               <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
                 <property name="position">1</property>
               </packing>
             </child>
           </object>
           <packing>
+            <property name="expand">True</property>
+            <property name="fill">True</property>
             <property name="position">0</property>
           </packing>
         </child>
         <child>
           <object class="GtkLabel" id="error">
             <property name="visible">True</property>
-            <property name="xalign">0</property>
+            <property name="can-focus">False</property>
             <property name="xpad">5</property>
+            <property name="width-chars">80</property>
             <property name="single-line-mode">True</property>
             <property name="max-width-chars">80</property>
-            <property name="width-chars">80</property>
+            <property name="xalign">0</property>
           </object>
           <packing>
             <property name="expand">False</property>
@@ -3860,7 +4214,7 @@ F1 S1</property>
       </object>
     </child>
     <child internal-child="accessible">
-      <object class="AtkObject" id="a11y-MainWindow1">
+      <object class="AtkObject" id="MainWindow-atkobject">
         <property name="AtkObject::accessible-name" translatable="yes" comments=" # Touchy is Copyright (c) 2009-2015  Chris Radek &lt;chris@timeguy.com&gt; # # Touchy is free software: you can redistribute it and/or modify # it under the terms of the GNU General Public License as published by # the Free Software Foundation, either version 2 of the License, or # (at your option) any later version. # # Touchy is distributed in the hope that it will be useful, # but WITHOUT ANY WARRANTY; without even the implied warranty of # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the # GNU General Public License for more details. ">window1</property>
       </object>
     </child>

--- a/src/emc/usr_intf/touchy/touchy.py
+++ b/src/emc/usr_intf/touchy/touchy.py
@@ -92,6 +92,18 @@ class touchy:
 
                 self.wTree = Gtk.Builder()
                 self.wTree.add_from_file(self.gladefile)
+                               
+                # CSS styling
+                screen = Gdk.Screen.get_default()
+                provider = Gtk.CssProvider()
+                style_context = Gtk.StyleContext()
+                style_context.add_provider_for_screen(screen, provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION)
+                css = b"""
+                button {
+                        padding: 0;
+                }
+                """
+                provider.load_from_data(css)
 
                 for w in ['wheelinc1', 'wheelinc2', 'wheelinc3',
                                 'wheelx', 'wheely', 'wheelz',


### PR DESCRIPTION
This converts the Touchy glade file to Gtk3
1. Automatic conversion with Glade 3,40
2. Replacement of VBox and VBox
3. Replacement of stauts GtkTable by GtkGrid (now the weird space is gone)
4. Set button padding to 0 via CSS because Gtk3 takes much more space than Gtk2

With the font setting suggested by #4131 the minimum size is 718x596:
<img width="718" height="596" alt="grafik" src="https://github.com/user-attachments/assets/d46fc378-b7e1-4b80-aedb-532a5e2ab91b" />

I think this should be merged first as basic Gtk3 conversion, then #4131 and then #4133.