### PR TITLE
build: Don't use 0 as NULL/nullptr in pointer compare and assignment

### DIFF
--- a/src/configure.ac
+++ b/src/configure.ac
@@ -1728,6 +1728,19 @@ add_to_cflags() {
 # Always add -Wextra
 add_to_cflags "-Wextra"
 
+# Add option to enable warnings when integer 0 is used to act
+# as NULL or nullptr in assignment or comparison.
+AC_ARG_ENABLE(wzero-as-null-pointer-constant,
+    AS_HELP_STRING(
+      [--enable-wzero-as-null-pointer-constant],
+      [Warn on zero being used as NULL pointer constant (-Wzero-as-null-pointer-constant).],
+    ),
+    [
+      case "$enableval" in
+        (yes) add_to_cflags "-Wzero-as-null-pointer-constant" ;;
+      esac
+    ])
+
 # The last thing before subst-exporting CFLAGS and CXXFLAGS is to add -Werror
 # if requested. Doing it earlier causes conf-tests to fail that are supposed to
 # succeed when they generate warnings.

--- a/src/emc/canterp/canterp.cc
+++ b/src/emc/canterp/canterp.cc
@@ -67,7 +67,7 @@ static char the_command_args[LINELEN] = { 0 };	// just the args part
 
 class Canterp : public InterpBase {
 public:
-    Canterp () : f(0), filename{} {}
+    Canterp () : f(NULL), filename{} {}
     char *error_text(int errcode, char *buf, size_t buflen) override;
     char *stack_name(int index, char *buf, size_t buflen) override;
     char *line_text(char *buf, size_t buflen) override;
@@ -209,7 +209,7 @@ static int canterp_parse(char *buffer)
        now we're at the args; skip first and last quotes when building
        args_ptr, and make commas spaces for easy parsing later
      */
-    last_quote_ptr = 0;
+    last_quote_ptr = NULL;
     inquote = 0;
     while (')' != *ptr && 0 != *ptr) {
 	if ('"' == *ptr) {
@@ -235,7 +235,7 @@ static int canterp_parse(char *buffer)
 	*cmd_ptr = 0;
 	return INTERP_ERROR;
     }
-    if (0 != last_quote_ptr)
+    if (NULL != last_quote_ptr)
 	*last_quote_ptr = 0;
     *args_ptr = 0;
     *cmd_ptr++ = ')';
@@ -692,7 +692,7 @@ int Canterp::execute(const char *line, int /*line_number*/) {
 }
 
 int Canterp::execute() {
-    return execute(0);
+    return execute(NULL);
 }
 
 int Canterp::open(const char *newfilename) {

--- a/src/emc/ini/inifile.cc
+++ b/src/emc/ini/inifile.cc
@@ -1106,9 +1106,9 @@ std::optional<rtapi_s64> IniFile::convertSInt(const std::string &_val)
 	char *eptr;
 
 	// Make sure we always use the C locale for conversion (thread local)
-	locale_t olc = uselocale(static_cast<locale_t>(0));
-	locale_t nlc = newlocale(LC_NUMERIC_MASK, "C", static_cast<locale_t>(0));
-	if(static_cast<locale_t>(0) == nlc) {
+	locale_t olc = uselocale(static_cast<locale_t>(nullptr));
+	locale_t nlc = newlocale(LC_NUMERIC_MASK, "C", static_cast<locale_t>(nullptr));
+	if(static_cast<locale_t>(nullptr) == nlc) {
 		print_msg("internal error: ConvertSInt(): Cannot set locale to \"C\" for strtoll");
 		return std::nullopt;
 	}
@@ -1135,9 +1135,9 @@ std::optional<rtapi_s64> IniFile::convertSInt(const IniFileTag *val) const
 	char *eptr;
 
 	// Make sure we always use the C locale for conversion (thread local)
-	locale_t olc = uselocale(static_cast<locale_t>(0));
-	locale_t nlc = newlocale(LC_NUMERIC_MASK, "C", static_cast<locale_t>(0));
-	if(static_cast<locale_t>(0) == nlc) {
+	locale_t olc = uselocale(static_cast<locale_t>(nullptr));
+	locale_t nlc = newlocale(LC_NUMERIC_MASK, "C", static_cast<locale_t>(nullptr));
+	if(static_cast<locale_t>(nullptr) == nlc) {
 		print_msg(fmt::format("{}:{}: internal error: Cannot set locale to \"C\" for strtoll", val->path, val->lineno));
 		return std::nullopt;
 	}
@@ -1171,9 +1171,9 @@ std::optional<rtapi_u64> IniFile::convertUInt(const std::string &_val)
 	}
 
 	// Make sure we always use the C locale for conversion (thread local)
-	locale_t olc = uselocale(static_cast<locale_t>(0));
-	locale_t nlc = newlocale(LC_NUMERIC_MASK, "C", static_cast<locale_t>(0));
-	if(static_cast<locale_t>(0) == nlc) {
+	locale_t olc = uselocale(static_cast<locale_t>(nullptr));
+	locale_t nlc = newlocale(LC_NUMERIC_MASK, "C", static_cast<locale_t>(nullptr));
+	if(static_cast<locale_t>(nullptr) == nlc) {
 		print_msg("internal error: ConvertUInt(): Cannot set locale to \"C\" for strtoull");
 		return std::nullopt;
 	}
@@ -1205,9 +1205,9 @@ std::optional<rtapi_u64> IniFile::convertUInt(const IniFileTag *val) const
 	}
 
 	// Make sure we always use the C locale for conversion (thread local)
-	locale_t olc = uselocale(static_cast<locale_t>(0));
-	locale_t nlc = newlocale(LC_NUMERIC_MASK, "C", static_cast<locale_t>(0));
-	if(static_cast<locale_t>(0) == nlc) {
+	locale_t olc = uselocale(static_cast<locale_t>(nullptr));
+	locale_t nlc = newlocale(LC_NUMERIC_MASK, "C", static_cast<locale_t>(nullptr));
+	if(static_cast<locale_t>(nullptr) == nlc) {
 		print_msg(fmt::format("{}:{}: internal error: Cannot set locale to \"C\" for strtoull", val->path, val->lineno));
 		return std::nullopt;
 	}
@@ -1235,9 +1235,9 @@ std::optional<double> IniFile::convertReal(const std::string &val)
 	char *eptr;
 
 	// Make sure we always use the C locale for conversion (thread local)
-	locale_t olc = uselocale(static_cast<locale_t>(0));
-	locale_t nlc = newlocale(LC_NUMERIC_MASK, "C", static_cast<locale_t>(0));
-	if(static_cast<locale_t>(0) == nlc) {
+	locale_t olc = uselocale(static_cast<locale_t>(nullptr));
+	locale_t nlc = newlocale(LC_NUMERIC_MASK, "C", static_cast<locale_t>(nullptr));
+	if(static_cast<locale_t>(nullptr) == nlc) {
 		print_msg("internal error: ConvertReal(): Cannot set locale to \"C\" for strtod");
 		return std::nullopt;
 	}
@@ -1262,9 +1262,9 @@ std::optional<double> IniFile::convertReal(const IniFileTag *val) const
 	char *eptr;
 
 	// Make sure we always use the C locale for conversion (thread local)
-	locale_t olc = uselocale(static_cast<locale_t>(0));
-	locale_t nlc = newlocale(LC_NUMERIC_MASK, "C", static_cast<locale_t>(0));
-	if(static_cast<locale_t>(0) == nlc) {
+	locale_t olc = uselocale(static_cast<locale_t>(nullptr));
+	locale_t nlc = newlocale(LC_NUMERIC_MASK, "C", static_cast<locale_t>(nullptr));
+	if(static_cast<locale_t>(nullptr) == nlc) {
 		print_msg(fmt::format("{}:{}: internal error: Cannot set locale to \"C\" for strtod", val->path, val->lineno));
 		return std::nullopt;
 	}

--- a/src/emc/ini/inihal.cc
+++ b/src/emc/ini/inihal.cc
@@ -144,7 +144,7 @@ int ini_hal_init(int numjoints)
     }
 
     the_inihal_data = (ptr_inihal_data *) hal_malloc(sizeof(ptr_inihal_data));
-    if (the_inihal_data == 0) {
+    if (the_inihal_data == NULL) {
         rtapi_print_msg(RTAPI_MSG_ERR,
                        "ini_hal_init: ERROR: hal_malloc() failed\n");
         hal_exit(comp_id);

--- a/src/emc/kinematics/genserfuncs.c
+++ b/src/emc/kinematics/genserfuncs.c
@@ -62,7 +62,7 @@ static struct haldata {
     genser_struct *kins;
     go_pose *pos; // used in various functions, we malloc it
                   // only once in genserKinematicsSetup()
-} *haldata = 0;
+} *haldata = NULL;
 
 static int total_joints;
 double j[GENSER_MAX_JOINTS];

--- a/src/emc/kinematics/lineardeltakins.cc
+++ b/src/emc/kinematics/lineardeltakins.cc
@@ -46,6 +46,8 @@ static object get_geometry()
     return make_tuple(R, L);
 }
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wzero-as-null-pointer-constant"
 BOOST_PYTHON_MODULE(lineardeltakins)
 {
     set_geometry(DELTA_RADIUS, DELTA_DIAGONAL_ROD);
@@ -54,3 +56,4 @@ BOOST_PYTHON_MODULE(lineardeltakins)
     def("forward", forward);
     def("inverse", inverse);
 }
+#pragma GCC diagnostic pop

--- a/src/emc/kinematics/rotarydeltakins.cc
+++ b/src/emc/kinematics/rotarydeltakins.cc
@@ -45,6 +45,8 @@ static object get_geometry()
     return make_tuple(platformradius, thighlength, shinlength, footradius);
 }
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wzero-as-null-pointer-constant"
 BOOST_PYTHON_MODULE(rotarydeltakins)
 {
     set_geometry(RDELTA_PFR, RDELTA_TL, RDELTA_SL, RDELTA_FR);
@@ -53,3 +55,4 @@ BOOST_PYTHON_MODULE(rotarydeltakins)
     def("forward", forward);
     def("inverse", inverse);
 }
+#pragma GCC diagnostic pop

--- a/src/emc/motion-logger/motion-logger.c
+++ b/src/emc/motion-logger/motion-logger.c
@@ -44,13 +44,13 @@ static struct motion_logger_data_t {
 FILE *logfile = NULL;
 char *logfile_name = NULL;
 
-emcmot_struct_t *emcmotStruct = 0;
+emcmot_struct_t *emcmotStruct = NULL;
 
-struct emcmot_command_t *c = 0;
-struct emcmot_status_t *emcmotStatus = 0;
-struct emcmot_config_t *emcmotConfig = 0;
-struct emcmot_internal_t *emcmotInternal = 0;
-struct emcmot_error_t *emcmotError = 0;
+struct emcmot_command_t *c = NULL;
+struct emcmot_status_t *emcmotStatus = NULL;
+struct emcmot_config_t *emcmotConfig = NULL;
+struct emcmot_internal_t *emcmotInternal = NULL;
+struct emcmot_error_t *emcmotError = NULL;
 
 static int mot_comp_id;
 
@@ -85,11 +85,11 @@ static int init_comm_buffers(void) {
     rtapi_print_msg(RTAPI_MSG_INFO,
 	"MOTION: init_comm_buffers() starting...\n");
 
-    emcmotStruct = 0;
-    emcmotInternal = 0;
-    emcmotStatus = 0;
-    c = 0;
-    emcmotConfig = 0;
+    emcmotStruct = NULL;
+    emcmotInternal = NULL;
+    emcmotStatus = NULL;
+    c = NULL;
+    emcmotConfig = NULL;
 
     /* allocate and initialize the shared memory structure */
     shmem_id = rtapi_shmem_new(DEFAULT_SHMEM_KEY, mot_comp_id, sizeof(emcmot_struct_t));

--- a/src/emc/motion/dbuf.c
+++ b/src/emc/motion/dbuf.c
@@ -187,7 +187,7 @@ int dbuf_get_string(dbuf_iter *di, const char **s) {
     // NUL, but let's be safe and not return a string if there's no terminated
     // string in the dbuf
     if(ch != 0) {
-        *s = 0;
+        *s = NULL;
         return -EAGAIN;
     }
 

--- a/src/emc/motion/emcmotutil.c
+++ b/src/emc/motion/emcmotutil.c
@@ -35,7 +35,7 @@
 
 int emcmotErrorInit(emcmot_error_t * errlog)
 {
-    if (errlog == 0) {
+    if (errlog == NULL) {
 	return -1;
     }
 
@@ -53,7 +53,7 @@ int emcmotErrorPutfv(emcmot_error_t * errlog, const char *fmt, va_list ap)
     struct dbuf_iter it;
     unsigned long long my_seq;
 
-    if (errlog == 0) {
+    if (errlog == NULL) {
 	return -1;
     }
 
@@ -108,7 +108,7 @@ int emcmotErrorGet(emcmot_error_t * errlog, char *error)
     unsigned long long w_res;
     unsigned long long w_com;
 
-    if (errlog == 0) {
+    if (errlog == NULL) {
 	return -1;
     }
 

--- a/src/emc/motion/usrmotintf.cc
+++ b/src/emc/motion/usrmotintf.cc
@@ -40,12 +40,12 @@ using namespace linuxcnc;
 
 static int inited = 0;		/* flag if inited */
 
-static emcmot_command_t *emcmotCommand = 0;
-static emcmot_status_t *emcmotStatus = 0;
-static emcmot_config_t *emcmotConfig = 0;
-static emcmot_internal_t *emcmotInternal = 0;
-static emcmot_error_t *emcmotError = 0;
-static emcmot_struct_t *emcmotStruct = 0;
+static emcmot_command_t *emcmotCommand = NULL;
+static emcmot_status_t *emcmotStatus = NULL;
+static emcmot_config_t *emcmotConfig = NULL;
+static emcmot_internal_t *emcmotInternal = NULL;
+static emcmot_error_t *emcmotError = NULL;
+static emcmot_struct_t *emcmotStruct = NULL;
 
 /* usrmotIniLoad() loads params (SHMEM_KEY, COMM_TIMEOUT)
    from named INI file */
@@ -89,7 +89,7 @@ int usrmotWriteEmcmotCommand(emcmot_command_t * c)
     c->commandNum = ++commandNum;
 
     /* check for mapped mem still around */
-    if (0 == emcmotCommand) {
+    if (NULL == emcmotCommand) {
         rcs_print("USRMOT: ERROR: can't connect to shared memory\n");
 	return EMCMOT_COMM_ERROR_CONNECT;
     }
@@ -126,7 +126,7 @@ int usrmotReadEmcmotStatus(emcmot_status_t * s)
     int split_read_count;
 
     /* check for shmem still around */
-    if (0 == emcmotStatus) {
+    if (NULL == emcmotStatus) {
 	return EMCMOT_COMM_ERROR_CONNECT;
     }
     split_read_count = 0;
@@ -152,7 +152,7 @@ int usrmotReadEmcmotConfig(emcmot_config_t * s)
     int split_read_count;
 
     /* check for shmem still around */
-    if (0 == emcmotConfig) {
+    if (NULL == emcmotConfig) {
 	return EMCMOT_COMM_ERROR_CONNECT;
     }
     split_read_count = 0;
@@ -177,7 +177,7 @@ int usrmotReadEmcmotInternal(emcmot_internal_t * s)
     int split_read_count;
 
     /* check for shmem still around */
-    if (0 == emcmotInternal) {
+    if (NULL == emcmotInternal) {
 	return EMCMOT_COMM_ERROR_CONNECT;
     }
     split_read_count = 0;
@@ -200,7 +200,7 @@ int usrmotReadEmcmotInternal(emcmot_internal_t * s)
 int usrmotReadEmcmotError(char *e)
 {
     /* check to see if ptr still around */
-    if (emcmotError == 0) {
+    if (emcmotError == NULL) {
 	return -1;
     }
 
@@ -609,10 +609,10 @@ int usrmotExit(void)
 	rtapi_exit(module_id);
     }
 
-    emcmotStruct = 0;
-    emcmotCommand = 0;
-    emcmotStatus = 0;
-    emcmotError = 0;
+    emcmotStruct = NULL;
+    emcmotCommand = NULL;
+    emcmotStatus = NULL;
+    emcmotError = NULL;
 /*! \todo Another #if 0 */
 #if 0
 /*! \todo FIXME - comp structs no longer in shmem */

--- a/src/emc/pythonplugin/python_plugin.cc
+++ b/src/emc/pythonplugin/python_plugin.cc
@@ -291,8 +291,8 @@ PythonPlugin::PythonPlugin(struct _inittab *inittab) :
     status(0),
     module_mtime(0),
     reload_on_change(0),
-    toplevel(0),
-    abs_path(0),
+    toplevel(NULL),
+    abs_path(NULL),
     log_level(0)
 {
   PyConfig config;

--- a/src/emc/rs274ngc/canonmodule.cc
+++ b/src/emc/rs274ngc/canonmodule.cc
@@ -36,6 +36,8 @@ static void wrap_canon_error(const char *s)
 }
 
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wzero-as-null-pointer-constant"
 BOOST_PYTHON_MODULE(emccanon) {
     using namespace boost::python;
     scope().attr("__doc__") =
@@ -269,3 +271,4 @@ BOOST_PYTHON_MODULE(emccanon) {
     def("GET_EXTERNAL_OFFSETS",&GET_EXTERNAL_OFFSETS);
 
 }
+#pragma GCC diagnostic pop

--- a/src/emc/rs274ngc/gcodemodule.cc
+++ b/src/emc/rs274ngc/gcodemodule.cc
@@ -120,6 +120,8 @@ static PyMemberDef LineCodeMembers[] = {
     {}
 };
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wzero-as-null-pointer-constant"
 static PyTypeObject LineCodeType = {
     PyVarObject_HEAD_INIT(NULL, 0)
     "gcode.linecode",       /*tp_name*/
@@ -180,6 +182,7 @@ static PyTypeObject LineCodeType = {
 #endif
 #endif
 };
+#pragma GCC diagnostic pop
 
 static PyObject *callback;
 static int interp_error;
@@ -854,8 +857,8 @@ void SET_NAIVECAM_TOLERANCE(double /*tolerance*/) { }
 #define RESULT_OK (result == INTERP_OK || result == INTERP_EXECUTE_FINISH)
 static PyObject *parse_file(PyObject * /*self*/, PyObject *args) {
     char *f;
-    char *unitcode=0, *initcode=0, *interpname=0;
-    PyObject *initcodes=0;
+    char *unitcode=NULL, *initcode=NULL, *interpname=NULL;
+    PyObject *initcodes=NULL;
     int error_line_offset = 0;
     struct timeval t0, t1;
     int wait = 1;
@@ -872,7 +875,7 @@ static PyObject *parse_file(PyObject * /*self*/, PyObject *args) {
 
     if(pinterp) {
         delete pinterp;
-        pinterp = 0;
+        pinterp = NULL;
     }
     if(interpname && *interpname)
         pinterp = interp_from_shlib(interpname);

--- a/src/emc/rs274ngc/interp_array.cc
+++ b/src/emc/rs274ngc/interp_array.cc
@@ -259,26 +259,26 @@ const int Interp::n_readonly_parameters = sizeof(readonly_parameters) / sizeof(i
    */
 const read_function_pointer Interp::default_readers[256] = {
 /* 00 */
-0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL,
 /* 10 */
-0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL,
 /* 20 */
-0, 0, 0,
+NULL, NULL, NULL,
 &Interp::read_parameter_setting, // reads # or ASCII 0x23
 &Interp::read_dollar,   // reads $ or ASCII 0x24
-0, 0, 0,
+NULL, NULL, NULL,
 &Interp::read_comment, // reads ( or ASCII 0x28
-0, 0, 0, 0, 0, 0, 0, 
+NULL, NULL, NULL, NULL, NULL, NULL, NULL,
 /* 30 */
-0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL,
 &Interp::read_semicolon, 
-0, 0, 0, 0,
+NULL, NULL, NULL, NULL,
 /* 40 */
-&Interp::read_atsign, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+&Interp::read_atsign, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL,
 /* 50 */
-0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, &Interp::read_carat, 0,
+NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, &Interp::read_carat, NULL,
 /* 60 */
-0,
+NULL,
 &Interp::read_a, // reads a or ASCII 0x61
 &Interp::read_b, // reads b or ASCII 0x62
 &Interp::read_c, // reads c or ASCII 0x63
@@ -292,7 +292,7 @@ const read_function_pointer Interp::default_readers[256] = {
 &Interp::read_k, // reads k or ASCII 0x6B
 &Interp::read_l, // reads l or ASCII 0x6C
 &Interp::read_m, // reads m or ASCII 0x6D
-0, 0,
+NULL, NULL,
 &Interp::read_p, // reads p or ASCII 0x70
 &Interp::read_q, // reads q or ASCII 0x71
 &Interp::read_r, // reads r or ASCII 0x72

--- a/src/emc/rs274ngc/interp_base.cc
+++ b/src/emc/rs274ngc/interp_base.cc
@@ -43,7 +43,7 @@ InterpBase *interp_from_shlib(const char *shlib) {
     interp_lib = dlopen(interp_path, RTLD_NOW);
     if(!interp_lib) {
         fprintf(stderr, "emcTaskInit: could not open interpreter '%s': %s\n", interp_path, dlerror());
-        return 0;
+        return NULL;
     }
     fprintf(stderr, "emcTaskInit: using custom interpreter '%s'\n", interp_path);
 
@@ -51,12 +51,12 @@ InterpBase *interp_from_shlib(const char *shlib) {
     Constructor constructor = (Constructor)dlsym(interp_lib, "makeInterp");
     if(!constructor) {
 	fprintf(stderr, "emcTaskInit: could not get symbol makeInterp from interpreter '%s': %s\n", shlib, dlerror());
-	return 0;
+	return NULL;
     }
     InterpBase *pinterp = constructor();
     if(!pinterp) {
 	fprintf(stderr, "emcTaskInit: makeInterp() returned NULL from interpreter '%s'\n", shlib);
-	return 0;
+	return NULL;
     }
     return pinterp;
 }

--- a/src/emc/rs274ngc/interp_convert.cc
+++ b/src/emc/rs274ngc/interp_convert.cc
@@ -4237,7 +4237,7 @@ if (is_user_defined_m_code(block, settings, 10) && ONCE_M(10)) {
  } else if ((block->m_modes[10] != -1)  && ONCE_M(10)){
      /* user-defined M codes */
     int index = block->m_modes[10];
-    if (USER_DEFINED_FUNCTION[index - 100] == 0) {
+    if (USER_DEFINED_FUNCTION[index - 100] == NULL) {
       CHKS(1, NCE_UNKNOWN_M_CODE_USED,index);
     }
     enqueue_M_USER_COMMAND(index,block->p_number,block->q_number);

--- a/src/emc/rs274ngc/interp_g7x.cc
+++ b/src/emc/rs274ngc/interp_g7x.cc
@@ -1056,7 +1056,7 @@ int Interp::convert_g7x(int /*mode*/,
     auto exit_call_level=settings->call_level;
     CHP(read((std::string("O")+std::to_string(static_cast<int>(block->q_number))+" CALL").c_str()));
     for(;;) {
-	if(block->o_name!=0)
+	if(block->o_name!=NULL)
 	    CHP(convert_control_functions(block, settings));
 	if(settings->call_level==exit_call_level)
 	    break;

--- a/src/emc/rs274ngc/interp_internal.cc
+++ b/src/emc/rs274ngc/interp_internal.cc
@@ -310,7 +310,7 @@ int Interp::init_block(block_pointer block)      //!< pointer to a block to be i
   block->radius_flag = false;
 
   block->o_type = O_none;
-  block->o_name = 0;
+  block->o_name = NULL;
   block->call_type = -1;
 
   return INTERP_OK;
@@ -345,7 +345,7 @@ int Interp::parse_line(char *line,       //!< array holding a line of RS274 code
   CHP(init_block(block));
   CHP(read_items(block, line, settings->parameters));
 
-  if(settings->skipping_o == 0)
+  if(settings->skipping_o == NULL)
   {
     CHP(enhance_block(block, settings));
     CHP(check_items(block, settings));

--- a/src/emc/rs274ngc/interp_o_word.cc
+++ b/src/emc/rs274ngc/interp_o_word.cc
@@ -488,7 +488,7 @@ int Interp::execute_return(setup_pointer settings, context_pointer current_frame
 	    }
 
 
-	    settings->sub_name = 0;
+	    settings->sub_name = NULL;
 	    if (previous_frame->subName)  {
 		settings->sub_name = previous_frame->subName;
 	    } else {

--- a/src/emc/rs274ngc/interp_read.cc
+++ b/src/emc/rs274ngc/interp_read.cc
@@ -1206,7 +1206,7 @@ int Interp::read_one_item(
   CHKS(((letter < ' ') || (letter > 'z')),
 	_("Bad character '\\%03o' used"), (unsigned char)letter);
   function_pointer = _readers[(int) letter]; /* Find the function pointer in the array */
-  CHKS((function_pointer == 0),
+  CHKS((function_pointer == NULL),
 	(!isprint(letter) || isspace(letter)) ?
 	    _("Bad character '\\%03o' used") : _("Bad character '%c' used"), letter);
   CHP((*this.*function_pointer)(line, counter, block, parameters)); /* Call the function */ 
@@ -1733,7 +1733,7 @@ int Interp::read_o(    /* ARGUMENTS                                     */
   else if ((block->o_type == O_endsub) || (block->o_type == O_return) ||
 	   (block->o_type == M_99))
     {
-	if ((_setup.skipping_o != 0) &&
+	if ((_setup.skipping_o != NULL) &&
 	    (0 != strcmp(_setup.skipping_o, block->o_name))) {
 	    return INTERP_OK;
 	}
@@ -1761,7 +1761,7 @@ int Interp::read_o(    /* ARGUMENTS                                     */
     {
       // we need to NOT evaluate parameters if skipping
       // skipping never ends on a "call"
-      if(_setup.skipping_o != 0)
+      if(_setup.skipping_o != NULL)
       {
           block->o_type = O_none;
           return INTERP_OK;
@@ -1809,7 +1809,7 @@ int Interp::read_o(    /* ARGUMENTS                                     */
   else if(block->o_type == O_while)
     {
       // TESTME !!!KL -- should not eval expressions if skipping ???
-      if((_setup.skipping_o != 0) &&
+      if((_setup.skipping_o != NULL) &&
 	 (0 != strcmp(_setup.skipping_o, block->o_name)))
       {
 	    return INTERP_OK;
@@ -1824,7 +1824,7 @@ int Interp::read_o(    /* ARGUMENTS                                     */
   else if(block->o_type == O_repeat)
       {
           // TESTME !!!KL -- should not eval expressions if skipping ???
-          if((_setup.skipping_o != 0) &&
+          if((_setup.skipping_o != NULL) &&
 	     (0 != strcmp(_setup.skipping_o, block->o_name)))
           {
 	    return INTERP_OK;
@@ -1839,7 +1839,7 @@ int Interp::read_o(    /* ARGUMENTS                                     */
   else if(block->o_type == O_if)
     {
       // TESTME !!!KL -- should not eval expressions if skipping ???
-      if((_setup.skipping_o != 0) &&
+      if((_setup.skipping_o != NULL) &&
 	 (0 != strcmp(_setup.skipping_o, block->o_name)))
       {
 	    return INTERP_OK;
@@ -1854,7 +1854,7 @@ int Interp::read_o(    /* ARGUMENTS                                     */
   else if(block->o_type == O_elseif)
     {
       // TESTME !!!KL -- should not eval expressions if skipping ???
-      if((_setup.skipping_o != 0) &&
+      if((_setup.skipping_o != NULL) &&
 	 (0 != strcmp(_setup.skipping_o, block->o_name)))
       {
 	    return INTERP_OK;
@@ -2185,7 +2185,7 @@ int Interp::read_parameter_setting(
                _setup.named_parameter_occurrence, param, value);
 
       dup = strstore(param); // no more need to free this
-      if(dup == 0)
+      if(dup == NULL)
       {
           ERS(NCE_OUT_OF_MEMORY);
       }

--- a/src/emc/rs274ngc/interpmodule.cc
+++ b/src/emc/rs274ngc/interpmodule.cc
@@ -829,6 +829,8 @@ static inline void set_parameter_g83_peck_clearance(Interp &interp, double value
     interp._setup.parameter_g83_peck_clearance = value;
 }
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wzero-as-null-pointer-constant"
 BOOST_PYTHON_MODULE(interpreter) {
     using namespace boost::python;
 
@@ -1062,3 +1064,4 @@ BOOST_PYTHON_MODULE(interpreter) {
 
     export_Arrays();
 }
+#pragma GCC diagnostic pop

--- a/src/emc/rs274ngc/rs274ngc_interp.hh
+++ b/src/emc/rs274ngc/rs274ngc_interp.hh
@@ -360,7 +360,7 @@ public:
  int cycle_traverse(block_pointer block, CANON_PLANE plane, double end1, double end2,
                           double end3);
  int enhance_block(block_pointer block, setup_pointer settings);
- int _execute(const char *command = 0);
+ int _execute(const char *command = NULL);
  int execute_binary(double *left, int operation, double *right);
  int execute_binary1(double *left, int operation, double *right);
  int execute_binary2(double *left, int operation, double *right);

--- a/src/emc/rs274ngc/rs274ngc_pre.cc
+++ b/src/emc/rs274ngc/rs274ngc_pre.cc
@@ -314,7 +314,7 @@ int Interp::_execute(const char *command)
 	   call_statenames[_setup.call_state]);
 
   // process control functions -- will skip if skipping
-  if ((eblock->o_name != 0) || _setup.mdi_interrupt)  {
+  if ((eblock->o_name != NULL) || _setup.mdi_interrupt)  {
       status = convert_control_functions(eblock, &_setup);
       CHP(status); // relinquish control if INTERP_EXECUTE_FINISH, INTERP_ERROR etc
       
@@ -334,7 +334,7 @@ int Interp::_execute(const char *command)
       logDebug("MDImode = %d", MDImode);
       while(MDImode && _setup.call_level) // we are still in a subroutine
       {
-          status = read(0);  // reads from current file and calls parse
+          status = read(NULL);  // reads from current file and calls parse
 	  if (status > INTERP_MIN_ERROR)
 	      CHP(status);
           status = execute();  // special handling for mdi errors
@@ -462,7 +462,7 @@ int Interp::_execute(const char *command)
 	      if (MDImode) {
 		  // need to trigger execution of parsed _setup.block1 here
 		  // replicate MDI oword execution code here
-		  if ((eblock->o_name != 0) ||
+		  if ((eblock->o_name != NULL) ||
 		      (_setup.mdi_interrupt)) { 
 
 		      status = convert_control_functions(eblock, &_setup);
@@ -473,7 +473,7 @@ int Interp::_execute(const char *command)
 		      }
 		      status = INTERP_OK;
 		      while(MDImode && _setup.call_level) { // we are still in a subroutine
-			  CHP(read(0));  // reads from current file and calls parse
+			  CHP(read(NULL));  // reads from current file and calls parse
 			  status = execute();  // special handling for mdi errors
 			  if (status == INTERP_EXECUTE_FINISH) 
 			      _setup.mdi_interrupt = true;
@@ -489,7 +489,7 @@ int Interp::_execute(const char *command)
 		  }
 	      } else {
 		  // this should get the osub going
-		  status = execute(0);
+		  status = execute(NULL);
 		  CHP(status);
 		  // when this is done, blocks[0] will be executed as per standard case
 		  // on endsub/return and g_codes/m_codes/settings recorded there.
@@ -539,7 +539,7 @@ int Interp::execute(const char *command)
 
 int Interp::execute()
 {
-  return Interp::execute(0);
+  return Interp::execute(NULL);
 }
 
 int Interp::execute(const char *command, int line_number)
@@ -598,7 +598,7 @@ int Interp::remap_finished(int phase)
 
 	    if (status < 0) {
 		// a remap was parsed, get the block going
-		return execute(0);
+		return execute(NULL);
 	    } else
 		return status;
 	} else {
@@ -1222,7 +1222,7 @@ int Interp::init()
   // initialization stuff for subroutines and control structures
   _setup.call_level = 0;
   _setup.defining_sub = 0;
-  _setup.skipping_o = 0;
+  _setup.skipping_o = NULL;
   _setup.offset_map.clear();
 
   _setup.lathe_diameter_mode = false;
@@ -1231,15 +1231,15 @@ int Interp::init()
   memcpy(_readers, default_readers, sizeof(default_readers));
 
   long axis_mask = GET_EXTERNAL_AXIS_MASK();
-  if(!(axis_mask & AXIS_MASK_X)) _readers[(int)'x'] = 0;
-  if(!(axis_mask & AXIS_MASK_Y)) _readers[(int)'y'] = 0;
-  if(!(axis_mask & AXIS_MASK_Z)) _readers[(int)'z'] = 0;
-  if(!(axis_mask & AXIS_MASK_A)) _readers[(int)'a'] = 0;
-  if(!(axis_mask & AXIS_MASK_B)) _readers[(int)'b'] = 0;
-  if(!(axis_mask & AXIS_MASK_C)) _readers[(int)'c'] = 0;
-  if(!(axis_mask & AXIS_MASK_U)) _readers[(int)'u'] = 0;
-  if(!(axis_mask & AXIS_MASK_V)) _readers[(int)'v'] = 0;
-  if(!(axis_mask & AXIS_MASK_W)) _readers[(int)'w'] = 0;
+  if(!(axis_mask & AXIS_MASK_X)) _readers[(int)'x'] = NULL;
+  if(!(axis_mask & AXIS_MASK_Y)) _readers[(int)'y'] = NULL;
+  if(!(axis_mask & AXIS_MASK_Z)) _readers[(int)'z'] = NULL;
+  if(!(axis_mask & AXIS_MASK_A)) _readers[(int)'a'] = NULL;
+  if(!(axis_mask & AXIS_MASK_B)) _readers[(int)'b'] = NULL;
+  if(!(axis_mask & AXIS_MASK_C)) _readers[(int)'c'] = NULL;
+  if(!(axis_mask & AXIS_MASK_U)) _readers[(int)'u'] = NULL;
+  if(!(axis_mask & AXIS_MASK_V)) _readers[(int)'v'] = NULL;
+  if(!(axis_mask & AXIS_MASK_W)) _readers[(int)'w'] = NULL;
 
   synch(); //synch first, then update the interface
 
@@ -1691,7 +1691,7 @@ int Interp::unwind_call(int status, const char *file, int line, const char *func
 	free_named_parameters(&_setup.sub_context[_setup.call_level]);
 	if(sub->subName) {
 	    logDebug("unwind_call leaving sub '%s'", sub->subName);
-	    sub->subName = 0;
+	    sub->subName = NULL;
 	}
 
 	if (sub->call_type != CT_NGC_M98_SUB) // M98:  pass #1..#30 from parent
@@ -1724,12 +1724,12 @@ int Interp::unwind_call(int status, const char *file, int line, const char *func
  
     if(_setup.sub_name) {
 	logDebug("unwind_call: exiting current sub '%s'\n", _setup.sub_name);
-	_setup.sub_name = 0;
+	_setup.sub_name = NULL;
     }
     _setup.remap_level = 0; // reset remapping stack
     _setup.defining_sub = 0;
-    _setup.skipping_o = 0;
-    _setup.skipping_to_sub = 0;
+    _setup.skipping_o = NULL;
+    _setup.skipping_to_sub = NULL;
     _setup.offset_map.clear();
     _setup.mdi_interrupt = false;
 
@@ -1738,7 +1738,7 @@ int Interp::unwind_call(int status, const char *file, int line, const char *func
 }
 
 int Interp::read() {
-  return read(0);
+  return read(NULL);
 }
 /***********************************************************************/
 

--- a/src/emc/sai/driver.cc
+++ b/src/emc/sai/driver.cc
@@ -676,7 +676,7 @@ usage:
         }
     }
   _sai._external_length_units =  0.03937007874016;
-  if (inifile!= 0) {
+  if (inifile!= NULL) {
       IniFile ini(inifile);
       if (!ini) {
         fprintf(stderr, "could not open supplied INI file %s\n", inifile);

--- a/src/emc/sai/saicanon.cc
+++ b/src/emc/sai/saicanon.cc
@@ -784,7 +784,7 @@ void GET_EXTERNAL_PARAMETER_FILE_NAME(
  int max_size)           /* maximum number of characters to copy */
 {
     // Paranoid checks
-    if (0 == file_name)
+    if (NULL == file_name)
 	return;
 
     if (max_size < 0)
@@ -971,7 +971,7 @@ double GET_EXTERNAL_TRAVERSE_RATE()
   return _sai._traverse_rate;
 }
 
-USER_DEFINED_FUNCTION_TYPE USER_DEFINED_FUNCTION[USER_DEFINED_FUNCTION_NUM] = {0};
+USER_DEFINED_FUNCTION_TYPE USER_DEFINED_FUNCTION[USER_DEFINED_FUNCTION_NUM] = {NULL};
 
 int USER_DEFINED_FUNCTION_ADD(USER_DEFINED_FUNCTION_TYPE func, int num)
 {
@@ -1111,7 +1111,7 @@ void CANON_ERROR(const char *fmt, ...)
 	va_start(ap, fmt);
 	char *err;
 	int res = vasprintf(&err, fmt, ap);
-	if(res < 0) err = 0;
+	if(res < 0) err = NULL;
 	va_end(ap);
 	if(err)
 	{

--- a/src/emc/task/emccanon.cc
+++ b/src/emc/task/emccanon.cc
@@ -3891,7 +3891,7 @@ void GET_EXTERNAL_PARAMETER_FILE_NAME(char *file_name,	/* string: to copy
 				      int max_size)
 {				/* maximum number of characters to copy */
     // Paranoid checks
-    if (0 == file_name)
+    if (NULL == file_name)
 	return;
 
     if (max_size < 0)
@@ -4156,7 +4156,7 @@ double GET_EXTERNAL_ANALOG_INPUT(int index, double /*def*/)
 
 
 USER_DEFINED_FUNCTION_TYPE USER_DEFINED_FUNCTION[USER_DEFINED_FUNCTION_NUM]
-    = { 0 };
+    = { NULL };
 
 int USER_DEFINED_FUNCTION_ADD(USER_DEFINED_FUNCTION_TYPE func, int num)
 {

--- a/src/emc/task/emctask.cc
+++ b/src/emc/task/emctask.cc
@@ -44,9 +44,9 @@ using namespace linuxcnc;
 /* flag for how we want to interpret traj coord mode, as mdi or auto */
 static EMC_TASK_MODE mdiOrAuto = EMC_TASK_MODE::AUTO;
 
-InterpBase *pinterp=0;
+InterpBase *pinterp=NULL;
 #define interp (*pinterp)
-setup_pointer _is = 0; // helper for gdb hardware watchpoints FIXME
+setup_pointer _is = NULL; // helper for gdb hardware watchpoints FIXME
 
 
 // Print error messages thrown by interpreter
@@ -60,7 +60,7 @@ static void print_interp_error(int retval)
 	return;
     }
 
-    if (0 != emcStatus) {
+    if (NULL != emcStatus) {
 	emcStatus->task.interpreter_errcode = retval;
     }
 
@@ -237,7 +237,7 @@ int emcTaskAbort()
     emcMotionAbort();
 
     // clear out the pending command
-    emcTaskCommand = 0;
+    emcTaskCommand = NULL;
     interp_list.clear();
 
     // clear out the interpreter state
@@ -451,7 +451,7 @@ int emcTaskPlanInit()
 
     Interp *i = dynamic_cast<Interp*>(pinterp);
     if(i) _is = &i->_setup; // FIXME
-    else  _is = 0;
+    else  _is = NULL;
     interp.ini_load(emc_inifile);
     waitFlag = 0;
 
@@ -464,7 +464,7 @@ int emcTaskPlanInit()
 	if (0 != rs274ngc_startup_code[0]) {
 	    retval = interp.execute(rs274ngc_startup_code);
 	    while (retval == INTERP_EXECUTE_FINISH) {
-		retval = interp.execute(0);
+		retval = interp.execute(NULL);
 	    }
 	    if (retval > INTERP_MIN_ERROR) {
 		print_interp_error(retval);
@@ -542,7 +542,7 @@ void emcTaskPlanExit()
 
 int emcTaskPlanOpen(const char *file)
 {
-    if (emcStatus != 0) {
+    if (emcStatus != NULL) {
 	emcStatus->task.motionLine = 0;
 	emcStatus->task.currentLine = 0;
 	emcStatus->task.readLine = 0;
@@ -590,7 +590,7 @@ int emcTaskPlanExecute(const char *command)
 {
     int inpos = emcStatus->motion.traj.inpos;	// 1 if in position, 0 if not.
 
-    if (command != 0) {		// Command is 0 if in AUTO mode, non-null if in MDI mode.
+    if (command != NULL) {		// Command is 0 if in AUTO mode, non-null if in MDI mode.
 	// Don't sync if not in position.
 	if ((*command != 0) && (inpos)) {
 	    interp.synch();
@@ -600,7 +600,7 @@ int emcTaskPlanExecute(const char *command)
     if (retval > INTERP_MIN_ERROR) {
 	print_interp_error(retval);
     }
-    if(command != 0) {
+    if(command != NULL) {
 	FINISH();
     }
 
@@ -617,7 +617,7 @@ int emcTaskPlanExecute(const char *command, int line_number)
     if (retval > INTERP_MIN_ERROR) {
 	print_interp_error(retval);
     }
-    if(command != 0) { // this means MDI
+    if(command != NULL) { // this means MDI
 	FINISH();
     }
 

--- a/src/emc/task/emctaskmain.cc
+++ b/src/emc/task/emctaskmain.cc
@@ -98,18 +98,18 @@ static emcmot_config_t emcmotConfig;
 
 
 // NML channels
-static RCS_CMD_CHANNEL *emcCommandBuffer = 0;
-static RCS_STAT_CHANNEL *emcStatusBuffer = 0;
-static NML *emcErrorBuffer = 0;
+static RCS_CMD_CHANNEL *emcCommandBuffer = NULL;
+static RCS_STAT_CHANNEL *emcStatusBuffer = NULL;
+static NML *emcErrorBuffer = NULL;
 
 // NML command channel data pointer
-static RCS_CMD_MSG *emcCommand = 0;
+static RCS_CMD_MSG *emcCommand = NULL;
 
 // global EMC status
-EMC_STAT *emcStatus = 0;
+EMC_STAT *emcStatus = NULL;
 
 // timer stuff
-static RCS_TIMER *timer = 0;
+static RCS_TIMER *timer = NULL;
 
 // flag signifying that INI file [TASK] CYCLE_TIME is <= 0.0, so
 // we should not delay at all between cycles. This means also that
@@ -310,7 +310,7 @@ static int argvize(const char *src, char *dst, char *argv[], int len)
 	bufptr++;
     }
 
-    argv[argvix] = 0;		// null-terminate the argv list
+    argv[argvix] = NULL;		// null-terminate the argv list
 
     return argvix;
 }
@@ -496,7 +496,7 @@ interpret_again:
 		    if (emcTaskPlanIsWait()) {
 			// delay reading of next line until all is done
 			if (interp_list.len() == 0 &&
-			    emcTaskCommand == 0 &&
+			    emcTaskCommand == NULL &&
 			    emcStatus->task.execState ==
 			    EMC_TASK_EXEC::DONE) {
 			    emcTaskPlanClearWait();
@@ -527,7 +527,7 @@ interpret_again:
 			    emcTaskPlanCommand((char *) &emcStatus->task.
 					       command);
 			    // and execute it
-			    execRetval = emcTaskPlanExecute(0);
+			    execRetval = emcTaskPlanExecute(NULL);
 			    // line number may need update after
 			    // returns from subprograms in external
 			    // files
@@ -647,7 +647,7 @@ static void mdi_execute_hook(void)
     if (mdi_execute_wait && emcTaskPlanIsWait()) {
 	// delay reading of next line until all is done
 	if (interp_list.len() == 0 &&
-	    emcTaskCommand == 0 &&
+	    emcTaskCommand == NULL &&
 	    emcStatus->task.execState ==
 	    EMC_TASK_EXEC::DONE) {
 	    emcTaskPlanClearWait();
@@ -671,7 +671,7 @@ static void mdi_execute_hook(void)
 
     // determine when a MDI command actually finishes normally.
     if (interp_list.len() == 0 &&
-	emcTaskCommand == 0 &&
+	emcTaskCommand == NULL &&
 	emcStatus->task.execState ==  EMC_TASK_EXEC::DONE &&
 	emcStatus->task.interpState != EMC_TASK_INTERP::IDLE &&
 	emcStatus->motion.traj.queue == 0 &&
@@ -704,7 +704,7 @@ void readahead_waiting(void)
 	// now handle call logic
 	// check for subsystems done
 	if (interp_list.len() == 0 &&
-	    emcTaskCommand == 0 &&
+	    emcTaskCommand == NULL &&
 	    emcStatus->motion.traj.queue == 0 &&
 	    emcStatus->io.status == RCS_STATUS::DONE)
 	    // finished
@@ -1499,7 +1499,7 @@ static int emcTaskPlan(void)
    */
 static EMC_TASK_EXEC emcTaskCheckPreconditions(NMLmsg * cmd)
 {
-    if (0 == cmd) {
+    if (NULL == cmd) {
 	return EMC_TASK_EXEC::DONE;
     }
 
@@ -1636,7 +1636,7 @@ static int emcTaskIssueCommand(NMLmsg * cmd)
     int execRetval = 0;
     static char remote_tmpfilename[LINELEN];   // path to temporary file received from remote process
 
-    if (0 == cmd) {
+    if (NULL == cmd) {
         if (emc_debug & EMC_DEBUG_TASK_ISSUE) {
             rcs_print("emcTaskIssueCommand() null command\n");
         }
@@ -2123,7 +2123,7 @@ static int emcTaskIssueCommand(NMLmsg * cmd)
 		}
 
 		// clear out the pending command
-		emcTaskCommand = 0;
+		emcTaskCommand = NULL;
 		interp_list.clear();
                 emcStatus->task.currentLine = 0;
 
@@ -2440,7 +2440,7 @@ static int emcTaskIssueCommand(NMLmsg * cmd)
    */
 static EMC_TASK_EXEC emcTaskCheckPostconditions(NMLmsg * cmd)
 {
-    if (0 == cmd) {
+    if (NULL == cmd) {
 	return EMC_TASK_EXEC::DONE;
     }
 
@@ -2593,7 +2593,7 @@ static int emcTaskExecute(void)
 	}
 
 	// clear out pending command
-	emcTaskCommand = 0;
+	emcTaskCommand = NULL;
 	interp_list.clear();
 	emcAbortCleanup(EMC_ABORT::TASK_EXEC_ERROR);
         emcStatus->task.currentLine = 0;
@@ -2615,12 +2615,12 @@ static int emcTaskExecute(void)
 	STEPPING_CHECK();
 	if (!emcStatus->motion.traj.queueFull &&
 	    emcStatus->task.interpState != EMC_TASK_INTERP::PAUSED) {
-	    if (0 == emcTaskCommand) {
+	    if (NULL == emcTaskCommand) {
 		// need a new command
 		emcTaskCommand = interp_list.get();
 		// interp_list now has line number associated with this-- get
 		// it
-		if (0 != emcTaskCommand) {
+		if (NULL != emcTaskCommand) {
 		    emcTaskEager = 1;
 		    emcStatus->task.currentLine = interp_list.get_line_number();
 		    emcStatus->task.callLevel = emcTaskPlanLevel();
@@ -2642,7 +2642,7 @@ static int emcTaskExecute(void)
 		    emcStatus->task.execState = emcTaskCheckPostconditions(emcTaskCommand.get());
 		    emcTaskEager = 1;
 		}
-		emcTaskCommand = 0;	// reset it
+		emcTaskCommand = NULL;	// reset it
 	    }
 	}
 	break;
@@ -2650,7 +2650,7 @@ static int emcTaskExecute(void)
     case EMC_TASK_EXEC::WAITING_FOR_MOTION_QUEUE:
 	STEPPING_CHECK();
 	if (!emcStatus->motion.traj.queueFull) {
-	    if (0 != emcTaskCommand) {
+	    if (NULL != emcTaskCommand) {
 		emcStatus->task.execState = emcTaskCheckPreconditions(emcTaskCommand.get());
 		emcTaskEager = 1;
 	    } else {
@@ -3058,38 +3058,38 @@ static int emctask_startup()
 static int emctask_shutdown(void)
 {
     // shut down the subsystems
-    if (0 != emcStatus) {
+    if (NULL != emcStatus) {
 	emcTaskHalt();
 	emcTaskPlanExit();
 	emcMotionHalt();
     }
     // delete the timer
-    if (0 != timer) {
+    if (NULL != timer) {
 	delete timer;
-	timer = 0;
+	timer = NULL;
     }
     // delete the NML channels
 
-    if (0 != emcErrorBuffer) {
+    if (NULL != emcErrorBuffer) {
 	delete emcErrorBuffer;
-	emcErrorBuffer = 0;
+	emcErrorBuffer = NULL;
     }
 
-    if (0 != emcStatusBuffer) {
+    if (NULL != emcStatusBuffer) {
 	delete emcStatusBuffer;
-	emcStatusBuffer = 0;
-	emcStatus = 0;
+	emcStatusBuffer = NULL;
+	emcStatus = NULL;
     }
 
-    if (0 != emcCommandBuffer) {
+    if (NULL != emcCommandBuffer) {
 	delete emcCommandBuffer;
-	emcCommandBuffer = 0;
-	emcCommand = 0;
+	emcCommandBuffer = NULL;
+	emcCommand = NULL;
     }
 
-    if (0 != emcStatus) {
+    if (NULL != emcStatus) {
 	delete emcStatus;
-	emcStatus = 0;
+	emcStatus = NULL;
     }
     return 0;
 }
@@ -3424,7 +3424,7 @@ int main(int argc, char *argv[])
 	    }
 
 	    // clear out the pending command
-	    emcTaskCommand = 0;
+	    emcTaskCommand = NULL;
 	    interp_list.clear();
 	    emcStatus->task.currentLine = 0;
 
@@ -3467,7 +3467,7 @@ int main(int argc, char *argv[])
 		   emcStatus->io.status == RCS_STATUS::DONE &&
 		   mdi_execute_queue.len() == 0 &&
 		   interp_list.len() == 0 &&
-		   emcTaskCommand == 0 &&
+		   emcTaskCommand == NULL &&
 		   emcStatus->task.interpState == EMC_TASK_INTERP::IDLE) {
 	    emcStatus->status = RCS_STATUS::DONE;
 	    emcStatus->task.status = RCS_STATUS::DONE;

--- a/src/emc/task/taskclass.cc
+++ b/src/emc/task/taskclass.cc
@@ -86,7 +86,7 @@ void Task::hal_init_pins(void)
 Task *task_methods;
 
 // global status structure
-EMC_IO_STAT *emcIoStatus = 0;
+EMC_IO_STAT *emcIoStatus = NULL;
 
 // glue
 

--- a/src/emc/tooldata/tool_watch.cc
+++ b/src/emc/tooldata/tool_watch.cc
@@ -37,7 +37,7 @@ int main(int argc, char **argv) {
     int hdr_ct     = 0;
     int invalid_ct = 0;
     int peek_ct    = 0;
-    RCS_STAT_CHANNEL *stat = 0;
+    RCS_STAT_CHANNEL *stat = NULL;
     char nmlfile[512];
 
     if(argc == 2) {

--- a/src/emc/tooldata/tooldata_db.cc
+++ b/src/emc/tooldata/tooldata_db.cc
@@ -240,7 +240,7 @@ int tooldata_db_init(char progname_plus_args[],int random_toolchanger)
     if (getenv( (char*)"DB_DEBUG") ) {db_debug = 1;}
     if (getenv( (char*)"DB_SHOW") )  {db_show  = 1;}
     int   child_argc = 0;
-    char* child_argv[MAX_DB_PROGRAM_ARGS] = {0};
+    char* child_argv[MAX_DB_PROGRAM_ARGS] = {NULL};
     char* saveptr;
     char* token = strtok_r(progname_plus_args, " ", &saveptr);
     while (token != NULL) {

--- a/src/emc/tooldata/tooldata_mmap.cc
+++ b/src/emc/tooldata/tooldata_mmap.cc
@@ -36,7 +36,7 @@
 
 static int           creator_fd;
 static char          filename[LINELEN] = {};
-static char*         tool_mmap_base = 0;
+static char*         tool_mmap_base = NULL;
 static EMC_TOOL_STAT const *toolstat;
 
 typedef struct {
@@ -148,7 +148,7 @@ int tool_mmap_creator(EMC_TOOL_STAT const * ptr,int random_toolchanger)
         perror("tool_mmap_creator(): file tail write fail");
         exit(EXIT_FAILURE);
     }
-    tool_mmap_base = (char*)mmap(0, TOOL_MMAP_SIZE, PROT_READ | PROT_WRITE,
+    tool_mmap_base = (char*)mmap(NULL, TOOL_MMAP_SIZE, PROT_READ | PROT_WRITE,
                                  MAP_SHARED, creator_fd, 0);
     if (tool_mmap_base == MAP_FAILED) {
         close(creator_fd);
@@ -180,10 +180,10 @@ int tool_mmap_user()
         ** So print message and return fail indicator.
         */
         fprintf(stderr,"tool_mmap_user(): tool mmap not available\n");
-        tool_mmap_base = (char*)0;
+        tool_mmap_base = (char*)NULL;
         return(-1);
     }
-    tool_mmap_base = (char*)mmap(0, TOOL_MMAP_SIZE, PROT_READ|PROT_WRITE,
+    tool_mmap_base = (char*)mmap(NULL, TOOL_MMAP_SIZE, PROT_READ|PROT_WRITE,
                                  MAP_SHARED, fd, 0);
 
     if (tool_mmap_base == MAP_FAILED) {

--- a/src/emc/usr_intf/axis/extensions/emcmodule.cc
+++ b/src/emc/usr_intf/axis/extensions/emcmodule.cc
@@ -852,6 +852,8 @@ static const char linuxcncinidoc[] =
     "Method documentation is provided with each method.\n"
     ;
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wzero-as-null-pointer-constant"
 static PyTypeObject Ini_Type = {
     PyVarObject_HEAD_INIT(NULL, 0)
     "linuxcnc.ini",              /*tp_name*/
@@ -912,6 +914,7 @@ static PyTypeObject Ini_Type = {
 #endif
 #endif
 };
+#pragma GCC diagnostic pop
 
 #define EMC_COMMAND_TIMEOUT 5.0  // how long to wait until timeout
 #define EMC_COMMAND_DELAY   0.01 // how long to sleep between checks
@@ -1567,6 +1570,8 @@ static PyGetSetDef Stat_getsetlist[] = {
     {}
 };
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wzero-as-null-pointer-constant"
 static PyTypeObject Stat_Type = {
     PyVarObject_HEAD_INIT(NULL, 0)
     "linuxcnc.stat",             /*tp_name*/
@@ -1627,6 +1632,7 @@ static PyTypeObject Stat_Type = {
 #endif
 #endif
 };
+#pragma GCC diagnostic pop
 
 static int Command_init(pyCommandChannel *self, PyObject * /*a*/, PyObject * /*k*/) {
     const char *file = get_nmlfile();
@@ -2364,6 +2370,8 @@ static PyMethodDef Command_methods[] = {
     {}
 };
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wzero-as-null-pointer-constant"
 static PyTypeObject Command_Type = {
     PyVarObject_HEAD_INIT(NULL, 0)
     "linuxcnc.command",          /*tp_name*/
@@ -2424,6 +2432,7 @@ static PyTypeObject Command_Type = {
 #endif
 #endif
 };
+#pragma GCC diagnostic pop
 
 static int Error_init(pyErrorChannel *self, PyObject * /*a*/, PyObject * /*k*/) {
     const char *file = get_nmlfile();
@@ -2489,6 +2498,8 @@ static PyMethodDef Error_methods[] = {
     {}
 };
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wzero-as-null-pointer-constant"
 static PyTypeObject Error_Type = {
     PyVarObject_HEAD_INIT(NULL, 0)
     "linuxcnc.error_channel",    /*tp_name*/
@@ -2549,6 +2560,7 @@ static PyTypeObject Error_Type = {
 #endif
 #endif
 };
+#pragma GCC diagnostic pop
 
 #define AXIS_MASK_A 0x08
 #define AXIS_MASK_B 0x10
@@ -2935,7 +2947,7 @@ static int Logger_init(pyPositionLogger *self, PyObject *a, PyObject * /*k*/) {
     self->npts = self->mpts = 0;
     self->exit = self->clear = 0;
     self->changed = 1;
-    self->st = 0;
+    self->st = NULL;
     self->is_xyuv = 0;
     self->foam_z = 0;
     self->foam_w = 1.5;  // temporarily hard-code
@@ -3227,6 +3239,8 @@ static PyMethodDef Logger_methods[] = {
     {},
 };
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wzero-as-null-pointer-constant"
 static PyTypeObject PositionLoggerType = {
     PyVarObject_HEAD_INIT(NULL, 0)
     "linuxcnc.positionlogger",   /*tp_name*/
@@ -3287,6 +3301,7 @@ static PyTypeObject PositionLoggerType = {
 #endif
 #endif
 };
+#pragma GCC diagnostic pop
 
 static PyMethodDef emc_methods[] = {
 #define METH(name, doc) { #name, (PyCFunction) py##name, METH_VARARGS, doc }

--- a/src/emc/usr_intf/axis/extensions/togl.c
+++ b/src/emc/usr_intf/axis/extensions/togl.c
@@ -1313,7 +1313,8 @@ static int Togl_Cmd(ClientData clientData, Tcl_Interp *interp,
    togl->TkWin = tkwin;
    togl->Interp = interp;
 #ifndef NO_TK_CURSOR
-   togl->Cursor = None;
+   //togl->Cursor = None;
+   togl->Cursor = NULL;
 #endif
    togl->Width = 0;
    togl->Height = 0;
@@ -1760,12 +1761,13 @@ static Window Togl_CreateWindow(Tk_Window tkwin,
          if (shareWith)
             shareCtx = shareWith->GlCtx;
          else
-            shareCtx = None;
+            shareCtx = NULL; //None;
          togl->GlCtx = glXCreateContext(dpy, visinfo, shareCtx, directCtx);
       }
       else {
          /* don't share display lists */
-         togl->GlCtx = glXCreateContext(dpy, visinfo, None, directCtx);
+         //togl->GlCtx = glXCreateContext(dpy, visinfo, None, directCtx);
+         togl->GlCtx = glXCreateContext(dpy, visinfo, NULL, directCtx);
       }
 
       if (togl->GlCtx == NULL) {

--- a/src/emc/usr_intf/emclcd.cc
+++ b/src/emc/usr_intf/emclcd.cc
@@ -292,7 +292,7 @@ struct option longopts[] = {
   {"autostart", 1, NULL, 'a'},
   {"server", 1, NULL, 's'},
   {"delay", 1, NULL, 'w'},
-  {0,0,0,0}
+  {NULL,0,NULL,0}
   };
 
 int sockfd = -1;
@@ -1604,27 +1604,27 @@ static void thisQuit()
 
     deleteScreens();
 
-    if (emcStatusBuffer != 0) {
+    if (emcStatusBuffer != NULL) {
 	// wait until current message has been received
 	emcCommandWaitReceived();
     }
 
     // clean up NML buffers
 
-    if (emcErrorBuffer != 0) {
+    if (emcErrorBuffer != NULL) {
 	delete emcErrorBuffer;
-	emcErrorBuffer = 0;
+	emcErrorBuffer = NULL;
     }
 
-    if (emcStatusBuffer != 0) {
+    if (emcStatusBuffer != NULL) {
 	delete emcStatusBuffer;
-	emcStatusBuffer = 0;
-	emcStatus = 0;
+	emcStatusBuffer = NULL;
+	emcStatus = NULL;
     }
 
-    if (emcCommandBuffer != 0) {
+    if (emcCommandBuffer != NULL) {
 	delete emcCommandBuffer;
-	emcCommandBuffer = 0;
+	emcCommandBuffer = NULL;
     }
 
     exit(0);
@@ -1681,11 +1681,11 @@ static void initMain()
     linearUnitConversion = LINEAR_UNITS_INCH;
     units = unInch; 
     angularUnitConversion = ANGULAR_UNITS_AUTO;
-    emcCommandBuffer = 0;
-    emcStatusBuffer = 0;
-    emcStatus = 0;
+    emcCommandBuffer = NULL;
+    emcStatusBuffer = NULL;
+    emcStatus = NULL;
 
-    emcErrorBuffer = 0;
+    emcErrorBuffer = NULL;
     error_string.clear();
     operator_text_string.clear();
     operator_display_string.clear();

--- a/src/emc/usr_intf/emcsh.cc
+++ b/src/emc/usr_intf/emcsh.cc
@@ -346,27 +346,27 @@ static void thisQuit(ClientData /*clientData*/)
 {
     EMC_NULL emc_null_msg;
 
-    if (0 != emcStatusBuffer) {
+    if (nullptr != emcStatusBuffer) {
 	// wait until current message has been received
 	emcCommandWaitReceived();
     }
 
     // clean up NML buffers
 
-    if (emcErrorBuffer != 0) {
+    if (emcErrorBuffer != nullptr) {
 	delete emcErrorBuffer;
-	emcErrorBuffer = 0;
+	emcErrorBuffer = nullptr;
     }
 
-    if (emcStatusBuffer != 0) {
+    if (emcStatusBuffer != nullptr) {
 	delete emcStatusBuffer;
-	emcStatusBuffer = 0;
-	emcStatus = 0;
+	emcStatusBuffer = nullptr;
+	emcStatus = nullptr;
     }
 
-    if (emcCommandBuffer != 0) {
+    if (emcCommandBuffer != nullptr) {
 	delete emcCommandBuffer;
-	emcCommandBuffer = 0;
+	emcCommandBuffer = nullptr;
     }
 
     return;
@@ -418,15 +418,15 @@ static int emc_ini(ClientData /*clientdata*/,
     if (!test_ini_args(interp, inifile, objc, "emc_ini"))
 	return TCL_ERROR;
 
-    varstr = Tcl_GetStringFromObj(objv[1], 0);
-    secstr = Tcl_GetStringFromObj(objv[2], 0);
+    varstr = Tcl_GetStringFromObj(objv[1], NULL);
+    secstr = Tcl_GetStringFromObj(objv[2], NULL);
 
     if (auto inival = inifile.findString(varstr, secstr)) {
         setresult(interp, inival->c_str());
     } else {
         const char *defaultstr = NULL;
         if (4 == objc)
-            defaultstr = Tcl_GetStringFromObj(objv[3], 0);
+            defaultstr = Tcl_GetStringFromObj(objv[3], NULL);
 
 	if (NULL != defaultstr)
 	    setresult(interp, defaultstr);
@@ -450,8 +450,8 @@ static int emc_ini_real(ClientData /*clientdata*/,
     if (!test_ini_args(interp, inifile, objc, "emc_ini_real"))
         return TCL_ERROR;
 
-    varstr = Tcl_GetStringFromObj(objv[1], 0);
-    secstr = Tcl_GetStringFromObj(objv[2], 0);
+    varstr = Tcl_GetStringFromObj(objv[1], NULL);
+    secstr = Tcl_GetStringFromObj(objv[2], NULL);
 
     if (auto inival = inifile.findReal(varstr, secstr)) {
         Tcl_SetObjResult(interp, Tcl_NewDoubleObj(*inival));
@@ -479,8 +479,8 @@ static int emc_ini_int(ClientData /*clientdata*/,
     if (!test_ini_args(interp, inifile, objc, "emc_ini_int"))
         return TCL_ERROR;
 
-    varstr = Tcl_GetStringFromObj(objv[1], 0);
-    secstr = Tcl_GetStringFromObj(objv[2], 0);
+    varstr = Tcl_GetStringFromObj(objv[1], NULL);
+    secstr = Tcl_GetStringFromObj(objv[2], NULL);
 
     if (auto inival = inifile.findInt(varstr, secstr)) {
         Tcl_SetObjResult(interp, Tcl_NewIntObj(*inival));
@@ -508,8 +508,8 @@ static int emc_ini_wideint(ClientData /*clientdata*/,
     if (!test_ini_args(interp, inifile, objc, "emc_ini_wideint"))
         return TCL_ERROR;
 
-    varstr = Tcl_GetStringFromObj(objv[1], 0);
-    secstr = Tcl_GetStringFromObj(objv[2], 0);
+    varstr = Tcl_GetStringFromObj(objv[1], NULL);
+    secstr = Tcl_GetStringFromObj(objv[2], NULL);
 
     if (auto inival = inifile.findSInt(varstr, secstr)) {
         Tcl_SetObjResult(interp, Tcl_NewWideIntObj(*inival));
@@ -537,8 +537,8 @@ static int emc_ini_bool(ClientData /*clientdata*/,
     if (!test_ini_args(interp, inifile, objc, "emc_ini_bool"))
         return TCL_ERROR;
 
-    varstr = Tcl_GetStringFromObj(objv[1], 0);
-    secstr = Tcl_GetStringFromObj(objv[2], 0);
+    varstr = Tcl_GetStringFromObj(objv[1], NULL);
+    secstr = Tcl_GetStringFromObj(objv[2], NULL);
 
     if (auto inival = inifile.findBool(varstr, secstr)) {
         Tcl_SetObjResult(interp, Tcl_NewBooleanObj(*inival));
@@ -618,7 +618,7 @@ static int emc_ini_variables(ClientData /*clientdata*/,
         return TCL_OK;
     }
 
-    const char *section = Tcl_GetStringFromObj(objv[1], 0);
+    const char *section = Tcl_GetStringFromObj(objv[1], NULL);
 
     // Append each variable and value to the list
     for (auto const &var : inifile.findVariables(section)) {
@@ -676,7 +676,7 @@ static int emc_ini_load(ClientData /*clientdata*/,
         return TCL_ERROR;
     }
 
-    const char *fname = Tcl_GetStringFromObj(objv[1], 0);
+    const char *fname = Tcl_GetStringFromObj(objv[1], NULL);
     if (!fname) {
         setresult(interp, "emc_ini_load: failed to read filename argument");
         return TCL_ERROR;
@@ -719,7 +719,7 @@ static int emc_Debug(ClientData /*clientdata*/,
     }
 
     if (objc == 2) {
-	if (0 != Tcl_GetIntFromObj(0, objv[1], &debug)) {
+	if (0 != Tcl_GetIntFromObj(NULL, objv[1], &debug)) {
 	    setresult(interp,"emc_debug: need debug level as integer");
 	    return TCL_ERROR;
 	}
@@ -755,7 +755,7 @@ static int emc_set_wait(ClientData /*clientdata*/,
     }
 
     if (objc == 2) {
-	objstr = Tcl_GetStringFromObj(objv[1], 0);
+	objstr = Tcl_GetStringFromObj(objv[1], NULL);
 	if (!strcmp(objstr, "received")) {
 	    emcWaitType = EMC_WAIT_RECEIVED;
 	    return TCL_OK;
@@ -777,7 +777,7 @@ static int emc_wait(ClientData /*clientdata*/,
 
     CHECKEMC
     if (objc == 2) {
-	objstr = Tcl_GetStringFromObj(objv[1], 0);
+	objstr = Tcl_GetStringFromObj(objv[1], NULL);
 	if (!strcmp(objstr, "received")) {
 	    if (0 != emcCommandWaitReceived()) {
 		setresult(interp,"timeout");
@@ -811,7 +811,7 @@ static int emc_set_timeout(ClientData /*clientdata*/,
     }
 
     if (objc == 2) {
-	if (TCL_OK == Tcl_GetDoubleFromObj(0, objv[1], &timeout)) {
+	if (TCL_OK == Tcl_GetDoubleFromObj(NULL, objv[1], &timeout)) {
 	    emcTimeout = timeout;
 	    return TCL_OK;
 	}
@@ -835,7 +835,7 @@ static int emc_update(ClientData /*clientdata*/,
     }
 
     if (objc == 2) {
-	objstr = Tcl_GetStringFromObj(objv[1], 0);
+	objstr = Tcl_GetStringFromObj(objv[1], NULL);
 	if (!strcmp(objstr, "none")) {
 	    emcUpdateType = EMC_UPDATE_NONE;
 	    return TCL_OK;
@@ -959,7 +959,7 @@ static int emc_estop(ClientData /*clientdata*/,
     }
 
     if (objc == 2) {
-	objstr = Tcl_GetStringFromObj(objv[1], 0);
+	objstr = Tcl_GetStringFromObj(objv[1], NULL);
 	if (!strcmp(objstr, "on")) {
 	    sendEstop();
 	    return TCL_OK;
@@ -995,7 +995,7 @@ static int emc_machine(ClientData /*clientdata*/,
     }
 
     if (objc == 2) {
-	objstr = Tcl_GetStringFromObj(objv[1], 0);
+	objstr = Tcl_GetStringFromObj(objv[1], NULL);
 	if (!strcmp(objstr, "on")) {
 	    sendMachineOn();
 	    return TCL_OK;
@@ -1039,7 +1039,7 @@ static int emc_mode(ClientData /*clientdata*/,
     }
 
     if (objc == 2) {
-	objstr = Tcl_GetStringFromObj(objv[1], 0);
+	objstr = Tcl_GetStringFromObj(objv[1], NULL);
 	if (!strcmp(objstr, "manual")) {
 	    sendManual();
 	    return TCL_OK;
@@ -1078,7 +1078,7 @@ static int emc_mist(ClientData /*clientdata*/,
     }
 
     if (objc == 2) {
-	objstr = Tcl_GetStringFromObj(objv[1], 0);
+	objstr = Tcl_GetStringFromObj(objv[1], NULL);
 	if (!strcmp(objstr, "on")) {
 	    sendMistOn();
 	    return TCL_OK;
@@ -1113,7 +1113,7 @@ static int emc_flood(ClientData /*clientdata*/,
     }
 
     if (objc == 2) {
-	objstr = Tcl_GetStringFromObj(objv[1], 0);
+	objstr = Tcl_GetStringFromObj(objv[1], NULL);
 	if (!strcmp(objstr, "on")) {
 	    sendFloodOn();
 	    return TCL_OK;
@@ -1139,13 +1139,13 @@ static int emc_spindle(ClientData /*clientdata*/,
     if (objc >= 2) {
         if (Tcl_GetIntFromObj(interp, objv[1], &spindle) != TCL_OK){ // not a likely spindle index first, then
             spindle = 0;
-            objstr = Tcl_GetStringFromObj(objv[1], 0);
+            objstr = Tcl_GetStringFromObj(objv[1], NULL);
         } else {
             if (spindle < 0 || spindle > EMCMOT_MAX_SPINDLES){ // should really be num_spindles, but not sure we know that here
                 setresult(interp,"invalid spindle index number");
                 return TCL_ERROR;
             }
-            objstr = Tcl_GetStringFromObj(objv[2], 0);
+            objstr = Tcl_GetStringFromObj(objv[2], NULL);
         }
     }
     if (objstr) {
@@ -1208,13 +1208,13 @@ static int emc_brake(ClientData /*clientdata*/,
     if (objc >= 2) {
         if (Tcl_GetIntFromObj(interp, objv[1], &spindle) != TCL_OK){ // not a likely spindle index first, then
             spindle = 0;
-            objstr = Tcl_GetStringFromObj(objv[1], 0);
+            objstr = Tcl_GetStringFromObj(objv[1], NULL);
         } else {
             if (spindle < 0 || spindle > EMCMOT_MAX_SPINDLES){ // FIXME: should really be num_spindles, but not sure we know that here
                 setresult(interp,"invalid spindle index number");
                 return TCL_ERROR;
             }
-            objstr = Tcl_GetStringFromObj(objv[2], 0);
+            objstr = Tcl_GetStringFromObj(objv[2], NULL);
         }
     }
 
@@ -1284,7 +1284,7 @@ static int emc_tool_offset(ClientData /*clientdata*/,
     }
 
     if (objc != 1) {
-       ch = Tcl_GetStringFromObj(objv[1], 0)[0];
+       ch = Tcl_GetStringFromObj(objv[1], NULL)[0];
     }
 
     switch (ch) {
@@ -1343,7 +1343,7 @@ static int emc_load_tool_table(ClientData /*clientdata*/,
 	return TCL_ERROR;
     }
 
-    if (0 != sendLoadToolTable(Tcl_GetStringFromObj(objv[1], 0))) {
+    if (0 != sendLoadToolTable(Tcl_GetStringFromObj(objv[1], NULL))) {
 	setresult(interp,"emc_load_tool_table: can't open file");
 	return TCL_OK;
     }
@@ -1365,15 +1365,15 @@ static int emc_set_tool_offset(ClientData /*clientdata*/,
 	return TCL_ERROR;
     }
 
-    if (0 != Tcl_GetIntFromObj(0, objv[1], &tool)) {
+    if (0 != Tcl_GetIntFromObj(NULL, objv[1], &tool)) {
 	setresult(interp,"emc_set_tool_offset: need tool as integer, 0..");
 	return TCL_ERROR;
     }
-    if (0 != Tcl_GetDoubleFromObj(0, objv[2], &length)) {
+    if (0 != Tcl_GetDoubleFromObj(NULL, objv[2], &length)) {
 	setresult(interp,"emc_set_tool_offset: need length as real number");
 	return TCL_ERROR;
     }
-    if (0 != Tcl_GetDoubleFromObj(0, objv[3], &diameter)) {
+    if (0 != Tcl_GetDoubleFromObj(NULL, objv[3], &diameter)) {
 	setresult(interp,"emc_set_tool_offset: need diameter as real number");
 	return TCL_ERROR;
     }
@@ -1402,7 +1402,7 @@ static int emc_abs_cmd_pos(ClientData /*clientdata*/,
 	updateStatus();
     }
 
-    char ch = Tcl_GetStringFromObj(objv[1], 0)[0];
+    char ch = Tcl_GetStringFromObj(objv[1], NULL)[0];
 
     switch (ch) {
     case 'x': case 'X':
@@ -1466,7 +1466,7 @@ static int emc_abs_act_pos(ClientData /*clientdata*/,
 	updateStatus();
     }
 
-    char ch = Tcl_GetStringFromObj(objv[1], 0)[0];
+    char ch = Tcl_GetStringFromObj(objv[1], NULL)[0];
 
     switch (ch) {
     case 'x': case 'X':
@@ -1530,7 +1530,7 @@ static int emc_rel_cmd_pos(ClientData /*clientdata*/,
 	updateStatus();
     }
 
-    char ch = Tcl_GetStringFromObj(objv[1], 0)[0];
+    char ch = Tcl_GetStringFromObj(objv[1], NULL)[0];
 
     double d = 0.0;
     switch (ch) {
@@ -1613,7 +1613,7 @@ static int emc_rel_act_pos(ClientData /*clientdata*/,
 	updateStatus();
     }
 
-    char ch = Tcl_GetStringFromObj(objv[1], 0)[0];
+    char ch = Tcl_GetStringFromObj(objv[1], NULL)[0];
 
     double d = 0.0;
     switch (ch) {
@@ -1698,7 +1698,7 @@ static int emc_joint_pos(ClientData /*clientdata*/,
 	updateStatus();
     }
 
-    if (TCL_OK == Tcl_GetIntFromObj(0, objv[1], &joint)) {
+    if (TCL_OK == Tcl_GetIntFromObj(NULL, objv[1], &joint)) {
 	posobj = Tcl_NewDoubleObj(emcStatus->motion.joint[joint].input);
     } else {
 	setresult(interp,"emc_joint_pos: bad integer argument");
@@ -1725,7 +1725,7 @@ static int emc_pos_offset(ClientData /*clientdata*/,
 	updateStatus();
     }
 
-    char ch = Tcl_GetStringFromObj(objv[1], 0)[0];
+    char ch = Tcl_GetStringFromObj(objv[1], NULL)[0];
 
     switch (ch) {
     case 'x': case 'X':
@@ -1789,7 +1789,7 @@ static int emc_joint_limit(ClientData /*clientdata*/,
 	updateStatus();
     }
 
-    if (TCL_OK == Tcl_GetIntFromObj(0, objv[1], &joint)) {
+    if (TCL_OK == Tcl_GetIntFromObj(NULL, objv[1], &joint)) {
 	if (joint < 0 || joint >= EMCMOT_MAX_JOINTS) {
 	    setresult(interp,"emc_joint_limit: joint out of bounds");
 	    return TCL_ERROR;
@@ -1833,7 +1833,7 @@ static int emc_joint_fault(ClientData /*clientdata*/,
 	updateStatus();
     }
 
-    if (TCL_OK == Tcl_GetIntFromObj(0, objv[1], &joint)) {
+    if (TCL_OK == Tcl_GetIntFromObj(NULL, objv[1], &joint)) {
 	if (joint < 0 || joint >= EMCMOT_MAX_JOINTS) {
 	    setresult(interp,"emc_joint_fault: joint out of bounds");
 	    return TCL_ERROR;
@@ -1872,7 +1872,7 @@ static int emc_override_limit(ClientData /*clientdata*/,
     }
 
     if (objc == 2) {
-	if (TCL_OK == Tcl_GetIntFromObj(0, objv[1], &on)) {
+	if (TCL_OK == Tcl_GetIntFromObj(NULL, objv[1], &on)) {
 	    if (on) {
 		if (0 != sendOverrideLimits(0)) {
 		    setresult(interp,"emc_override_limit: can't send command");
@@ -1911,7 +1911,7 @@ static int emc_joint_homed(ClientData /*clientdata*/,
 	updateStatus();
     }
 
-    if (TCL_OK == Tcl_GetIntFromObj(0, objv[1], &joint)) {
+    if (TCL_OK == Tcl_GetIntFromObj(NULL, objv[1], &joint)) {
 	if (joint < 0 || joint >= EMCMOT_MAX_JOINTS) {
 	    setresult(interp,"emc_joint_homed: joint out of bounds");
 	    return TCL_ERROR;
@@ -1942,10 +1942,10 @@ static int emc_mdi(ClientData /*clientdata*/,
 	return TCL_ERROR;
     }
     // bug-- check for string overflow
-    rtapi_strxcpy(string, Tcl_GetStringFromObj(objv[1], 0));
+    rtapi_strxcpy(string, Tcl_GetStringFromObj(objv[1], NULL));
     for (t = 2; t < objc; t++) {
 	rtapi_strxcat(string, " ");
-	rtapi_strxcat(string, Tcl_GetStringFromObj(objv[t], 0));
+	rtapi_strxcat(string, Tcl_GetStringFromObj(objv[t], NULL));
     }
 
     if (0 != sendMdiCmd(string)) {
@@ -1967,7 +1967,7 @@ static int emc_home(ClientData /*clientdata*/,
 	return TCL_ERROR;
     }
 
-    if (TCL_OK == Tcl_GetIntFromObj(0, objv[1], &joint)) {
+    if (TCL_OK == Tcl_GetIntFromObj(NULL, objv[1], &joint)) {
 	sendHome(joint);
 	return TCL_OK;
     }
@@ -1987,7 +1987,7 @@ static int emc_unhome(ClientData /*clientdata*/,
 	return TCL_ERROR;
     }
 
-    if (TCL_OK == Tcl_GetIntFromObj(0, objv[1], &joint)) {
+    if (TCL_OK == Tcl_GetIntFromObj(NULL, objv[1], &joint)) {
 	sendUnHome(joint);
 	return TCL_OK;
     }
@@ -2008,11 +2008,11 @@ static int emc_jog_stop(ClientData /*clientdata*/,
 	setresult(interp,"emc_jog_stop: need joint,jogmode");
 	return TCL_ERROR;
     }
-    if (0 != Tcl_GetIntFromObj(0, objv[1], &joint)) {
+    if (0 != Tcl_GetIntFromObj(NULL, objv[1], &joint)) {
 	setresult(interp,"emc_jog_stop: need joint as integer, 0|1");
 	return TCL_ERROR;
     }
-    if (0 != Tcl_GetIntFromObj(0, objv[2], &jjogmode)) {
+    if (0 != Tcl_GetIntFromObj(NULL, objv[2], &jjogmode)) {
 	setresult(interp,"emc_jog_stop: need jogmode as integer, 0..");
 	return TCL_ERROR;
     }
@@ -2037,15 +2037,15 @@ static int emc_jog(ClientData /*clientdata*/,
 	return TCL_ERROR;
     }
 
-    if (0 != Tcl_GetIntFromObj(0, objv[1], &joint)) {
+    if (0 != Tcl_GetIntFromObj(NULL, objv[1], &joint)) {
 	setresult(interp,"emc_jog: need joint as integer, 0|1");
 	return TCL_ERROR;
     }
-    if (0 != Tcl_GetIntFromObj(0, objv[2], &jjogmode)) {
+    if (0 != Tcl_GetIntFromObj(NULL, objv[2], &jjogmode)) {
 	setresult(interp,"emc_jog: need jogmode as integer, 0..");
 	return TCL_ERROR;
     }
-    if (0 != Tcl_GetDoubleFromObj(0, objv[3], &speed)) {
+    if (0 != Tcl_GetDoubleFromObj(NULL, objv[3], &speed)) {
 	setresult(interp,"emc_jog: need speed as real number");
 	return TCL_ERROR;
     }
@@ -2073,19 +2073,19 @@ static int emc_jog_incr(ClientData /*clientdata*/,
 	return TCL_ERROR;
     }
 
-    if (0 != Tcl_GetIntFromObj(0, objv[1], &joint)) {
+    if (0 != Tcl_GetIntFromObj(NULL, objv[1], &joint)) {
 	setresult(interp,"emc_jog_incr: need joint as integer, 0|1");
 	return TCL_ERROR;
     }
-    if (0 != Tcl_GetIntFromObj(0, objv[2], &jjogmode)) {
+    if (0 != Tcl_GetIntFromObj(NULL, objv[2], &jjogmode)) {
 	setresult(interp,"emc_jog_incr: need jogmode as integer, 0..");
 	return TCL_ERROR;
     }
-    if (0 != Tcl_GetDoubleFromObj(0, objv[3], &speed)) {
+    if (0 != Tcl_GetDoubleFromObj(NULL, objv[3], &speed)) {
 	setresult(interp,"emc_jog_incr: need speed as real number");
 	return TCL_ERROR;
     }
-    if (0 != Tcl_GetDoubleFromObj(0, objv[4], &incr)) {
+    if (0 != Tcl_GetDoubleFromObj(NULL, objv[4], &incr)) {
 	setresult(interp,"emc_jog_incr: need increment as real number");
 	return TCL_ERROR;
     }
@@ -2122,7 +2122,7 @@ static int emc_feed_override(ClientData /*clientdata*/,
 	return TCL_ERROR;
     }
 
-    if (TCL_OK == Tcl_GetIntFromObj(0, objv[1], &percent)) {
+    if (TCL_OK == Tcl_GetIntFromObj(NULL, objv[1], &percent)) {
 	sendFeedOverride(((double) percent) / 100.0);
 	return TCL_OK;
     }
@@ -2156,7 +2156,7 @@ static int emc_rapid_override(ClientData /*clientdata*/,
 	return TCL_ERROR;
     }
 
-    if (TCL_OK == Tcl_GetIntFromObj(0, objv[1], &percent)) {
+    if (TCL_OK == Tcl_GetIntFromObj(NULL, objv[1], &percent)) {
 	sendRapidOverride(((double) percent) / 100.0);
 	return TCL_OK;
     }
@@ -2185,18 +2185,18 @@ static int emc_spindle_override(ClientData /*clientdata*/,
     }
 
     if (objc == 2){
-		if (TCL_OK == Tcl_GetIntFromObj(0, objv[1], &percent)) {
+		if (TCL_OK == Tcl_GetIntFromObj(NULL, objv[1], &percent)) {
 		sendSpindleOverride(spindle, ((double) percent) / 100.0);
 		return TCL_OK;
 		}
     }
 
     if (objc == 3){ // spindle number included
-		if (TCL_OK != Tcl_GetIntFromObj(0, objv[1], &spindle)) {
+		if (TCL_OK != Tcl_GetIntFromObj(NULL, objv[1], &spindle)) {
 		    setresult(interp,"emc_spindle_override: malformed spindle number");
 		    return TCL_ERROR;
 		}
-		if (TCL_OK != Tcl_GetIntFromObj(0, objv[2], &percent)) {
+		if (TCL_OK != Tcl_GetIntFromObj(NULL, objv[2], &percent)) {
 		    setresult(interp,"emc_spindle_override: need percent");
 		    return TCL_ERROR;
 		}
@@ -2230,7 +2230,7 @@ static int emc_open(ClientData /*clientdata*/,
 	return TCL_ERROR;
     }
 
-    if (0 != sendProgramOpen(Tcl_GetStringFromObj(objv[1], 0))) {
+    if (0 != sendProgramOpen(Tcl_GetStringFromObj(objv[1], NULL))) {
 	setresult(interp,"emc_open: can't open file");
 	return TCL_OK;
     }
@@ -2252,7 +2252,7 @@ static int emc_run(ClientData /*clientdata*/,
     }
 
     if (objc == 2) {
-	if (0 != Tcl_GetIntFromObj(0, objv[1], &line)) {
+	if (0 != Tcl_GetIntFromObj(NULL, objv[1], &line)) {
 	    setresult(interp,"emc_run: need integer start line");
 	    return TCL_ERROR;
 	}
@@ -2297,7 +2297,7 @@ static int emc_optional_stop(ClientData /*clientdata*/,
     }
 
     if (objc == 2) {
-	if (TCL_OK == Tcl_GetIntFromObj(0, objv[1], &on)) {
+	if (TCL_OK == Tcl_GetIntFromObj(NULL, objv[1], &on)) {
 	    if (0 != sendSetOptionalStop(on)) {
 		    setresult(interp,"emc_optional_stop: can't send command");
 		    return TCL_OK;
@@ -2521,7 +2521,7 @@ static int emc_joint_type(ClientData /*clientdata*/,
 	updateStatus();
     }
 
-    if (TCL_OK == Tcl_GetIntFromObj(0, objv[1], &joint)) {
+    if (TCL_OK == Tcl_GetIntFromObj(NULL, objv[1], &joint)) {
 	if (joint < 0 || joint >= EMCMOT_MAX_JOINTS) {
 	    setresult(interp,"emc_joint_type: joint out of bounds");
 	    return TCL_ERROR;
@@ -2562,7 +2562,7 @@ static int emc_joint_units(ClientData /*clientdata*/,
 	updateStatus();
     }
 
-    if (TCL_OK == Tcl_GetIntFromObj(0, objv[1], &joint)) {
+    if (TCL_OK == Tcl_GetIntFromObj(NULL, objv[1], &joint)) {
 	if (joint < 0 || joint >= EMCMOT_MAX_JOINTS) {
 	    setresult(interp,"emc_joint_units: joint out of bounds");
 	    return TCL_ERROR;
@@ -2874,7 +2874,7 @@ static int emc_linear_unit_conversion(ClientData /*clientdata*/,
     }
 
     if (objc == 2) {
-	objstr = Tcl_GetStringFromObj(objv[1], 0);
+	objstr = Tcl_GetStringFromObj(objv[1], NULL);
 	if (!strcmp(objstr, "inch")) {
 	    linearUnitConversion = LINEAR_UNITS_INCH;
 	    return TCL_OK;
@@ -2931,7 +2931,7 @@ static int emc_angular_unit_conversion(ClientData /*clientdata*/,
     }
 
     if (objc == 2) {
-	objstr = Tcl_GetStringFromObj(objv[1], 0);
+	objstr = Tcl_GetStringFromObj(objv[1], NULL);
 	if (!strcmp(objstr, "deg")) {
 	    angularUnitConversion = ANGULAR_UNITS_DEG;
 	    return TCL_OK;
@@ -3175,7 +3175,7 @@ static int emc_joint_backlash(ClientData /*clientdata*/,
 	return TCL_ERROR;
     }
     // get joint number
-    if (0 != Tcl_GetIntFromObj(0, objv[1], &joint) ||
+    if (0 != Tcl_GetIntFromObj(NULL, objv[1], &joint) ||
 	joint < 0 || joint >= EMCMOT_MAX_JOINTS) {
 	setresult(interp,"emc_joint_backlash: need joint as integer, 0..EMCMOT_MAX_JOINTS-1");
 	return TCL_ERROR;
@@ -3188,7 +3188,7 @@ static int emc_joint_backlash(ClientData /*clientdata*/,
 	return TCL_OK;
     } else {
 	// want to set new value
-	if (0 != Tcl_GetDoubleFromObj(0, objv[2], &backlash)) {
+	if (0 != Tcl_GetDoubleFromObj(NULL, objv[2], &backlash)) {
 	    setresult(interp,"emc_joint_backlash: need backlash as real number");
 	    return TCL_ERROR;
 	}
@@ -3214,7 +3214,7 @@ static int emc_joint_enable(ClientData /*clientdata*/,
 	return TCL_ERROR;
     }
 
-    if (0 != Tcl_GetIntFromObj(0, objv[1], &joint) ||
+    if (0 != Tcl_GetIntFromObj(NULL, objv[1], &joint) ||
 	joint < 0 || joint >= EMCMOT_MAX_JOINTS) {
 	setresult(interp,"emc_joint_enable: need joint as integer, 0..EMCMOT_MAX_JOINTS-1");
 	return TCL_ERROR;
@@ -3229,7 +3229,7 @@ static int emc_joint_enable(ClientData /*clientdata*/,
 	return TCL_OK;
     }
     // else we were given 0 or 1 to enable/disable it
-    if (0 != Tcl_GetIntFromObj(0, objv[2], &val)) {
+    if (0 != Tcl_GetIntFromObj(NULL, objv[2], &val)) {
 	setresult(interp,"emc_joint_enable: need 0, 1 for disable, enable");
 	return TCL_ERROR;
     }
@@ -3251,15 +3251,15 @@ static int emc_joint_load_comp(ClientData /*clientdata*/,
 	return TCL_ERROR;
     }
 
-    if (0 != Tcl_GetIntFromObj(0, objv[1], &joint) ||
+    if (0 != Tcl_GetIntFromObj(NULL, objv[1], &joint) ||
 	joint < 0 || joint >= EMCMOT_MAX_JOINTS) {
 	setresult(interp,"emc_joint_load_comp: need joint as integer, 0..EMCMOT_MAX_JOINTS-1");
 	return TCL_ERROR;
     }
     // copy objv[1] to file arg, to make sure it's not modified
-    rtapi_strxcpy(file, Tcl_GetStringFromObj(objv[2], 0));
+    rtapi_strxcpy(file, Tcl_GetStringFromObj(objv[2], NULL));
 
-    if (0 != Tcl_GetIntFromObj(0, objv[3], &type)) {
+    if (0 != Tcl_GetIntFromObj(NULL, objv[3], &type)) {
 	setresult(interp,"emc_joint_load_comp: <type> must be an int");
     }
 
@@ -3275,7 +3275,7 @@ int emc_teleop_enable(ClientData /*clientdata*/,
     int enable;
 
     if (objc != 1) {
-	if (0 != Tcl_GetIntFromObj(0, objv[1], &enable)) {
+	if (0 != Tcl_GetIntFromObj(NULL, objv[1], &enable)) {
 	    setresult(interp,"emc_teleop_enable: <enable> must be an integer");
 	    return TCL_ERROR;
 	}
@@ -3368,13 +3368,13 @@ int emc_probe_move(ClientData /*clientdata*/,
 	return TCL_ERROR;
     }
 
-    if (0 != Tcl_GetDoubleFromObj(0, objv[1], &x)) {
+    if (0 != Tcl_GetDoubleFromObj(NULL, objv[1], &x)) {
 	setresult(interp,"emc_probe_move: <x> must be a double");
     }
-    if (0 != Tcl_GetDoubleFromObj(0, objv[2], &y)) {
+    if (0 != Tcl_GetDoubleFromObj(NULL, objv[2], &y)) {
 	setresult(interp,"emc_probe_move: <y> must be a double");
     }
-    if (0 != Tcl_GetDoubleFromObj(0, objv[3], &z)) {
+    if (0 != Tcl_GetDoubleFromObj(NULL, objv[3], &z)) {
 	setresult(interp,"emc_probe_move: <z> must be a double");
     }
 
@@ -3398,7 +3398,7 @@ static int emc_probed_pos(ClientData /*clientdata*/,
 	updateStatus();
     }
 
-    char ch = Tcl_GetStringFromObj(objv[1], 0)[0];
+    char ch = Tcl_GetStringFromObj(objv[1], NULL)[0];
 
     switch (ch) {
     case 'x': case 'X':
@@ -3466,7 +3466,7 @@ static int emc_pendant(ClientData /*clientdata*/,
 
     CHECKEMC
     if (objc == 2) {
-	port = Tcl_GetStringFromObj(objv[1], 0);
+	port = Tcl_GetStringFromObj(objv[1], NULL);
 	if ((!strcmp(port, "/dev/psaux")) | (!strcmp(port,
 						     "/dev/ttyS0")) |
 	    (!strcmp(port, "/dev/ttyS1"))) {
@@ -3530,10 +3530,10 @@ static int localint(ClientData /*clientdata*/,
 	return TCL_ERROR;
     }
 
-    if (0 != Tcl_GetDoubleFromObj(0, objv[1], &val)) {
+    if (0 != Tcl_GetDoubleFromObj(NULL, objv[1], &val)) {
 	resstring[0] = 0;
 	rtapi_strxcat(resstring, "expected number but got \"");
-	strncat(resstring, Tcl_GetStringFromObj(objv[1], 0),
+	strncat(resstring, Tcl_GetStringFromObj(objv[1], NULL),
 		sizeof(resstring) - strlen(resstring) - 2);
 	rtapi_strxcat(resstring, "\"");
 	setresult(interp, resstring);
@@ -3565,10 +3565,10 @@ static int localround(ClientData /*clientdata*/,
 	return TCL_ERROR;
     }
 
-    if (0 != Tcl_GetDoubleFromObj(0, objv[1], &val)) {
+    if (0 != Tcl_GetDoubleFromObj(NULL, objv[1], &val)) {
 	resstring[0] = 0;
 	rtapi_strxcat(resstring, "expected number but got \"");
-	strncat(resstring, Tcl_GetStringFromObj(objv[1], 0),
+	strncat(resstring, Tcl_GetStringFromObj(objv[1], NULL),
 		sizeof(resstring) - strlen(resstring) - 2);
 	rtapi_strxcat(resstring, "\"");
 	setresult(interp,resstring);
@@ -3624,7 +3624,7 @@ static int multihead(ClientData /*clientdata*/,
 
 static void sigQuit(int /*sig*/)
 {
-    thisQuit((ClientData) 0);
+    thisQuit((ClientData) NULL);
 }
 
 static void initMain()
@@ -3635,11 +3635,11 @@ static void initMain()
     emcUpdateType = EMC_UPDATE_AUTO;
     linearUnitConversion = LINEAR_UNITS_AUTO;
     angularUnitConversion = ANGULAR_UNITS_AUTO;
-    emcCommandBuffer = 0;
-    emcStatusBuffer = 0;
-    emcStatus = 0;
+    emcCommandBuffer = NULL;
+    emcStatusBuffer = NULL;
+    emcStatus = NULL;
 
-    emcErrorBuffer = 0;
+    emcErrorBuffer = NULL;
     error_string.clear();
     operator_text_string.clear();
     operator_display_string.clear();
@@ -3681,7 +3681,7 @@ int emc_init(ClientData /*cd*/, Tcl_Interp *interp, int argc, const char **argv)
     emcCommandSerialNumber = emcStatus->echo_serial_number;
 
     // attach our quit function to exit
-    Tcl_CreateExitHandler(thisQuit, (ClientData) 0);
+    Tcl_CreateExitHandler(thisQuit, (ClientData) NULL);
 
     // attach our quit function to SIGINT
     signal(SIGINT, sigQuit);

--- a/src/emc/usr_intf/halui.cc
+++ b/src/emc/usr_intf/halui.cc
@@ -255,12 +255,12 @@ static EMC_TASK_MODE halui_old_mode = EMC_TASK_MODE::MANUAL;
 static int halui_sent_mdi = 0;
 
 // the NML channels to the EMC task
-static RCS_CMD_CHANNEL *emcCommandBuffer = 0;
-static RCS_STAT_CHANNEL *emcStatusBuffer = 0;
-EMC_STAT *emcStatus = 0;
+static RCS_CMD_CHANNEL *emcCommandBuffer = NULL;
+static RCS_STAT_CHANNEL *emcStatusBuffer = NULL;
+EMC_STAT *emcStatus = NULL;
 
 // the NML channel for errors
-static NML *emcErrorBuffer = 0;
+static NML *emcErrorBuffer = NULL;
 
 // the serial number to use.
 static int emcCommandSerialNumber = 0;
@@ -281,25 +281,25 @@ static int emcTaskNmlGet()
     int retval = 0;
 
     // try to connect to EMC cmd
-    if (emcCommandBuffer == 0) {
+    if (emcCommandBuffer == NULL) {
 	emcCommandBuffer =
 	    new RCS_CMD_CHANNEL(emcFormat, "emcCommand", "xemc",
 				emc_nmlfile);
 	if (!emcCommandBuffer->valid()) {
 	    delete emcCommandBuffer;
-	    emcCommandBuffer = 0;
+	    emcCommandBuffer = NULL;
 	    retval = -1;
 	}
     }
     // try to connect to EMC status
-    if (emcStatusBuffer == 0) {
+    if (emcStatusBuffer == NULL) {
 	emcStatusBuffer =
 	    new RCS_STAT_CHANNEL(emcFormat, "emcStatus", "xemc",
 				 emc_nmlfile);
 	if (!emcStatusBuffer->valid()) {
 	    delete emcStatusBuffer;
-	    emcStatusBuffer = 0;
-	    emcStatus = 0;
+	    emcStatusBuffer = NULL;
+	    emcStatus = NULL;
 	    retval = -1;
 	} else {
 	    emcStatus = reinterpret_cast<EMC_STAT *>(emcStatusBuffer->get_address());
@@ -313,12 +313,12 @@ static int emcErrorNmlGet()
 {
     int retval = 0;
 
-    if (emcErrorBuffer == 0) {
+    if (emcErrorBuffer == NULL) {
 	emcErrorBuffer =
 	    new NML(nmlErrorFormat, "emcError", "xemc", emc_nmlfile);
 	if (!emcErrorBuffer->valid()) {
 	    delete emcErrorBuffer;
-	    emcErrorBuffer = 0;
+	    emcErrorBuffer = NULL;
 	    retval = -1;
 	}
     }
@@ -373,7 +373,7 @@ static int updateStatus()
 {
     NMLTYPE type;
 
-    if (0 == emcStatus || 0 == emcStatusBuffer) {
+    if (NULL == emcStatus || NULL == emcStatusBuffer) {
         rtapi_print("halui: %s: no status buffer\n", __func__);
         return -1;
     }
@@ -466,9 +466,9 @@ static void thisQuit()
     //don't forget the big HAL sin ;)
     hal_exit(comp_id);
 
-    if(emcCommandBuffer) { delete emcCommandBuffer;  emcCommandBuffer = 0; }
-    if(emcStatusBuffer) { delete emcStatusBuffer;  emcStatusBuffer = 0; }
-    if(emcErrorBuffer) { delete emcErrorBuffer;  emcErrorBuffer = 0; }
+    if(emcCommandBuffer) { delete emcCommandBuffer;  emcCommandBuffer = NULL; }
+    if(emcStatusBuffer) { delete emcStatusBuffer;  emcStatusBuffer = NULL; }
+    if(emcErrorBuffer) { delete emcErrorBuffer;  emcErrorBuffer = NULL; }
     exit(0);
 }
 
@@ -557,7 +557,7 @@ int halui_hal_init(void)
 
     /* STEP 2: allocate shared memory for halui data */
     halui_data = (halui_str *) hal_malloc(sizeof(halui_str));
-    if (halui_data == 0) {
+    if (halui_data == NULL) {
 	rtapi_print_msg(RTAPI_MSG_ERR,
 			"HALUI: ERROR: hal_malloc() failed\n");
 	hal_exit(comp_id);

--- a/src/emc/usr_intf/schedrmt.cc
+++ b/src/emc/usr_intf/schedrmt.cc
@@ -281,7 +281,7 @@ struct option longopts[] = {
   {"connectpw", 1, NULL, 'w'},
   {"enablepw", 1, NULL, 'e'},
   {"path", 1, NULL, 'd'},
-  {0,0,0,0}
+  {NULL,0,NULL,0}
   };
 
 
@@ -289,27 +289,27 @@ static void thisQuit()
 {
     EMC_NULL emc_null_msg;
 
-    if (emcStatusBuffer != 0) {
+    if (emcStatusBuffer != NULL) {
 	// wait until current message has been received
 	emcCommandWaitReceived();
     }
 
     // clean up NML buffers
 
-    if (emcErrorBuffer != 0) {
+    if (emcErrorBuffer != NULL) {
 	delete emcErrorBuffer;
-	emcErrorBuffer = 0;
+	emcErrorBuffer = NULL;
     }
 
-    if (emcStatusBuffer != 0) {
+    if (emcStatusBuffer != NULL) {
 	delete emcStatusBuffer;
-	emcStatusBuffer = 0;
-	emcStatus = 0;
+	emcStatusBuffer = NULL;
+	emcStatus = NULL;
     }
 
-    if (emcCommandBuffer != 0) {
+    if (emcCommandBuffer != NULL) {
 	delete emcCommandBuffer;
-	emcCommandBuffer = 0;
+	emcCommandBuffer = NULL;
     }
 
     exit(0);
@@ -1139,7 +1139,7 @@ void *checkQueue(void * /*arg*/)
     updateQueue();
     sleep((unsigned)pollDelay);
     }
-  return 0;
+  return NULL;
 }  
 
 void *readClient(void * /*arg*/)
@@ -1201,7 +1201,7 @@ finished:
   close(context->cliSock);
   free(context);
 fail:
-  pthread_exit((void *)0);
+  pthread_exit(NULL);
   sessions--;  // FIXME: not reached
 }
 
@@ -1236,11 +1236,11 @@ static void initMain()
     emcUpdateType = EMC_UPDATE_AUTO;
     linearUnitConversion = LINEAR_UNITS_AUTO;
     angularUnitConversion = ANGULAR_UNITS_AUTO;
-    emcCommandBuffer = 0;
-    emcStatusBuffer = 0;
-    emcStatus = 0;
+    emcCommandBuffer = NULL;
+    emcStatusBuffer = NULL;
+    emcStatus = NULL;
 
-    emcErrorBuffer = 0;
+    emcErrorBuffer = NULL;
     error_string.clear();
     operator_text_string.clear();
     operator_display_string.clear();

--- a/src/emc/usr_intf/shcom.cc
+++ b/src/emc/usr_intf/shcom.cc
@@ -71,26 +71,26 @@ int emcTaskNmlGet()
     int retval = 0;
 
     // try to connect to EMC cmd
-    if (emcCommandBuffer == 0) {
+    if (emcCommandBuffer == nullptr) {
 	emcCommandBuffer =
 	    new RCS_CMD_CHANNEL(emcFormat, "emcCommand", "xemc",
 				emc_nmlfile);
 	if (!emcCommandBuffer->valid()) {
 	    delete emcCommandBuffer;
-	    emcCommandBuffer = 0;
+	    emcCommandBuffer = nullptr;
 	    retval = -1;
 	}
     }
     // try to connect to EMC status
-    if (emcStatusBuffer == 0) {
+    if (emcStatusBuffer == nullptr) {
 	emcStatusBuffer =
 	    new RCS_STAT_CHANNEL(emcFormat, "emcStatus", "xemc",
 				 emc_nmlfile);
 	if (!emcStatusBuffer->valid()
 	    || EMC_STAT_TYPE != emcStatusBuffer->peek()) {
 	    delete emcStatusBuffer;
-	    emcStatusBuffer = 0;
-	    emcStatus = 0;
+	    emcStatusBuffer = nullptr;
+	    emcStatus = nullptr;
 	    retval = -1;
 	} else {
 	    emcStatus = static_cast<EMC_STAT *>(emcStatusBuffer->get_address());
@@ -104,12 +104,12 @@ int emcErrorNmlGet()
 {
     int retval = 0;
 
-    if (emcErrorBuffer == 0) {
+    if (emcErrorBuffer == nullptr) {
 	emcErrorBuffer =
 	    new NML(nmlErrorFormat, "emcError", "xemc", emc_nmlfile);
 	if (!emcErrorBuffer->valid()) {
 	    delete emcErrorBuffer;
-	    emcErrorBuffer = 0;
+	    emcErrorBuffer = nullptr;
 	    retval = -1;
 	}
     }

--- a/src/hal/classicladder/classicladder.c
+++ b/src/hal/classicladder/classicladder.c
@@ -136,13 +136,13 @@ void process_options (int argc, char *argv[])
 	{
 		int option_index = 0;
 		static const struct option long_options[] = {
-			{"nogui", no_argument, 0, 'n'},
-			{"modmaster",no_argument,0,'m'},
-			{"modslave",no_argument,0,'s'},
-			{"debug",no_argument,0,'d'},
-			{"modbus_port", required_argument, 0, 'p'},
-			{"newpath", required_argument, 0, 'f'},
-			{0, 0, 0, 0},
+			{"nogui", no_argument, NULL, 'n'},
+			{"modmaster",no_argument,NULL,'m'},
+			{"modslave",no_argument,NULL,'s'},
+			{"debug",no_argument,NULL,'d'},
+			{"modbus_port", required_argument, NULL, 'p'},
+			{"newpath", required_argument, NULL, 'f'},
+			{NULL, 0, NULL, 0},
 		};
 
 		int c = getopt_long(argc, argv, "",

--- a/src/hal/classicladder/classicladder_gtk.c
+++ b/src/hal/classicladder/classicladder_gtk.c
@@ -345,7 +345,7 @@ static void IncrementVScrollBar( int IncrementValue )
 	}
 	gtk_adjustment_changed( AdjustVScrollBar );
 	InfosGene->OffsetHiddenTopRungDisplayed	= gtk_adjustment_get_value(AdjustVScrollBar);
-	VScrollBar_value_changed_event( AdjustVScrollBar, 0 );
+	VScrollBar_value_changed_event( AdjustVScrollBar, NULL );
 }
 
 static gboolean mouse_scroll_event( GtkWidget *widget, GdkEventScroll *event )
@@ -1046,9 +1046,9 @@ void MainSectionWindowInitGtk()
 	UpdateVScrollBar();
 
 	gtk_signal_connect(GTK_OBJECT (AdjustVScrollBar), "value-changed",
-						GTK_SIGNAL_FUNC(VScrollBar_value_changed_event), 0);
+						GTK_SIGNAL_FUNC(VScrollBar_value_changed_event), NULL);
 	gtk_signal_connect(GTK_OBJECT (AdjustHScrollBar), "value-changed",
-						GTK_SIGNAL_FUNC(HScrollBar_value_changed_event), 0);
+						GTK_SIGNAL_FUNC(HScrollBar_value_changed_event), NULL);
 
 	/* Create the status bar */
     StatusBar = gtk_statusbar_new ();
@@ -1201,7 +1201,7 @@ void MainSectionWindowInitGtk()
 							| GDK_POINTER_MOTION_HINT_MASK);
 
 	gtk_signal_connect( GTK_OBJECT(MainSectionWindow), "delete_event",
-		GTK_SIGNAL_FUNC(MainSectionWindowDeleteEvent), 0 );
+		GTK_SIGNAL_FUNC(MainSectionWindowDeleteEvent), NULL );
 	gtk_widget_show (MainSectionWindow);
 
 	GetTheSizesForRung();
@@ -1360,7 +1360,7 @@ void ShowErrorMessage(const char * title, const char * text, const char * button
 	g_signal_connect_swapped (okay_button, "clicked",
 							G_CALLBACK (ErrorMessageDeleteEvent), dialog);
         g_signal_connect( dialog, "delete_event",
-		G_CALLBACK(ErrorMessageDeleteEvent), 0 );
+		G_CALLBACK(ErrorMessageDeleteEvent), NULL );
 	gtk_container_add (GTK_CONTAINER (gtk_dialog_get_action_area(GTK_DIALOG(dialog))),
 					okay_button);
 	gtk_widget_grab_focus(okay_button);

--- a/src/hal/classicladder/edit_gtk.c
+++ b/src/hal/classicladder/edit_gtk.c
@@ -479,31 +479,31 @@ void EditorInitGtk()
 	EditorButtonAdd = gtk_button_new_with_label (_("Add"));
 	gtk_box_pack_start (GTK_BOX (vbox), EditorButtonAdd, FALSE, FALSE, 0);
 	gtk_signal_connect(GTK_OBJECT (EditorButtonAdd), "clicked",
-						GTK_SIGNAL_FUNC(ButtonAddRung), 0);
+						GTK_SIGNAL_FUNC(ButtonAddRung), NULL);
 	gtk_widget_show (EditorButtonAdd);
 	EditorButtonIns = gtk_button_new_with_label (_("Insert"));
 	gtk_box_pack_start (GTK_BOX (vbox), EditorButtonIns, FALSE, FALSE, 0);
 	gtk_signal_connect(GTK_OBJECT (EditorButtonIns), "clicked",
-						GTK_SIGNAL_FUNC(ButtonInsertRung), 0);
+						GTK_SIGNAL_FUNC(ButtonInsertRung), NULL);
 	gtk_widget_show (EditorButtonIns);
 	EditorButtonDel = gtk_button_new_with_label (_("Delete"));
 	gtk_box_pack_start (GTK_BOX (vbox), EditorButtonDel, FALSE, FALSE, 0);
 	gtk_signal_connect(GTK_OBJECT (EditorButtonDel), "clicked",
-						GTK_SIGNAL_FUNC(ButtonDeleteCurrentRung), 0);
+						GTK_SIGNAL_FUNC(ButtonDeleteCurrentRung), NULL);
 	gtk_widget_show (EditorButtonDel);
 	EditorButtonModify = gtk_button_new_with_label (_("Modify"));
 	gtk_box_pack_start (GTK_BOX (vbox), EditorButtonModify, FALSE, FALSE, 0);
 	gtk_signal_connect(GTK_OBJECT (EditorButtonModify), "clicked",
-						GTK_SIGNAL_FUNC(ButtonModifyCurrentRung), 0);
+						GTK_SIGNAL_FUNC(ButtonModifyCurrentRung), NULL);
 	gtk_widget_show (EditorButtonModify);
 	EditorButtonOk = gtk_button_new_with_label (_("Ok"));
 	gtk_box_pack_start (GTK_BOX (vbox), EditorButtonOk, FALSE, FALSE, 0);
 	gtk_signal_connect(GTK_OBJECT (EditorButtonOk), "clicked",
-						GTK_SIGNAL_FUNC(ButtonOkCurrentRung), 0);
+						GTK_SIGNAL_FUNC(ButtonOkCurrentRung), NULL);
 	EditorButtonCancel = gtk_button_new_with_label (_("Cancel"));
 	gtk_box_pack_start (GTK_BOX (vbox), EditorButtonCancel, FALSE, FALSE, 0);
 	gtk_signal_connect(GTK_OBJECT (EditorButtonCancel), "clicked",
-						GTK_SIGNAL_FUNC(ButtonCancelCurrentRung), 0);
+						GTK_SIGNAL_FUNC(ButtonCancelCurrentRung), NULL);
 
 	InitAllForToolbar( );
 //ForGTK3, deprecated...	TheTooltips = gtk_tooltips_new();
@@ -518,7 +518,7 @@ void EditorInitGtk()
 #endif
 
 	gtk_signal_connect( GTK_OBJECT(EditWindow), "delete_event",
-		GTK_SIGNAL_FUNC(EditorWindowDeleteEvent), 0 );
+		GTK_SIGNAL_FUNC(EditorWindowDeleteEvent), NULL);
 
 	gtk_window_set_resizable( GTK_WINDOW( EditWindow ), FALSE );
 //gtk_widget_show (EditWindow);

--- a/src/hal/classicladder/editproperties_gtk.c
+++ b/src/hal/classicladder/editproperties_gtk.c
@@ -292,13 +292,13 @@ void PropertiesInitGtk()
 	ButtonApplyProperties = gtk_button_new_with_label(_("Apply"));
 	gtk_box_pack_start (GTK_BOX (hbox[NumParam]), ButtonApplyProperties, TRUE, FALSE, 0);
 	gtk_signal_connect(GTK_OBJECT (ButtonApplyProperties), "clicked",
-						GTK_SIGNAL_FUNC(SaveElementProperties), 0);
+						GTK_SIGNAL_FUNC(SaveElementProperties), NULL);
 	gtk_widget_set_sensitive( ButtonApplyProperties, FALSE );
 	gtk_widget_show( ButtonApplyProperties );
 
 //    gtk_widget_show (PropertiesWindow);
 
 	gtk_signal_connect( GTK_OBJECT(PropertiesWindow), "delete_event",
-		GTK_SIGNAL_FUNC(PropertiesWindowDeleteEvent), 0 );
+		GTK_SIGNAL_FUNC(PropertiesWindowDeleteEvent), NULL);
 }
 

--- a/src/hal/classicladder/files.c
+++ b/src/hal/classicladder/files.c
@@ -211,7 +211,7 @@ char LoadRung(char * FileName,StrRung * BufRung)
                             if (atoi(&Line[5])>2)
                             {
                                 printf(_("Rung version not supported...\n"));
-                                LineOk = FALSE;
+                                LineOk = NULL;
                             }
                         }
                         if(strncmp(&Line[1],"LABEL=",6)==0)
@@ -826,7 +826,7 @@ char LoadSectionsParams(char * FileName)
                             if (atoi(&Line[5])>1)
                             {
                                 printf(_("Sections file version not supported...\n"));
-                                LineOk = FALSE;
+                                LineOk = NULL;
                             }
                         }
                         // #NAMExxx=....
@@ -999,7 +999,7 @@ char LoadModbusIOConfParams(char * FileName)
 						}
 						else
 						{
-							LineOk = FALSE;
+							LineOk = NULL;
 						}
 					}
 					else
@@ -1082,7 +1082,7 @@ char LoadSymbols(char * FileName)
 							if (atoi(&Line[5])>1)
 							{
 								printf(_("Symbols file version not supported...\n"));
-								LineOk = FALSE;
+								LineOk = NULL;
 							}
 						}
 						break;

--- a/src/hal/classicladder/files_sequential.c
+++ b/src/hal/classicladder/files_sequential.c
@@ -95,7 +95,7 @@ char LoadSequential(char * FileName)
 							if (atoi(&Line[5])>1)
 							{
 								printf(_("Sequential version not supported...\n"));
-								LineOk = FALSE;
+								LineOk = NULL;
 							}
 						}
 						break;

--- a/src/hal/classicladder/manager_gtk.c
+++ b/src/hal/classicladder/manager_gtk.c
@@ -474,12 +474,12 @@ void AddSectionWindowInit( )
 	ButtonOk = gtk_button_new_with_label(_("Ok"));
 	gtk_box_pack_start (GTK_BOX (vbox), ButtonOk, TRUE, FALSE, 0);
 	gtk_signal_connect(GTK_OBJECT (ButtonOk), "clicked",
-		GTK_SIGNAL_FUNC(ButtonAddSectionDoneClickSignal), 0);
+		GTK_SIGNAL_FUNC(ButtonAddSectionDoneClickSignal), NULL);
 	gtk_widget_show (ButtonOk);
 	gtk_window_set_modal(GTK_WINDOW(AddSectionWindow),TRUE);
 	gtk_window_set_position(GTK_WINDOW(AddSectionWindow),GTK_WIN_POS_CENTER);
 	gtk_signal_connect( GTK_OBJECT(AddSectionWindow), "delete_event",
-		GTK_SIGNAL_FUNC(AddSectionWindowDeleteEvent), 0 );
+		GTK_SIGNAL_FUNC(AddSectionWindowDeleteEvent), NULL);
 }
 
 GtkUIManager * ManageruiManager;
@@ -575,11 +575,11 @@ void ManagerInitGtk()
 	gtk_widget_show( ScrollWin );
 
 	gtk_signal_connect(GTK_OBJECT (ListViewSections), "cursor-changed",
-		GTK_SIGNAL_FUNC(TreeViewCursorChangedSignal), 0);
+		GTK_SIGNAL_FUNC(TreeViewCursorChangedSignal), NULL);
 
 //v0.9.20	ManagerDisplaySections( );
 	gtk_signal_connect( GTK_OBJECT(ManagerWindow), "delete_event",
-		GTK_SIGNAL_FUNC(ManagerWindowDeleteEvent), 0 );
+		GTK_SIGNAL_FUNC(ManagerWindowDeleteEvent), NULL);
 gtk_window_set_default_size ( GTK_WINDOW(ManagerWindow), -1, 130);
 
 gtk_widget_show (ManagerWindow);

--- a/src/hal/classicladder/spy_vars_gtk.c
+++ b/src/hal/classicladder/spy_vars_gtk.c
@@ -247,7 +247,7 @@ gtk_entry_set_width_chars( GTK_ENTRY(offsetboolvar[ ColumnVar ]), 4 );
 	UpdateAllLabelsBoolsVars( );
 	
 	gtk_signal_connect( GTK_OBJECT(SpyBoolVarsWindow), "delete_event",
-		GTK_SIGNAL_FUNC(BoolVarsWindowDeleteEvent), 0 );
+		GTK_SIGNAL_FUNC(BoolVarsWindowDeleteEvent), NULL);
 
 //	gtk_window_set_policy( GTK_WINDOW(SpyBoolVarsWindow), FALSE/*allow_shrink*/, FALSE/*allow_grow*/, TRUE/*auto_shrink*/ );
 }
@@ -332,7 +332,7 @@ void ModifyVarWindowInitGtk( )
                                         GTK_SIGNAL_FUNC(ModifyVarWindowDeleteEvent), NULL );
 
 	gtk_signal_connect( GTK_OBJECT(ModifyVarValueWindow), "delete_event",
-		GTK_SIGNAL_FUNC(ModifyVarWindowDeleteEvent), 0 );
+		GTK_SIGNAL_FUNC(ModifyVarWindowDeleteEvent), NULL);
 }
 
 
@@ -596,7 +596,7 @@ void FreeVarsWindowInitGtk( )
                                         GTK_SIGNAL_FUNC(OpenModifyVarWindow_clicked_event), (void *)(intptr_t)NumVarSpy );
 	}
 	gtk_signal_connect( GTK_OBJECT(SpyFreeVarsWindow), "delete_event",
-		GTK_SIGNAL_FUNC(FreeVarsWindowDeleteEvent), 0 );
+		GTK_SIGNAL_FUNC(FreeVarsWindowDeleteEvent), NULL);
 }
 
 

--- a/src/hal/classicladder/symbols_gtk.c
+++ b/src/hal/classicladder/symbols_gtk.c
@@ -213,7 +213,7 @@ void SymbolsInitGtk()
 	SymbolsWindow = gtk_window_new( GTK_WINDOW_TOPLEVEL );
 	gtk_window_set_title( GTK_WINDOW( SymbolsWindow ), _("Symbols names") );
 	gtk_signal_connect( GTK_OBJECT( SymbolsWindow ), "delete_event",
-		GTK_SIGNAL_FUNC(SymbolsWindowDeleteEvent), 0 );
+		GTK_SIGNAL_FUNC(SymbolsWindowDeleteEvent), NULL);
 
 	vbox = gtk_vbox_new(FALSE,0);
 

--- a/src/hal/components/sampler_usr.c
+++ b/src/hal/components/sampler_usr.c
@@ -183,7 +183,7 @@ int main(int argc, char **argv)
 	goto out;
     }
     hal_ready(comp_id);
-    int res = hal_stream_attach(&stream, comp_id, SAMPLER_SHMEM_KEY+channel, 0);
+    int res = hal_stream_attach(&stream, comp_id, SAMPLER_SHMEM_KEY+channel, NULL);
     if (res < 0) {
 	errno = -res;
 	perror("hal_stream_attach");

--- a/src/hal/components/streamer_usr.c
+++ b/src/hal/components/streamer_usr.c
@@ -163,7 +163,7 @@ int main(int argc, char **argv)
     }
     hal_ready(comp_id);
     /* open shmem for user/RT comms (stream) */
-    int r = hal_stream_attach(&stream, comp_id, STREAMER_SHMEM_KEY+channel, 0);
+    int r = hal_stream_attach(&stream, comp_id, STREAMER_SHMEM_KEY+channel, NULL);
     if ( r < 0 ) {
 	errno = -r;
 	perror("hal_stream_attach");

--- a/src/hal/hal_lib.c
+++ b/src/hal/hal_lib.c
@@ -74,8 +74,8 @@ MODULE_LICENSE("GPL");
 #include <time.h>
 #endif
 
-char *hal_shmem_base = 0;
-hal_data_t *hal_data = 0;
+char *hal_shmem_base = NULL;
+hal_data_t *hal_data = NULL;
 static int lib_module_id = -1;	/* RTAPI module ID for library module */
 static int lib_mem_id = 0;	/* RTAPI shmem ID for library module */
 
@@ -176,7 +176,7 @@ int hal_init(const char *name)
     char hal_name[HAL_NAME_LEN + 1];
     hal_comp_t *comp;
 
-    if (name == 0) {
+    if (name == NULL) {
 	rtapi_print_msg(RTAPI_MSG_ERR, "HAL: ERROR: no component name\n");
 	return -EINVAL;
     }
@@ -240,7 +240,7 @@ int hal_init(const char *name)
     /* get mutex before manipulating the shared data */
     rtapi_mutex_get(&(hal_data->mutex));
     /* make sure name is unique in the system */
-    if (halpr_find_comp_by_name(hal_name) != 0) {
+    if (halpr_find_comp_by_name(hal_name) != NULL) {
 	/* a component with this name already exists */
 	rtapi_mutex_give(&(hal_data->mutex));
 	rtapi_print_msg(RTAPI_MSG_ERR,
@@ -250,7 +250,7 @@ int hal_init(const char *name)
     }
     /* allocate a new component structure */
     comp = halpr_alloc_comp_struct();
-    if (comp == 0) {
+    if (comp == NULL) {
 	/* couldn't allocate structure */
 	rtapi_mutex_give(&(hal_data->mutex));
 	rtapi_print_msg(RTAPI_MSG_ERR,
@@ -289,7 +289,7 @@ int hal_exit(int comp_id)
     hal_comp_t *comp;
     char name[HAL_NAME_LEN + 1];
 
-    if (hal_data == 0) {
+    if (hal_data == NULL) {
 	rtapi_print_msg(RTAPI_MSG_ERR,
 	    "HAL: ERROR: exit called before init\n");
 	return -EINVAL;
@@ -372,14 +372,14 @@ void *hal_malloc(long int size)
 {
     void *retval;
 
-    if (hal_data == 0) {
+    if (hal_data == NULL) {
 	rtapi_print_msg(RTAPI_MSG_ERR,
 	    "HAL: ERROR: hal_malloc called before init\n");
-	return 0;
+	return NULL;
     }
     if (size <= 0) {
         rtapi_print_msg(RTAPI_MSG_ERR, "HAL: ERROR: hal_malloc bad size: %ld\n", size);
-        return 0;
+        return NULL;
     }
 
     /* get the mutex */
@@ -389,7 +389,7 @@ void *hal_malloc(long int size)
     /* release the mutex */
     rtapi_mutex_give(&(hal_data->mutex));
     /* check return value */
-    if (retval == 0) {
+    if (retval == NULL) {
 	rtapi_print_msg(RTAPI_MSG_DBG,
 	    "HAL: hal_malloc() can't allocate %ld bytes\n", size);
     }
@@ -544,7 +544,7 @@ char *hal_comp_name(int comp_id)
     locking types defined in hal.h
 */
 int hal_set_lock(unsigned char lock_type) {
-    if (hal_data == 0) {
+    if (hal_data == NULL) {
 	rtapi_print_msg(RTAPI_MSG_ERR,
 	    "HAL: ERROR: set_lock called before init\n");
 	return -EINVAL;
@@ -558,7 +558,7 @@ int hal_set_lock(unsigned char lock_type) {
 */
 
 unsigned char hal_get_lock() {
-    if (hal_data == 0) {
+    if (hal_data == NULL) {
 	rtapi_print_msg(RTAPI_MSG_ERR,
 	    "HAL: ERROR: get_lock called before init\n");
 	return -EINVAL;
@@ -720,7 +720,7 @@ int hal_pin_new(const char *name, hal_type_t type, hal_pin_dir_t dir,
     hal_pin_t *new, *ptr;
     hal_comp_t *comp;
 
-    if (hal_data == 0) {
+    if (hal_data == NULL) {
 	rtapi_print_msg(RTAPI_MSG_ERR,
 	    "HAL: ERROR: pin_new called before init\n");
 	return -EINVAL;
@@ -764,7 +764,7 @@ int hal_pin_new(const char *name, hal_type_t type, hal_pin_dir_t dir,
     rtapi_mutex_get(&(hal_data->mutex));
     /* validate comp_id */
     comp = halpr_find_comp_by_id(comp_id);
-    if (comp == 0) {
+    if (comp == NULL) {
 	/* bad comp_id */
 	rtapi_mutex_give(&(hal_data->mutex));
 	rtapi_print_msg(RTAPI_MSG_ERR,
@@ -801,7 +801,7 @@ int hal_pin_new(const char *name, hal_type_t type, hal_pin_dir_t dir,
     }
     /* allocate a new variable structure */
     new = alloc_pin_struct();
-    if (new == 0) {
+    if (new == NULL) {
 	/* alloc failed */
 	rtapi_mutex_give(&(hal_data->mutex));
 	rtapi_print_msg(RTAPI_MSG_ERR,
@@ -859,7 +859,7 @@ int hal_pin_alias(const char *pin_name, const char *alias)
     hal_pin_t *pin, *ptr;
     hal_oldname_t *oldname;
 
-    if (hal_data == 0) {
+    if (hal_data == NULL) {
 	rtapi_print_msg(RTAPI_MSG_ERR,
 	    "HAL: ERROR: pin_alias called before init\n");
 	return -EINVAL;
@@ -988,7 +988,7 @@ int hal_signal_new(const char *name, hal_type_t type)
     hal_sig_t *new, *ptr;
     void *data_addr;
 
-    if (hal_data == 0) {
+    if (hal_data == NULL) {
 	rtapi_print_msg(RTAPI_MSG_ERR,
 	    "HAL: ERROR: signal_new called before init\n");
 	return -EINVAL;
@@ -1009,7 +1009,7 @@ int hal_signal_new(const char *name, hal_type_t type)
     /* get mutex before accessing shared data */
     rtapi_mutex_get(&(hal_data->mutex));
     /* check for an existing signal with the same name */
-    if (halpr_find_sig_by_name(name) != 0) {
+    if (halpr_find_sig_by_name(name) != NULL) {
 	rtapi_mutex_give(&(hal_data->mutex));
 	rtapi_print_msg(RTAPI_MSG_ERR,
 	    "HAL: ERROR: duplicate signal '%s'\n", name);
@@ -1045,7 +1045,7 @@ with the C standard.
     }
     /* allocate a new signal structure */
     new = alloc_sig_struct();
-    if ((new == 0) || (data_addr == 0)) {
+    if ((new == NULL) || (data_addr == NULL)) {
 	/* alloc failed */
 	rtapi_mutex_give(&(hal_data->mutex));
 	rtapi_print_msg(RTAPI_MSG_ERR,
@@ -1116,7 +1116,7 @@ int hal_signal_delete(const char *name)
     hal_sig_t *sig;
     rtapi_intptr_t *prev, next;
 
-    if (hal_data == 0) {
+    if (hal_data == NULL) {
 	rtapi_print_msg(RTAPI_MSG_ERR,
 	    "HAL: ERROR: signal_delete called before init\n");
 	return -EINVAL;
@@ -1163,7 +1163,7 @@ int hal_link(const char *pin_name, const char *sig_name)
     hal_comp_t *comp;
     void **data_ptr_addr, *data_addr;
 
-    if (hal_data == 0) {
+    if (hal_data == NULL) {
 	rtapi_print_msg(RTAPI_MSG_ERR,
 	    "HAL: ERROR: link called before init\n");
 	return -EINVAL;
@@ -1175,12 +1175,12 @@ int hal_link(const char *pin_name, const char *sig_name)
 	return -EPERM;
     }
     /* make sure we were given a pin name */
-    if (pin_name == 0) {
+    if (pin_name == NULL) {
 	rtapi_print_msg(RTAPI_MSG_ERR, "HAL: ERROR: pin name not given\n");
 	return -EINVAL;
     }
     /* make sure we were given a signal name */
-    if (sig_name == 0) {
+    if (sig_name == NULL) {
 	rtapi_print_msg(RTAPI_MSG_ERR, "HAL: ERROR: signal name not given\n");
 	return -EINVAL;
     }
@@ -1190,7 +1190,7 @@ int hal_link(const char *pin_name, const char *sig_name)
     rtapi_mutex_get(&(hal_data->mutex));
     /* locate the pin */
     pin = halpr_find_pin_by_name(pin_name);
-    if (pin == 0) {
+    if (pin == NULL) {
 	/* not found */
 	rtapi_mutex_give(&(hal_data->mutex));
 	rtapi_print_msg(RTAPI_MSG_ERR,
@@ -1199,7 +1199,7 @@ int hal_link(const char *pin_name, const char *sig_name)
     }
     /* locate the signal */
     sig = halpr_find_sig_by_name(sig_name);
-    if (sig == 0) {
+    if (sig == NULL) {
 	/* not found */
 	rtapi_mutex_give(&(hal_data->mutex));
 	rtapi_print_msg(RTAPI_MSG_ERR,
@@ -1331,7 +1331,7 @@ int hal_unlink(const char *pin_name)
 {
     hal_pin_t *pin;
 
-    if (hal_data == 0) {
+    if (hal_data == NULL) {
 	rtapi_print_msg(RTAPI_MSG_ERR,
 	    "HAL: ERROR: unlink called before init\n");
 	return -EINVAL;
@@ -1343,7 +1343,7 @@ int hal_unlink(const char *pin_name)
 	return -EPERM;
     }
     /* make sure we were given a pin name */
-    if (pin_name == 0) {
+    if (pin_name == NULL) {
 	rtapi_print_msg(RTAPI_MSG_ERR, "HAL: ERROR: pin name not given\n");
 	return -EINVAL;
     }
@@ -1353,7 +1353,7 @@ int hal_unlink(const char *pin_name)
     rtapi_mutex_get(&(hal_data->mutex));
     /* locate the pin */
     pin = halpr_find_pin_by_name(pin_name);
-    if (pin == 0) {
+    if (pin == NULL) {
 	/* not found */
 	rtapi_mutex_give(&(hal_data->mutex));
 	rtapi_print_msg(RTAPI_MSG_ERR,
@@ -1498,7 +1498,7 @@ int hal_param_new(const char *name, hal_type_t type, hal_param_dir_t dir, void *
     hal_param_t *new, *ptr;
     hal_comp_t *comp;
 
-    if (hal_data == 0) {
+    if (hal_data == NULL) {
 	rtapi_print_msg(RTAPI_MSG_ERR,
 	    "HAL: ERROR: param_new called before init\n");
 	return -EINVAL;
@@ -1532,7 +1532,7 @@ int hal_param_new(const char *name, hal_type_t type, hal_param_dir_t dir, void *
     rtapi_mutex_get(&(hal_data->mutex));
     /* validate comp_id */
     comp = halpr_find_comp_by_id(comp_id);
-    if (comp == 0) {
+    if (comp == NULL) {
 	/* bad comp_id */
 	rtapi_mutex_give(&(hal_data->mutex));
 	rtapi_print_msg(RTAPI_MSG_ERR,
@@ -1569,7 +1569,7 @@ int hal_param_new(const char *name, hal_type_t type, hal_param_dir_t dir, void *
     }
     /* allocate a new parameter structure */
     new = alloc_param_struct();
-    if (new == 0) {
+    if (new == NULL) {
 	/* alloc failed */
 	rtapi_mutex_give(&(hal_data->mutex));
 	rtapi_print_msg(RTAPI_MSG_ERR,
@@ -1655,7 +1655,7 @@ int hal_param_set(const char *name, hal_type_t type, void *value_addr)
     hal_param_t *param;
     void *d_ptr;
 
-    if (hal_data == 0) {
+    if (hal_data == NULL) {
 	rtapi_print_msg(RTAPI_MSG_ERR,
 	    "HAL: ERROR: param_set called before init\n");
 	return -EINVAL;
@@ -1673,7 +1673,7 @@ int hal_param_set(const char *name, hal_type_t type, void *value_addr)
 
     /* search param list for name */
     param = halpr_find_param_by_name(name);
-    if (param == 0) {
+    if (param == NULL) {
 	/* parameter not found */
 	rtapi_mutex_give(&(hal_data->mutex));
 	rtapi_print_msg(RTAPI_MSG_ERR,
@@ -1737,7 +1737,7 @@ int hal_param_alias(const char *param_name, const char *alias)
     hal_param_t *param, *ptr;
     hal_oldname_t *oldname;
 
-    if (hal_data == 0) {
+    if (hal_data == NULL) {
 	rtapi_print_msg(RTAPI_MSG_ERR,
 	    "HAL: ERROR: param_alias called before init\n");
 	return -EINVAL;
@@ -2299,7 +2299,7 @@ int hal_add_funct_to_thread(const char *funct_name, const char *thread_name, int
     int n;
     hal_funct_entry_t *funct_entry;
 
-    if (hal_data == 0) {
+    if (hal_data == NULL) {
 	rtapi_print_msg(RTAPI_MSG_ERR,
 	    "HAL: ERROR: add_funct called before init\n");
 	return -EINVAL;
@@ -2324,14 +2324,14 @@ int hal_add_funct_to_thread(const char *funct_name, const char *thread_name, int
 	return -EINVAL;
     }
     /* make sure we were given a function name */
-    if (funct_name == 0) {
+    if (funct_name == NULL) {
 	/* no name supplied */
 	rtapi_mutex_give(&(hal_data->mutex));
 	rtapi_print_msg(RTAPI_MSG_ERR, "HAL: ERROR: missing function name\n");
 	return -EINVAL;
     }
     /* make sure we were given a thread name */
-    if (thread_name == 0) {
+    if (thread_name == NULL) {
 	/* no name supplied */
 	rtapi_mutex_give(&(hal_data->mutex));
 	rtapi_print_msg(RTAPI_MSG_ERR, "HAL: ERROR: missing thread name\n");
@@ -2339,7 +2339,7 @@ int hal_add_funct_to_thread(const char *funct_name, const char *thread_name, int
     }
     /* search function list for the function */
     funct = halpr_find_funct_by_name(funct_name);
-    if (funct == 0) {
+    if (funct == NULL) {
 	/* function not found */
 	rtapi_mutex_give(&(hal_data->mutex));
 	rtapi_print_msg(RTAPI_MSG_ERR,
@@ -2355,7 +2355,7 @@ int hal_add_funct_to_thread(const char *funct_name, const char *thread_name, int
     }
     /* search thread list for thread_name */
     thread = halpr_find_thread_by_name(thread_name);
-    if (thread == 0) {
+    if (thread == NULL) {
 	/* thread not found */
 	rtapi_mutex_give(&(hal_data->mutex));
 	rtapi_print_msg(RTAPI_MSG_ERR,
@@ -2400,7 +2400,7 @@ int hal_add_funct_to_thread(const char *funct_name, const char *thread_name, int
     }
     /* allocate a funct entry structure */
     funct_entry = alloc_funct_entry_struct();
-    if (funct_entry == 0) {
+    if (funct_entry == NULL) {
 	/* alloc failed */
 	rtapi_mutex_give(&(hal_data->mutex));
 	rtapi_print_msg(RTAPI_MSG_ERR,
@@ -2427,7 +2427,7 @@ int hal_init_funct_to_thread(const char *funct_name, const char *thread_name, in
     int n;
     hal_funct_entry_t *funct_entry;
 
-    if (hal_data == 0) {
+    if (hal_data == NULL) {
         rtapi_print_msg(RTAPI_MSG_ERR,
             "HAL: ERROR: init_funct called before init\n");
         return -EINVAL;
@@ -2444,7 +2444,7 @@ int hal_init_funct_to_thread(const char *funct_name, const char *thread_name, in
         return -EINVAL;
     }
 
-    if (funct_name == 0 || thread_name == 0) {
+    if (funct_name == NULL || thread_name == NULL) {
         rtapi_print_msg(RTAPI_MSG_ERR,
             "HAL: ERROR: missing function or thread name\n");
         return -EINVAL;
@@ -2457,7 +2457,7 @@ int hal_init_funct_to_thread(const char *funct_name, const char *thread_name, in
     rtapi_mutex_get(&(hal_data->mutex));
 
     funct = halpr_find_funct_by_name(funct_name);
-    if (funct == 0) {
+    if (funct == NULL) {
         rtapi_mutex_give(&(hal_data->mutex));
         rtapi_print_msg(RTAPI_MSG_ERR,
             "HAL: ERROR: function '%s' not found\n", funct_name);
@@ -2465,7 +2465,7 @@ int hal_init_funct_to_thread(const char *funct_name, const char *thread_name, in
     }
 
     thread = halpr_find_thread_by_name(thread_name);
-    if (thread == 0) {
+    if (thread == NULL) {
         rtapi_mutex_give(&(hal_data->mutex));
         rtapi_print_msg(RTAPI_MSG_ERR,
             "HAL: ERROR: thread '%s' not found\n", thread_name);
@@ -2514,7 +2514,7 @@ int hal_init_funct_to_thread(const char *funct_name, const char *thread_name, in
     /* allow the same funct to be on funct_list and init_funct_list, and to be
        referenced multiple times in the init list itself (no users-cap check) */
     funct_entry = alloc_funct_entry_struct();
-    if (funct_entry == 0) {
+    if (funct_entry == NULL) {
         rtapi_mutex_give(&(hal_data->mutex));
         rtapi_print_msg(RTAPI_MSG_ERR,
             "HAL: ERROR: insufficient memory for thread->init function link\n");
@@ -2539,7 +2539,7 @@ int hal_del_funct_from_thread(const char *funct_name, const char *thread_name)
     hal_list_t *list_root, *list_entry;
     hal_funct_entry_t *funct_entry;
 
-    if (hal_data == 0) {
+    if (hal_data == NULL) {
 	rtapi_print_msg(RTAPI_MSG_ERR,
 	    "HAL: ERROR: del_funct called before init\n");
 	return -EINVAL;
@@ -2557,14 +2557,14 @@ int hal_del_funct_from_thread(const char *funct_name, const char *thread_name)
     /* get mutex before accessing data structures */
     rtapi_mutex_get(&(hal_data->mutex));
     /* make sure we were given a function name */
-    if (funct_name == 0) {
+    if (funct_name == NULL) {
 	/* no name supplied */
 	rtapi_mutex_give(&(hal_data->mutex));
 	rtapi_print_msg(RTAPI_MSG_ERR, "HAL: ERROR: missing function name\n");
 	return -EINVAL;
     }
     /* make sure we were given a thread name */
-    if (thread_name == 0) {
+    if (thread_name == NULL) {
 	/* no name supplied */
 	rtapi_mutex_give(&(hal_data->mutex));
 	rtapi_print_msg(RTAPI_MSG_ERR, "HAL: ERROR: missing thread name\n");
@@ -2572,7 +2572,7 @@ int hal_del_funct_from_thread(const char *funct_name, const char *thread_name)
     }
     /* search function list for the function */
     funct = halpr_find_funct_by_name(funct_name);
-    if (funct == 0) {
+    if (funct == NULL) {
 	/* function not found */
 	rtapi_mutex_give(&(hal_data->mutex));
 	rtapi_print_msg(RTAPI_MSG_ERR,
@@ -2588,7 +2588,7 @@ int hal_del_funct_from_thread(const char *funct_name, const char *thread_name)
     }
     /* search thread list for thread_name */
     thread = halpr_find_thread_by_name(thread_name);
-    if (thread == 0) {
+    if (thread == NULL) {
 	/* thread not found */
 	rtapi_mutex_give(&(hal_data->mutex));
 	rtapi_print_msg(RTAPI_MSG_ERR,
@@ -2625,7 +2625,7 @@ int hal_del_funct_from_thread(const char *funct_name, const char *thread_name)
 int hal_start_threads(void)
 {
     /* a trivial function for a change! */
-    if (hal_data == 0) {
+    if (hal_data == NULL) {
 	rtapi_print_msg(RTAPI_MSG_ERR,
 	    "HAL: ERROR: start_threads called before init\n");
 	return -EINVAL;
@@ -2646,7 +2646,7 @@ int hal_start_threads(void)
 int hal_stop_threads(void)
 {
     /* wow, two in a row! */
-    if (hal_data == 0) {
+    if (hal_data == NULL) {
 	rtapi_print_msg(RTAPI_MSG_ERR,
 	    "HAL: ERROR: stop_threads called before init\n");
 	return -EINVAL;
@@ -2756,7 +2756,7 @@ hal_comp_t *halpr_find_comp_by_name(const char *name)
 	next = comp->next_ptr;
     }
     /* if loop terminates, we reached end of list with no match */
-    return 0;
+    return NULL;
 }
 
 hal_pin_t *halpr_find_pin_by_name(const char *name)
@@ -2784,7 +2784,7 @@ hal_pin_t *halpr_find_pin_by_name(const char *name)
 	next = pin->next_ptr;
     }
     /* if loop terminates, we reached end of list with no match */
-    return 0;
+    return NULL;
 }
 
 hal_sig_t *halpr_find_sig_by_name(const char *name)
@@ -2804,7 +2804,7 @@ hal_sig_t *halpr_find_sig_by_name(const char *name)
 	next = sig->next_ptr;
     }
     /* if loop terminates, we reached end of list with no match */
-    return 0;
+    return NULL;
 }
 
 hal_param_t *halpr_find_param_by_name(const char *name)
@@ -2832,7 +2832,7 @@ hal_param_t *halpr_find_param_by_name(const char *name)
 	next = param->next_ptr;
     }
     /* if loop terminates, we reached end of list with no match */
-    return 0;
+    return NULL;
 }
 
 hal_thread_t *halpr_find_thread_by_name(const char *name)
@@ -2852,7 +2852,7 @@ hal_thread_t *halpr_find_thread_by_name(const char *name)
 	next = thread->next_ptr;
     }
     /* if loop terminates, we reached end of list with no match */
-    return 0;
+    return NULL;
 }
 
 hal_funct_t *halpr_find_funct_by_name(const char *name)
@@ -2872,7 +2872,7 @@ hal_funct_t *halpr_find_funct_by_name(const char *name)
 	next = funct->next_ptr;
     }
     /* if loop terminates, we reached end of list with no match */
-    return 0;
+    return NULL;
 }
 
 hal_comp_t *halpr_find_comp_by_id(int id)
@@ -2892,7 +2892,7 @@ hal_comp_t *halpr_find_comp_by_id(int id)
 	next = comp->next_ptr;
     }
     /* if loop terminates, we reached end of list without finding a match */
-    return 0;
+    return NULL;
 }
 
 hal_pin_t *halpr_find_pin_by_owner(hal_comp_t * owner, hal_pin_t * start)
@@ -2903,7 +2903,7 @@ hal_pin_t *halpr_find_pin_by_owner(hal_comp_t * owner, hal_pin_t * start)
     /* get offset of 'owner' component */
     owner_ptr = SHMOFF(owner);
     /* is this the first call? */
-    if (start == 0) {
+    if (start == NULL) {
 	/* yes, start at beginning of pin list */
 	next = hal_data->pin_list_ptr;
     } else {
@@ -2920,7 +2920,7 @@ hal_pin_t *halpr_find_pin_by_owner(hal_comp_t * owner, hal_pin_t * start)
 	next = pin->next_ptr;
     }
     /* if loop terminates, we reached end of list without finding a match */
-    return 0;
+    return NULL;
 }
 
 hal_param_t *halpr_find_param_by_owner(hal_comp_t * owner,
@@ -2932,7 +2932,7 @@ hal_param_t *halpr_find_param_by_owner(hal_comp_t * owner,
     /* get offset of 'owner' component */
     owner_ptr = SHMOFF(owner);
     /* is this the first call? */
-    if (start == 0) {
+    if (start == NULL) {
 	/* yes, start at beginning of param list */
 	next = hal_data->param_list_ptr;
     } else {
@@ -2949,7 +2949,7 @@ hal_param_t *halpr_find_param_by_owner(hal_comp_t * owner,
 	next = param->next_ptr;
     }
     /* if loop terminates, we reached end of list without finding a match */
-    return 0;
+    return NULL;
 }
 
 hal_funct_t *halpr_find_funct_by_owner(hal_comp_t * owner,
@@ -2961,7 +2961,7 @@ hal_funct_t *halpr_find_funct_by_owner(hal_comp_t * owner,
     /* get offset of 'owner' component */
     owner_ptr = SHMOFF(owner);
     /* is this the first call? */
-    if (start == 0) {
+    if (start == NULL) {
 	/* yes, start at beginning of function list */
 	next = hal_data->funct_list_ptr;
     } else {
@@ -2978,7 +2978,7 @@ hal_funct_t *halpr_find_funct_by_owner(hal_comp_t * owner,
 	next = funct->next_ptr;
     }
     /* if loop terminates, we reached end of list without finding a match */
-    return 0;
+    return NULL;
 }
 
 hal_pin_t *halpr_find_pin_by_sig(hal_sig_t * sig, hal_pin_t * start)
@@ -2989,7 +2989,7 @@ hal_pin_t *halpr_find_pin_by_sig(hal_sig_t * sig, hal_pin_t * start)
     /* get offset of 'sig' component */
     sig_ptr = SHMOFF(sig);
     /* is this the first call? */
-    if (start == 0) {
+    if (start == NULL) {
 	/* yes, start at beginning of pin list */
 	next = hal_data->pin_list_ptr;
     } else {
@@ -3006,7 +3006,7 @@ hal_pin_t *halpr_find_pin_by_sig(hal_sig_t * sig, hal_pin_t * start)
 	next = pin->next_ptr;
     }
     /* if loop terminates, we reached end of list without finding a match */
-    return 0;
+    return NULL;
 }
 
 /***********************************************************************
@@ -3270,7 +3270,7 @@ static int init_hal_data(void)
     hal_data->sig_free_ptr = 0;
     hal_data->param_free_ptr = 0;
     hal_data->funct_free_ptr = 0;
-    hal_data->pending_constructor = 0;
+    hal_data->pending_constructor = NULL;
     hal_data->constructor_prefix[0] = 0;
     list_init_entry(&(hal_data->funct_entry_free));
     hal_data->thread_free_ptr = 0;
@@ -3312,7 +3312,7 @@ static void *shmalloc_up(long int size)
     /* is there enough memory available? */
     if ((hal_data->shmem_top - tmp_bot) < size) {
 	/* no */
-	return 0;
+	return NULL;
     }
     /* memory is available, allocate it */
     retval = SHMPTR(tmp_bot);
@@ -3351,7 +3351,7 @@ static void *shmalloc_dn(long int size)
     /* is there enough memory available? */
     if (tmp_top < hal_data->shmem_bot) {
 	/* no */
-	return 0;
+	return NULL;
     }
     /* memory is available, allocate it */
     retval = SHMPTR(tmp_top);
@@ -3382,7 +3382,7 @@ hal_comp_t *halpr_alloc_comp_struct(void)
 	p->comp_id = 0;
 	p->mem_id = 0;
 	p->type = COMPONENT_TYPE_USER;
-	p->shmem_base = 0;
+	p->shmem_base = NULL;
 	p->name[0] = '\0';
     }
     return p;
@@ -3546,8 +3546,8 @@ static hal_funct_entry_t *alloc_funct_entry_struct(void)
     if (p) {
 	/* make sure it's empty */
 	p->funct_ptr = 0;
-	p->arg = 0;
-	p->funct = 0;
+	p->arg = NULL;
+	p->funct = NULL;
     }
     return p;
 }
@@ -3650,7 +3650,7 @@ static void free_comp_struct(hal_comp_t * comp)
     comp->comp_id = 0;
     comp->mem_id = 0;
     comp->type = COMPONENT_TYPE_USER;
-    comp->shmem_base = 0;
+    comp->shmem_base = NULL;
     comp->name[0] = '\0';
     /* add it to free list */
     comp->next_ptr = hal_data->comp_free_ptr;
@@ -3745,8 +3745,8 @@ static void free_sig_struct(hal_sig_t * sig)
     hal_pin_t *pin;
 
     /* look for pins linked to this signal */
-    pin = halpr_find_pin_by_sig(sig, 0);
-    while (pin != 0) {
+    pin = halpr_find_pin_by_sig(sig, NULL);
+    while (pin != NULL) {
 	/* found one, unlink it */
 	unlink_pin(pin);
 	/* check for another pin linked to the signal */
@@ -3868,8 +3868,8 @@ static void free_funct_entry_struct(hal_funct_entry_t * funct_entry)
     }
     /* clear contents of struct */
     funct_entry->funct_ptr = 0;
-    funct_entry->arg = 0;
-    funct_entry->funct = 0;
+    funct_entry->arg = NULL;
+    funct_entry->funct = NULL;
     /* add it to free list */
     list_add_after((hal_list_t *) funct_entry, &(hal_data->funct_entry_free));
 }

--- a/src/hal/halmodule.cc
+++ b/src/hal/halmodule.cc
@@ -64,9 +64,9 @@ struct scoped_lc_numeric_c {
     scoped_lc_numeric_c() {
         // Make sure we always use the C locale for conversion (thread local)
         // cppcheck-suppress useInitializationList
-        oldlc = uselocale(static_cast<locale_t>(0));
-        newlc = newlocale(LC_NUMERIC_MASK, "C", static_cast<locale_t>(0));
-        if(static_cast<locale_t>(0) == newlc) {
+        oldlc = uselocale(static_cast<locale_t>(NULL));
+        newlc = newlocale(LC_NUMERIC_MASK, "C", static_cast<locale_t>(NULL));
+        if(static_cast<locale_t>(NULL) == newlc) {
             // FIXME: This is not nice, to print directly to stderr...
             fprintf(stderr, "halmodule: internal error: Cannot set locale to \"C\" for numeric conversions");
             return;
@@ -75,7 +75,7 @@ struct scoped_lc_numeric_c {
     }
 
     ~scoped_lc_numeric_c() {
-        if(static_cast<locale_t>(0) != newlc) {
+        if(static_cast<locale_t>(NULL) != newlc) {
             uselocale(oldlc);
             freelocale(newlc);
         }
@@ -176,7 +176,7 @@ bool from_python(PyObject *o, bool *b)
     }
 
     // Try the usual int(obj) conversion
-    PyObject *tmp = 0;
+    PyObject *tmp = NULL;
     long long l;
     tmp = PyLong_Check(o) ? o : PyNumber_Long(o);
     if(!tmp) goto fail;
@@ -217,7 +217,7 @@ bool from_python(PyObject *o, double *d) {
 }
 
 bool from_python(PyObject *o, rtapi_u32 *u) {
-    PyObject *tmp = 0;
+    PyObject *tmp = NULL;
     long long l;
     tmp = PyLong_Check(o) ? o : PyNumber_Long(o);
     if(!tmp) goto fail;
@@ -238,7 +238,7 @@ fail:
 }
 
 bool from_python(PyObject *o, rtapi_s32 *i) {
-    PyObject *tmp = 0;
+    PyObject *tmp = NULL;
     long long l;
     tmp = PyLong_Check(o) ? o : PyNumber_Long(o);
     if(!tmp) goto fail;
@@ -259,7 +259,7 @@ fail:
 }
 
 bool from_python(PyObject *o, rtapi_u64 *u) {
-    PyObject *tmp = 0;
+    PyObject *tmp = NULL;
     unsigned long long l;
     tmp = PyLong_Check(o) ? o : PyNumber_Long(o);
     if(!tmp) goto fail;
@@ -277,7 +277,7 @@ fail:
 }
 
 bool from_python(PyObject *o, rtapi_s64 *i) {
-    PyObject *tmp = 0;
+    PyObject *tmp = NULL;
     long long l;
     tmp = PyLong_Check(o) ? o : PyNumber_Long(o);
     if(!tmp) goto fail;
@@ -364,7 +364,7 @@ static PyObject *pyhal_error(int code) {
 static int pyhal_init(PyObject *_self, PyObject *args, PyObject *kw) {
     (void)kw;
     const char *name;
-    const char *prefix = 0;
+    const char *prefix = NULL;
     halobject *self = reinterpret_cast<halobject *>(_self);
 
     if(!PyArg_ParseTuple(args, "s|s:hal.component", &name, &prefix)) return -1;
@@ -397,13 +397,13 @@ static void pyhal_exit_impl(halobject *self) {
     self->hal_id = 0;
 
     free(self->name);
-    self->name = 0;
+    self->name = NULL;
 
     free(self->prefix);
-    self->prefix = 0;
+    self->prefix = NULL;
 
     delete self->items;
-    self->items = 0;
+    self->items = NULL;
 }
 
 static void pyhal_delete(PyObject *_self) {
@@ -816,6 +816,8 @@ static PyMappingMethods halobject_map = {
     pyhal_setattro
 };
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wzero-as-null-pointer-constant"
 static
 PyTypeObject halobject_type = {
     PyVarObject_HEAD_INIT(NULL, 0)
@@ -876,6 +878,7 @@ PyTypeObject halobject_type = {
 #endif
 #endif
 };
+#pragma GCC diagnostic pop
 
 static const char * pin_type2name(hal_type_t type) {
     switch (type) {
@@ -1164,6 +1167,8 @@ static PyMethodDef halpin_methods[] = {
     {},
 };
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wzero-as-null-pointer-constant"
 static
 PyTypeObject halpin_type = {
     PyVarObject_HEAD_INIT(NULL, 0)
@@ -1224,6 +1229,7 @@ PyTypeObject halpin_type = {
 #endif
 #endif
 };
+#pragma GCC diagnostic pop
 
 static PyObject * pyhal_pin_new(halitem * pin, const char * name) {
     pyhalitem * pypin = PyObject_New(pyhalitem, &halpin_type);
@@ -1406,9 +1412,9 @@ PyObject *set_p(PyObject * /*self*/, PyObject *args) {
     // Search pin and then param
     // We are more likely to set a pin than a param
     hal_pin_t *pin = halpr_find_pin_by_name(name);
-    if(pin == 0) {
+    if(pin == NULL) {
         hal_param_t *param = halpr_find_param_by_name(name);
-        if (param == 0) {
+        if (param == NULL) {
             // Found neither pin nor param
             PyErr_Format(PyExc_RuntimeError, "pin or param not found");
             return NULL;
@@ -1460,7 +1466,7 @@ PyObject *set_s(PyObject * /*self*/, PyObject *args) {
     scoped_hal_mutex _hallock; // get mutex before accessing shared data
 
     sig = halpr_find_sig_by_name(name);
-    if (sig == 0) {
+    if (sig == NULL) {
         PyErr_Format(PyExc_RuntimeError,
             "signal not found");
         return NULL;
@@ -1568,7 +1574,7 @@ PyObject *get_info_pins(PyObject * /*self*/, PyObject * /*args*/) {
             sig = (hal_sig_t*)SHMPTR(pin->signal);
             d_ptr = reinterpret_cast<hal_data_u *>(SHMPTR(sig->data_ptr));
         } else {
-            sig = 0;
+            sig = NULL;
             d_ptr = &(pin->dummysig);
         }
 
@@ -1668,8 +1674,8 @@ PyObject *get_info_signals(PyObject * /*self*/, PyObject * /*args*/) {
         d_ptr = reinterpret_cast<hal_data_u *>(SHMPTR(sig->data_ptr));
 
     /* it have a writer? */
-        pin = halpr_find_pin_by_sig(sig, 0);
-        while (pin != 0) {
+        pin = halpr_find_pin_by_sig(sig, NULL);
+        while (pin != NULL) {
             if (pin->dir == HAL_OUT){break;}
             pin = halpr_find_pin_by_sig(sig, pin);
         }
@@ -1679,49 +1685,49 @@ PyObject *get_info_signals(PyObject * /*self*/, PyObject * /*args*/) {
                 obj = Py_BuildValue("{s:s,s:N,s:s,s:N}",
                         str_n, sig->name,
                         str_v, PyBool_FromLong((long)d_ptr->b),
-                        str_d, (pin != 0) ? pin->name : NULL,
+                        str_d, (pin != NULL) ? pin->name : NULL,
                         str_t, PyLong_FromLong(HAL_BIT));
                 break;
             case HAL_U32:
                 obj = Py_BuildValue("{s:s,s:k,s:s,s:N}",
                         str_n, sig->name,
                         str_v, (unsigned long)d_ptr->u,
-                        str_d, (pin != 0) ? pin->name : NULL,
+                        str_d, (pin != NULL) ? pin->name : NULL,
                         str_t, PyLong_FromLong(HAL_U32));
                 break;
             case HAL_S32:
                 obj = Py_BuildValue("{s:s,s:l,s:s,s:N}",
                         str_n, sig->name,
                         str_v, (long)d_ptr->s,
-                        str_d, (pin != 0) ? pin->name : NULL,
+                        str_d, (pin != NULL) ? pin->name : NULL,
                         str_t, PyLong_FromLong(HAL_S32));
                 break;
             case HAL_U64:
                 obj = Py_BuildValue("{s:s,s:K,s:s,s:N}",
                         str_n, sig->name,
                         str_v, (unsigned long long)d_ptr->lu,
-                        str_d, (pin != 0) ? pin->name : NULL,
+                        str_d, (pin != NULL) ? pin->name : NULL,
                         str_t, PyLong_FromLong(HAL_U64));
                 break;
             case HAL_S64:
                 obj = Py_BuildValue("{s:s,s:L,s:s,s:N}",
                         str_n, sig->name,
                         str_v, (long long)d_ptr->ls,
-                        str_d, (pin != 0) ? pin->name : NULL,
+                        str_d, (pin != NULL) ? pin->name : NULL,
                         str_t, PyLong_FromLong(HAL_S64));
                 break;
             case HAL_FLOAT:
                 obj = Py_BuildValue("{s:s,s:d,s:s,s:N}",
                         str_n, sig->name,
                         str_v, (double)d_ptr->f,
-                        str_d, (pin != 0) ? pin->name : NULL,
+                        str_d, (pin != NULL) ? pin->name : NULL,
                         str_t, PyLong_FromLong(HAL_FLOAT));
                 break;
             case HAL_PORT:
                 obj = Py_BuildValue("{s:s,s:l,s:s,s:N}",
                         str_n, sig->name,
                         str_v, (long)d_ptr->p,
-                        str_d, (pin != 0) ? pin->name : NULL,
+                        str_d, (pin != NULL) ? pin->name : NULL,
                         str_t, PyLong_FromLong(HAL_PORT));
                 break;
             case HAL_TYPE_UNSPECIFIED: /* fallthrough */ ;
@@ -1730,7 +1736,7 @@ PyObject *get_info_signals(PyObject * /*self*/, PyObject * /*args*/) {
                  obj = Py_BuildValue("{s:s,s:s,s:s,s:s}",
                         str_n, sig->name,
                         str_v, NULL,
-                        str_d, (pin != 0) ? pin->name : NULL,
+                        str_d, (pin != NULL) ? pin->name : NULL,
                         str_t, NULL);
                  break;
         }
@@ -1840,7 +1846,7 @@ struct shmobject {
 
 static int pyshm_init(PyObject *_self, PyObject *args, PyObject * /*kw*/) {
     shmobject *self = reinterpret_cast<shmobject *>(_self);
-    self->comp = 0;
+    self->comp = NULL;
     self->shm_id = -1;
 
     if(!PyArg_ParseTuple(args, "O!ik", &halobject_type, &self->comp, &self->key, &self->size))
@@ -1848,7 +1854,7 @@ static int pyshm_init(PyObject *_self, PyObject *args, PyObject * /*kw*/) {
 
     self->shm_id = rtapi_shmem_new(self->key, self->comp->hal_id, self->size);
     if(self->shm_id < 0) {
-        self->comp = 0;
+        self->comp = NULL;
         self->size = 0;
         pyrtapi_error(self->shm_id);
         return -1;
@@ -1927,6 +1933,8 @@ static PyMethodDef shm_methods[] = {
     {},
 };
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wzero-as-null-pointer-constant"
 static
 PyTypeObject shm_type = {
     PyVarObject_HEAD_INIT(NULL, 0)
@@ -1987,6 +1995,7 @@ PyTypeObject shm_type = {
 #endif
 #endif
 };
+#pragma GCC diagnostic pop
 
 struct streamobj {
     PyObject_HEAD
@@ -2070,7 +2079,7 @@ PyObject *stream_read(PyObject *_self, PyObject * /*unused*/) {
     }
 
     PyObject *r = PyTuple_New(n);
-    if(!r) return 0;
+    if(!r) return NULL;
 
     for(int i=0; i<n; i++) {
         PyObject *o;
@@ -2093,7 +2102,7 @@ PyObject *stream_read(PyObject *_self, PyObject * /*unused*/) {
         }
         if(!o) {
             Py_DECREF(r);
-            return 0;
+            return NULL;
         }
         PyTuple_SET_ITEM(r, i, o);
     }
@@ -2139,7 +2148,7 @@ PyObject *stream_write(PyObject *_self, PyObject *args) {
     }
     int r = hal_stream_write(&self->stream, buf.data());
     if(r < 0) {
-        errno = -r; PyErr_SetFromErrno(PyExc_IOError); return 0;
+        errno = -r; PyErr_SetFromErrno(PyExc_IOError); return NULL;
     }
     Py_INCREF(Py_None);
     return Py_None;
@@ -2206,6 +2215,8 @@ static PyObject *pystream_repr(PyObject *_self) {
         self->creator ? " creator" : "");
 }
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wzero-as-null-pointer-constant"
 static
 PyTypeObject stream_type = {
     PyVarObject_HEAD_INIT(NULL, 0)
@@ -2266,6 +2277,7 @@ PyTypeObject stream_type = {
 #endif
 #endif
 };
+#pragma GCC diagnostic pop
 
 
 static PyMethodDef module_methods[] = {

--- a/src/hal/user_comps/gs2_vfd.c
+++ b/src/hal/user_comps/gs2_vfd.c
@@ -127,21 +127,21 @@ static int done;
 char *modname = "gs2_vfd";
 
 static struct option long_options[] = {
-    {"bits", 1, 0, 'b'},
-    {"device", 1, 0, 'd'},
-    {"debug", 0, 0, 'g'},
-    {"help", 0, 0, 'h'},
-    {"name", 1, 0, 'n'},
-    {"parity", 1, 0, 'p'},
-    {"rate", 1, 0, 'r'},
-    {"stopbits", 1, 0, 's'},
-    {"target", 1, 0, 't'},
-    {"verbose", 0, 0, 'v'},
+    {"bits", 1, NULL, 'b'},
+    {"device", 1, NULL, 'd'},
+    {"debug", 0, NULL, 'g'},
+    {"help", 0, NULL, 'h'},
+    {"name", 1, NULL, 'n'},
+    {"parity", 1, NULL, 'p'},
+    {"rate", 1, NULL, 'r'},
+    {"stopbits", 1, NULL, 's'},
+    {"target", 1, NULL, 't'},
+    {"verbose", 0, NULL, 'v'},
     {"accel-seconds", required_argument, NULL, 'A'},
     {"decel-seconds", required_argument, NULL, 'D'},
     {"braking-resistor", no_argument, NULL, 'R'},
     {"disable", no_argument, NULL, 'X'},
-    {0,0,0,0}
+    {NULL,0,NULL,0}
 };
 
 static char *option_string = "gb:d:hn:p:r:s:t:vA:D:RX";
@@ -674,7 +674,7 @@ int main(int argc, char **argv)
 
     /* grab some shmem to store the HAL data in */
     haldata = (haldata_t *)hal_malloc(sizeof(haldata_t));
-    if ((haldata == 0) || done) {
+    if ((haldata == NULL) || done) {
         printf("%s: ERROR: unable to allocate shared memory\n", modname);
         retval = -1;
         goto out_close;

--- a/src/hal/user_comps/huanyang-vfd/hy_vfd.c
+++ b/src/hal/user_comps/huanyang-vfd/hy_vfd.c
@@ -150,25 +150,25 @@ static void quit_signal_handler(int sig) {
 char *modname = "hy_vfd";
 
 static struct option long_options[] = {
-		{"bits", 1, 0, 'b'},
-		{"device", 1, 0, 'd'},
-		{"debug", 0, 0, 'g'},
-		{"help", 0, 0, 'h'},
-		{"name", 1, 0, 'n'},
-		{"parity", 1, 0, 'p'},
-		{"rate", 1, 0, 'r'},
-		{"stopbits", 1, 0, 's'},
-		{"target", 1, 0, 't'},
-		{"max-frequency", 1, 0, 'F'},
-		{"min-frequency", 1, 0, 'f'},
-		{"base-frequency", 1, 0, 'B'},
-		{"motor-voltage", 1, 0, 'V'},
-		{"motor-current", 1, 0, 'I'},
-		{"motor-speed", 1, 0, 'S'},
-		{"motor-poles", 1, 0, 'P'},
-		{"register", 1, 0, 'x'},
-		{"regdump", 0, 0, 'y'},
-		{0,0,0,0}
+		{"bits", 1, NULL, 'b'},
+		{"device", 1, NULL, 'd'},
+		{"debug", 0, NULL, 'g'},
+		{"help", 0, NULL, 'h'},
+		{"name", 1, NULL, 'n'},
+		{"parity", 1, NULL, 'p'},
+		{"rate", 1, NULL, 'r'},
+		{"stopbits", 1, NULL, 's'},
+		{"target", 1, NULL, 't'},
+		{"max-frequency", 1, NULL, 'F'},
+		{"min-frequency", 1, NULL, 'f'},
+		{"base-frequency", 1, NULL, 'B'},
+		{"motor-voltage", 1, NULL, 'V'},
+		{"motor-current", 1, NULL, 'I'},
+		{"motor-speed", 1, NULL, 'S'},
+		{"motor-poles", 1, NULL, 'P'},
+		{"register", 1, NULL, 'x'},
+		{"regdump", 0, NULL, 'y'},
+		{NULL,0,NULL,0}
 };
 
 static char *option_string = "b:d:ghn:p:r:s:t:F:f:B:V:I:S:P:";
@@ -896,7 +896,7 @@ int main(int argc, char **argv)
 	/* grab some shmem to store the HAL data in */
 	haldata = (haldata_t *)hal_malloc(sizeof(haldata_t));
 
-	if ((haldata == 0) || done) {
+	if ((haldata == NULL) || done) {
 		printf("%s: ERROR: unable to allocate shared memory\n", modname);
 		retval = -1;
 		goto out_close;

--- a/src/hal/user_comps/hy_gt_vfd.c
+++ b/src/hal/user_comps/hy_gt_vfd.c
@@ -91,18 +91,18 @@ float min_freq = 0.0;
 int baud;
 
 static struct option long_options[] = {
-    {"device", 1, 0, 'd'},
-    {"rate", 1, 0, 'r'},
-    {"bits", 1, 0, 'b'},
-    {"parity", 1, 0, 'p'},
-    {"stopbits", 1, 0, 's'},
-    {"target", 1, 0, 't'},
-    {"verbose", 0, 0, 'v'},
-    {"help", 0, 0, 'h'},
-    {"motor-max-speed", 1, 0, 'S'},
-    {"max-frequency", 1, 0, 'F'},
-    {"min-frequency", 1, 0, 'f'},
-    {0,0,0,0}
+    {"device", 1, NULL, 'd'},
+    {"rate", 1, NULL, 'r'},
+    {"bits", 1, NULL, 'b'},
+    {"parity", 1, NULL, 'p'},
+    {"stopbits", 1, NULL, 's'},
+    {"target", 1, NULL, 't'},
+    {"verbose", 0, NULL, 'v'},
+    {"help", 0, NULL, 'h'},
+    {"motor-max-speed", 1, NULL, 'S'},
+    {"max-frequency", 1, NULL, 'F'},
+    {"min-frequency", 1, NULL, 'f'},
+    {NULL,0,NULL,0}
 };
 
 static char *option_string = "d:r:b:p:s:t:vhS:F:f:";

--- a/src/hal/user_comps/pi500_vfd/pi500_vfd.comp
+++ b/src/hal/user_comps/pi500_vfd/pi500_vfd.comp
@@ -156,12 +156,12 @@ void userinit(int argc, char **argv)
 	int c = 0;
 
 	static struct option options[] = {
-		{"baud",   required_argument, 0, 0 },
-		{"parity", required_argument, 0, 0 },
-		{"databits", required_argument, 0, 0 },
-		{"stopbits", required_argument, 0, 0 },
-		{"device", required_argument, 0, 0 },
-		{0, 0, 0, 0}
+		{"baud",   required_argument, NULL, 0 },
+		{"parity", required_argument, NULL, 0 },
+		{"databits", required_argument, NULL, 0 },
+		{"stopbits", required_argument, NULL, 0 },
+		{"device", required_argument, NULL, 0 },
+		{NULL, 0, NULL, 0}
 	};	
 
 	while(1) {

--- a/src/hal/user_comps/svd-ps_vfd.c
+++ b/src/hal/user_comps/svd-ps_vfd.c
@@ -83,18 +83,18 @@ float min_freq = 0.0;
 int baud;
 
 static struct option long_options[] = {
-    {"device", 1, 0, 'd'},
-    {"rate", 1, 0, 'r'},
-    {"bits", 1, 0, 'b'},
-    {"parity", 1, 0, 'p'},
-    {"stopbits", 1, 0, 's'},
-    {"target", 1, 0, 't'},
-    {"verbose", 0, 0, 'v'},
-    {"help", 0, 0, 'h'},
-    {"motor-max-speed", 1, 0, 'S'},
-    {"max-frequency", 1, 0, 'F'},
-    {"min-frequency", 1, 0, 'f'},
-    {0,0,0,0}
+    {"device", 1, NULL, 'd'},
+    {"rate", 1, NULL, 'r'},
+    {"bits", 1, NULL, 'b'},
+    {"parity", 1, NULL, 'p'},
+    {"stopbits", 1, NULL, 's'},
+    {"target", 1, NULL, 't'},
+    {"verbose", 0, NULL, 'v'},
+    {"help", 0, NULL, 'h'},
+    {"motor-max-speed", 1, NULL, 'S'},
+    {"max-frequency", 1, NULL, 'F'},
+    {"min-frequency", 1, NULL, 'f'},
+    {NULL,0,NULL,0}
 };
 
 static char *option_string = "d:r:b:p:s:t:vhS:F:f:";

--- a/src/hal/user_comps/vfdb_vfd/vfdb_vfd.c
+++ b/src/hal/user_comps/vfdb_vfd/vfdb_vfd.c
@@ -212,14 +212,14 @@ enum connstate {NOT_CONNECTED, OPENING, CONNECTING, CONNECTED, RECOVER, DONE};
 
 static char *option_string = "dhrmn:S:I:";
 static struct option long_options[] = {
-        {"debug", no_argument, 0, 'd'},
-        {"help", no_argument, 0, 'h'},
-        {"modbus-debug", no_argument, 0, 'm'},
-        {"report-device", no_argument, 0, 'r'},
-        {"ini", required_argument, 0, 'I'},     // default: getenv(INI_FILE_NAME)
-        {"section", required_argument, 0, 'S'}, // default section = LIBMODBUS
-        {"name", required_argument, 0, 'n'},    // vfd-b
-        {0,0,0,0}
+        {"debug", no_argument, NULL, 'd'},
+        {"help", no_argument, NULL, 'h'},
+        {"modbus-debug", no_argument, NULL, 'm'},
+        {"report-device", no_argument, NULL, 'r'},
+        {"ini", required_argument, NULL, 'I'},     // default: getenv(INI_FILE_NAME)
+        {"section", required_argument, NULL, 'S'}, // default section = LIBMODBUS
+        {"name", required_argument, NULL, 'n'},    // vfd-b
+        {NULL,0,NULL,0}
 };
 
 
@@ -710,7 +710,7 @@ int main(int argc, char **argv)
 
     // grab some shmem to store the HAL data in
     p->haldata = (haldata_t *)hal_malloc(sizeof(haldata_t));
-    if ((p->haldata == 0) || (connection_state == DONE)) {
+    if ((p->haldata == NULL) || (connection_state == DONE)) {
         fprintf(stderr, "%s: ERROR: unable to allocate shared memory\n", p->modname);
         retval = -1;
         goto finish;

--- a/src/hal/user_comps/vfs11_vfd/vfs11_vfd.c
+++ b/src/hal/user_comps/vfs11_vfd/vfs11_vfd.c
@@ -332,14 +332,14 @@ enum connstate {NOT_CONNECTED, OPENING, CONNECTING, CONNECTED, RECOVER, DONE};
 
 static char *option_string = "dhrmn:S:I:";
 static struct option long_options[] = {
-    {"debug", no_argument, 0, 'd'},
-    {"help", no_argument, 0, 'h'},
-    {"modbus-debug", no_argument, 0, 'm'},
-    {"report-device", no_argument, 0, 'r'},
-    {"ini", required_argument, 0, 'I'},     // default: getenv(INI_FILE_NAME)
-    {"section", required_argument, 0, 'S'}, // default section = LIBMODBUS
-    {"name", required_argument, 0, 'n'},    // vfs11_vfd
-    {0,0,0,0}
+    {"debug", no_argument, NULL, 'd'},
+    {"help", no_argument, NULL, 'h'},
+    {"modbus-debug", no_argument, NULL, 'm'},
+    {"report-device", no_argument, NULL, 'r'},
+    {"ini", required_argument, NULL, 'I'},     // default: getenv(INI_FILE_NAME)
+    {"section", required_argument, NULL, 'S'}, // default section = LIBMODBUS
+    {"name", required_argument, NULL, 'n'},    // vfs11_vfd
+    {NULL,0,NULL,0}
 };
 
 
@@ -932,7 +932,7 @@ int main(int argc, char **argv)
 
     // grab some shmem to store the HAL data in
     p->haldata = (haldata_t *)hal_malloc(sizeof(haldata_t));
-    if ((p->haldata == 0) || (connection_state == DONE)) {
+    if ((p->haldata == NULL) || (connection_state == DONE)) {
 	fprintf(stderr, "%s: ERROR: unable to allocate shared memory\n", p->modname);
 	retval = -1;
 	goto finish;

--- a/src/hal/user_comps/wj200_vfd/wj200_vfd.comp
+++ b/src/hal/user_comps/wj200_vfd/wj200_vfd.comp
@@ -196,12 +196,12 @@ void userinit(int argc, char **argv)
 	int c = 0;
 
 	static struct option options[] = {
-		{"baud",   required_argument, 0, 0 },
-		{"parity", required_argument, 0, 0 },
-		{"databits", required_argument, 0, 0 },
-		{"stopbits", required_argument, 0, 0 },
-		{"device", required_argument, 0, 0 },
-		{0, 0, 0, 0}
+		{"baud",   required_argument, NULL, 0 },
+		{"parity", required_argument, NULL, 0 },
+		{"databits", required_argument, NULL, 0 },
+		{"stopbits", required_argument, NULL, 0 },
+		{"device", required_argument, NULL, 0 },
+		{NULL, 0, NULL, 0}
 	};
 
 	while(1) {

--- a/src/hal/user_comps/xhc-whb04b-6/hal.h
+++ b/src/hal/user_comps/xhc-whb04b-6/hal.h
@@ -179,7 +179,7 @@ public:
     struct Out
     {
     public:
-        hal_bit_t* button_pin[64] = {0};
+        hal_bit_t* button_pin[64] = {nullptr};
 
         //! to be connected to \ref halui.flood.off
         hal_bit_t  * floodStop{nullptr};

--- a/src/hal/user_comps/xhc-whb04b-6/main.cc
+++ b/src/hal/user_comps/xhc-whb04b-6/main.cc
@@ -228,7 +228,7 @@ int main(int argc, char** argv)
                 return printUsage(basename(argv[0]), WhbComponent->getName());
                 break;
             case 'P':
-                 WhbComponent->setUsbProductId(std::stoi(optarg, 0, 16));
+                 WhbComponent->setUsbProductId(std::stoi(optarg, nullptr, 16));
                 break;
             default:
                 return printUsage(basename(argv[0]), WhbComponent->getName(), true);

--- a/src/hal/utils/halcmd.c
+++ b/src/hal/utils/halcmd.c
@@ -302,7 +302,7 @@ static int count_args(char **argv) {
     return i;
 }
 
-#define ARG(i) (argc > i ? argv[i] : 0)
+#define ARG(i) (argc > i ? argv[i] : NULL)
 #define REST(i) (argc > i ? argv + i : argv + argc)
 
 static int parse_cmd1(char **argv) {
@@ -340,7 +340,7 @@ static int parse_cmd1(char **argv) {
 		    argv[d++] = argv[s];
 		}
 	    }
-	    argv[d] = 0;
+	    argv[d] = NULL;
 	    argc = d;
 	}
 

--- a/src/hal/utils/halcmd_commands.cc
+++ b/src/hal/utils/halcmd_commands.cc
@@ -167,12 +167,12 @@ int do_linkpp_cmd(char *first_pin_name, char *second_pin_name)
     /* check if the pins are there */
     first_pin = halpr_find_pin_by_name(first_pin_name);
     second_pin = halpr_find_pin_by_name(second_pin_name);
-    if (first_pin == 0) {
+    if (first_pin == NULL) {
 	/* first pin not found*/
 	rtapi_mutex_give(&(hal_data->mutex));
 	halcmd_error("pin '%s' not found\n", first_pin_name);
 	return -EINVAL; 
-    } else if (second_pin == 0) {
+    } else if (second_pin == NULL) {
 	rtapi_mutex_give(&(hal_data->mutex));
 	halcmd_error("pin '%s' not found\n", second_pin_name);
 	return -EINVAL; 
@@ -278,7 +278,7 @@ int do_source_cmd(char *hal_filename) {
     while(1) {
         char *readresult = fgets(buf, MAX_CMD_LEN, f);
         halcmd_set_linenumber(linenumber++);
-        if(readresult == 0) {
+        if(readresult == NULL) {
             if(feof(f)) break;
             halcmd_error("Error reading file: %s\n", strerror(errno));
             result = -EINVAL;
@@ -415,7 +415,7 @@ int do_delf_cmd(char *func, char *thread) {
 
 static int preflight_net_cmd(char *signal, hal_sig_t *sig, char *pins[]) {
     int i, type=-1, writers=0, bidirs=0, pincnt=0;
-    char *writer_name=0, *bidir_name=0;
+    char *writer_name=NULL, *bidir_name=NULL;
     /* if signal already exists, use its info */
     if (sig) {
 	type = sig->type;
@@ -438,7 +438,7 @@ static int preflight_net_cmd(char *signal, hal_sig_t *sig, char *pins[]) {
     }
 
     for(i=0; pins[i] && *pins[i]; i++) {
-        hal_pin_t *pin = 0;
+        hal_pin_t *pin = NULL;
         pin = halpr_find_pin_by_name(pins[i]);
         if(!pin) {
             halcmd_error("Pin '%s' does not exist\n",
@@ -785,9 +785,9 @@ int do_setp_cmd(char *name, char *value)
     rtapi_mutex_get(&(hal_data->mutex));
     /* search param list for name */
     param = halpr_find_param_by_name(name);
-    if (param == 0) {
+    if (param == NULL) {
         pin = halpr_find_pin_by_name(name);
-        if(pin == 0) {
+        if(pin == NULL) {
             rtapi_mutex_give(&(hal_data->mutex));
             halcmd_error("parameter or pin '%s' not found\n", name);
             return -EINVAL;
@@ -908,7 +908,7 @@ int do_getp_cmd(char *name)
             sig = SHMPTR(pin->signal);
             d_ptr = SHMPTR(sig->data_ptr);
         } else {
-            sig = 0;
+            sig = NULL;
             d_ptr = &(pin->dummysig);
         }
         halcmd_output("%s\n", data_value2((int) type, d_ptr));
@@ -933,7 +933,7 @@ int do_sets_cmd(char *name, char *value)
     rtapi_mutex_get(&(hal_data->mutex));
     /* search signal list for name */
     sig = halpr_find_sig_by_name(name);
-    if (sig == 0) {
+    if (sig == NULL) {
 	rtapi_mutex_give(&(hal_data->mutex));
 	halcmd_error("signal '%s' not found\n", name);
 	return -EINVAL;
@@ -969,7 +969,7 @@ int do_stype_cmd(char *name)
     rtapi_mutex_get(&(hal_data->mutex));
     /* search signal list for name */
     sig = halpr_find_sig_by_name(name);
-    if (sig == 0) {
+    if (sig == NULL) {
 	rtapi_mutex_give(&(hal_data->mutex));
 	halcmd_error("signal '%s' not found\n", name);
 	return -EINVAL;
@@ -992,7 +992,7 @@ int do_gets_cmd(char *name)
     rtapi_mutex_get(&(hal_data->mutex));
     /* search signal list for name */
     sig = halpr_find_sig_by_name(name);
-    if (sig == 0) {
+    if (sig == NULL) {
 	rtapi_mutex_give(&(hal_data->mutex));
 	halcmd_error("signal '%s' not found\n", name);
 	return -EINVAL;
@@ -1006,7 +1006,7 @@ int do_gets_cmd(char *name)
 }
 
 static int get_type(char ***patterns) {
-    char *typestr = 0;
+    char *typestr = NULL;
     if(!(*patterns)) return -1;
     if(!(*patterns)[0]) return -1;
     if((*patterns)[0][0] != '-' || (*patterns)[0][1] != 't') return -1;
@@ -1244,7 +1244,7 @@ int do_loadrt_cmd(char *mod_name, char *args[])
     rtapi_mutex_get(&(hal_data->mutex));
     /* search component list for the newly loaded component */
     comp = halpr_find_comp_by_name(mod_name);
-    if (comp == 0) {
+    if (comp == NULL) {
 	rtapi_mutex_give(&(hal_data->mutex));
 	halcmd_error("module '%s' not loaded\n", mod_name);
 	return -EINVAL;
@@ -1580,7 +1580,7 @@ int do_loadusr_cmd(const char *args[])
     /* get program and component name */
     args += optind;
     prog_name = *args++;
-    if (prog_name == 0) { return -EINVAL; }
+    if (prog_name == NULL) { return -EINVAL; }
     if(!new_comp_name) {
 	new_comp_name = guess_comp_name(prog_name);
     }
@@ -1792,7 +1792,7 @@ static void print_pin_info(int type, char **patterns)
 		sig = SHMPTR(pin->signal);
 		dptr = SHMPTR(sig->data_ptr);
 	    } else {
-		sig = 0;
+		sig = NULL;
 		dptr = &(pin->dummysig);
 	    }
 	    if (scriptmode == 0) {
@@ -1810,7 +1810,7 @@ static void print_pin_info(int type, char **patterns)
 		    data_value2((int) pin->type, dptr),
 		    pin->name);
 	    } 
-	    if (sig == 0) {
+	    if (sig == NULL) {
 		halcmd_output("\n");
 	    } else {
 		halcmd_output(" %s %s\n", data_arrow1((int) pin->dir), sig->name);
@@ -1875,8 +1875,8 @@ static void print_sig_info(int type, char **patterns)
 	    halcmd_output("%s  %s  %s\n", data_type((int) sig->type),
 		data_value((int) sig->type, dptr), sig->name);
 	    /* look for pin(s) linked to this signal */
-	    pin = halpr_find_pin_by_sig(sig, 0);
-	    while (pin != 0) {
+	    pin = halpr_find_pin_by_sig(sig, NULL);
+	    while (pin != NULL) {
 		halcmd_output("                                 %s %s\n",
 		    data_arrow2((int) pin->dir), pin->name);
 		pin = halpr_find_pin_by_sig(sig, pin);
@@ -1907,8 +1907,8 @@ static void print_script_sig_info(int type, char **patterns)
 	    halcmd_output("%s  %s  %s", data_type((int) sig->type),
 		data_value2((int) sig->type, dptr), sig->name);
 	    /* look for pin(s) linked to this signal */
-	    pin = halpr_find_pin_by_sig(sig, 0);
-	    while (pin != 0) {
+	    pin = halpr_find_pin_by_sig(sig, NULL);
+	    while (pin != NULL) {
 		halcmd_output(" %s %s",
 		    data_arrow2((int) pin->dir), pin->name);
 		pin = halpr_find_pin_by_sig(sig, pin);
@@ -2060,7 +2060,7 @@ static void print_thread_info(char **patterns)
                     sig = SHMPTR(pin->signal);
                     dptr = SHMPTR(sig->data_ptr);
                 } else {
-                    sig = 0;
+                    sig = NULL;
                     dptr = &(pin->dummysig);
                 }
 
@@ -2569,7 +2569,7 @@ int do_save_cmd(const char *type, char *filename)
 	return -1;
 	}
     }
-    if (type == 0 || *type == '\0') {
+    if (type == NULL || *type == '\0') {
 	type = "all";
     }
     if (   (strcmp(type, "all")  == 0)
@@ -2649,7 +2649,7 @@ static void save_comps(FILE *dst)
         return;
 	}
 
-    std::vector<hal_comp_t *> comps(ncomps, nullptr);
+    std::vector<hal_comp_t *> comps(ncomps, NULL);
     hal_comp_t **compptr = comps.data();
     next = hal_data->comp_list_ptr;
     while(next != 0)  {
@@ -2782,14 +2782,14 @@ static void save_nets(FILE *dst, int arrow)
             int state = 0, first = 1;
 
             /* If there are no pins connected to this signal, do nothing */
-            pin = halpr_find_pin_by_sig(sig, 0);
+            pin = halpr_find_pin_by_sig(sig, NULL);
             if(!pin) continue;
 
             fprintf(dst, "net %s", sig->name);
 
             /* Step 1: Output pin, if any */
             
-            for(pin = halpr_find_pin_by_sig(sig, 0); pin;
+            for(pin = halpr_find_pin_by_sig(sig, NULL); pin;
                     pin = halpr_find_pin_by_sig(sig, pin)) {
                 if(pin->dir != HAL_OUT) continue;
                 fprintf(dst, " %s", pin->name);
@@ -2797,7 +2797,7 @@ static void save_nets(FILE *dst, int arrow)
             }
             
             /* Step 2: I/O pins, if any */
-            for(pin = halpr_find_pin_by_sig(sig, 0); pin;
+            for(pin = halpr_find_pin_by_sig(sig, NULL); pin;
                     pin = halpr_find_pin_by_sig(sig, pin)) {
                 if(pin->dir != HAL_IO) continue;
                 fprintf(dst, " ");
@@ -2809,7 +2809,7 @@ static void save_nets(FILE *dst, int arrow)
             if(!first) state = 1;
 
             /* Step 3: Input pins, if any */
-            for(pin = halpr_find_pin_by_sig(sig, 0); pin;
+            for(pin = halpr_find_pin_by_sig(sig, NULL); pin;
                     pin = halpr_find_pin_by_sig(sig, pin)) {
                 if(pin->dir != HAL_IN) continue;
                 fprintf(dst, " ");
@@ -2820,12 +2820,12 @@ static void save_nets(FILE *dst, int arrow)
             fprintf(dst, "\n");
         } else if(arrow == 2) {
             /* If there are no pins connected to this signal, do nothing */
-            pin = halpr_find_pin_by_sig(sig, 0);
+            pin = halpr_find_pin_by_sig(sig, NULL);
             if(!pin) continue;
 
             fprintf(dst, "net %s", sig->name);
-            pin = halpr_find_pin_by_sig(sig, 0);
-            while (pin != 0) {
+            pin = halpr_find_pin_by_sig(sig, NULL);
+            while (pin != NULL) {
                 fprintf(dst, " %s", pin->name);
                 pin = halpr_find_pin_by_sig(sig, pin);
             }
@@ -2833,8 +2833,8 @@ static void save_nets(FILE *dst, int arrow)
         } else {
             fprintf(dst, "newsig %s %s\n",
                     sig->name, data_type((int) sig->type));
-            pin = halpr_find_pin_by_sig(sig, 0);
-            while (pin != 0) {
+            pin = halpr_find_pin_by_sig(sig, NULL);
+            while (pin != NULL) {
                 if (arrow != 0) {
                     arrow_str = data_arrow2((int) pin->dir);
                 } else {

--- a/src/hal/utils/halcmd_completion.c
+++ b/src/hal/utils/halcmd_completion.c
@@ -724,7 +724,7 @@ char **halcmd_completer(const char *text, int start, int end, hal_completer_func
     } else if(startswith(buffer, "source ") && argno == 1) {
         rtapi_mutex_give(&(hal_data->mutex));
         // leaves rl_attempted_completion_over = 0 to complete from filesystem
-        return 0;
+        return NULL;
     } else if(startswith(buffer, "loadusr ") && argno < 3) {
         rtapi_mutex_give(&(hal_data->mutex));
         // leaves rl_attempted_completion_over = 0 to complete from filesystem

--- a/src/hal/utils/halcmd_main.c
+++ b/src/hal/utils/halcmd_main.c
@@ -380,7 +380,7 @@ static int release_HAL_mutex(void)
 
 static char **completion_callback(const char *text, hal_generator_func cb) {
     int state = 0;
-    char *s = 0;
+    char *s = NULL;
     do {
         s = cb(text, state);
         if(s) printf("%s\n", s);

--- a/src/hal/utils/halcompile.g
+++ b/src/hal/utils/halcompile.g
@@ -373,7 +373,7 @@ static int comp_id;
     if options.get("userspace"):
         print("#include <stdlib.h>", file=f)
 
-    print("struct __comp_state *__comp_first_inst=0, *__comp_last_inst=0;", file=f)
+    print("struct __comp_state *__comp_first_inst=NULL, *__comp_last_inst=NULL;", file=f)
 
     print("", file=f)
     for name, fp in functions:
@@ -526,7 +526,7 @@ static int comp_id;
             print("static int default_count=%s, count=0;" \
                 % options.get("default_count", 1), file=f)
             if options.get("userspace"):
-                print("char *names[%d] = {0,};"%(MAX_USERSPACE_NAMES), file=f)
+                print("char *names[%d] = {NULL,};"%(MAX_USERSPACE_NAMES), file=f)
             else:
                 print("RTAPI_MP_INT(count, \"number of %s\");" % comp_name, file=f)
                 print("char *names = \"\"; // comma separated names", file=f)
@@ -717,7 +717,7 @@ int __comp_parse_names(int *argc, char **argv) {
     return 0;
 }
 """%MAX_USERSPACE_NAMES, file=f)
-        print("int argc=0; char **argv=0;", file=f)
+        print("int argc=0; char **argv=NULL;", file=f)
         print("int main(int argc_, char **argv_) {"    , file=f)
         print("    argc = argc_; argv = argv_;", file=f)
         if not options.get("singleton"):

--- a/src/hal/utils/halrmt.c
+++ b/src/hal/utils/halrmt.c
@@ -403,7 +403,7 @@ struct option longopts[] = {
   {"sessions", 1, NULL, 's'},
   {"connectpw", 1, NULL, 'w'},
   {"enablepw", 1, NULL, 'e'},
-  {0,0,0,0}
+  {NULL,0,NULL,0}
 };
 
 const char *commands[] = {"HELLO", "SET", "GET", "QUIT", "SHUTDOWN", "HELP", ""};
@@ -671,7 +671,7 @@ static int doLinkpp(char *first_pin_name, char *second_pin_name, connectionRecTy
     /* check if the pins are there */
     first_pin = halpr_find_pin_by_name(first_pin_name);
     second_pin = halpr_find_pin_by_name(second_pin_name);
-    if (first_pin == 0) {
+    if (first_pin == NULL) {
 	/* first pin not found*/
       rtapi_mutex_give(&(hal_data->mutex));
       snprintf(errorStr, sizeof(errorStr), "HAL:%d: ERROR: pin '%s' not found\n", linenumber, first_pin_name);
@@ -679,7 +679,7 @@ static int doLinkpp(char *first_pin_name, char *second_pin_name, connectionRecTy
       return -EINVAL; 
       } 
     else 
-      if (second_pin == 0) {
+      if (second_pin == NULL) {
 	rtapi_mutex_give(&(hal_data->mutex));
         snprintf(errorStr, sizeof(errorStr), "HAL:%d: ERROR: pin '%s' not found", linenumber, second_pin_name);
         sockWriteError(nakStr, context);
@@ -749,7 +749,7 @@ static int preflightNet(char *signal, hal_sig_t *sig, char *pins[], connectionRe
     }
 
     for(i=0; pins[i] && *pins[i]; i++) {
-        hal_pin_t *pin = 0;
+        hal_pin_t *pin = NULL;
         pin = halpr_find_pin_by_name(pins[i]);
         if(!pin) {
 //            halcmd_error("pin '%s' does not exist\n", pins[i]);
@@ -970,9 +970,9 @@ static int doSetp(char *name, char *value, connectionRecType *context)
     rtapi_mutex_get(&(hal_data->mutex));
     /* search param list for name */
     param = halpr_find_param_by_name(name);
-    if (param == 0) {
+    if (param == NULL) {
         pin = halpr_find_pin_by_name(name);
-        if(pin == 0) {
+        if(pin == NULL) {
             rtapi_mutex_give(&(hal_data->mutex));
             snprintf(errorStr, sizeof(errorStr),
                 "HAL:%d: ERROR: parameter or pin '%s' not found\n", linenumber, name);
@@ -1033,7 +1033,7 @@ static int doSets(char *name, char *value, connectionRecType *context)
     rtapi_mutex_get(&(hal_data->mutex));
     /* search signal list for name */
     sig = halpr_find_sig_by_name(name);
-    if (sig == 0) {
+    if (sig == NULL) {
 	rtapi_mutex_give(&(hal_data->mutex));
 	snprintf(errorStr, sizeof(errorStr),
 	    "HAL:%d: ERROR: signal '%s' not found\n", linenumber, name);
@@ -1224,7 +1224,7 @@ static int doLoadRt(char *mod_name, char *args[], connectionRecType *context)
     rtapi_mutex_get(&(hal_data->mutex));
     /* search component list for the newly loaded component */
     comp = halpr_find_comp_by_name(mod_name);
-    if (comp == 0) {
+    if (comp == NULL) {
 	rtapi_mutex_give(&(hal_data->mutex));
         snprintf(errorStr, sizeof(errorStr), "module '%s' not loaded", mod_name);
         sockWriteError(nakStr, context);
@@ -1722,7 +1722,7 @@ static void getPinInfo(char *pattern, int valuesOnly, connectionRecType *context
 	  dptr = SHMPTR(sig->data_ptr);
 	  } 
         else {
-	  sig = 0;
+	  sig = NULL;
 	  dptr = &(pin->dummysig);
 	  }
 	if (valuesOnly == 0)  
@@ -1861,7 +1861,7 @@ static void getThreadInfo(char *pattern, connectionRecType *context)
                 sig = SHMPTR(pin->signal);
                 dptr = SHMPTR(sig->data_ptr);
             } else {
-                sig = 0;
+                sig = NULL;
                 dptr = &(pin->dummysig);
             }
             runtime_pin_value = (int)*(int*)dptr;
@@ -2219,8 +2219,8 @@ static void save_nets(FILE *dst, int arrow)
     while (next != 0) {
 	sig = SHMPTR(next);
 	fprintf(dst, "newsig %s %s\n", sig->name, data_type((int) sig->type));
-	pin = halpr_find_pin_by_sig(sig, 0);
-	while (pin != 0) {
+	pin = halpr_find_pin_by_sig(sig, NULL);
+	while (pin != NULL) {
 	    if (arrow != 0) {
 		arrow_str = data_arrow2((int) pin->dir);
 	    } else {
@@ -2887,7 +2887,7 @@ static cmdResponseType setUnload(char *s, connectionRecType *context)
 static cmdResponseType setLoadUsr(char *s, connectionRecType *context)
 {
   (void)context;
-  char *argv[MAX_TOK+1] = {0};
+  char *argv[MAX_TOK+1] = {NULL};
 
   argv[0] = s;
   argv[1] = "\0";

--- a/src/hal/utils/halsh.c
+++ b/src/hal/utils/halsh.c
@@ -251,8 +251,8 @@ int Hal_Init(Tcl_Interp *interp) {
         return TCL_ERROR;
     }
 
-    Tcl_CreateCommand(interp, "hal", halCmd, 0, halExit);
-    Tcl_CreateCommand(interp, "hal_stream", halStreamCmd, 0, NULL);
+    Tcl_CreateCommand(interp, "hal", halCmd, NULL, halExit);
+    Tcl_CreateCommand(interp, "hal_stream", halStreamCmd, NULL, NULL);
 
     Tcl_PkgProvide(interp, "Hal", "1.0");
     return TCL_OK;

--- a/src/hal/utils/scope.c
+++ b/src/hal/utils/scope.c
@@ -648,13 +648,13 @@ static void define_menubar(GtkWidget *vboxtop) {
     fileopenconfiguration = gtk_menu_item_new_with_mnemonic(_("_Open Configuration..."));
     gtk_menu_shell_append(GTK_MENU_SHELL(filemenu), fileopenconfiguration);
     g_signal_connect_swapped(fileopenconfiguration, "activate",
-            G_CALLBACK(open_configuration), 0);
+            G_CALLBACK(open_configuration), NULL);
     gtk_widget_show(fileopenconfiguration);
 
     filesaveconfiguration = gtk_menu_item_new_with_mnemonic(_("_Save Configuration..."));
     gtk_menu_shell_append(GTK_MENU_SHELL(filemenu), filesaveconfiguration);
     g_signal_connect_swapped(filesaveconfiguration, "activate",
-            G_CALLBACK(save_configuration), 0);
+            G_CALLBACK(save_configuration), NULL);
     gtk_widget_show(filesaveconfiguration);
 
     gtk_menu_shell_append(GTK_MENU_SHELL(filemenu), sep1);
@@ -670,7 +670,7 @@ static void define_menubar(GtkWidget *vboxtop) {
     filesavedatafile = gtk_menu_item_new_with_mnemonic(_("S_ave Log File"));
     gtk_menu_shell_append(GTK_MENU_SHELL(filemenu), filesavedatafile);
     g_signal_connect_swapped(filesavedatafile, "activate",
-            G_CALLBACK(save_log_cb), 0);
+            G_CALLBACK(save_log_cb), NULL);
     gtk_widget_show(filesavedatafile);
 
     gtk_menu_shell_append(GTK_MENU_SHELL(filemenu), sep2);
@@ -679,7 +679,7 @@ static void define_menubar(GtkWidget *vboxtop) {
     filequit = gtk_menu_item_new_with_mnemonic(_("_Quit"));
     gtk_menu_shell_append(GTK_MENU_SHELL(filemenu), filequit);
     g_signal_connect_swapped(filequit, "activate",
-            G_CALLBACK(quit), 0);
+            G_CALLBACK(quit), NULL);
     gtk_widget_show(filequit);
 
     helpabout = gtk_menu_item_new_with_mnemonic(_("_About Halscope"));

--- a/src/hal/utils/scope_disp.c
+++ b/src/hal/utils/scope_disp.c
@@ -92,7 +92,7 @@ void init_display(void)
 
     /* allocate a user space buffer */
     ctrl_usr->disp_buf = g_malloc(sizeof(scope_data_t) * ctrl_shm->buf_len);
-    if (ctrl_usr->disp_buf == 0) {
+    if (ctrl_usr->disp_buf == NULL) {
 	/* malloc failed */
 	/* should never get here - gmalloc checks its return value */
 	exit(-1);

--- a/src/hal/utils/scope_horiz.c
+++ b/src/hal/utils/scope_horiz.c
@@ -197,11 +197,11 @@ static void init_horiz_window(void)
     g_signal_connect(horiz->disp_area, "draw",
             G_CALLBACK(refresh_pos_disp), NULL);
     g_signal_connect(horiz->disp_area, "button_press_event",
-        G_CALLBACK(horiz_press), 0);
+        G_CALLBACK(horiz_press), NULL);
     g_signal_connect(horiz->disp_area, "button_release_event",
-        G_CALLBACK(horiz_release), 0);
+        G_CALLBACK(horiz_release), NULL);
     g_signal_connect(horiz->disp_area, "motion_notify_event",
-        G_CALLBACK(horiz_motion), 0);
+        G_CALLBACK(horiz_motion), NULL);
     gtk_widget_set_events(GTK_WIDGET(horiz->disp_area),
         GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK
         | GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK);

--- a/src/libnml/cms/cms.cc
+++ b/src/libnml/cms/cms.cc
@@ -134,7 +134,7 @@ CMS::CMS(long s)
     min_compatible_version = 0;
     confirm_write = 0;
     disable_final_write_raw_for_dma = 0;
-    subdiv_data = 0;
+    subdiv_data = NULL;
     enable_diagnostics = 0;
     dpi = NULL;
     di = NULL;
@@ -183,7 +183,7 @@ CMS::CMS(long s)
  /* 1 force this CMS object to be in server mode. */
 CMS::CMS(const char *bufline_in, const char *procline_in, int set_to_server)
 {
-    char *word[32]={0,};	/* Array of pointers to strings.  */
+    char *word[32]={NULL,};	/* Array of pointers to strings.  */
     char *buffer_type_name;	/* pointer to buffer type name from bufline */
     char *proc_type_name;	/* pointer to process type from procline */
     int i;

--- a/src/libnml/cms/cms_cfg.cc
+++ b/src/libnml/cms/cms_cfg.cc
@@ -341,9 +341,9 @@ int cms_config(CMS ** cms, const char *bufname, const char *procname, const char
     CONFIG_SEARCH_STRUCT search;
     char buf[LINELEN];
     char buf2[LINELEN];
-    char *default_ptr = 0;
+    char *default_ptr = NULL;
 
-    if (0 == bufname || 0 == procname || 0 == filename) {
+    if (NULL == bufname || NULL == procname || NULL == filename) {
 	return -1;
     }
     rcs_print_debug(PRINT_CMS_CONFIG_INFO, "cms_config arguments:\n");
@@ -365,7 +365,7 @@ int cms_config(CMS ** cms, const char *bufname, const char *procname, const char
 	search.bufname_for_procline = "default";
 	find_proc_and_buffer_lines(&search);
 	if (search.error_type == CONFIG_SEARCH_OK) {
-	    default_ptr = 0;
+	    default_ptr = NULL;
 	    strncpy(buf, search.proc_line, LINELEN);
 	    default_ptr = strstr(buf, "default");
 	    if (default_ptr) {
@@ -430,17 +430,17 @@ int cms_config(CMS ** cms, const char *bufname, const char *procname, const char
 int hostname_matches_bufferline(char *bufline)
 {
     char my_hostname[256];
-    struct hostent *my_hostent_ptr = 0;
-    struct hostent *buffer_hostent_ptr = 0;
+    struct hostent *my_hostent_ptr = NULL;
+    struct hostent *buffer_hostent_ptr = NULL;
     struct hostent my_hostent;
     char my_hostent_addresses[16][16];
     int num_my_hostent_addresses = 0;
     struct in_addr myaddress;
     int j, k;
-    char *buffer_host = 0;
+    char *buffer_host = NULL;
     char *word[4];		/* array of pointers to words from line */
 
-    if (0 == bufline) {
+    if (NULL == bufline) {
 	return 0;
     }
 
@@ -449,7 +449,7 @@ int hostname_matches_bufferline(char *bufline)
 	return 0;
     }
     buffer_host = word[3];
-    if (buffer_host == 0) {
+    if (buffer_host == NULL) {
 	return 0;
     }
 
@@ -461,7 +461,7 @@ int hostname_matches_bufferline(char *bufline)
 	return 1;
     }
     my_hostent_ptr = gethostbyname(my_hostname);
-    if (0 == my_hostent_ptr) {
+    if (NULL == my_hostent_ptr) {
 	return 0;
     }
     myaddress.s_addr = *((int *) my_hostent_ptr->h_addr_list[0]);
@@ -476,7 +476,7 @@ int hostname_matches_bufferline(char *bufline)
        they are clobbered when we try to get the hostentry for buffer_host */
     my_hostent = *my_hostent_ptr;
     memset(my_hostent_addresses, 0, 256);
-    for (j = 0; j < 16 && 0 != my_hostent.h_addr_list[j]; j++) {
+    for (j = 0; j < 16 && NULL != my_hostent.h_addr_list[j]; j++) {
 	memcpy(my_hostent_addresses[j], my_hostent.h_addr_list[j],
 	    my_hostent.h_length);
     }
@@ -485,7 +485,7 @@ int hostname_matches_bufferline(char *bufline)
 	return 0;
     }
     buffer_hostent_ptr = gethostbyname(buffer_host);
-    if (0 == buffer_hostent_ptr) {
+    if (NULL == buffer_hostent_ptr) {
 	return 0;
     }
     j = 0;
@@ -495,7 +495,7 @@ int hostname_matches_bufferline(char *bufline)
     }
     while (j < num_my_hostent_addresses && j < 16) {
 	k = 0;
-	while (k < 16 && buffer_hostent_ptr->h_addr_list[k] != 0) {
+	while (k < 16 && buffer_hostent_ptr->h_addr_list[k] != NULL) {
 	    if (!memcmp
 		(my_hostent_addresses[j], buffer_hostent_ptr->h_addr_list[k],
 		    my_hostent.h_length)) {
@@ -511,7 +511,7 @@ int hostname_matches_bufferline(char *bufline)
 
 void find_proc_and_buffer_lines(CONFIG_SEARCH_STRUCT * s)
 {
-    if (s == 0) {
+    if (s == NULL) {
 	return;
     }
 

--- a/src/libnml/cms/cms_srv.cc
+++ b/src/libnml/cms/cms_srv.cc
@@ -624,7 +624,7 @@ REMOTE_CMS_REPLY *CMS_SERVER::process_request(REMOTE_CMS_REQUEST * _request)
 	{
 	    REMOTE_GET_BUF_NAME_REPLY *namereply = &local_port->namereply;
 	    const char *name = get_buffer_name(request->buffer_number);
-	    if (0 == name) {
+	    if (NULL == name) {
 		return NULL;
 	    }
 	    strncpy(namereply->name, name, 31);

--- a/src/libnml/cms/tcp_srv.cc
+++ b/src/libnml/cms/tcp_srv.cc
@@ -523,7 +523,7 @@ void *tcpsvr_handle_blocking_request(void *_req)
     char temp_buffer[0x2000];
     if (_req == NULL) {
 	tcpsvr_threads_returned_early++;
-	return 0;
+	return NULL;
     }
     double dtimeout =
 	((double) (blocking_read_req->timeout_millis + 10)) / 1000.0;
@@ -541,7 +541,7 @@ void *tcpsvr_handle_blocking_request(void *_req)
 
     if (NULL == server || NULL == _client_tcp_port) {
 	tcpsvr_threads_returned_early++;
-	return 0;
+	return NULL;
     }
     memset(temp_buffer, 0, 0x2000);
     REMOTE_BLOCKING_READ_REPLY *read_reply;
@@ -571,7 +571,7 @@ void *tcpsvr_handle_blocking_request(void *_req)
 	delete blocking_read_req;
 	_client_tcp_port->threadId = 0;
 	tcpsvr_threads_returned_early++;
-	return 0;
+	return NULL;
     }
     putbe32(temp_buffer, _client_tcp_port->serial_number);
     putbe32(temp_buffer + 4, read_reply->status);
@@ -590,7 +590,7 @@ void *tcpsvr_handle_blocking_request(void *_req)
 	    delete blocking_read_req;
 	    _client_tcp_port->threadId = 0;
 	    tcpsvr_threads_returned_early++;
-	    return 0;
+	    return NULL;
 	}
     } else {
 	_client_tcp_port->blocking = 0;
@@ -602,7 +602,7 @@ void *tcpsvr_handle_blocking_request(void *_req)
 	    delete blocking_read_req;
 	    _client_tcp_port->threadId = 0;
 	    tcpsvr_threads_returned_early++;
-	    return 0;
+	    return NULL;
 	}
 	if (read_reply->size > 0) {
 	    if (sendn
@@ -614,7 +614,7 @@ void *tcpsvr_handle_blocking_request(void *_req)
 		delete blocking_read_req;
 		_client_tcp_port->threadId = 0;
 		tcpsvr_threads_returned_early++;
-		return 0;
+		return NULL;
 	    }
 	}
     }

--- a/src/libnml/nml/nml.cc
+++ b/src/libnml/nml/nml.cc
@@ -170,7 +170,7 @@ NML::NML(NML_FORMAT_PTR f_ptr, const char *buf, const char *proc, const char *fi
     const int set_to_server, const int set_to_master)
 {
     registered_with_server = 0;
-    cms_for_msg_string_conversions = 0;
+    cms_for_msg_string_conversions = NULL;
     info_printed = 0;
     blocking_read_poll_interval = -1.0;
     forced_type = 0;
@@ -341,7 +341,7 @@ NML::NML(const char *buf, const char *proc, const char *file, const int set_to_s
 	file = default_nml_config_file;
     }
     registered_with_server = 0;
-    cms_for_msg_string_conversions = 0;
+    cms_for_msg_string_conversions = NULL;
     snprintf(bufname, 40 , "%s", buf);
     snprintf(procname, 40, "%s", proc);
     snprintf(cfgfilename, 160, "%s", file);
@@ -454,7 +454,7 @@ NML::NML(const char *buf, const char *proc, const char *file, const int set_to_s
 NML::NML(const char * buffer_line, const char * proc_line)
 {
     registered_with_server = 0;
-    cms_for_msg_string_conversions = 0;
+    cms_for_msg_string_conversions = NULL;
     cms = (CMS *) NULL;
     blocking_read_poll_interval = -1.0;
     forced_type = 0;
@@ -597,7 +597,7 @@ void NML::register_with_server()
 NML::NML(NML * nml_ptr, const int set_to_server, const int set_to_master)
 {
     registered_with_server = 0;
-    cms_for_msg_string_conversions = 0;
+    cms_for_msg_string_conversions = NULL;
     already_deleted = 0;
     forced_type = 0;
     cms = (CMS *) NULL;
@@ -766,7 +766,7 @@ void NML::delete_channel()
     if (NULL != cms_for_msg_string_conversions
 	&& cms != cms_for_msg_string_conversions) {
 	delete cms_for_msg_string_conversions;
-	cms_for_msg_string_conversions = 0;
+	cms_for_msg_string_conversions = NULL;
     }
     if (NULL != cms) {
 	rcs_print_debug(PRINT_NML_DESTRUCTORS, " delete (CMS *) %p;\n", cms);
@@ -2001,7 +2001,7 @@ const char *NML::msg2str(NMLmsg * nml_msg)
 		    cms_for_msg_string_conversions->size > 2048) ||
 		cms_for_msg_string_conversions->size < 4 * msg_length) {
 		delete cms_for_msg_string_conversions;
-		cms_for_msg_string_conversions = 0;
+		cms_for_msg_string_conversions = NULL;
 	    }
 	}
 	if (NULL == cms_for_msg_string_conversions) {
@@ -2043,7 +2043,7 @@ NMLTYPE NML::str2msg(const char *string)
 		    cms_for_msg_string_conversions->size > 2048) ||
 		cms_for_msg_string_conversions->size < 4 * string_length) {
 		delete cms_for_msg_string_conversions;
-		cms_for_msg_string_conversions = 0;
+		cms_for_msg_string_conversions = NULL;
 	    }
 	}
 	if (NULL == cms_for_msg_string_conversions) {
@@ -2297,7 +2297,7 @@ int NML::print_queue_info()
 NML *nmlWaitOpen(NML_FORMAT_PTR fPtr, char *buffer, char *name, char *file,
     double sleepTime)
 {
-    NML *nmlChannel = 0;
+    NML *nmlChannel = NULL;
 
     RCS_PRINT_DESTINATION_TYPE olddest = get_rcs_print_destination();
     set_rcs_print_destination(RCS_PRINT_TO_NULL);

--- a/src/libnml/os_intf/_sem.c
+++ b/src/libnml/os_intf/_sem.c
@@ -138,7 +138,7 @@ rcs_sem_t *rcs_sem_open(key_t name, int oflag, /* int mode */ ...)
 
 int rcs_sem_close(rcs_sem_t * sem)
 {
-    if (sem != 0) {
+    if (sem != NULL) {
 	free(sem);
     }
     return 0;
@@ -212,7 +212,7 @@ int rcs_sem_wait(rcs_sem_t * sem, double timeout)
     sops.sem_op = SEM_TAKE;
     sops.sem_flg = 0;
     
-    if (0 == sem) {
+    if (NULL == sem) {
 	return -1;
     }
 

--- a/src/libnml/os_intf/_shm.c
+++ b/src/libnml/os_intf/_shm.c
@@ -232,7 +232,7 @@ shm_t *rcs_shm_open(key_t key, size_t size, int oflag, /* int mode */ ...)
     /* map shmem area into local address space */
     shmflg = 0;
     shmflg &= ~SHM_RDONLY;
-    if ((shm->addr = (void *) shmat(shm->id, 0, shmflg)) == (void *) -1) {
+    if ((shm->addr = (void *) shmat(shm->id, NULL, shmflg)) == (void *) -1) {
 	shm->create_errno = errno;
 	rcs_print_error("shmat(%d,0,%d) failed:(errno = %d): %s\n", shm->id,
 	    shmflg, errno, strerror(errno));

--- a/src/libnml/posemath/_posemath.c
+++ b/src/libnml/posemath/_posemath.c
@@ -344,7 +344,7 @@ int pmQuatRotConvert(PmQuaternion const * const q, PmRotationVector * const r)
 	return pmErrno = PM_NORM_ERR;
     }
 #endif
-    if (r == 0) {
+    if (r == NULL) {
 #ifdef PM_PRINT_ERROR
 	pmPrintError("pmQuatRotConvert: null pointer passed as rotation vector\n");
 #endif
@@ -1347,7 +1347,7 @@ int pmQuatMag(PmQuaternion const * const q, double *d)
     PmRotationVector r;
     int r1;
 
-    if (0 == d) {
+    if (NULL == d) {
 	return pmErrno = PM_ERR;
     }
 
@@ -1392,7 +1392,7 @@ int pmQuatNorm(PmQuaternion const * const q1, PmQuaternion * const qout)
 
 int pmQuatInv(PmQuaternion const * const q1, PmQuaternion * const qout)
 {
-    if (qout == 0) {
+    if (qout == NULL) {
 	return pmErrno = PM_ERR;
     }
 
@@ -1447,7 +1447,7 @@ int pmQuatScalDiv(PmQuaternion const * const q, double s, PmQuaternion * const q
 
 int pmQuatQuatMult(PmQuaternion const * const q1, PmQuaternion const * const q2, PmQuaternion * const qout)
 {
-    if (qout == 0) {
+    if (qout == NULL) {
 	return pmErrno = PM_ERR;
     }
 
@@ -1611,7 +1611,7 @@ int pmLineInit(PmLine * const line, PmPose const * const start, PmPose const * c
     double rmag = 0.0;
     PmQuaternion startQuatInverse;
 
-    if (0 == line) {
+    if (NULL == line) {
         return pmErrno = PM_ERR;
     }
 
@@ -1696,7 +1696,7 @@ int pmCartLineInit(PmCartLine * const line, PmCartesian const * const start, PmC
 {
     int r1 = PM_OK, r2 = PM_OK;
 
-    if (0 == line) {
+    if (NULL == line) {
         return pmErrno = PM_ERR;
     }
 

--- a/src/libnml/posemath/gomath.c
+++ b/src/libnml/posemath/gomath.c
@@ -2801,7 +2801,7 @@ int go_quat_matrix_convert(const go_quat * quat,
   int retval;
 
   /* check for an initialized matrix */
-  if (0 == matrix->el[0]) return GO_RESULT_ERROR;
+  if (NULL == matrix->el[0]) return GO_RESULT_ERROR;
   /* check for a 3x3 matrix */
   if (matrix->rows != 3 || matrix->cols != 3) return GO_RESULT_ERROR;
 
@@ -2820,7 +2820,7 @@ int go_mat_matrix_convert(const go_mat * mat,
 				go_matrix * matrix)
 {
   /* check for an initialized matrix */
-  if (0 == matrix->el[0]) return GO_RESULT_ERROR;
+  if (NULL == matrix->el[0]) return GO_RESULT_ERROR;
   /* check for a 3x3 matrix */
   if (matrix->rows != 3 || matrix->cols != 3) return GO_RESULT_ERROR;
 
@@ -2838,7 +2838,7 @@ int go_matrix_matrix_add(const go_matrix * a,
   go_integer row, col;
 
   /* check for an initialized matrix */
-  if (0 == a->el[0] || 0 == b->el[0] || 0 == apb->el[0]) return GO_RESULT_ERROR;
+  if (NULL == a->el[0] || NULL == b->el[0] || NULL == apb->el[0]) return GO_RESULT_ERROR;
   /* check for matching rows and cols */
   if (a->rows != b->rows || a->cols != b->cols ||
       b->rows != apb->rows || b->cols != apb->cols) return GO_RESULT_ERROR;
@@ -2858,7 +2858,7 @@ int go_matrix_matrix_copy(const go_matrix * src,
   go_integer row, col;
 
   /* check for an initialized matrix */
-  if (0 == src->el[0] || 0 == dst->el[0]) return GO_RESULT_ERROR;
+  if (NULL == src->el[0] || NULL == dst->el[0]) return GO_RESULT_ERROR;
 
   /* check for matching rows and cols */
   if (src->rows != dst->rows || src->cols != dst->cols) return GO_RESULT_ERROR;
@@ -2881,7 +2881,7 @@ int go_matrix_matrix_mult(const go_matrix * a,
   go_integer row, col, i;
 
   /* check for an initialized matrix */
-  if (0 == a->el[0] || 0 == b->el[0] || 0 == ab->el[0]) return GO_RESULT_ERROR;
+  if (NULL == a->el[0] || NULL == b->el[0] || NULL == ab->el[0]) return GO_RESULT_ERROR;
   /* check for consistent rows and cols */
   if (a->cols != b->rows ||
       a->rows != ab->rows ||
@@ -2928,7 +2928,7 @@ int go_matrix_vector_mult(const go_matrix * a,
   go_integer row, i;
 
   /* check for an initialized matrix */
-  if (0 == a->el[0]) return GO_RESULT_ERROR;
+  if (NULL == a->el[0]) return GO_RESULT_ERROR;
 
   if (axv == v) {
     ptrin = a->elcpy[0];
@@ -2971,7 +2971,7 @@ int go_matrix_vector_cross(const go_matrix * a,
   go_integer row, col;
 
   /* check for an initialized matrix */
-  if (0 == a->el[0] || 0 == axv->el[0]) return GO_RESULT_ERROR;
+  if (NULL == a->el[0] || NULL == axv->el[0]) return GO_RESULT_ERROR;
   /* check for consistent rows and cols */
   if (a->rows != 3 ||
       axv->rows != 3 ||
@@ -3017,7 +3017,7 @@ int go_matrix_transpose(const go_matrix * a,
   go_integer row, col;
 
   /* check for fixed matrix */
-  if (0 == a->el[0] || 0 == at->el[0]) return GO_RESULT_ERROR;
+  if (NULL == a->el[0] || NULL == at->el[0]) return GO_RESULT_ERROR;
 
   if (at == a) {
     ptrin = a->elcpy;
@@ -3052,7 +3052,7 @@ int go_matrix_inv(const go_matrix * m, /* M x N */
   int retval;
 
   /* check for fixed matrix */
-  if (0 == m->el[0] || 0 == minv->el[0]) return GO_RESULT_ERROR;
+  if (NULL == m->el[0] || NULL == minv->el[0]) return GO_RESULT_ERROR;
 
   N = m->rows;
 

--- a/src/libnml/posemath/gomath.h
+++ b/src/libnml/posemath/gomath.h
@@ -540,7 +540,7 @@ typedef struct {
 } go_matrix;
 
 #define GO_MATRIX_DECLARE(M,Mspace,_rows,_cols) \
-go_matrix M = {0, 0, 0, 0, 0, 0}; \
+go_matrix M = {0, 0, NULL, NULL, NULL, NULL}; \
 struct { \
   go_real * el[_rows]; \
   go_real * elcpy[_rows]; \

--- a/src/libnml/posemath/posemath.cc
+++ b/src/libnml/posemath/posemath.cc
@@ -22,7 +22,7 @@
 
 // place to reference arrays when bounds are exceeded
 static double noElement = 0.0;
-static PM_CARTESIAN *noCart = 0;
+static PM_CARTESIAN *noCart = nullptr;
 
 
 // PM_CARTESIAN class
@@ -358,7 +358,7 @@ PM_CARTESIAN & PM_ROTATION_MATRIX::operator [](int n) {
     case 2:
 	return z;
     default:
-	if (0 == noCart) {
+	if (nullptr == noCart) {
 	    noCart = new PM_CARTESIAN(0.0, 0.0, 0.0);
 	}
 	return (*noCart);	// need to return a PM_CARTESIAN &
@@ -730,7 +730,7 @@ PM_CARTESIAN & PM_HOMOGENEOUS::operator [](int n) {
 	noElement = 1.0;
 	return tran;
     default:
-	if (0 == noCart) {
+	if (nullptr == noCart) {
 	    noCart = new PM_CARTESIAN(0.0, 0.0, 0.0);
 	}
 	return (*noCart);	// need to return a PM_CARTESIAN &

--- a/src/module_helper/module_helper.c
+++ b/src/module_helper/module_helper.c
@@ -110,12 +110,12 @@ void error(int argc, char **argv) {
  */
 char *check_whitelist(char *target, char *table[]) {
     int i;
-    if(!target) return 0;
+    if(!target) return NULL;
     for(i=0; table[i]; i++) {
         int sz = strlen(table[i]);
         if(!strncmp(target, table[i], sz)) return target + sz;
     }
-    return 0;
+    return NULL;
 }
 
 /* Check that the given module is in the whitelist.  It's in the whitelist

--- a/src/rtapi/rtapi_pci.cc
+++ b/src/rtapi/rtapi_pci.cc
@@ -266,7 +266,7 @@ void rtapi_pci_unregister_driver(struct rtapi_pci_driver *driver)
         delete dev;
     }
     delete &DEVICES(driver);
-    driver->private_data = 0;
+    driver->private_data = nullptr;
 }
 
 typedef std::map<void rtapi__iomem*, size_t> IoMap;

--- a/src/rtapi/uspace_common.h
+++ b/src/rtapi/uspace_common.h
@@ -69,7 +69,7 @@ int rtapi_shmem_new(int key, int module_id, unsigned long int size)
   rtapi_shmem_handle *shmem;
   int i;
 
-  for (i=0,shmem=0 ; i < MAX_SHM; i++) {
+  for (i=0,shmem=NULL ; i < MAX_SHM; i++) {
     if(shmem_array[i].magic == SHMEM_MAGIC) {
       if (shmem_array[i].key == key) {
         shmem_array[i].count ++;
@@ -140,7 +140,7 @@ shmget_again:
 #endif
 
   /* and map it into process space */
-  shmem->mem = shmat(shmem->id, 0, 0);
+  shmem->mem = shmat(shmem->id, NULL, 0);
   if ((ssize_t) (shmem->mem) == -1) {
     rtapi_print_msg(RTAPI_MSG_ERR, "rtapi_shmem_new failed due to shmat()\n");
     return -errno;
@@ -299,10 +299,10 @@ static         int  uuid_mem_id = 0;
 int rtapi_init(const char *modname)
 {
     (void)modname;
-    static uuid_data_t* uuid_data   = 0;
+    static uuid_data_t* uuid_data   = NULL;
     static const   int  uuid_id     = 0;
 
-    static char* uuid_shmem_base = 0;
+    static char* uuid_shmem_base = NULL;
     int retval,id;
     void *uuid_mem;
 
@@ -320,7 +320,7 @@ int rtapi_init(const char *modname)
         rtapi_exit(uuid_id);
         return -EINVAL;
     }
-    if (uuid_shmem_base == 0) {
+    if (uuid_shmem_base == NULL) {
         uuid_shmem_base =        (char *) uuid_mem;
         uuid_data       = (uuid_data_t *) uuid_mem;
     }
@@ -348,8 +348,8 @@ int rtapi_is_kernelspace() { return 0; }
 static inline int detect_preempt_rt() {
     struct utsname u;
     if(uname(&u) < 0) return 0;
-    return strcasestr(u.version, "PREEMPT RT") != 0
-        || strcasestr(u.version, "PREEMPT_RT") != 0;
+    return strcasestr(u.version, "PREEMPT RT") != NULL
+        || strcasestr(u.version, "PREEMPT_RT") != NULL;
 }
 #else
 static inline int detect_preempt_rt() {

--- a/src/rtapi/uspace_posix.cc
+++ b/src/rtapi/uspace_posix.cc
@@ -52,9 +52,9 @@ struct PosixApp : RtapiApp {
             return -EINVAL;
 
         pthread_cancel(task->thr);
-        pthread_join(task->thr, 0);
+        pthread_join(task->thr, nullptr);
         task->magic = 0;
-        task_array[id] = 0;
+        task_array[id] = nullptr;
         delete task;
         return 0;
     }

--- a/src/rtapi/uspace_rtapi_app.cc
+++ b/src/rtapi/uspace_rtapi_app.cc
@@ -113,7 +113,7 @@ int RtapiApp::prio_next_lower(int prio) const {
 int RtapiApp::allocate_task_id() {
     for (int n = 0; n < MAX_TASKS; n++) {
         RtapiTask **taskptr = &(task_array[n]);
-        if (__sync_bool_compare_and_swap(taskptr, (RtapiTask *)0, TASK_MAGIC_INIT))
+        if (__sync_bool_compare_and_swap(taskptr, (RtapiTask *)nullptr, TASK_MAGIC_INIT))
             return n;
     }
     return -ENOSPC;


### PR DESCRIPTION
There are many places in the sources where the value `0` is used to mean `NULL` or `nullptr`. The ultimate value of these may all be zero, but they are of very different types (pointer vs. integer). This leads to confusion in comparison and wrong assignments where one forgets to dereference or an instance in classicladder assigning `FALSE` to a pointer.

This PR fixes all (detected) instances that gcc and clang could find using the `-Wzero-as-null-pointer-constant` option and is selectable at configure time. There are a few instances in the C/C++ to Python interface code where this option is explicitly ignored with a pragma because the system's headers use the same confusion and cannot be easily fixed.