### PR TITLE
Fix: hal_lib: Add missing EXPORT_SYMBOL(hal_get_realtime_type)

### DIFF
--- a/src/hal/hal_lib.c
+++ b/src/hal/hal_lib.c
@@ -4692,6 +4692,7 @@ EXPORT_SYMBOL(hal_set_unready);
 EXPORT_SYMBOL(hal_exit);
 EXPORT_SYMBOL(hal_malloc);
 EXPORT_SYMBOL(hal_comp_name);
+EXPORT_SYMBOL(hal_get_realtime_type);
 
 EXPORT_SYMBOL(hal_pin_bit_new);
 EXPORT_SYMBOL(hal_pin_float_new);


### PR DESCRIPTION
In https://github.com/LinuxCNC/linuxcnc/pull/4132, I missed the needed EXPORT_SYMBOL to use this function in RT components.