### PR TITLE
[WIP] Drop the need for exporting TCLLIBPATH, use system path

### DIFF
--- a/lib/python/.gitignore
+++ b/lib/python/.gitignore
@@ -4,3 +4,4 @@ gmoccapy/
 stepconf/
 pncconf/
 pyui/
+rs274/options.py

--- a/lib/python/rs274/options.py.in
+++ b/lib/python/rs274/options.py.in
@@ -18,11 +18,13 @@
 
 import nf, os
 
-# lib/tcltk/emc2 for installed emc
-# tcl            for run-in-place emc
-for candidate in 'lib/tcltk/linuxcnc', 'tcl':
-    LINUXCNC_TCL = os.path.join(nf.PREFIX, candidate, 'linuxcnc.tcl')
-    if os.path.exists(LINUXCNC_TCL): break
+# System Tcl directory for installed emc
+# tcl                  for run-in-place emc
+rip_tcl_path = os.path.join(nf.PREFIX, 'tcl', 'linuxcnc.tcl')
+if os.path.exists(rip_tcl_path):
+    LINUXCNC_TCL = rip_tcl_path
+else:
+    LINUXCNC_TCL = os.path.join("@EMC2_TCL_DIR@", "linuxcnc.tcl")
 
 options = '''
 . configure -bg #d9d9d9

--- a/src/Makefile.inc.in
+++ b/src/Makefile.inc.in
@@ -66,7 +66,7 @@ LANGUAGES = @LANGUAGES@
 docsdir = ${prefix}/share/doc/linuxcnc
 sampleconfsdir = ${prefix}/share/doc/linuxcnc/examples/sample-configs
 ncfilesdir = ${prefix}/share/linuxcnc/ncfiles
-tcldir = ${prefix}/lib/tcltk/linuxcnc
+tcldir = @EMC2_TCL_DIR@
 
 
 # /Standard configure directories

--- a/src/configure.ac
+++ b/src/configure.ac
@@ -726,9 +726,10 @@ else
     EMC2_SCRIPT=$EMC2_BIN_DIR/linuxcnc
     EMC2_SUFFIX=""
     EMC2_ICON=linuxcncicon
-    EMC2_TCL_DIR=${prefix}/lib/tcltk/linuxcnc
-    EMC2_TCL_LIB_DIR=${prefix}/lib/tcltk/linuxcnc
-    EMC2_LANG_DIR=${prefix}/lib/tcltk/linuxcnc/msgs
+    TCL_GET_DIR=$(echo 'puts [[tcl::pkgconfig get scriptdir,runtime]]' | tclsh)
+    EMC2_TCL_DIR="${TCL_GET_DIR}/linuxcnc"
+    EMC2_TCL_LIB_DIR="${EMC2_TCL_DIR}"
+    EMC2_LANG_DIR="${EMC2_TCL_DIR}/msgs"
     EMC2_PO_DIR=${prefix}/share/locale
     EMC2_HELP_DIR=${prefix}/share/doc/linuxcnc
     case $MODULE_DIR in
@@ -1758,6 +1759,7 @@ AC_CONFIG_FILES(Makefile.inc)
 AC_CONFIG_FILES(Makefile.modinc)
 AC_CONFIG_FILES(../tcl/linuxcnc.tcl)
 AC_CONFIG_FILES(../lib/python/nf.py)
+AC_CONFIG_FILES(../lib/python/rs274/options.py)
 AC_CONFIG_FILES([../scripts/linuxcncmkdesktop], [chmod +x ../scripts/linuxcncmkdesktop])
 AC_CONFIG_FILES(../share/applications/linuxcnc-latency.desktop)
 AC_CONFIG_FILES(../share/applications/linuxcnc-latency-histogram.desktop)


### PR DESCRIPTION
Files in the debian/ folder still need to be adjusted to respect these changes. This avoids hard-coding LinuxCNC to use a path outside of the system's default Tcl search path, making it no longer required to specify TCLLIBPATH on Gentoo and Fedora. Logging in and out in order to update the environmental variables so the icons/menu entries work is also no longer needed.