### PR TITLE
Tclsh mcodes: Add -ini option to 'emc_init' call

### DIFF
--- a/configs/sim/axis/vismach/millturn/mcodes/M128
+++ b/configs/sim/axis/vismach/millturn/mcodes/M128
@@ -4,7 +4,7 @@ set switchkins_pin 3     ;# agree with inifile
 set coords "x y z"       ;# agree with inifile
 
 package require Linuxcnc ;# must be before Hal
-emc_init -quick
+emc_init -ini $::env(INI_FILE_NAME) -quick
 package require Hal
 parse_ini $::env(INI_FILE_NAME)
 

--- a/configs/sim/axis/vismach/millturn/mcodes/M129
+++ b/configs/sim/axis/vismach/millturn/mcodes/M129
@@ -4,7 +4,7 @@ set switchkins_pin 3     ;# agree with inifile
 set coords "x y z"       ;# axis declared must provide MIN_LIMIT_TURN and MAX_LIMIT_TURN in inifile
 
 package require Linuxcnc ;# must be before Hal
-emc_init -quick
+emc_init -ini $::env(INI_FILE_NAME) -quick
 package require Hal
 parse_ini $::env(INI_FILE_NAME)
 

--- a/configs/sim/axis/vismach/puma/mcodes/M128
+++ b/configs/sim/axis/vismach/puma/mcodes/M128
@@ -5,7 +5,7 @@ set switchkins_pin 3     ;# agree with inifile
 set coords "x y z a b c" ;# agree with inifile module coordinates=
 
 package require Linuxcnc ;# must be beore Hal
-emc_init -quick
+emc_init -ini $::env(INI_FILE_NAME) -quick
 package require Hal
 parse_ini $::env(INI_FILE_NAME)
 

--- a/configs/sim/axis/vismach/puma/mcodes/M129
+++ b/configs/sim/axis/vismach/puma/mcodes/M129
@@ -6,7 +6,7 @@ set max_joints     6     ;# agree with inifile
 set coords "x y z a b c" ;# agree with module coordinates=
 
 package require Linuxcnc ;# must be beore Hal
-emc_init -quick
+emc_init -ini $::env(INI_FILE_NAME) -quick
 package require Hal
 parse_ini $::env(INI_FILE_NAME)
 

--- a/configs/sim/axis/vismach/puma/mcodes/M130
+++ b/configs/sim/axis/vismach/puma/mcodes/M130
@@ -6,7 +6,7 @@ set max_joints     6     ;# agree with inifile
 set coords "x y z a b c" ;# agree with module coordinates=
 
 package require Linuxcnc ;# must be beore Hal
-emc_init -quick
+emc_init -ini $::env(INI_FILE_NAME) -quick
 package require Hal
 parse_ini $::env(INI_FILE_NAME)
 


### PR DESCRIPTION
Avoids 'emc.ini: error: Cannot open ini-file (errno=2 (No such file or directory))' on 'emc_init' call.

For more see:
https://github.com/LinuxCNC/linuxcnc/issues/4203