### PR TITLE
Add missing and reverse default mutex for getter/setter

### DIFF
--- a/src/hal/hal_priv.h
+++ b/src/hal/hal_priv.h
@@ -118,7 +118,7 @@
 */
 
 #define HAL_KEY   0x48414C32	/* key used to open HAL shared memory */
-#define HAL_VER   0x00000011	/* version code */
+#define HAL_VER   0x00000012	/* version code */
 #define HAL_SIZE  (2*256*4096)
 #define HAL_PSEUDO_COMP_PREFIX "__" /* prefix to identify a pseudo component */
 

--- a/src/rtapi/rtapi_mutex.h
+++ b/src/rtapi/rtapi_mutex.h
@@ -41,6 +41,17 @@
 
 typedef unsigned long rtapi_mutex_t;
 
+/*
+ * The normal mutex functions use zero (0) as the unlocked state and one (1) as
+ * the locked state.
+ * The mutex functions with the _rd suffix are `reverse default' versions, in
+ * which the locked state is represented by zero (0) and the unlocked state by
+ * one (1).
+ *
+ * A shared memory recursive mutex must be initialized in the locked state.
+ * This maps cleanly to reverse default when the shared memory is created,
+ * which defaults to zero and thus a locked mutex.
+ */
 
 /**
  * @brief Releases the mutex.
@@ -51,6 +62,9 @@ typedef unsigned long rtapi_mutex_t;
  */
     static __inline__ void rtapi_mutex_give(unsigned long *mutex) {
 	test_and_clear_bit(0, mutex);
+    }
+    static __inline__ void rtapi_mutex_give_rd(unsigned long *mutex) {
+	test_and_set_bit(0, mutex);
     }
 /**
  * @brief Non-blocking attempt to get the mutex.
@@ -67,6 +81,9 @@ typedef unsigned long rtapi_mutex_t;
     static __inline__ int rtapi_mutex_try(unsigned long *mutex) {
 	return test_and_set_bit(0, mutex);
     }
+    static __inline__ int rtapi_mutex_try_rd(unsigned long *mutex) {
+	return !test_and_clear_bit(0, mutex);
+    }
 
 /**
  * @brief Blocking attempt to gGet the mutex.
@@ -78,6 +95,15 @@ typedef unsigned long rtapi_mutex_t;
  */
     static __inline__ void rtapi_mutex_get(unsigned long *mutex) {
 	while (test_and_set_bit(0, mutex)) {
+#if defined(__KERNEL__)
+	    schedule();
+#else
+	    sched_yield();
+#endif
+	}
+    }
+    static __inline__ void rtapi_mutex_get_rd(unsigned long *mutex) {
+	while (!test_and_clear_bit(0, mutex)) {
 #if defined(__KERNEL__)
 	    schedule();
 #else

--- a/src/rtapi/rtapi_stdint.h
+++ b/src/rtapi/rtapi_stdint.h
@@ -79,5 +79,10 @@ typedef uintptr_t rtapi_uintptr_t;
 typedef double    rtapi_real;
 typedef rtapi_s64 rtapi_sint;
 typedef rtapi_u64 rtapi_uint;
+typedef rtapi_intptr_t rtapi_port;
+
+#define RTAPI_SINT_MAX RTAPI_INT64_MAX
+#define RTAPI_SINT_MIN RTAPI_INT64_MIN
+#define RTAPI_UINT_MAX RTAPI_UINT64_MAX
 
 #endif


### PR DESCRIPTION
This is on top of #4099 that did not make it in there:
* a missing type and limits
* reverse default mutex

The HAL version is also upped because it crossed in #4132 and both need to change the version.