### PR TITLE
2.9 Fix: Replace deprecated 'locale.format()'

### DIFF
--- a/lib/python/gladevcp/calculatorwidget.py
+++ b/lib/python/gladevcp/calculatorwidget.py
@@ -299,11 +299,11 @@ class Calculator( Gtk.Box ):
         self.displayOperand( "+" )
 
     def displayMmInch( self, widget ):
-        self.eval_string = "("+ self.eval_string + ") / " + locale.format("%f", float(25.4))
+        self.eval_string = "("+ self.eval_string + ") / " + locale.format_string("%f", float(25.4))
         self.compute()
 
     def displayInchMm( self, widget ):
-        self.eval_string = "("+ self.eval_string + ") * " + locale.format("%f", float(25.4))
+        self.eval_string = "("+ self.eval_string + ") * " + locale.format_string("%f", float(25.4))
         self.compute()
 
     def on_ok_button_clicked ( self, widget ):

--- a/lib/python/gladevcp/offsetpage_widget.py
+++ b/lib/python/gladevcp/offsetpage_widget.py
@@ -352,7 +352,7 @@ class OffsetPage(Gtk.Box):
             return
         # set the text in the table
         try:
-            self.store[row][col] = locale.format("%10.4f", locale.atof(new_text))
+            self.store[row][col] = locale.format_string("%10.4f", locale.atof(new_text))
         except:
             print(_("offsetpage widget error: unrecognized float input"))
         # make sure we switch to correct units for machine and rotational, row 2, does not get converted

--- a/lib/python/gladevcp/tooledit_widget.py
+++ b/lib/python/gladevcp/tooledit_widget.py
@@ -477,7 +477,7 @@ class ToolEdit(Gtk.Box):
         # validate input for float columns
         elif col in range(3,15):
             try:
-                self.model[path][col] = locale.format("%10.4f",locale.atof(new_text))
+                self.model[path][col] = locale.format_string("%10.4f",locale.atof(new_text))
             except:
                 pass
         # validate input for orientation: check if int and valid range

--- a/src/emc/usr_intf/pncconf/pncconf.py
+++ b/src/emc/usr_intf/pncconf/pncconf.py
@@ -4865,7 +4865,7 @@ Clicking 'existing custom program' will avoid this warning. "),False):
 
                 encoder_cpr = get_value(w[("encoderline")]) * 4
                 encoder_scale = (encoder_pulley_ratio * encoder_worm_ratio * encoder_pitch * encoder_cpr) / rotary_scale
-                w["calcencoder_scale"].set_text(locale.format("%.4f", (encoder_scale)))
+                w["calcencoder_scale"].set_text(locale.format_string("%.4f", (encoder_scale)))
             else:
                 w["calcencoder_scale"].set_sensitive(False)
                 w["encoderscaleframe"].set_sensitive(False)


### PR DESCRIPTION
 Replace deprecated 'locale.format()' with 'locale.format_string()'

Fixes this issue (but now also fixed in all other places I found) :
https://github.com/LinuxCNC/linuxcnc/issues/4254
