### PR TITLE
shellcheck: Resolve tilde expansion issue and ensure detection in CI

### DIFF
--- a/.github/scripts/configure.sh
+++ b/.github/scripts/configure.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+set -eu #Needed so CI fails when anything is wrong
+set -x
+
+#Any arguments are passed to configure
+
+cd src
+./autogen.sh
+./configure "$@" --disable-check-runtime-deps --enable-werror

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,10 +150,13 @@ jobs:
     - name: Install dependencies
       run: |
         set -x
-        sudo apt-get -q update
+        .github/scripts/install-deps.sh
         sudo apt-get --yes install shellcheck
+    - name: Configure
+      run: |
+        set -x
+        .github/scripts/configure.sh
     - name: Shellcheck
-      continue-on-error: true
       run: |
         set -x
         scripts/shellcheck.sh

--- a/src/configure.ac
+++ b/src/configure.ac
@@ -721,7 +721,7 @@ if test "xyes" = "x$RUN_IN_PLACE"; then
     EMC2_PO_DIR=$EMC2_HOME/share/locale
     EMC2_HELP_DIR=$EMC2_HOME/docs/help
     EMC2_RTLIB_DIR=$EMC2_HOME/rtlib
-    LINUXCNC_CONFIG_PATH="~/linuxcnc/configs:$EMC2_HOME/configs"
+    LINUXCNC_CONFIG_PATH="\$HOME/linuxcnc/configs:$EMC2_HOME/configs"
     LINUXCNC_CONFIG_PATH_TCL="$::env(HOME)/linuxcnc/configs:$EMC2_HOME/configs"
     EMC2_NCFILES_DIR=$EMC2_HOME/nc_files
     REALTIME=$EMC2_HOME/scripts/realtime
@@ -743,7 +743,7 @@ else
         */linuxcnc*) EMC2_RTLIB_DIR=$MODULE_DIR ;;
 	*) EMC2_RTLIB_DIR=$MODULE_DIR/linuxcnc
     esac
-    LINUXCNC_CONFIG_PATH="~/linuxcnc/configs:/usr/local/etc/linuxcnc/configs:"$(eval echo $EMC2_HELP_DIR)"/examples/sample-configs"
+    LINUXCNC_CONFIG_PATH="\$HOME/linuxcnc/configs:/usr/local/etc/linuxcnc/configs:"$(eval echo $EMC2_HELP_DIR)"/examples/sample-configs"
     LINUXCNC_CONFIG_PATH_TCL="$::env(HOME)/linuxcnc/configs:/usr/local/etc/linuxcnc/configs:"$(eval echo $EMC2_HELP_DIR)"/examples/sample-configs"
     EMC2_NCFILES_DIR=${prefix}/share/linuxcnc/ncfiles
     REALTIME=${prefix}/lib/linuxcnc/realtime


### PR DESCRIPTION
This should be the final shellcheck issue.

The tilde expansion issue was only detected after configure had run and the proper scripts generated. The tilde has been replaced by the `$HOME` equivalent and gets expanded at the right time.

CI for shellcheck now adds a configure step so that it will expand the *.in scripts, which will subsequently be tested by shellcheck.

The shellcheck CI also removes the "continue-on-error: true" marker. It is no longer needed and CI should now fail if a script does not pass.