### PR TITLE
qtvcp: fix undefined name in gcode_editor QScintilla import fallback

### DIFF
--- a/lib/python/qtvcp/widgets/gcode_editor.py
+++ b/lib/python/qtvcp/widgets/gcode_editor.py
@@ -62,8 +62,9 @@ except ImportError:
     if qtpy.PYQT5:
         try:
             from PyQt5.Qsci import QsciScintilla, QsciLexerCustom, QsciLexerPython
-        except ImportError:
+        except ImportError as e:
             LOG.critical("Can't import QsciScintilla - is package python3-pyqt5.qsci installed?", exc_info=e)
+            sys.exit(1)
     else:
         try:
             from PyQt6.Qsci import QsciScintilla, QsciLexerCustom, QsciLexerPython


### PR DESCRIPTION
The PyQt5 branch of the QScintilla import fallback in `gcode_editor.py` caught `ImportError` without binding it (`as e`), then passed `exc_info=e` to `LOG.critical`, raising `NameError`. Since qtvcp installs a modal-dialog `sys.excepthook` at startup, that turns a missing `python3-pyqt5.qsci` into an indefinite hang under headless/CI (the dialog blocks forever, the GUI never reaches its event loop or honors SIGTERM) instead of a clean exit.

Fix binds the exception and `sys.exit(1)`, matching the PyQt6 branch below it.

Verified on Fedora 43 / Python 3.14.5 with `python3-qscintilla-qt5` removed: before, `qtdragon-quit` hangs (`GUI still alive 15s after SIGTERM`); after, it logs the actionable message and exits in ~6s.
