### PR TITLE
CI: don't cancel package builds across the matrix on one failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,6 +183,9 @@ jobs:
   package-arch:
     runs-on: ${{ matrix.runner }}
     strategy:
+      # don't cancel the stable-distribution builds when an unstable one
+      # (debian:sid) breaks due to archive churn
+      fail-fast: false
       matrix:
         runner: ["ubuntu-24.04", "ubuntu-24.04-arm"]
         image: ["debian:bookworm", "debian:trixie", "debian:sid"]
@@ -267,6 +270,9 @@ jobs:
   package-indep:
     runs-on: ubuntu-24.04
     strategy:
+      # don't cancel the stable-distribution builds when an unstable one
+      # (debian:sid) breaks due to archive churn
+      fail-fast: false
       matrix:
         image: ["debian:bookworm", "debian:trixie", "debian:sid"]
     container:


### PR DESCRIPTION
The package-arch and package-indep matrices use the default fail-fast behavior, so a failure in one matrix job cancels all the others.

Right now the debian:sid packaging jobs fail because sid is temporarily uninstallable (the adios2 2.11 to 2.12 transition broke the python3-opencv dependency chain, see https://bugs.debian.org/1135890). That alone is expected archive churn, but with fail-fast the bookworm and trixie package builds get cancelled too, so the whole packaging matrix turns red on every PR.

This sets fail-fast: false on both matrices so each distribution builds independently and only the genuinely broken job fails.