### PR TITLE
scripts: report missing INI file before parse check

### DIFF
--- a/scripts/linuxcnc.in
+++ b/scripts/linuxcnc.in
@@ -406,6 +406,14 @@ function run_applications () {
     done
 }
 
+# Make sure the INI file exists before trying to parse it. Otherwise a
+# missing file would be reported as a file with errors.
+if [ ! -f "$INIFILE" ] ; then
+    echo "Could not find INI file '$INIFILE'"
+    trap '' EXIT
+    exit 1
+fi
+
 # Test whether we have a valid INI-file that can be parsed without error.
 # Running inivalue without section/variable filter should return the value of
 # the first variable in the first section of the file. If that fails, there is
@@ -422,14 +430,6 @@ export PATH=$CONFIG_DIR/bin:$PATH
 [ -z "$RUNTESTS" ] && echo "Machine configuration directory is '$INI_DIR'"
 echo "Machine configuration file is '$INI_NAME'"
 
-# make sure INI file exists (the tcl script just did this, so we could 
-# eliminate this test, but it does no harm)
-
-if [ ! -f "$INIFILE" ] ; then
-    echo "Could not find INI file '$INIFILE'"
-    trap '' EXIT
-    exit 1
-fi
 echo INIFILE="$INIFILE" >> "$PRINT_FILE"
 
 ################################################################################


### PR DESCRIPTION
I typed a wrong INI path and got "E: The INI-file contains errors that need to be fixed", which confused me; the file did not even exist.

Cause: the `inivalue` parse check runs before the file-existence check, so a missing file is reported as a broken one. This moves the existence check ahead of the parse check and drops the now-redundant later copy.

Tested in a RIP build:
- missing file: `Could not find INI file '/nothinghere.ini'`
- existing broken file: still `E: The INI-file contains errors that need to be fixed.`

@bsathome FYI, this touches the pre-run check from 1b96a45175.
