### PR TITLE
shellcheck: Fix remaining warnings in scripts.

### DIFF
--- a/debian/update-dch-from-git
+++ b/debian/update-dch-from-git
@@ -9,6 +9,8 @@ source scripts/githelper.sh
 githelper "$1"
 
 GIT_VERSION=$(scripts/get-version-from-git "$GIT_BRANCH")
+# Need to use $? because we need the output capture
+# shellcheck disable=SC2181
 if [ $? -ne 0 ]; then
     echo "error determining version!"
     exit 1

--- a/docs/src/asciideps
+++ b/docs/src/asciideps
@@ -1,14 +1,16 @@
-#!/bin/sh
+#!/bin/bash
 
 set -e
 
 test -z "$1" && exit 0
 test -f "$1" || exit 1
 
+includestack=( )
+
 includes () {
 	DIR=$(dirname "$1")
 
-	for f in $(sed -ne "s|^include::\(.*\)\[\]$|$DIR/\1|p" "$1"); do
+	while IFS= read -r f; do
 		# components_gen.adoc will contain only generated content
 		case "$f" in
 			*/components_gen.adoc)
@@ -16,8 +18,15 @@ includes () {
 			;;
 		esac
 		echo "$f"
+		ff=$(realpath "$f")
+		if [[ " ${includestack[*]} " =~ [[:space:]]${ff}[[:space:]] ]]; then
+			echo "Include file recursion detected on '$f'. Skipped." >&2
+			continue
+		fi
+		includestack+=("$ff")
 		includes "$f"
-	done
+		unset 'includestack[${#includestack[@]}-1]'
+	done < <(sed -ne "s|^include::\(.*\)\[\]$|$DIR/\1|p" "$1")
 }
 
 images() {

--- a/scripts/linuxcnc_info.in
+++ b/scripts/linuxcnc_info.in
@@ -90,7 +90,7 @@ function parse_after_colon () {
 
 function tryversion () {
   prog="$1"
-  if [ $(command -v "$prog") ] ; then
+  if [ "$(command -v "$prog")" ] ; then
      ans=$($prog --version 2>/dev/null)
      if [ -z "$ans" ] ; then
        echo "?"
@@ -165,9 +165,14 @@ for n in $(linuxcnc_var all) ; do
    show "${n%%=*}" "${n##*=}"
 done
 
+# Not everybody runs Debian based distros
 echo
-echo "dpkg -l '*linuxcnc*':"
-dpkg -l '*linuxcnc*'
+if command -v dpkg > /dev/null; then
+    echo "dpkg -l '*linuxcnc*':"
+    dpkg -l '*linuxcnc*'
+else
+    echo "No 'dpkg' available, different distro, probably."
+fi
 echo
 
 [ -n "$VIEWER" ] && $VIEWER "$ofile"

--- a/scripts/rip-environment.in
+++ b/scripts/rip-environment.in
@@ -118,8 +118,8 @@ if ! $as_command; then
     else
         _iningc () {
             case "$3" in
-            *.ini) COMPREPLY=($(compgen -o plusdirs -f -X '!*.ngc' -- "$2")) ;;
-            *) COMPREPLY=($(compgen -o plusdirs -f -X '!*.ini' -- "$2"))
+            *.ini) mapfile -t COMPREPLY < <(compgen -o plusdirs -f -X '!*.ngc' -- "$2") ;;
+            *) mapfile -t COMPREPLY < <(compgen -o plusdirs -f -X '!*.ini' -- "$2")
             esac
         }
         complete -o plusdirs -F _iningc emc axis


### PR DESCRIPTION
This cleans up the last of the shellcheck warnings seen in CI. The clean source tree is does no longer contain any messages in the scripts.

However, there is one left _after_ running configure in the expanded linuxcnc script. This is in the quoted value of the `LINUXCNC_CONFIG_PATH` that contains a path and the first entry starts with a tilde. However, quoted strings are not tilde expanded and shellcheck complains.

The expansion comes from configure.ac and is probably meant to be expanded to the user running LinuxCNC. But it seems to be broken the way it is done. After searching, the LINUXCNC_CONFIG_PATH environment variable is apparently not used, anywhere. So maybe it should be removed.