### PR TITLE
build: fix stale soname symlink after a library version bump

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -534,6 +534,7 @@ genclean:
 	find . -name '*.o' |xargs rm -f
 	-rm -rf objects
 	-rm -f $(TARGETS)
+	-rm -f ../lib/*.so.[0-9]*
 	-rm -f $(GENERATED_MANPAGES)
 	-rm -f ../rtlib/*.$(MODULE_EXT)
 	-rm -f hal/components/conv_*.comp

--- a/src/emc/ini/Submakefile
+++ b/src/emc/ini/Submakefile
@@ -19,8 +19,15 @@ $(patsubst ./emc/ini/%,../include/%,$(LIBLCNCINICXINCS)): ../include/%.hh: ./emc
 ../lib/liblinuxcncini.so.1: $(call TOOBJS,$(LIBLCNCINISRCS))
 	$(ECHO) Creating shared library $(notdir $@)
 	@mkdir -p ../lib
-	@rm -f $@
+	@rm -f $(basename $@).[0-9]*
 	$(Q)$(CXX) $(LDFLAGS) -Wl,-soname,$(notdir $@) -shared -o $@ $^ -lfmt
+
+# Explicit symlink rule: the generic ../lib/%.so pattern rules in src/Makefile
+# match both %.so.0 and %.so.1, and the %.so.0 rule wins when a stale .so.0 is
+# left over from before this library's soname bump. Bind the dev symlink to the
+# current soname explicitly so it always repoints in a single build pass.
+../lib/liblinuxcncini.so: ../lib/liblinuxcncini.so.1
+	ln -sf $(notdir $<) $@
 
 # Command-line utility for reading ini-files
 INIVALUESRCS := emc/ini/inivalue.cc


### PR DESCRIPTION
When a library soname is bumped (here `liblinuxcncini.so.0` to `.so.1`), an incremental tree keeps the old `.so.0` on disk, and the dev symlink `../lib/liblinuxcncini.so` gets repointed at the stale lib: the generic `../lib/%.so` pattern rules in `src/Makefile` match both `%.so.0` and `%.so.1`, and the `.so.0` rule is listed first so it wins. Everything then links against the old library and fails with undefined symbols (`IniFile::mapLinearUnits`), breaking the python `linuxcnc` module, `linuxcnc_check_ini` and startup.

Clean builds are immune, so CI never sees it; only people building incrementally across the bump are hit. `make clean` does not help either, because `.so.0` is no longer in `$(TARGETS)` so `rm -f $(TARGETS)` leaves it behind.

Fixes:
- the `liblinuxcncini.so.1` rule removes any leftover `.so.[0-9]*` sibling.
- an explicit `liblinuxcncini.so` to `.so.1` symlink rule, which overrides the ambiguous pattern pair so the symlink repoints to the current soname in a single build pass (the rm alone only self-heals on a second `make`).
- `genclean` also removes `../lib/*.so.[0-9]*` so stale versioned libraries no longer survive `make clean`.

@BsAtHome flagging you as reviewer. AndyPugh, myself, and Peter Wallace from Mesa all fell into this same trap; I walked Peter through it on Discord. A general fix for everyone seems nicer than the `git clean -dxf` we keep recommending, and it avoids that step entirely. Any reason not to do it?