### PR TITLE
docs(build): fix English HTML stylesheet path one level too shallow

### DIFF
--- a/docs/src/Submakefile
+++ b/docs/src/Submakefile
@@ -1223,6 +1223,10 @@ endif
 # is one greater than the topic-relative slash count.
 $(DOC_SRCDIR)/%.html: LCNC_CSSREL=$(shell python3 -c "print('../' * (1 + '$*'.count('/')))")
 $(DOC_OUT_ADOC)/%.html: LCNC_CSSREL=$(shell python3 -c "print('../' * '$*'.count('/'))")
+# English renders under $(DOC_OUT_ADOC)/en with a stem that omits the en/
+# prefix (DOC_SRCS_EN paths carry no lang dir), so its slash count is one short
+# of the output depth.  Add the +1 here, matching the $(DOC_SRCDIR) rule above.
+$(DOC_OUT_ADOC)/en/%.html: LCNC_CSSREL=$(shell python3 -c "print('../' * (1 + '$*'.count('/')))")
 
 # asciidoctor HTML rule used for every language.
 #	$1 lang tag (en, de, ...)


### PR DESCRIPTION
English doc pages were rendering unstyled: they linked `en/asciidoctor.css` (which does not exist) instead of the stylesheet at the html root.

Cause: since c774b793f9 English renders from `build/adoc/en` with a build-rule stem that omits the `en/` prefix, so the `$(DOC_OUT_ADOC)/%.html` cssrel rule counts one directory too few and emits `../` instead of `../../`. Translated languages were unaffected (their stem includes the lang dir), and man pages use their own rule.

Fix: add an `$(DOC_OUT_ADOC)/en/%.html` cssrel rule with the `+1`, matching the `$(DOC_SRCDIR)` path that carried it before.

Verified on a clean full build (all 8 languages): every English page's stylesheet depth now matches its directory depth (1174 en+de pages checked, 0 mismatches), man pages and index pages unchanged, checkref clean, and a second build is a no-op with a clean repo.