### PR TITLE
build: clean stale versioned libraries in genclean

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -569,6 +569,7 @@ genclean:
 	find . -name '*.o' |xargs rm -f
 	-rm -rf objects
 	-rm -f $(TARGETS)
+	-rm -f ../lib/*.so.[0-9]*
 	-rm -f $(GENERATED_MANPAGES)
 	-rm -f ../rtlib/*.$(MODULE_EXT)
 	-rm -f hal/components/conv_*.comp


### PR DESCRIPTION
Backport of the `genclean` part of #4180 to 2.9.

`genclean` removed only `$(TARGETS)`, so a leftover `../lib/*.so.N` from a prior build (for example a soname left behind when switching branches in a RIP tree, since `liblinuxcncini` is `.so.0` in 2.9 and `.so.1` in 2.10) survived `make clean`. Glob the versioned libraries so `make clean` removes them too.