### PR TITLE
docs(html): add a topbar extension slot for post-processing add-ons

### DIFF
--- a/docs/src/docinfo-header.html.in
+++ b/docs/src/docinfo-header.html.in
@@ -13,5 +13,8 @@
     <span class="lcnc-sep" aria-hidden="true">&bull;</span>
     <a data-lcnc-link="4" href="{lcnc-cssrel}en/gcode.html">G-Code Quick Reference</a>
   </nav>
+  <!-- Extension slot for optional post-processing add-ons (for example a search
+       box injected by a separate tool). Empty in the base build. -->
+  <div class="lcnc-topbar-slot" data-lcnc-slot="topbar-end"></div>
 @LANGUAGE_SWITCHER@
 </header>


### PR DESCRIPTION
Following the discussion here, this is reduced to the minimal in-tree piece: a generic, empty extension slot in the docs topbar.

The base build stays minimalist and fetches nothing. The slot (`data-lcnc-slot="topbar-end"`) is an empty placeholder that out-of-tree post-processing can fill, for example to bolt on search, without the LinuxCNC build depending on anything extra. It is empty in the base build, so a plain docs build is unchanged.

As a concrete consumer, I built search as a separate project that downloads the docs artifact, plugs a pagefind search box into this slot, builds a per-language index, and emits searchable docs: https://github.com/grandixximo/linuxcnc-doc-search . Anyone can run their own post-processing against the same slot.
