### PR TITLE
emccalib: ignore ini refs embedded in pin names (#4165)

### DIFF
--- a/tcl/bin/emccalib.tcl
+++ b/tcl/bin/emccalib.tcl
@@ -179,12 +179,16 @@ proc find_ini_refs {stanza} {
             if { [lindex $halcommand 1] == "\=" } {
                 set tmpstring "setp [lindex $halcommand 0] [lindex $halcommand 2]"
             }
+            # tunable item is the setp value (3rd token); ignore ini refs
+            # that only appear inside the pin name (issue #4165)
+            set valuestring [lindex $tmpstring 2]
             for {set sfx 0} {$sfx < $::EC($stanza,howmany)} {incr sfx} {
                 set tabno $::EC($stanza,$sfx,tabno)
                 set itag [lindex $::EC($stanza,suffixes) $sfx]
-                if {[string match *${stanza}${itag}* $tmpstring]} {
+                if {[string match *${stanza}${itag}* $valuestring]} {
                     # this is a hal file search ordered loop
-                    set thisininame [string trimright [lindex [split $tmpstring "\]" ] end ]]
+                    set thisininame [lindex [split $valuestring "\]" ] end ]
+                    set thisininame [string map {( "" ) ""} $thisininame]
                     set lowername "[string tolower $thisininame]"
                     set thishalcommand [lindex $tmpstring 1]
                     set tmpval [string trim [hal getp [halcmdSubstitute $thishalcommand]]]


### PR DESCRIPTION
Fixes #4165.

The calibration tool (`emccalib.tcl`) crashed with `invalid command name ".main.top.fpage2.next-(mesa_pwm_pin).dither true"` when a HAL file used ini-variable expansion inside a pin name, e.g.:

```
setp hm2_[MESA](BOARD).0.pwmgen.[JOINT_2](MESA_PWM_PIN).dither true
```

`find_ini_refs` matched the stanza anywhere on the line and derived the ini name by splitting the whole line on `]` and taking the last token. That assumes the ini reference is the setp *value* (`setp pid.0.Pgain [JOINT_0]PGAIN`). With the reference in the pin name it produced `(mesa_pwm_pin).dither true`, yielding an invalid Tk widget path that later blew up in `iniTuneButtonpress`.

Fix: only treat a line as tunable when the ini reference is the setp value (3rd token), and derive the name from that token (stripping parens for the `[SEC](NAME)` form).

Verified on @NoGare's config: pin-name refs are now ignored, while genuine tunables on the same lines (`.scale [JOINT_2]SCALE`, `[JOINT_2](ENCODER_SCALE)`) still appear; normal `setp pin [SEC]NAME` configs are unaffected.

@NoGare please test against your config and confirm.
