### PR TITLE
docs(i18n): declare the correct html lang on translated pages

### DIFF
--- a/docs/src/Submakefile
+++ b/docs/src/Submakefile
@@ -785,6 +785,7 @@ $(DOC_OUT_HTML)/$(1)/man/%.html: $(2)/% $(DOC_SRCDIR)/docinfo.html $(DOC_SRCDIR)
 			-a compat-mode \
 			-a mansource=LinuxCNC \
 			-a manmanual='LinuxCNC Documentation' \
+			-a "lang=$(1)" \
 			-a "lcnc-cssrel=../../../" \
 			-a "lcnc-lang-label=$(LANG_LABEL_$(1))" \
 			-a "lcnc-subpath=$$(patsubst $(DOC_OUT_HTML)/$(1)/%,%,$$@)" \


### PR DESCRIPTION
Several translated pages render `<html lang="en">` instead of their actual language. This fixes two cases:

- **Russian and Ukrainian doc pages:** the `:lang:` attribute in `ru.po` and `uk.po` was left untranslated as `"en"`, so every ru/uk page declared English. Set to `ru` and `uk`.
- **Translated man pages (all languages):** the manpage HTML build rule never passed asciidoctor's `lang` attribute, so every language's man pages rendered `<html lang="en">`. Pass `lang=<tag>` per language so they declare their own language, matching the translated doc pages.

A correct `lang` is standard accessibility and i18n hygiene: it drives screen-reader pronunciation, hyphenation, font selection, and per-language tooling. It is also what the in-browser docs search (#4184) keys off to show results in the page's language, so without this those pages fall back to the English index.

Each is a one-line change; no content or layout changes.
