### PR TITLE
motion: drive joint.N.index-enable only on edges (fix #3556)

### DIFF
--- a/src/emc/motion/homing.c
+++ b/src/emc/motion/homing.c
@@ -111,6 +111,7 @@ typedef struct {
   bool         homed;                // OUT pin
   bool         home_sw;              // IN  pin
   bool         index_enable;         // IO  pin
+  bool         index_enable_prev;    // last value driven onto index_enable pin
   bool         joint_in_sequence;
   int          pause_timer;
   double       home_offset;          // intfc, updateable
@@ -559,7 +560,16 @@ static void base_write_homing_out_pins(int njoints)
         *(addr->homing)       = H[jno].homing;       // OUT
         *(addr->homed)        = H[jno].homed;        // OUT
         *(addr->home_state)   = H[jno].home_state;   // OUT
-        *(addr->index_enable) = H[jno].index_enable; // IO
+        // index_enable is a HAL_IO pin: the encoder driver also writes it
+        // (clears it on the index pulse). We do not own it, so we must not
+        // clamp it every cycle; drive it only on our own edges and otherwise
+        // leave it to whoever else is on the signal.
+        if (H[jno].index_enable && !H[jno].index_enable_prev) {
+            *(addr->index_enable) = 1; // arm the index search
+        } else if (!H[jno].index_enable && H[jno].index_enable_prev) {
+            *(addr->index_enable) = 0; // release if aborted while armed
+        }
+        H[jno].index_enable_prev = H[jno].index_enable;
     }
 }
 


### PR DESCRIPTION
## Problem

Netting `joint.N.index-enable` to `spindle.N.index-enable` (common when homing a lathe spindle/C-axis to its encoder index) breaks G33/G33.1: the sync move rapids to target instead of waiting for the index. Confirmed on hardware in #3556.

## Cause

`joint.N.index-enable` is a `HAL_IO` pin with two writers by design: homing writes `1` to arm an index search, the encoder writes `0` to clear it. `base_write_homing_out_pins()` wrote it every servo cycle, so idle homing clamped the shared signal low and overwrote the spindle's sync request the same cycle. Motion then saw the pin low and dropped the sync.

## Fix

A writer that does not own an IO pin must not clamp it. Drive `joint.N.index-enable` only on homing's own edges: write `1` on the rising edge to arm, write `0` on the falling edge to release an aborted search, otherwise leave it to the encoder. Idle homing no longer touches the pin.

## Testing

Headless `sim_spindle` repro, MDI over NML:

| case | before | after |
|------|--------|-------|
| `G33 X-50 K1`, joint index netted to spindle | rapids, ~165 mm/s, 1.8 s | synced, ~10 mm/s, 30.5 s |
| `G33 X-50 K1`, stock wiring | ~10 mm/s | ~10 mm/s (unchanged) |
| index-only homing (`HOME_USE_INDEX`) | homes | homes (unchanged) |

Fixes #3556
