### PR TITLE
axis: Call component's exit to remove the HAL component at exit.

### DIFF
--- a/src/emc/usr_intf/axis/scripts/axis.py
+++ b/src/emc/usr_intf/axis/scripts/axis.py
@@ -4304,5 +4304,6 @@ live_plotter.update()
 live_plotter.error_task()
 o.mainloop()
 live_plotter.stop()
+comp.exit()
 
 # vim:sw=4:sts=4:et:

--- a/src/emc/usr_intf/axis/scripts/hal_manualtoolchange.py
+++ b/src/emc/usr_intf/axis/scripts/hal_manualtoolchange.py
@@ -115,4 +115,5 @@ try:
         app.after(100)
         app.update()
 except KeyboardInterrupt:
+    h.exit();
     pass


### PR DESCRIPTION
Axis' components `axisui` and its helper `hal_manualtoolchange` would not call hal_exit to remove the component when the programs exits. This leaves dangling components in HAL memory. This PR ensures to properly call the component's exit when the program exits.