### PR TITLE
qtvcp: move return out of finally in SAVE_PROGRAM

### DIFF
--- a/lib/python/qtvcp/qt_action.py
+++ b/lib/python/qtvcp/qt_action.py
@@ -394,7 +394,7 @@ class _Lcnc_Action(object):
                 outfile.close()
             except:
                 pass
-            return npath
+        return npath
 
     def SET_AXIS_ORIGIN(self, axis, value):
         if axis == '' or axis.upper() not in ("XYZABCUVW"):


### PR DESCRIPTION
`return npath` sat inside the `finally` block, which silently overrode the `except` branch's `return None`. SAVE_PROGRAM returned a valid looking path even when the write failed, swallowing the exception. Dedenting it to the method body restores the intended error semantics and clears the SyntaxWarning Python 3.14 emits for `return` in `finally`.

Fixes #4169. Same approach as #4075.