### PR TITLE
qtvcp: don't pop a modal error dialog when headless

### DIFF
--- a/src/emc/usr_intf/qtvcp/qtvcp.py
+++ b/src/emc/usr_intf/qtvcp/qtvcp.py
@@ -556,6 +556,25 @@ Pressing cancel will close linuxcnc.""" % target)
                     + "information may be useful in troubleshooting:\n"
                     + 'LinuxCNC Version  : %s\n'% self.INFO.LINUXCNC_VERSION)
 
+            # Always surface unhandled exceptions to stderr/log. A crash is a
+            # serious problem that must be visible in CI logs, not buried in a
+            # dialog that the run never captures.
+            sys.stderr.write(''.join(lines))
+            sys.stderr.flush()
+            LOG.critical("Qtvcp unhandled exception:\n{}".format(''.join(lines)))
+
+            # Offscreen (e.g. CI): nobody can dismiss a modal dialog, so
+            # msg.exec_() below would block forever; if this happens during
+            # construction it hangs before the SIGTERM handler is armed and the
+            # process cannot be killed cleanly. Exit instead of popping a dialog.
+            app = QtWidgets.QApplication.instance()
+            if app is None or app.platformName() == 'offscreen':
+                try:
+                    self.shutdown()
+                except Exception:
+                    pass
+                os._exit(1)
+
             msg = QtWidgets.QMessageBox()
             msg.setIcon(QtWidgets.QMessageBox.Critical)
             msg.setText(self._message)


### PR DESCRIPTION
qtvcp's `excepthook` shows a modal `QMessageBox` for uncaught exceptions. Under an offscreen/headless platform (CI) nobody can dismiss it, so `msg.exec_()` blocks forever. When the exception happens during screen construction, this hangs before the event loop arms the SIGTERM handler, so the process cannot be terminated cleanly and `tests/ui-smoke/qtdragon-quit` times out with the GUI still alive. This matches the intermittent F43 failures in #4169: any flaky construction-time error lands here, and a rerun that avoids it passes.

When `QApplication` is absent or offscreen, the hook now logs the traceback, runs the normal shutdown, and exits instead of showing the dialog. The error is still reported (stderr + log + non-zero exit); only the dialog is skipped, and the interactive path is unchanged.

Reproduced and verified on a Fedora 43 / Python 3.14.5 uspace build by injecting an exception during construction: before, the test hangs 15s; after, it exits immediately with the traceback in the log.

@BsAtHome, three things:
- The guard triggers on the offscreen platform, which the qtdragon ui-smoke tests use. The xvfb/xcb smoke tests (touchy, gmoccapy) are not offscreen and so are unchanged. Should I broaden the condition, for example to also fire when there is no controlling tty, so those get the same protection?
- Could you test whether this clears the intermittent qtdragon-quit failures on your F43 setup? With a complete dependency set I could not reproduce the exact flakiness here, only the underlying hang via fault injection, so a confirmation on the real CI would help.
- Worth a dedicated ui-smoke regression test for this? I can add one with a deliberately-broken test screen (a handler that raises in `__init__`) loaded via its own config, asserting the process exits promptly instead of hanging, without putting test-only code in qtvcp.
