### PR TITLE
touchy: open at a sensible minimum window height

### DIFF
--- a/src/emc/usr_intf/touchy/touchy.py
+++ b/src/emc/usr_intf/touchy/touchy.py
@@ -851,10 +851,13 @@ class touchy:
                 # Open at the content size, capped to the screen; this avoids an
                 # off-screen window without forcing a screen-sized minimum. A
                 # user-saved geometry (window_geometry pref) takes precedence.
+                # Floor the height at 500 px: the Startup tab is the smallest
+                # and would otherwise size the window to ~270 px tall and clip
+                # all the other tabs.
                 if self.window_geometry == "default":
                     nat = child.get_preferred_size()[1]
-                    win.resize(min(nat.width, area.width),
-                               min(nat.height, area.height))
+                    target_h = min(max(nat.height, 500), area.height)
+                    win.resize(min(nat.width, area.width), target_h)
                 GLib.idle_add(self._offer_fit, child, area)
             except Exception:
                 pass


### PR DESCRIPTION
## Summary

Touchy sizes its window to the active notebook tab's preferred size on first map. The Startup tab (the default) is the smallest of the six, so the window opens around 984x274 and the other tabs (Status, Auto, Preferences) are clipped until the user resizes manually.

Floor the initial height at 500 px in `_fit_to_monitor`'s default branch so every tab is usable out of the box, capped at the work area so we never open off-screen. A 600 px touchscreen panel with a top and bottom bar still has room; on a smaller display the existing monitor cap keeps the window on-screen. The minimum size request is untouched so the user can still resize smaller.

@andypugh I need this to see touchy in a representative state in the ui-smoke confirm shots (the test runs touchy at 1024x600, the common 7" panel size). Planning to merge so I can keep building out the ui-smoke tests on top.

## Test plan

- [x] Boot touchy at 1920x1080: window opens at 984x500 (was 984x274), Status / Auto / Preferences tabs all show their content
- [x] Boot touchy at 1024x600: window opens at 984x500, fills the panel, no "Shrink to fit and save" InfoBar
- [x] Boot touchy at 800x600: window opens at 800x500, InfoBar offers shrink as before
- [x] User can still resize the window below 500 px tall after launch