### PR TITLE
qtvcp: arm terminate/interrupt handlers before screen construction

### DIFF
--- a/src/emc/usr_intf/qtvcp/qtvcp.py
+++ b/src/emc/usr_intf/qtvcp/qtvcp.py
@@ -114,6 +114,23 @@ class QTVCP:
         global APP
         APP = MyApplication(sys.argv)
 
+        # Install signal handlers before the slow screen construction. SIGINT's
+        # default handler raises KeyboardInterrupt, so an interrupt mid-build
+        # would otherwise be an unhandled exception. Before the loop runs
+        # APP.quit() is a no-op, so exit cleanly instead.
+        self._loop_running = False
+        def _handle_quit_signal(signum, frame):
+            if self._loop_running:
+                APP.quit()
+            else:
+                try:
+                    self.shutdown()
+                except Exception:
+                    pass
+                os._exit(0)
+        signal.signal(signal.SIGTERM, _handle_quit_signal)
+        signal.signal(signal.SIGINT, _handle_quit_signal)
+
         # a specific path has been set to load from or...
         # no path set but -ini is present: default qtvcp screen...or
         # oops error
@@ -447,17 +464,8 @@ Pressing cancel will close linuxcnc.""" % target)
             if (INITITLE !=''):
                 window.setWindowTitle(INITITLE)
 
-        # catch control c and terminate signals
-        # Quit the Qt event loop on the signal so APP.exec() returns and the
-        # shutdown() below runs the normal cleanup once. Calling shutdown()
-        # directly from the handler would clean up but leave the loop running.
-        # Quitting the loop also bypasses the window-close confirmation dialog,
-        # which is correct for a terminate request and leaves that interactive
-        # feature untouched. Qt's C++ event loop does not return to Python often
-        # enough to run Python signal handlers, so a periodic no-op timer yields
-        # to the interpreter to let them fire.
-        signal.signal(signal.SIGTERM, lambda *a: APP.quit())
-        signal.signal(signal.SIGINT, lambda *a: APP.quit())
+        # Handlers were installed above. Qt's C++ event loop rarely returns to
+        # Python, so a periodic no-op timer yields to let them fire.
         self._signal_timer = QtCore.QTimer()
         self._signal_timer.timeout.connect(lambda: None)
         self._signal_timer.start(200)
@@ -478,7 +486,9 @@ Pressing cancel will close linuxcnc.""" % target)
 
         # start loop
         global _app
+        self._loop_running = True
         _app = APP.exec()
+        self._loop_running = False
         self.shutdown()
 
     # finds the postgui file name and INI file path


### PR DESCRIPTION
qtvcp installs its SIGTERM/SIGINT handlers only just before the event loop, after screen construction. Python's default SIGINT handler raises `KeyboardInterrupt`, so an interrupt arriving mid-construction becomes an unhandled exception before any qtvcp handler is in place. That is the `KeyboardInterrupt` in `led_widget.sizeHint` seen in #4169: on a slow build the terminate signal lands while widgets are still being built, and the test hangs.

This installs the handlers right after `QApplication` is created. A `_loop_running` flag distinguishes the two cases: before the event loop is up `APP.quit()` would be a no-op, so a signal runs the normal shutdown and exits cleanly; once the loop is running it quits the loop as before. The interactive path is unchanged.

Verified on a Fedora 43 / Python 3.14.5 build by sending SIGINT during construction: on master the GUI hangs (no log); with this change it exits cleanly in a couple of seconds with no traceback. A normal run still passes.

This is complementary to #4183, not a replacement. #4183 makes any construction-time exception visible in the logs and avoids the modal hang offscreen; this PR stops the specific signal-during-construction case from becoming an exception at all, so the common flaky path is a clean quit. They are independent (each fixes the test on its own off master) and can be merged separately or together.

@BsAtHome, could you test this one on your F43 setup too? With this change the construction-time interrupt should be a clean quit, so I would expect `qtdragon-quit` to pass with no `KeyboardInterrupt` in `result` (whereas #4183 passes but logs the trace).
