### PR TITLE
check_config: validate INI datatypes (numeric / enum / duplicate) before comparison

### DIFF
--- a/lib/hallib/check_config.tcl
+++ b/lib/hallib/check_config.tcl
@@ -142,6 +142,51 @@ proc validate_identity_kins_limits {} {
   return $emsg
 } ;# validate_identity_kins_limits
 
+proc assert_ini_datatypes {} {
+  # Datatype assertions, run right after parse_ini, before any comparison.
+  # numeric: must be a real number (covers integers too: string is double)
+  set numeric {
+    MIN_LIMIT MAX_LIMIT MAX_VELOCITY MAX_ACCELERATION MAX_JERK
+    FERROR MIN_FERROR BACKLASH
+    P I D FF0 FF1 FF2 BIAS DEADBAND MAX_OUTPUT MAX_ERROR
+    INPUT_SCALE OUTPUT_SCALE SCALE
+    HOME HOME_OFFSET HOME_SEARCH_VEL HOME_LATCH_VEL HOME_FINAL_VEL
+    HOME_SEQUENCE STEPGEN_MAXVEL STEPGEN_MAXACCEL
+  }
+  # enum: must match a fixed set (case-insensitive, mirroring LinuxCNC's
+  # caseless maps mapJointType / convertBool)
+  set bool {TRUE YES 1 ON FALSE NO 0 OFF}
+  array set enum [list \
+    TYPE                        {LINEAR ANGULAR} \
+    HOME_USE_INDEX              $bool \
+    HOME_IGNORE_LIMITS          $bool \
+    HOME_IS_SHARED              $bool \
+    HOME_INDEX_NO_ENCODER_RESET $bool \
+    VOLATILE_HOME               $bool \
+    LOCKING_INDEXER             $bool \
+  ]
+  set emsg ""
+  foreach g [info globals] {
+    if {![string match JOINT_* $g] && ![string match AXIS_* $g]} continue
+    foreach item [array names ::$g] {
+      set val [set ::${g}($item)]
+      if {[llength $val] > 1} {
+        # duplicate key -> multi-element value; no point checking its datatype
+        lappend emsg "\[$g\]$item has duplicate/multiple values: <$val>"
+      } elseif {[lsearch -exact $numeric $item] >= 0} {
+        if {![string is double -strict $val]} {
+          lappend emsg "\[$g\]$item must be numeric, got: <$val> (stray text or inline comment in INI?)"
+        }
+      } elseif {[info exists enum($item)]} {
+        if {[lsearch -nocase $enum($item) $val] < 0} {
+          lappend emsg "\[$g\]$item must be one of {$enum($item)}, got: <$val>"
+        }
+      }
+    }
+  }
+  if {"$emsg" != ""} {err_exit $emsg}
+} ;# assert_ini_datatypes
+
 proc check_extrajoints {} {
   if ![info exists ::EMCMOT(EMCMOT)] return
   if {[string first motmod $::EMCMOT(EMCMOT)] <= 0} return
@@ -161,30 +206,6 @@ proc check_extrajoints {} {
   }
 } ;#check_extrajoints
 
-proc warn_for_multiple_ini_values {} {
-  set sections [info globals]
-  set sections_to_check {JOINT_ AXIS_}
-
-  foreach section $sections {
-    set enforce 0
-    foreach csection $sections_to_check {
-      if {[string first $csection $section] >= 0} {
-        set enforce 1
-        break
-      }
-    }
-    if !$enforce continue
-    foreach name [array names ::$section] {
-       set gsection ::$section
-       set val [set [set gsection]($name)]
-       set len [llength $val]
-       if {$len > 1} {
-         lappend ::wmsg "Unexpected multiple values \[$section\]$name: $val"
-       }
-    }
-  }
-} ;# warn_for_multiple_ini_values
-
 #----------------------------------------------------------------------
 # begin
 package require Linuxcnc ;# parse_ini
@@ -198,6 +219,8 @@ if ![file readable $inifile] {
    err_exit [list "File not readable <$inifile>"]
 }
 parse_ini $inifile
+
+assert_ini_datatypes
 
 check_mandatory_items
 
@@ -233,7 +256,6 @@ switch $::kins(module) {
 }
 check_extrajoints
 
-warn_for_multiple_ini_values
 #parray ::kins
 set emsg [validate_identity_kins_limits]
 consistent_coords_for_trivkins $::kins(coordinates)


### PR DESCRIPTION
## Problem

`check_config.tcl` compares `[JOINT_n]`/`[AXIS_L]` limits with Tcl `>`/`<`.
Tcl compares numerically only when *both* operands are valid numbers; otherwise
it silently does a **string** comparison. So a limit line carrying stray text —
e.g. an inline `# comment` — gets compared as a string.

With equal limits like:

    [AXIS_A]
    MAX_LIMIT = 3600000                # placeholder
    [JOINT_4]
    MAX_LIMIT = 3600000                  # placeholder

`3600000 == 3600000`, yet check_config reports
`[JOINT_4]MAX_LIMIT < [AXIS_A]MAX_LIMIT` — because the *strings* (comments +
differing whitespace) compare unequal. Pass/fail flips on trailing spaces, and
the error points at the wrong thing.

## Fix

Add `assert_ini_datatypes`, run once right after `parse_ini`, before any
comparison. For each `[JOINT_n]`/`[AXIS_L]` item:

- **duplicate keys** (multi-valued result) → error;
- **numeric** items must satisfy `string is double -strict` (ints and reals);
- **enum** items must match a fixed set, **case-insensitively**, mirroring
  LinuxCNC's caseless maps:
  - `TYPE` → `{LINEAR ANGULAR}` (`IniFile::mapJointType`)
  - boolean home flags → `{TRUE YES 1 ON FALSE NO 0 OFF}` (`IniFile::convertBool`)
- unknown items are left alone.

Errors name the `[SECTION]ITEM` and the offending value.

### Behavior change
Duplicate `[JOINT_]`/`[AXIS_]` keys are now an **error**, replacing the warn-only
`warn_for_multiple_ini_values` (removed; same scope, now fatal).

## Testing
Patched checker vs a working 5-joint INI and corrupted copies:
- **Accepted:** valid int & real, lowercase `TYPE=angular`, all eight boolean spellings.
- **Rejected (clear message each):** inline comment on a limit, `abc`, `1,000`,
  `1.2.3`, `TYPE=LINER`, `HOME_USE_INDEX=MAYBE`, duplicate key.

## Note
I'm not a software developer by trade, and this is my first day using LinuxCNC,
so I'd genuinely welcome feedback on the approach, the Tcl style, or the
numeric/enum item lists — happy to revise.
