### PR TITLE
docs: fix French PDF build with babel-french 4.x (TeX Live 2025)

### DIFF
--- a/docs/src/emc2.sty
+++ b/docs/src/emc2.sty
@@ -8,6 +8,16 @@
 %% Just use the original package and pass the options.
 \RequirePackageWithOptions{docbook}
 
+%% babel-french 4.x (TeX Live 2025) removed the legacy \frenchbsetup keys
+%% (e.g. CompactItemize) that dblatex's dbk_locale.sty still passes.
+%% Use the modern \frenchsetup interface when available (babel-french >= 3.0).
+\makeatletter
+\@ifundefined{frenchsetup}{}{%
+  \let\frenchbsetup\@gobble
+  \frenchsetup{StandardItemizeEnv=true,StandardItemLabels=true}%
+}
+\makeatother
+
 % Sidebar is a boxed minipage that can contain verbatim.
 % Changed shadow box to double box.
 \renewenvironment{sidebar}[1][0.95\textwidth]{


### PR DESCRIPTION
**Problem**

The `package-indep (debian:sid)` CI job fails building the French PDF documentation:

```
Master_Developer.tex:38: The key 'FBsetup/CompactItemize' is unknown
Error: xelatex compilation failed
dh_auto_build: error: cd src && make -j4 docs returned exit code 2
```

**Root cause**

babel-french 4.x (TeX Live 2025, now in Debian sid) removed legacy option keys such as `CompactItemize`, deprecated since babel-french 3.0 (2015). dblatex 0.3.12's `dbk_locale.sty` still calls `\frenchbsetup{CompactItemize=false}` from its `\babelsetup{fr}` hook. The `\frenchbsetup` macro itself still exists as an alias, so dblatex's `\@ifundefined` guard passes, but the removed key now raises a fatal l3keys "unknown key" error. This affects any distro shipping TeX Live 2025+; sid is simply the first CI image to carry it.

**Fix**

In `docs/src/emc2.sty` (loaded before the hook executes), when the modern `\frenchsetup` interface is available (babel-french >= 3.0), neutralize the legacy `\frenchbsetup` macro and apply the documented modern equivalent of `CompactItemize=false` (`StandardItemizeEnv=true, StandardItemLabels=true`). Older toolchains keep the previous behavior via the `\@ifundefined` guard, so bullseye/bookworm/trixie output is unchanged.

**Testing**

- Reproduced the exact CI failure in a `debian:sid` container with the pristine style file; the fixed file builds the French test PDF.
- Ran the full CI-equivalent build in `debian:sid` (`debian/configure`, `apt build-dep --indep-only`, `debuild --build=all`): completes with exit 0, including `docs/src/fr/Master_Developer.pdf` and the `linuxcnc-doc-fr` package.
