### PR TITLE
gtk_mesa_tests: Fix calculation in %

### DIFF
--- a/lib/python/gladevcp/builtin-panels/gtk_mesa_tests/gtk_mesa_tests.glade
+++ b/lib/python/gladevcp/builtin-panels/gtk_mesa_tests/gtk_mesa_tests.glade
@@ -2,16 +2,6 @@
 <!-- Generated with glade 3.40.0 -->
 <interface>
   <requires lib="gtk+" version="3.24"/>
-  <object class="GtkAdjustment" id="adj_cpu_speed_nic">
-    <property name="upper">10000000</property>
-    <property name="step-increment">1</property>
-    <property name="page-increment">10</property>
-  </object>
-  <object class="GtkAdjustment" id="adj_cpu_speed_servo">
-    <property name="upper">10000000</property>
-    <property name="step-increment">1</property>
-    <property name="page-increment">10</property>
-  </object>
   <object class="GtkAdjustment" id="adj_read_tmax">
     <property name="upper">1000000000000</property>
     <property name="step-increment">1</property>
@@ -68,10 +58,52 @@
                         <property name="can-focus">False</property>
                         <property name="orientation">vertical</property>
                         <child>
-                          <!-- n-columns=3 n-rows=4 -->
+                          <!-- n-columns=3 n-rows=3 -->
                           <object class="GtkGrid">
                             <property name="visible">True</property>
                             <property name="can-focus">False</property>
+                            <child>
+                              <object class="GtkLabel">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                                <property name="margin-start">5</property>
+                                <property name="margin-end">5</property>
+                                <property name="label" translatable="yes">Servo Thread</property>
+                              </object>
+                              <packing>
+                                <property name="left-attach">2</property>
+                                <property name="top-attach">0</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkSpinButton" id="sbtn_servo_thread_tmax">
+                                <property name="visible">True</property>
+                                <property name="can-focus">True</property>
+                                <property name="valign">center</property>
+                                <property name="margin-start">5</property>
+                                <property name="margin-end">5</property>
+                                <property name="width-chars">10</property>
+                                <property name="xalign">1</property>
+                                <property name="adjustment">adj_servo_thread_tmax</property>
+                              </object>
+                              <packing>
+                                <property name="left-attach">1</property>
+                                <property name="top-attach">0</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkLabel">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                                <property name="margin-start">5</property>
+                                <property name="margin-end">5</property>
+                                <property name="label" translatable="yes">Servo Thread</property>
+                              </object>
+                              <packing>
+                                <property name="left-attach">2</property>
+                                <property name="top-attach">1</property>
+                              </packing>
+                            </child>
                             <child>
                               <object class="GtkButton" id="btn_servo_thread_tmax">
                                 <property name="label" translatable="yes"> Get tmax</property>
@@ -87,12 +119,12 @@
                               </object>
                               <packing>
                                 <property name="left-attach">0</property>
-                                <property name="top-attach">1</property>
+                                <property name="top-attach">0</property>
                               </packing>
                             </child>
                             <child>
-                              <object class="GtkButton" id="btn_cpu_speed_servo">
-                                <property name="label" translatable="yes">Get CPU speed</property>
+                              <object class="GtkButton" id="btn_servo_thread_period">
+                                <property name="label" translatable="yes">Get period</property>
                                 <property name="visible">True</property>
                                 <property name="can-focus">True</property>
                                 <property name="receives-default">True</property>
@@ -101,11 +133,28 @@
                                 <property name="margin-end">5</property>
                                 <property name="margin-top">5</property>
                                 <property name="margin-bottom">5</property>
-                                <signal name="released" handler="on_btn_cpu_speed_servo_released" swapped="no"/>
+                                <signal name="released" handler="on_btn_servo_thread_period_released" swapped="no"/>
                               </object>
                               <packing>
                                 <property name="left-attach">0</property>
-                                <property name="top-attach">0</property>
+                                <property name="top-attach">1</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkSpinButton" id="sbtn_servo_thread_period">
+                                <property name="visible">True</property>
+                                <property name="can-focus">True</property>
+                                <property name="valign">center</property>
+                                <property name="margin-start">5</property>
+                                <property name="margin-end">5</property>
+                                <property name="width-chars">10</property>
+                                <property name="text" translatable="yes">0</property>
+                                <property name="xalign">1</property>
+                                <property name="adjustment">adj_servo_thread_period</property>
+                              </object>
+                              <packing>
+                                <property name="left-attach">1</property>
+                                <property name="top-attach">1</property>
                               </packing>
                             </child>
                             <child>
@@ -123,40 +172,7 @@
                               </object>
                               <packing>
                                 <property name="left-attach">0</property>
-                                <property name="top-attach">3</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkSpinButton" id="sbtn_cpu_speed_servo">
-                                <property name="visible">True</property>
-                                <property name="can-focus">True</property>
-                                <property name="valign">center</property>
-                                <property name="margin-start">5</property>
-                                <property name="margin-end">5</property>
-                                <property name="width-chars">10</property>
-                                <property name="xalign">1</property>
-                                <property name="adjustment">adj_cpu_speed_servo</property>
-                                <property name="numeric">True</property>
-                              </object>
-                              <packing>
-                                <property name="left-attach">1</property>
-                                <property name="top-attach">0</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkSpinButton" id="sbtn_servo_thread_tmax">
-                                <property name="visible">True</property>
-                                <property name="can-focus">True</property>
-                                <property name="valign">center</property>
-                                <property name="margin-start">5</property>
-                                <property name="margin-end">5</property>
-                                <property name="width-chars">10</property>
-                                <property name="xalign">1</property>
-                                <property name="adjustment">adj_servo_thread_tmax</property>
-                              </object>
-                              <packing>
-                                <property name="left-attach">1</property>
-                                <property name="top-attach">1</property>
+                                <property name="top-attach">2</property>
                               </packing>
                             </child>
                             <child>
@@ -178,87 +194,7 @@
                               </object>
                               <packing>
                                 <property name="left-attach">1</property>
-                                <property name="top-attach">3</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkComboBoxText" id="cbx_cpu_units_servo">
-                                <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                                <property name="valign">center</property>
-                                <property name="margin-start">5</property>
-                                <property name="margin-end">5</property>
-                                <property name="active">0</property>
-                                <items>
-                                  <item id="MHz" translatable="yes">MHz</item>
-                                  <item id="GHz" translatable="yes">GHz</item>
-                                </items>
-                                <signal name="changed" handler="on_cbx_cpu_units_servo_changed" swapped="no"/>
-                              </object>
-                              <packing>
-                                <property name="left-attach">2</property>
-                                <property name="top-attach">0</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkButton" id="btn_servo_thread_period">
-                                <property name="label" translatable="yes">Get period</property>
-                                <property name="visible">True</property>
-                                <property name="can-focus">True</property>
-                                <property name="receives-default">True</property>
-                                <property name="valign">center</property>
-                                <property name="margin-start">5</property>
-                                <property name="margin-end">5</property>
-                                <property name="margin-top">5</property>
-                                <property name="margin-bottom">5</property>
-                                <signal name="released" handler="on_btn_servo_thread_period_released" swapped="no"/>
-                              </object>
-                              <packing>
-                                <property name="left-attach">0</property>
                                 <property name="top-attach">2</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkLabel">
-                                <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                                <property name="margin-start">5</property>
-                                <property name="margin-end">5</property>
-                                <property name="label" translatable="yes">Servo Thread</property>
-                              </object>
-                              <packing>
-                                <property name="left-attach">2</property>
-                                <property name="top-attach">2</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkSpinButton" id="sbtn_servo_thread_period">
-                                <property name="visible">True</property>
-                                <property name="can-focus">True</property>
-                                <property name="valign">center</property>
-                                <property name="margin-start">5</property>
-                                <property name="margin-end">5</property>
-                                <property name="width-chars">10</property>
-                                <property name="text" translatable="yes">0</property>
-                                <property name="xalign">1</property>
-                                <property name="adjustment">adj_servo_thread_period</property>
-                              </object>
-                              <packing>
-                                <property name="left-attach">1</property>
-                                <property name="top-attach">2</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkLabel">
-                                <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                                <property name="margin-start">5</property>
-                                <property name="margin-end">5</property>
-                                <property name="label" translatable="yes">Servo Thread</property>
-                              </object>
-                              <packing>
-                                <property name="left-attach">2</property>
-                                <property name="top-attach">1</property>
                               </packing>
                             </child>
                             <child>
@@ -398,28 +334,10 @@ is 80% of the Servo Thread Period</property>
                     <property name="margin-bottom">5</property>
                     <property name="label-xalign">0</property>
                     <child>
-                      <!-- n-columns=3 n-rows=6 -->
+                      <!-- n-columns=3 n-rows=5 -->
                       <object class="GtkGrid">
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
-                        <child>
-                          <object class="GtkButton" id="btn_cpu_speed_nic">
-                            <property name="label" translatable="yes">Get CPU speed</property>
-                            <property name="visible">True</property>
-                            <property name="can-focus">True</property>
-                            <property name="receives-default">True</property>
-                            <property name="valign">center</property>
-                            <property name="margin-start">5</property>
-                            <property name="margin-end">5</property>
-                            <property name="margin-top">5</property>
-                            <property name="margin-bottom">5</property>
-                            <signal name="released" handler="on_btn_cpu_speed_nic_released" swapped="no"/>
-                          </object>
-                          <packing>
-                            <property name="left-attach">0</property>
-                            <property name="top-attach">0</property>
-                          </packing>
-                        </child>
                         <child>
                           <object class="GtkButton" id="btn_read_tmax">
                             <property name="label" translatable="yes">Get read.tmax</property>
@@ -435,7 +353,7 @@ is 80% of the Servo Thread Period</property>
                           </object>
                           <packing>
                             <property name="left-attach">0</property>
-                            <property name="top-attach">1</property>
+                            <property name="top-attach">0</property>
                           </packing>
                         </child>
                         <child>
@@ -453,7 +371,7 @@ is 80% of the Servo Thread Period</property>
                           </object>
                           <packing>
                             <property name="left-attach">0</property>
-                            <property name="top-attach">2</property>
+                            <property name="top-attach">1</property>
                           </packing>
                         </child>
                         <child>
@@ -471,116 +389,6 @@ is 80% of the Servo Thread Period</property>
                           </object>
                           <packing>
                             <property name="left-attach">0</property>
-                            <property name="top-attach">4</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkFrame">
-                            <property name="visible">True</property>
-                            <property name="can-focus">False</property>
-                            <property name="valign">center</property>
-                            <property name="margin-start">5</property>
-                            <property name="margin-end">5</property>
-                            <property name="margin-top">5</property>
-                            <property name="margin-bottom">5</property>
-                            <property name="label-xalign">0</property>
-                            <child>
-                              <object class="GtkLabel" id="lbl_result_nic">
-                                <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                                <property name="label" translatable="yes">%</property>
-                              </object>
-                            </child>
-                            <child type="label_item">
-                              <placeholder/>
-                            </child>
-                          </object>
-                          <packing>
-                            <property name="left-attach">1</property>
-                            <property name="top-attach">4</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkSpinButton" id="sbtn_cpu_speed_nic">
-                            <property name="visible">True</property>
-                            <property name="can-focus">True</property>
-                            <property name="valign">center</property>
-                            <property name="margin-start">5</property>
-                            <property name="margin-end">5</property>
-                            <property name="width-chars">10</property>
-                            <property name="xalign">1</property>
-                            <property name="adjustment">adj_cpu_speed_nic</property>
-                          </object>
-                          <packing>
-                            <property name="left-attach">1</property>
-                            <property name="top-attach">0</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkSpinButton" id="sbtn_read_tmax">
-                            <property name="visible">True</property>
-                            <property name="can-focus">True</property>
-                            <property name="valign">center</property>
-                            <property name="margin-start">5</property>
-                            <property name="margin-end">5</property>
-                            <property name="width-chars">10</property>
-                            <property name="xalign">1</property>
-                            <property name="adjustment">adj_read_tmax</property>
-                          </object>
-                          <packing>
-                            <property name="left-attach">1</property>
-                            <property name="top-attach">1</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkSpinButton" id="sbtn_write_tmax">
-                            <property name="visible">True</property>
-                            <property name="can-focus">True</property>
-                            <property name="valign">center</property>
-                            <property name="margin-start">5</property>
-                            <property name="margin-end">5</property>
-                            <property name="width-chars">10</property>
-                            <property name="xalign">1</property>
-                            <property name="adjustment">adj_write_tmax</property>
-                          </object>
-                          <packing>
-                            <property name="left-attach">1</property>
-                            <property name="top-attach">2</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkComboBoxText" id="cbx_cpu_units_nic">
-                            <property name="visible">True</property>
-                            <property name="can-focus">False</property>
-                            <property name="valign">center</property>
-                            <property name="margin-start">5</property>
-                            <property name="margin-end">5</property>
-                            <property name="active">0</property>
-                            <items>
-                              <item id="MHz" translatable="yes">MHz</item>
-                              <item id="GHz" translatable="yes">GHz</item>
-                            </items>
-                            <signal name="changed" handler="on_cbx_cpu_units_nic_changed" swapped="no"/>
-                          </object>
-                          <packing>
-                            <property name="left-attach">2</property>
-                            <property name="top-attach">0</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkSpinButton" id="sbtn_servo_thread_period_nic">
-                            <property name="visible">True</property>
-                            <property name="can-focus">True</property>
-                            <property name="valign">center</property>
-                            <property name="margin-start">5</property>
-                            <property name="margin-end">5</property>
-                            <property name="width-chars">10</property>
-                            <property name="text" translatable="yes">0</property>
-                            <property name="xalign">1</property>
-                            <property name="adjustment">adj_servo_thread_period_nic</property>
-                          </object>
-                          <packing>
-                            <property name="left-attach">1</property>
                             <property name="top-attach">3</property>
                           </packing>
                         </child>
@@ -599,20 +407,7 @@ is 80% of the Servo Thread Period</property>
                           </object>
                           <packing>
                             <property name="left-attach">0</property>
-                            <property name="top-attach">3</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkLabel">
-                            <property name="visible">True</property>
-                            <property name="can-focus">False</property>
-                            <property name="margin-start">5</property>
-                            <property name="margin-end">5</property>
-                            <property name="label" translatable="yes">Servo Thread</property>
-                          </object>
-                          <packing>
-                            <property name="left-attach">2</property>
-                            <property name="top-attach">3</property>
+                            <property name="top-attach">2</property>
                           </packing>
                         </child>
                         <child>
@@ -643,8 +438,96 @@ try increasing the thread period.</property>
                           </object>
                           <packing>
                             <property name="left-attach">0</property>
-                            <property name="top-attach">5</property>
+                            <property name="top-attach">4</property>
                             <property name="width">3</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkSpinButton" id="sbtn_read_tmax">
+                            <property name="visible">True</property>
+                            <property name="can-focus">True</property>
+                            <property name="valign">center</property>
+                            <property name="margin-start">5</property>
+                            <property name="margin-end">5</property>
+                            <property name="width-chars">10</property>
+                            <property name="xalign">1</property>
+                            <property name="adjustment">adj_read_tmax</property>
+                          </object>
+                          <packing>
+                            <property name="left-attach">1</property>
+                            <property name="top-attach">0</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkSpinButton" id="sbtn_write_tmax">
+                            <property name="visible">True</property>
+                            <property name="can-focus">True</property>
+                            <property name="valign">center</property>
+                            <property name="margin-start">5</property>
+                            <property name="margin-end">5</property>
+                            <property name="width-chars">10</property>
+                            <property name="xalign">1</property>
+                            <property name="adjustment">adj_write_tmax</property>
+                          </object>
+                          <packing>
+                            <property name="left-attach">1</property>
+                            <property name="top-attach">1</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkSpinButton" id="sbtn_servo_thread_period_nic">
+                            <property name="visible">True</property>
+                            <property name="can-focus">True</property>
+                            <property name="valign">center</property>
+                            <property name="margin-start">5</property>
+                            <property name="margin-end">5</property>
+                            <property name="width-chars">10</property>
+                            <property name="text" translatable="yes">0</property>
+                            <property name="xalign">1</property>
+                            <property name="adjustment">adj_servo_thread_period_nic</property>
+                          </object>
+                          <packing>
+                            <property name="left-attach">1</property>
+                            <property name="top-attach">2</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkFrame">
+                            <property name="visible">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="valign">center</property>
+                            <property name="margin-start">5</property>
+                            <property name="margin-end">5</property>
+                            <property name="margin-top">5</property>
+                            <property name="margin-bottom">5</property>
+                            <property name="label-xalign">0</property>
+                            <child>
+                              <object class="GtkLabel" id="lbl_result_nic">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                                <property name="label" translatable="yes">%</property>
+                              </object>
+                            </child>
+                            <child type="label_item">
+                              <placeholder/>
+                            </child>
+                          </object>
+                          <packing>
+                            <property name="left-attach">1</property>
+                            <property name="top-attach">3</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkLabel">
+                            <property name="visible">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="margin-start">5</property>
+                            <property name="margin-end">5</property>
+                            <property name="label" translatable="yes">Servo Thread</property>
+                          </object>
+                          <packing>
+                            <property name="left-attach">2</property>
+                            <property name="top-attach">2</property>
                           </packing>
                         </child>
                         <child>

--- a/lib/python/gladevcp/builtin-panels/gtk_mesa_tests/gtk_mesa_tests.py
+++ b/lib/python/gladevcp/builtin-panels/gtk_mesa_tests/gtk_mesa_tests.py
@@ -337,9 +337,6 @@ class MesaTests:
 
         combo_unit = self.builder.get_object("cbx_cpu_units_servo")
         unit = combo_unit.get_active_id()
-        
-        spin_speed = self.builder.get_object("sbtn_cpu_speed_servo")
-        cpu_speed = spin_speed.get_value()
 
         label_result = self.builder.get_object("lbl_result_servo")
 
@@ -356,24 +353,8 @@ class MesaTests:
             buffer.insert(buffer.get_end_iter(), "Servo Thread period must be greater than 0")
             return
 
-        if cpu_speed <= 0:
-            if buffer.get_char_count() > 0:
-                buffer.insert(buffer.get_end_iter(), "\n\n")
-            buffer.insert(buffer.get_end_iter(), "CPU Speed must be greater than 0")
-            return
-
-        # Unit conversion        
-        if unit == "MHz":
-            cpu_speed_hz = cpu_speed * 1E6
-        elif unit == "GHz":
-            cpu_speed_hz = cpu_speed * 1E9
-
         # Calculation
-        cpu_clock_time = 0.000000001 * period
-        clocks_per_period = cpu_speed_hz * cpu_clock_time
-
-        cpu_clocks_used = t_max / clocks_per_period
-        result = cpu_clocks_used * 100
+        result = t_max / period * 100
         label_result.set_text(f'{result:.0f}%')
 
 
@@ -474,9 +455,6 @@ class MesaTests:
 
         combo_unit = self.builder.get_object("cbx_cpu_units_nic")
         unit = combo_unit.get_active_id()
-        
-        spin_speed = self.builder.get_object("sbtn_cpu_speed_nic")
-        cpu_speed = spin_speed.get_value()
 
         label_result = self.builder.get_object("lbl_result_nic")
 
@@ -499,25 +477,9 @@ class MesaTests:
             buffer.insert(buffer.get_end_iter(), "Servo Thread period must be greater than 0")
             return
 
-        if cpu_speed <= 0:
-            if buffer.get_char_count() > 0:
-                buffer.insert(buffer.get_end_iter(), "\n\n")
-            buffer.insert(buffer.get_end_iter(), "CPU Speed must be greater than 0")
-            return
-
-        # Unit conversion        
-        if unit == "MHz":
-            cpu_speed_hz = cpu_speed * 1E6
-        elif unit == "GHz":
-            cpu_speed_hz = cpu_speed * 1E9
-
         # Calculation
         rw_tmax = read_tmax + write_tmax
-        cpu_clock_time = 0.000000001 * period
-        clocks_per_period = cpu_speed_hz * cpu_clock_time
-
-        packet_time = rw_tmax / clocks_per_period
-        result = packet_time * 100
+        result = rw_tmax / period * 100
         label_result.set_text(f'{result:.0f}%')
 
     def on_btn_packet_error_released(self, gtkbutton):

--- a/lib/python/gladevcp/builtin-panels/gtk_mesa_tests/gtk_mesa_tests.py
+++ b/lib/python/gladevcp/builtin-panels/gtk_mesa_tests/gtk_mesa_tests.py
@@ -93,79 +93,6 @@ class MesaTests:
         dialog.destroy()
         return password or None
 
-
-    def get_cpu_speed(self, gtkbutton, textview_id, combo_units_id, spin_speed_id):
-        prompt = None
-        # Get / cache sudo password
-        if not self.password:
-            self.password = self.ask_sudo_password(gtkbutton)
-
-        # Get CPU information
-        if self.password != None:
-            p = Popen(['sudo', '-S', 'dmidecode', '-t', 'processor'],
-                stdin=PIPE, stderr=PIPE, stdout=PIPE, text=True)
-            prompt = p.communicate(self.password + '\n')
-        if prompt:
-            ret = prompt[0].splitlines()
-
-
-        # Get UI objects
-        textview = self.builder.get_object(textview_id)
-        buffer = textview.get_buffer()
-
-        combo_units = self.builder.get_object(combo_units_id)
-        spin_speed = self.builder.get_object(spin_speed_id)
-
-
-        # Check if the buffer is empty
-        if buffer.get_char_count() > 0:
-            # Buffer is not empty → add a newline before appending
-            buffer.insert(buffer.get_end_iter(), "\n")
-
-        if self.password is None:
-            if buffer.get_char_count() > 0:
-                buffer.insert(buffer.get_end_iter(), "\n")
-            buffer.insert(buffer.get_end_iter(), "Operation cancelled. No password provided.")
-            return
-
-        for line in ret:
-
-            if 'Speed' in line:
-                if buffer.get_char_count() > 0:
-                    buffer.insert(buffer.get_end_iter(), "\n")
-                buffer.insert(buffer.get_end_iter(), line.strip())
-            if 'Current Speed' in line:
-                try:
-                    #line = "Current Speed: 4.200 GHz" # Uncomment for testing GUI (test GHy)
-                    #line = "Current Speed: 3600000 Hz" # Uncomment for testing GUI (test wrong value)
-                    parts = line.split()
-                    value = float(parts[2])   # e.g. "3200" → 3200
-                    unit  = parts[3]        # e.g. "MHz" or "GHz"
-
-                    # Force an exception if unit is invalid
-                    if not unit in ("MHz", "GHz"):
-                        raise ValueError("Invalid unit")
-
-                    spin_speed.set_value(value)
-                    combo_units.set_active_id(unit)
-                except Exception:
-                    # Write an error message to the text buffer
-                    buffer.insert(buffer.get_end_iter(), "\nFailed to retrieve CPU speed information.")
-
-    def handle_cpu_unit_change(self, combo, spinbutton_id):
-        spin_speed = self.builder.get_object(spinbutton_id)
-
-        # Get selected unit ("MHz" or "GHz")
-        unit = combo.get_active_id()
-
-        # Set digits depending on unit
-        # MHz → no decimals
-        # GHz → three decimals
-        if unit == "MHz":
-            spin_speed.set_digits(0)
-        elif unit == "GHz":
-            spin_speed.set_digits(3)
-
     def on_btn_ip_nic_released(self, gtkbutton):
         ip = subprocess.check_output(['ip', '-br', 'addr', 'show'], text=True)
 
@@ -246,17 +173,6 @@ class MesaTests:
         # Replace TextView content with notification message
         buffer.set_text("Output copied to clipboard")
 
-    def on_btn_cpu_speed_servo_released(self, gtkbutton):
-        self.get_cpu_speed(
-            gtkbutton,
-            textview_id="textview_servo",
-            combo_units_id="cbx_cpu_units_servo",
-            spin_speed_id="sbtn_cpu_speed_servo",
-        )
-
-    def on_cbx_cpu_units_servo_changed(self, combo):
-        self.handle_cpu_unit_change(combo, "sbtn_cpu_speed_servo")
-
     def on_btn_servo_thread_tmax_released(self, gtkbutton):
         result = subprocess.check_output("halcmd show param servo-thread.tmax",shell=True, text=True)
 
@@ -283,19 +199,6 @@ class MesaTests:
 
         spin_thread_tmax = self.builder.get_object("sbtn_servo_thread_tmax")
         spin_thread_tmax.set_value(value)
-
-
-
-    def on_btn_cpu_speed_nic_released(self, gtkbutton):
-        self.get_cpu_speed(
-            gtkbutton,
-            textview_id="textview_nic",
-            combo_units_id="cbx_cpu_units_nic",
-            spin_speed_id="sbtn_cpu_speed_nic",
-        )
-
-    def on_cbx_cpu_units_nic_changed(self, combo):
-        self.handle_cpu_unit_change(combo, "sbtn_cpu_speed_nic")
 
     def on_btn_servo_thread_period_released(self, combo):
         result = subprocess.check_output("halcmd show thread servo-thread",shell=True, text=True)
@@ -334,9 +237,6 @@ class MesaTests:
 
         spin_thread_period = self.builder.get_object("sbtn_servo_thread_period")
         period = spin_thread_period.get_value()
-
-        combo_unit = self.builder.get_object("cbx_cpu_units_servo")
-        unit = combo_unit.get_active_id()
 
         label_result = self.builder.get_object("lbl_result_servo")
 
@@ -452,9 +352,6 @@ class MesaTests:
 
         spin_thread_period = self.builder.get_object("sbtn_servo_thread_period_nic")
         period = spin_thread_period.get_value()
-
-        combo_unit = self.builder.get_object("cbx_cpu_units_nic")
-        unit = combo_unit.get_active_id()
 
         label_result = self.builder.get_object("lbl_result_nic")
 


### PR DESCRIPTION
https://github.com/LinuxCNC/linuxcnc/pull/4082 changed the time values from cycles to ns. 

This broke the calculation of % values and the CPU clock is not needed any more.

Discovered here: https://github.com/LinuxCNC/linuxcnc/pull/4199

TBD: Remove the CPU Speed read fully? I would say yes.