### PR TITLE
task: reset canon length units on program open (fixes #4194)

### DIFF
--- a/src/emc/task/emctask.cc
+++ b/src/emc/task/emctask.cc
@@ -14,6 +14,7 @@
 ********************************************************************/
 
 #include <stdlib.h>
+#include <math.h>		// fabs()
 #include <rtapi_string.h>	// rtapi_strlcpy()
 #include <sys/stat.h>		// struct stat
 #include <unistd.h>		// stat()
@@ -546,6 +547,17 @@ int emcTaskPlanOpen(const char *file)
 	emcStatus->task.motionLine = 0;
 	emcStatus->task.currentLine = 0;
 	emcStatus->task.readLine = 0;
+    }
+
+    // Reset canon length units to machine default before re-opening.
+    // Without this, G20/G21 from the previous run persists in
+    // canon.lengthUnits, causing FROM_PROG_LEN() to convert differently
+    // on re-run for G-code commands that appear before G20/G21.
+    double units = GET_EXTERNAL_LENGTH_UNITS();
+    if (fabs(units - 1.0 / 25.4) < 1.0e-3) {
+        USE_LENGTH_UNITS(CANON_UNITS_INCHES);
+    } else if (fabs(units - 1.0) < 1.0e-3) {
+        USE_LENGTH_UNITS(CANON_UNITS_MM);
     }
 
     int retval = interp.open(file);


### PR DESCRIPTION
### Root cause

`canon.lengthUnits` (in `emccanon.cc`) is module-global and is only updated when the interpreter emits `USE_LENGTH_UNITS`, i.e. when it reaches a G20/G21. It is never reset when a program is reopened. So on a re-run, the program-open and setup conversions that happen before the units word are done with the **previous** run's units (off by 25.4x), while the first run used the machine default.

That difference is small, but it perturbs the entry velocity into the first segments. On the S-curve planner the short-tangent ramp/no-ramp decision is sensitive to the live entry velocity (see the analysis in #4194), so the perturbation flips borderline segments and cascades through the rest of the run. The net effect is that the entire second run commands a different, rougher velocity profile than the first, even though the G-code is identical.

### Fix

Reset `canon.lengthUnits` to the machine default in `emcTaskPlanOpen()` before reopening the interpreter, so every run starts from the same canon unit state:

```c
double units = GET_EXTERNAL_LENGTH_UNITS();
if (fabs(units - 1.0 / 25.4) < 1.0e-3) {
    USE_LENGTH_UNITS(CANON_UNITS_INCHES);
} else if (fabs(units - 1.0) < 1.0e-3) {
    USE_LENGTH_UNITS(CANON_UNITS_MM);
}
```

### Testing

- `axis_mm_scurve`, PLANNER_TYPE=1, dense micro-segment file: before the fix the 2nd+ runs are rough; after the fix every run matches the first.
- Long single run: smooth start to end, no degradation toward the end after the fix.
- Present on both 2.9 and 2.10. This PR targets 2.10; a byte-identical back-port to 2.9 will follow once this finalizes, so the periodic 2.9 to 2.10 back-merge stays conflict-free.

@greatEndian I believe this is the source of the run-to-run difference. Could you test it against your `axis_mm_scurve` dense micro-segment file and confirm both the rerun roughness and any long-run degradation are gone for you?

Fixes #4194
