### PR TITLE
docs: fix sidebar scaffold on section-less pages

### DIFF
--- a/docs/src/lang_switcher_postprocess.py
+++ b/docs/src/lang_switcher_postprocess.py
@@ -397,9 +397,11 @@ def _scaffold_sidebar(content, nav):
     """Section-less pages have no toc2 container; add the body classes and
     insert the sidebar div after the page <h1>."""
     def body_cls(m):
-        cls = m.group(1)
-        return m.group(0) if 'toc2' in cls else f'<body class="{cls} toc2 toc-left"'
-    content = re.sub(r'<body class="([^"]*)"', body_cls, content, count=1)
+        attrs, cls = m.group(1), m.group(2)
+        if 'toc2' in cls:
+            return m.group(0)
+        return f'<body{attrs} class="{cls} toc2 toc-left"'
+    content = re.sub(r'<body\b([^>]*?) class="([^"]*)"', body_cls, content, count=1)
     div = f'<div id="toc" class="toc2">{nav}</div>\n'
     return re.sub(r'(<div id="header">.*?</h1>\s*)',
                   lambda m: m.group(1) + div, content, count=1, flags=re.DOTALL)


### PR DESCRIPTION
## Problem

The example pages `examples/pci-parallel-port.html` and `examples/mpg.html` render without the left sidebar margin (page content overlaps the navigation tree).

## Cause

These pages have no `==` sections, so asciidoctor emits no left-TOC and no `toc2 toc-left` body classes. `lang_switcher_postprocess.py` scaffolds the sidebar for such pages, but its body-class rewrite used the regex `<body class="...">`, which requires `class` immediately after `<body `. Pages with a title anchor (`[[cha:pci-parallel-port]]`) emit `<body id="cha:pci-parallel-port" class="book">`, so the regex never matched and `toc2 toc-left` was never added. The sidebar `div` still got inserted (it keys off the `<h1>`), so the nav showed but `padding-left:320px` was never applied, leaving the overlap.

Section-ful pages get `toc2 toc-left` straight from asciidoctor, which masked the bug.

## Fix

Match optional attributes before `class` in the body tag.

## Verification

Built `make htmldocs` locally and rendered both pages: body is now `book toc2 toc-left`, `padding-left` is 320px, content clears the sidebar.
