### PR TITLE
Drop the need for exporting TCLLIBPATH, use system path [v2]

### DIFF
--- a/debian/control.top.in
+++ b/debian/control.top.in
@@ -42,6 +42,7 @@ Build-Depends:
     python3-dev,
     python3-tk,
     python3-xlib,
+    tcl,
     tcl@TCLTK_VERSION@-dev,
     tclx,
     tk@TCLTK_VERSION@-dev,

--- a/debian/linuxcnc.install.in
+++ b/debian/linuxcnc.install.in
@@ -113,7 +113,7 @@ usr/bin/xyzbc-trt-gui
 usr/lib/lib*.so.*
 usr/lib/linuxcnc
 usr/lib/python3
-usr/lib/tcltk
+usr/share/tcltk
 
 usr/share/axis
 usr/share/glade

--- a/debian/rules.in
+++ b/debian/rules.in
@@ -145,8 +145,8 @@ override_dh_compress:
 override_dh_fixperms:
 	dh_fixperms -X/linuxcnc_module_helper -X/rtapi_app
 	# In case that only the indep packages are built
-	if [ -x  "$(DESTDIR)/usr/lib/tcltk/linuxcnc/linuxcnc.tcl" ]; then \
-		chmod -x $(DESTDIR)/usr/lib/tcltk/linuxcnc/linuxcnc.tcl; \
+	if [ -x  "$(DESTDIR)/usr/share/tcltk/linuxcnc/linuxcnc.tcl" ]; then \
+		chmod -x $(DESTDIR)/usr/share/tcltk/linuxcnc/linuxcnc.tcl; \
 	fi
 	# override_dh_python3: # not executed, so we attach it to fixperms
 	DEB_HOST_ARCH=`dpkg-architecture -qDEB_HOST_ARCH` dh_python3

--- a/lib/python/nf.py.in
+++ b/lib/python/nf.py.in
@@ -105,6 +105,7 @@ def find_prefix(f):
     return find_prefix(os.path.dirname(f))
 
 PREFIX = "@prefix@"
+EMC2_TCL_DIR = "@EMC2_TCL_DIR@"
 SHARE = os.path.join(PREFIX, "share", "axis")
 tcl_libdir = os.path.join(SHARE, "tcl")
 

--- a/lib/python/rs274/options.py
+++ b/lib/python/rs274/options.py
@@ -18,11 +18,10 @@
 
 import nf, os
 
-# lib/tcltk/emc2 for installed emc
-# tcl            for run-in-place emc
-for candidate in 'lib/tcltk/linuxcnc', 'tcl':
-    LINUXCNC_TCL = os.path.join(nf.PREFIX, candidate, 'linuxcnc.tcl')
-    if os.path.exists(LINUXCNC_TCL): break
+# system Tcl path for installed emc
+# tcl             for run-in-place emc
+rip = os.path.join(nf.PREFIX, 'tcl', 'linuxcnc.tcl')
+LINUXCNC_TCL = rip if os.path.exists(rip) else os.path.join(nf.EMC2_TCL_DIR, 'linuxcnc.tcl')
 
 options = '''
 . configure -bg #d9d9d9

--- a/src/Makefile.inc.in
+++ b/src/Makefile.inc.in
@@ -66,7 +66,7 @@ LANGUAGES = @LANGUAGES@
 docsdir = ${prefix}/share/doc/linuxcnc
 sampleconfsdir = ${prefix}/share/doc/linuxcnc/examples/sample-configs
 ncfilesdir = ${prefix}/share/linuxcnc/ncfiles
-tcldir = ${prefix}/lib/tcltk/linuxcnc
+tcldir = @EMC2_TCL_DIR@
 
 
 # /Standard configure directories

--- a/src/configure.ac
+++ b/src/configure.ac
@@ -690,6 +690,15 @@ AC_DEFINE_UNQUOTED([EMC2_DEFAULT_TOOLTABLE], "$DEFAULT_TOOLTABLE", [Default nml 
 # we decide based on RIP or install where stuff goes                         #
 ##############################################################################
 
+AC_ARG_WITH([tcl-dir],
+    [AS_HELP_STRING([--with-tcl-dir=DIR],
+        [directory for LinuxCNC Tcl scripts (default: auto-detected from tcl_pkgPath)])],
+    [EMC2_TCL_DIR="$withval"],
+    [TCL_GET_DIR=$(echo [['set d [lindex [lsearch -all -inline -glob $tcl_pkgPath /usr/share/*] 0]; if {$d eq ""} {set d [lindex [lsearch -all -inline -glob $tcl_pkgPath /usr/lib*] 0]}; puts $d']] | tclsh 2>/dev/null)
+     AS_IF([test -z "$TCL_GET_DIR"],
+           [AC_MSG_ERROR([could not determine Tcl package dir from tcl_pkgPath])])
+     EMC2_TCL_DIR="$TCL_GET_DIR/linuxcnc"])
+
 fe () {
     # Fully expand argument.  Example:
     # ${datadir} -> ${datarootdir} -> ${prefix}/share -> /usr/local
@@ -726,9 +735,9 @@ else
     EMC2_SCRIPT=$EMC2_BIN_DIR/linuxcnc
     EMC2_SUFFIX=""
     EMC2_ICON=linuxcncicon
-    EMC2_TCL_DIR=${prefix}/lib/tcltk/linuxcnc
-    EMC2_TCL_LIB_DIR=${prefix}/lib/tcltk/linuxcnc
-    EMC2_LANG_DIR=${prefix}/lib/tcltk/linuxcnc/msgs
+    EMC2_TCL_DIR="${TCL_GET_DIR}/linuxcnc"
+    EMC2_TCL_LIB_DIR="${EMC2_TCL_DIR}"
+    EMC2_LANG_DIR="${EMC2_TCL_DIR}/msgs"
     EMC2_PO_DIR=${prefix}/share/locale
     EMC2_HELP_DIR=${prefix}/share/doc/linuxcnc
     case $MODULE_DIR in

--- a/src/configure.ac
+++ b/src/configure.ac
@@ -735,7 +735,6 @@ else
     EMC2_SCRIPT=$EMC2_BIN_DIR/linuxcnc
     EMC2_SUFFIX=""
     EMC2_ICON=linuxcncicon
-    EMC2_TCL_DIR="${TCL_GET_DIR}/linuxcnc"
     EMC2_TCL_LIB_DIR="${EMC2_TCL_DIR}"
     EMC2_LANG_DIR="${EMC2_TCL_DIR}/msgs"
     EMC2_PO_DIR=${prefix}/share/locale


### PR DESCRIPTION
I don't know how to restore my last PR properly with the fixed tree so making a new one.

This avoids hard-coding LinuxCNC to use a path outside of the system's default Tcl search path, making it no longer required to specify TCLLIBPATH on Gentoo and Fedora. Logging in and out in order to update the environmental variables so the icons/menu entries work is also no longer needed.