### PR TITLE
hostmot2: Fix sserial error test to use 1 << x and not 1 < x

### DIFF
--- a/src/hal/drivers/mesa-hostmot2/sserial.c
+++ b/src/hal/drivers/mesa-hostmot2/sserial.c
@@ -75,7 +75,7 @@ int hm2_sserial_wait(hostmot2_t *hm2, hm2_sserial_instance_t *inst, long period)
                 "Timeout waiting for CMD to clear\n");
         return -1;
     }
-    if (*(inst->data_reg_read) & (1 < inst->remotes[inst->r_index].index)){
+    if (*(inst->data_reg_read) & (1 << inst->remotes[inst->r_index].index)){
         HM2_ERR("Error after doit clear\n");
         return -1;
     }


### PR DESCRIPTION
This is a partial fix for #4144, where it was discovered that the error check of a bit field used `1 < x` instead of `1 << x`.

The other issue will be cleaned up separately. See #4144 for details.