### PR TITLE
Preview "too large" gate: stop per-frame console spam, keep run_warn reliable

### DIFF
--- a/lib/python/rs274/glcanon.py
+++ b/lib/python/rs274/glcanon.py
@@ -532,6 +532,8 @@ class GlCanonDraw:
         # TODO I don't see any calculation for 1/4 of system_memory_gb ? CMorley 2024
         self.max_file_size = min(system_memory_gb, 20) * 1024 * 1024
 
+        self.preview_too_large = False
+
         try:
             if os.environ["INI_FILE_NAME"]:
                 self.inifile = linuxcnc.ini(os.environ["INI_FILE_NAME"])
@@ -1318,10 +1320,8 @@ class GlCanonDraw:
         self.draw_grid()
 
         show_program = self.get_show_program()
-        if os.path.exists(s.file):
-            if 0 < self.max_file_size < os.stat(s.file).st_size :
-                print("File too large to load, disabling preview.")
-                show_program = False
+        if self.preview_too_large:
+            show_program = False
 
         if show_program:
             if self.get_program_alpha():
@@ -2015,6 +2015,7 @@ class GlCanonDraw:
 
     def load_preview(self, f, canon, *args):
         self.set_canon(canon)
+        self.preview_too_large = False
         result, seq = gcode.parse(f, canon, *args)
 
         if result <= gcode.MIN_ERROR:
@@ -2024,6 +2025,14 @@ class GlCanonDraw:
             self.stale_dlist('program_norapids')
             self.stale_dlist('select_rapids')
             self.stale_dlist('select_norapids')
+
+        # Parsed fully (extents and limit check stay valid); only drawing is
+        # suppressed.
+        if 0 < self.max_file_size and os.path.exists(f) \
+                and self.max_file_size < os.stat(f).st_size:
+            self.preview_too_large = True
+            print("Preview disabled: file exceeds GRAPHICAL_MAX_FILE_SIZE."
+                  " The program still runs, but without a graphical extents check.")
 
         return result, seq
 

--- a/lib/python/rs274/glcanon.py
+++ b/lib/python/rs274/glcanon.py
@@ -129,6 +129,8 @@ class GLCanon(Translated, ArcsToSegmentsMixin):
         self.min_extents_notool_zero_rxy = [9e99,9e99,9e99]
         self.max_extents_notool_zero_rxy = [-9e99,-9e99,-9e99]
         self.colors = colors
+        # Set if the parse was aborted, so the extents above are only partial.
+        self.preview_incomplete = False
         self.in_arc = 0
         self.xo = self.yo = self.zo = self.ao = self.bo = self.co = self.uo = self.vo = self.wo = 0
         self.dwell_time = 0
@@ -2016,7 +2018,15 @@ class GlCanonDraw:
     def load_preview(self, f, canon, *args):
         self.set_canon(canon)
         self.preview_too_large = False
-        result, seq = gcode.parse(f, canon, *args)
+        canon.preview_incomplete = False
+        try:
+            result, seq = gcode.parse(f, canon, *args)
+        except KeyboardInterrupt:
+            # Aborted parse: extents cover only the parsed portion. Flag it so
+            # callers do not treat the partial check as complete.
+            canon.preview_incomplete = True
+            canon.calc_extents()
+            raise
 
         if result <= gcode.MIN_ERROR:
             self.canon.progress.nextphase(1)

--- a/lib/python/rs274/glcanon.py
+++ b/lib/python/rs274/glcanon.py
@@ -132,6 +132,8 @@ class GLCanon(Translated, ArcsToSegmentsMixin):
         self.min_extents_notool_zero_rxy = [9e99,9e99,9e99]
         self.max_extents_notool_zero_rxy = [-9e99,-9e99,-9e99]
         self.colors = colors
+        # Set if the parse was aborted, so the extents above are only partial.
+        self.preview_incomplete = False
         self.in_arc = 0
         self.xo = self.yo = self.zo = self.ao = self.bo = self.co = self.uo = self.vo = self.wo = 0
         self.dwell_time = 0
@@ -1452,7 +1454,15 @@ class GlCanonDraw:
     def load_preview(self, f, canon, *args):
         self.set_canon(canon)
         self.preview_too_large = False
-        result, seq = gcode.parse(f, canon, *args)
+        canon.preview_incomplete = False
+        try:
+            result, seq = gcode.parse(f, canon, *args)
+        except KeyboardInterrupt:
+            # Aborted parse: extents cover only the parsed portion. Flag it so
+            # callers do not treat the partial check as complete.
+            canon.preview_incomplete = True
+            canon.calc_extents()
+            raise
 
         if result <= gcode.MIN_ERROR:
             self.canon.progress.nextphase(1)

--- a/lib/python/rs274/glcanon.py
+++ b/lib/python/rs274/glcanon.py
@@ -706,9 +706,10 @@ class GlCanonDraw:
         # the cap is left as it behaves rather than as it was described.
         self.max_file_size = min(system_memory_gb, 20) * 1024 * 1024
 
-        #: Name of the file the size limit last refused, so that the refusal is
-        #: reported once instead of on every frame. See _resolve_show_program.
-        self._refused_file = None
+        #: Set once per load in load_preview() when the file exceeds the size
+        #: limit; _resolve_show_program() reads it instead of re-stat'ing the
+        #: file on every frame.
+        self.preview_too_large = False
 
         try:
             if os.environ["INI_FILE_NAME"]:
@@ -1274,26 +1275,12 @@ class GlCanonDraw:
     def _resolve_show_program(self):
         """get_show_program(), refused for a file too large to preview.
 
-        Called from frame_context(), so this runs once per frame - which is why
-        the refusal is latched on the file it refused rather than logged where
-        it is decided. Unlatched, a single over-size file produces a warning per
-        redraw for as long as it stays loaded. Latching on the name and not on a
-        bool means a different over-size file still reports.
+        The size decision is made once per load in load_preview(); this only
+        reads the flag, so no file is stat'ed per frame.
         """
-        show_program = self.get_show_program()
-        s = self.stat
-        if (os.path.exists(s.file)
-                and 0 < self.max_file_size < os.stat(s.file).st_size):
-            if self._refused_file != s.file:
-                self._refused_file = s.file
-                log.warning("%s is larger than the %.0f MB preview limit; "
-                            "preview disabled for it",
-                            s.file, self.max_file_size / (1024 * 1024))
+        if self.preview_too_large:
             return False
-        # Cleared rather than left set, so that loading a small file and then
-        # coming back to the big one reports it again.
-        self._refused_file = None
-        return show_program
+        return self.get_show_program()
 
     def lathe_historical_config(self,trajcoordinates):
         # detect historical lathe config with dummy joint 1
@@ -1464,6 +1451,7 @@ class GlCanonDraw:
 
     def load_preview(self, f, canon, *args):
         self.set_canon(canon)
+        self.preview_too_large = False
         result, seq = gcode.parse(f, canon, *args)
 
         if result <= gcode.MIN_ERROR:
@@ -1471,6 +1459,16 @@ class GlCanonDraw:
             canon.calc_extents()
             self.stale_dlist('program_rapids')
             self.stale_dlist('program_norapids')
+
+        # Parsed fully (extents and the run-time limit check stay valid); only
+        # drawing is suppressed.
+        if 0 < self.max_file_size and os.path.exists(f) \
+                and self.max_file_size < os.stat(f).st_size:
+            self.preview_too_large = True
+            log.warning("%s is larger than the %.0f MB preview limit; "
+                        "preview disabled for it. The program still runs, "
+                        "but without a graphical extents check.",
+                        f, self.max_file_size / (1024 * 1024))
 
         return result, seq
 

--- a/src/emc/usr_intf/axis/scripts/axis.py
+++ b/src/emc/usr_intf/axis/scripts/axis.py
@@ -1901,6 +1901,11 @@ def run_warn():
             if o.canon.max_extents_notool[i] > machine_limit_max[i]:
                 warnings.append(_("Program exceeds machine maximum on axis %s")
                     % "XYZABCUVW"[i])
+        # A truncated preview only checked part of the program; warn rather
+        # than imply a clean all-clear.
+        if getattr(o.canon, "preview_incomplete", False):
+            warnings.append(_("G-code preview was truncated before completion; "
+                "machine limits could not be fully checked."))
     if warnings:
         text = "\n".join(warnings)
         return int(root_window.tk.call("nf_dialog", ".error",

--- a/src/emc/usr_intf/axis/scripts/axis.py
+++ b/src/emc/usr_intf/axis/scripts/axis.py
@@ -1893,6 +1893,11 @@ def run_warn():
             if o.canon.max_extents_notool[i] > machine_limit_max[i]:
                 warnings.append(_("Program exceeds machine maximum on axis %s")
                     % "XYZABCUVW"[i])
+        # A truncated preview only checked part of the program; warn rather
+        # than imply a clean all-clear.
+        if getattr(o.canon, "preview_incomplete", False):
+            warnings.append(_("G-code preview was truncated before completion; "
+                "machine limits could not be fully checked."))
     if warnings:
         text = "\n".join(warnings)
         return int(root_window.tk.call("nf_dialog", ".error",


### PR DESCRIPTION
Addresses #4197.

The `File too large to load, disabling preview.` spam exposed deeper issues with the `GRAPHICAL_MAX_FILE_SIZE` gate. Two commits.

**1. Decide "too large" once at load.** The check ran in `redraw()`, so it printed every frame and re-stat'd the file each repaint, and it only suppressed drawing (the file is parsed regardless). Now decided once in `load_preview()`; `redraw()` reads a flag. No new INI, no change for normal files.

**2. Warn when `run_warn` used a truncated preview.** `run_warn()` checks extents from the preview parse. On an aborted parse (`PREVIEW_TIMEOUT` or cancel), `calc_extents()` is skipped, so `run_warn()` gives a silent false all-clear, a latent hole today. Now it computes partial extents on abort and flags the preview incomplete, so `run_warn()` reports the truncation.

**On segment-count (the max-segments idea):** I backed off. File size is a poor proxy, but segments are not universal either (a DEBUG/MSG-only loop emits none yet still burns parse time). The honest "how much we process" measure is time, and `PREVIEW_TIMEOUT` already provides it, so I did not add a third knob.

**Open question:** `PREVIEW_TIMEOUT` is the real runaway/infinite-loop guard but is off by default and AXIS-only. With commit 2 making `run_warn` honest, a default becomes safe (normal programs parse in well under a second). Should it get a sane default and move into the shared `check_abort` for all GUIs?

Longer term, shaders (#3547) would remove the need for this gate.
