### PR TITLE
CI: Set timeouts so it doesn't run forever (2.9)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,7 @@ jobs:
 
   rip-and-test:
     runs-on: ubuntu-24.04
+    timeout-minutes: 45
     steps:
     - name: Dump GitHub context
       env:
@@ -57,6 +58,7 @@ jobs:
 
   rip-rtai:
     runs-on: ubuntu-24.04
+    timeout-minutes: 45
     steps:
     - name: Dump GitHub context
       env:
@@ -84,6 +86,7 @@ jobs:
 
   rip-and-test-clang:
     runs-on: ubuntu-24.04
+    timeout-minutes: 45
     steps:
     - name: Dump GitHub context
       env:
@@ -118,6 +121,7 @@ jobs:
 # Not supported on 2.9
 #  cppcheck:
 #    runs-on: ubuntu-24.04
+#    timeout-minutes: 45
 #    steps:
 #    - name: Checkout repository
 #      uses: actions/checkout@v6
@@ -141,6 +145,7 @@ jobs:
 
   htmldocs:
     runs-on: ubuntu-24.04
+    timeout-minutes: 60
     steps:
     - name: Dump GitHub context
       env:
@@ -179,6 +184,7 @@ jobs:
 
   package-arch:
     runs-on: ${{ matrix.runner }}
+    timeout-minutes: 75
     strategy:
       matrix:
         runner: ["ubuntu-24.04", "ubuntu-24.04-arm"]
@@ -274,6 +280,7 @@ jobs:
 
   package-indep:
     runs-on: ubuntu-24.04
+    timeout-minutes: 75
     strategy:
       matrix:
         image: ["debian:bullseye", "debian:bookworm", "debian:trixie", "debian:sid"]


### PR DESCRIPTION
Timeout set roughly to 3x the normal runtime and some spare.

This results in 45...74 min.

https://github.com/LinuxCNC/linuxcnc/pull/4207 back ported to 2.9

Not that urgent, most PR's go to master. Feel free to merge if https://github.com/LinuxCNC/linuxcnc/pull/4207 behaves nicely.