### PR TITLE
radiobutton: fix unused-parameter build error

### DIFF
--- a/src/hal/components/radiobutton.comp
+++ b/src/hal/components/radiobutton.comp
@@ -16,6 +16,7 @@ pin in float input-##[32:personality] "Possible output values";
 pin out float value "currently-selected output value";
 
 function _;
+option period no;
 license "GPL 2+";
 author "Andy Pugh";
 


### PR DESCRIPTION
radiobutton.comp ignores `period`, but defaults to `option period` on, so the generated FUNCTION carried an unused `long period` and broke the RT build under `-Werror=unused-parameter`. Adding `option period no;` drops the parameter.

master currently fails `rip-and-test` / `rip-and-test-clang` because of this.

@bsathome @hansu @andypugh  please merge.