### PR TITLE
docs(html): limit index section toggle to the label width

### DIFF
--- a/docs/src/index.css
+++ b/docs/src/index.css
@@ -18,4 +18,5 @@ summary {
   margin-bottom: 0.15em;
   font-family: sans-serif;
   cursor: pointer;
+  width: fit-content;
 }


### PR DESCRIPTION
## Summary

On the documentation index page, clicking anywhere on a section row toggled the expandable `<details>` section, including the empty space far to the right of the label. The native `<details>`/`<summary>` markup introduced in 277dafcfcd ("apply bertho's index.html JS-free patch") renders `<summary>` as a full-width `list-item`, so the whole row became the click target.

This restores the intended behavior: only the section name is clickable. Clicks in the empty space to the right of the label no longer toggle the section.

## Change

`docs/src/index.css`: add `width: fit-content;` to `summary`, shrinking the click target to the label width.

## Verification

Built the index page locally and tested with a headless browser across all 17 `<details>` sections:

- clicking the label name toggles the section
- clicking the empty space to the right of the name does nothing (the hit target is the `<details>` container, not the `<summary>`)

@BsAtHome I remember that I already fixed this once, and I think it was you being annoyed by the thing expanding when you clicked on the right side, or am I remembering wrong?
