### PR TITLE
hal: Make HAL mutex recursive and use acquire/release functions

### DIFF
--- a/src/hal/Submakefile
+++ b/src/hal/Submakefile
@@ -3,7 +3,7 @@
 ../include/hal.h: ./hal/hal.h
 	cp $^ $@
 
-HALLIBSRCS := hal/hal_lib.c $(ULAPISRCS)
+HALLIBSRCS := hal/hal_lib.c hal/hal_lib_extra.c $(ULAPISRCS)
 $(call TOOBJSDEPS, $(HALLIBSRCS)): EXTRAFLAGS += -fPIC $(ULAPI_CFLAGS)
 USERSRCS += $(HALLIBSRCS)
 ifeq ($(BUILD_SYS),uspace)

--- a/src/hal/hal.h
+++ b/src/hal/hal.h
@@ -1320,6 +1320,36 @@ static inline rtapi_s64 hal_extend_counter(rtapi_s64 old, rtapi_s64 newlow, int 
     return (rtapi_u64)old + (diff_shifted >> nshift); // unsigned to avoid signed overflow
 }
 
+// Only enable the query API when we are compiling the user-land HAL library
+#ifdef ULAPI
+
+//
+// *** Special functions for rtapi_app and halcmd ***
+//
+// Invoke the constructor for a new instance
+// Uspace/rtapi_app only. Not implemented in halcmd/halrmt.
+int hal_comp_invoke_make(const char *compname, const char *newname, const char *arg);
+
+// Add the insmod arguments to a named (and just loaded) RT component
+// The 'args' argument must be in HAL memory.
+int hal_comp_insmod_args(const char *compname, const char *args);
+
+// -----------------------------------------------------
+// Release the HAL mutex with brute force
+// WARNING:
+// *   Do not use this function in normal code. You will
+// *   probably kill your running instance when you do.
+// *   It is only to recover from an error and you need
+// *   to be able to shut down your instance.
+int hal_mutex_force_release(void);
+// -----------------------------------------------------
+
+// HAL will pretend that the exact base period requested is possible.
+// This mode is not suitable for running real hardware.
+// Returns zero (0) on success or a negative -EACCES error if already set.
+int hal_enforce_exact_base_period(void);
+
+#endif // ULAPI
 
 RTAPI_END_DECLS
 

--- a/src/hal/hal_lib.c
+++ b/src/hal/hal_lib.c
@@ -53,6 +53,20 @@
 
 */
 
+// Special case to get gettid() to work properly for recursive mutex.
+// Doing this in a rtapi_*.h header is a pain because hal_priv.h is still
+// included everywhere and it would fail because of include ordering.
+#ifdef __KERNEL__
+#include <asm/current.h>
+#define halpr_gettid() ((int)(get_current()->pid))
+#else
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+#include <unistd.h>
+#define halpr_gettid() ((int)gettid())
+#endif
+
 #include <rtapi.h>		/* RTAPI realtime OS API */
 #include "hal.h"		/* HAL public API decls */
 #include "hal_priv.h"		/* HAL private decls */
@@ -159,6 +173,86 @@ static void free_thread_struct(hal_thread_t * thread);
 static void thread_task(void *arg);
 #endif /* RTAPI */
 
+//
+// Recursive locking/unlocking with a mutex
+// The recursion resilience is required because callbacks could potentially
+// call back into hal_lib and cause severe problems. We must either prevent
+// callbacks from re-entering hal_lib or deal with it and use recursion. The
+// lesser evil is recursion. None of the code that is called using the mutex is
+// real-time anyway.
+//
+// ==> The initial state requires the mutex to be in the locked state.
+// ==> That is why it uses a 'reverse default' mutex, where zero means
+// ==> that it is in the locked state. The shared memory is initialized
+// ==> with zeros at creation time so this works as expected.
+//
+// When a thread acquires the lock, then 'lockcnt' will be increased. The first
+// thread will fall-through and set its thread ID and the recursion counter. A
+// next thread wanting the lock will see a 'lockcnt' of at least 2 and will
+// wait on the mutex if it is not already the owner. If it is the same thread,
+// then it will increase the recursion level without waiting.
+// The unlock decreases the recursion level and, when the recursion level
+// reaches zero, clears the thread ID storage. If then 'lockcnt' is still
+// larger than zero after its decrease when the recursion level is zero, then
+// we know that there is a thread waiting and the mutex is signalled.
+//
+// Proper function depends on the interlocked inc/dec operation on 'lockcnt'.
+//
+int halpr_mutex_acquire(void)
+{
+    int tid = halpr_gettid(); // Caller thread ID
+    int cnt = __sync_add_and_fetch(&hal_data->lockcnt, 1); // Interlocked increment
+    if(cnt > 1) {
+        // A call to lock beyond the first one
+        if(tid != hal_data->locktid)
+            rtapi_mutex_get_rd(&(hal_data->priv_rdmutex));
+    }
+    // Getting here means we have the lock
+    hal_data->locktid = tid;
+    return ++hal_data->locklvl; // Increase recursion level and return it
+}
+
+int halpr_mutex_release(void)
+{
+    int lvl = --hal_data->locklvl; // Decrease recursion level
+    if(lvl < 0) {
+        rtapi_print_msg(RTAPI_MSG_ERR, "halpr_mutex_release: release at recursion level %d < 0. "
+                                       "Prepare for a lockup/crash.\n", lvl);
+        hal_data->locklvl = lvl = 0; // Try some 'sanity'
+    }
+    if(0 == lvl)
+        hal_data->locktid = 0; // Recursion level reached zero
+    int cnt = __sync_sub_and_fetch(&hal_data->lockcnt, 1); // Interlocked decrement
+    if(cnt < 0) {
+        rtapi_print_msg(RTAPI_MSG_ERR, "halpr_mutex_release: lockcnt %d < 0. "
+                                       "Prepare for a lockup/crash.\n", lvl);
+        cnt = __sync_sub_and_fetch(&hal_data->lockcnt, cnt); // Increase to try 'sanity'
+    }
+    if(cnt > 0 && 0 == lvl) {
+        // We are at the lowest recursion level and someone is waiting,
+        // release the mutex for the waiting thread. That thread will wake up
+        // and reacquire the mutex.
+        rtapi_mutex_give_rd(&(hal_data->priv_rdmutex));
+    }
+    return lvl;
+}
+
+void halpr_mutex_force_release(void)
+{
+    int lvl = hal_data->locklvl; // Save recursion level
+    hal_data->locktid = 0;       // Clear ownership
+    hal_data->locklvl = 0;       // Clear recursion
+    int cnt = __sync_add_and_fetch(&hal_data->lockcnt, 0); // Get the value
+    if(lvl > cnt) {
+        rtapi_print_msg(RTAPI_MSG_ERR, "halpr_mutex_force_release: inconsistent recursion state: lvl=%d > cnt=%d\n", lvl, cnt);
+        cnt = lvl; // Never subtract more than recursion level
+    } else if(lvl == cnt && hal_data->priv_rdmutex) {
+        rtapi_print_msg(RTAPI_MSG_ERR, "halpr_mutex_force_release: inconsistent lock state: locked and lvl=cnt=%d\n", cnt);
+    }
+    __sync_sub_and_fetch(&hal_data->lockcnt, lvl);  // Interlocked subtract
+    rtapi_mutex_give_rd(&(hal_data->priv_rdmutex)); // Unconditional release
+}
+
 /***********************************************************************
 *                  PUBLIC (API) FUNCTION CODE                          *
 ************************************************************************/
@@ -238,11 +332,11 @@ int hal_init(const char *name)
 	return -EINVAL;
     }
     /* get mutex before manipulating the shared data */
-    rtapi_mutex_get(&(hal_data->mutex));
+    halpr_mutex_acquire();
     /* make sure name is unique in the system */
     if (halpr_find_comp_by_name(hal_name) != NULL) {
 	/* a component with this name already exists */
-	rtapi_mutex_give(&(hal_data->mutex));
+	halpr_mutex_release();
 	rtapi_print_msg(RTAPI_MSG_ERR,
 	    "HAL: ERROR: duplicate component name '%s'\n", hal_name);
 	rtapi_exit(comp_id);
@@ -252,7 +346,7 @@ int hal_init(const char *name)
     comp = halpr_alloc_comp_struct();
     if (comp == NULL) {
 	/* couldn't allocate structure */
-	rtapi_mutex_give(&(hal_data->mutex));
+	halpr_mutex_release();
 	rtapi_print_msg(RTAPI_MSG_ERR,
 	    "HAL: ERROR: insufficient memory for component '%s'\n", hal_name);
 	rtapi_exit(comp_id);
@@ -275,7 +369,7 @@ int hal_init(const char *name)
     comp->next_ptr = hal_data->comp_list_ptr;
     hal_data->comp_list_ptr = SHMOFF(comp);
     /* done with list, release mutex */
-    rtapi_mutex_give(&(hal_data->mutex));
+    halpr_mutex_release();
     /* done */
     rtapi_print_msg(RTAPI_MSG_DBG,
 	"HAL: component '%s' initialized, ID = %02d\n", hal_name, comp_id);
@@ -296,13 +390,13 @@ int hal_exit(int comp_id)
     }
     rtapi_print_msg(RTAPI_MSG_DBG, "HAL: removing component %02d\n", comp_id);
     /* grab mutex before manipulating list */
-    rtapi_mutex_get(&(hal_data->mutex));
+    halpr_mutex_acquire();
     /* search component list for 'comp_id' */
     prev = &(hal_data->comp_list_ptr);
     next = *prev;
     if (next == 0) {
 	/* list is empty - should never happen, but... */
-	rtapi_mutex_give(&(hal_data->mutex));
+	halpr_mutex_release();
 	rtapi_print_msg(RTAPI_MSG_ERR,
 	    "HAL: ERROR: component %d not found\n", comp_id);
 	return -EINVAL;
@@ -314,7 +408,7 @@ int hal_exit(int comp_id)
 	next = *prev;
 	if (next == 0) {
 	    /* reached end of list without finding component */
-	    rtapi_mutex_give(&(hal_data->mutex));
+	    halpr_mutex_release();
 	    rtapi_print_msg(RTAPI_MSG_ERR,
 		"HAL: ERROR: component %d not found\n", comp_id);
 	    return -EINVAL;
@@ -345,7 +439,7 @@ int hal_exit(int comp_id)
     }
 #endif
     /* release mutex */
-    rtapi_mutex_give(&(hal_data->mutex));
+    halpr_mutex_release();
     --ref_cnt;
 #ifdef ULAPI
     if(ref_cnt == 0) {
@@ -383,11 +477,11 @@ void *hal_malloc(long int size)
     }
 
     /* get the mutex */
-    rtapi_mutex_get(&(hal_data->mutex));
+    halpr_mutex_acquire();
     /* allocate memory */
     retval = shmalloc_up(size);
     /* release the mutex */
-    rtapi_mutex_give(&(hal_data->mutex));
+    halpr_mutex_release();
     /* check return value */
     if (retval == NULL) {
 	rtapi_print_msg(RTAPI_MSG_DBG,
@@ -401,13 +495,13 @@ int hal_set_constructor(int comp_id, constructor make) {
     int next;
     hal_comp_t *comp;
 
-    rtapi_mutex_get(&(hal_data->mutex));
+    halpr_mutex_acquire();
 
     /* search component list for 'comp_id' */
     next = hal_data->comp_list_ptr;
     if (next == 0) {
 	/* list is empty - should never happen, but... */
-	rtapi_mutex_give(&(hal_data->mutex));
+	halpr_mutex_release();
 	rtapi_print_msg(RTAPI_MSG_ERR,
 	    "HAL: ERROR: component %d not found\n", comp_id);
 	return -EINVAL;
@@ -419,7 +513,7 @@ int hal_set_constructor(int comp_id, constructor make) {
 	next = comp->next_ptr;
 	if (next == 0) {
 	    /* reached end of list without finding component */
-	    rtapi_mutex_give(&(hal_data->mutex));
+	    halpr_mutex_release();
 	    rtapi_print_msg(RTAPI_MSG_ERR,
 		"HAL: ERROR: component %d not found\n", comp_id);
 	    return -EINVAL;
@@ -429,17 +523,17 @@ int hal_set_constructor(int comp_id, constructor make) {
     
     comp->make = make;
 
-    rtapi_mutex_give(&(hal_data->mutex));
+    halpr_mutex_release();
     return 0;
 }
 #endif
 
 int hal_set_unready(int comp_id) {
     hal_comp_t *comp;
-    rtapi_mutex_get(&(hal_data->mutex));
+    halpr_mutex_acquire();
     comp = halpr_find_comp_by_id(comp_id);
     if (comp) { comp->ready = 0; }
-    rtapi_mutex_give(&(hal_data->mutex));
+    halpr_mutex_release();
     if (comp) {return 0;}
     rtapi_print_msg(RTAPI_MSG_ERR,
          "HAL: ERROR: hal_set_unready(): component %d not found\n", comp_id);
@@ -450,13 +544,13 @@ int hal_ready(int comp_id) {
     int next;
     hal_comp_t *comp;
 
-    rtapi_mutex_get(&(hal_data->mutex));
+    halpr_mutex_acquire();
 
     /* search component list for 'comp_id' */
     next = hal_data->comp_list_ptr;
     if (next == 0) {
 	/* list is empty - should never happen, but... */
-	rtapi_mutex_give(&(hal_data->mutex));
+	halpr_mutex_release();
 	rtapi_print_msg(RTAPI_MSG_ERR,
 	    "HAL: ERROR: component %d not found\n", comp_id);
 	return -EINVAL;
@@ -468,7 +562,7 @@ int hal_ready(int comp_id) {
 	next = comp->next_ptr;
 	if (next == 0) {
 	    /* reached end of list without finding component */
-	    rtapi_mutex_give(&(hal_data->mutex));
+	    halpr_mutex_release();
 	    rtapi_print_msg(RTAPI_MSG_ERR,
 		"HAL: ERROR: component %d not found\n", comp_id);
 	    return -EINVAL;
@@ -478,11 +572,11 @@ int hal_ready(int comp_id) {
     if(comp->ready > 0) {
         rtapi_print_msg(RTAPI_MSG_ERR,
                 "HAL: ERROR: Component '%s' already ready\n", comp->name);
-        rtapi_mutex_give(&(hal_data->mutex));
+        halpr_mutex_release();
         return -EINVAL;
     }
     comp->ready = 1;
-    rtapi_mutex_give(&(hal_data->mutex));
+    halpr_mutex_release();
     return 0;
 }
 
@@ -490,13 +584,13 @@ int hal_unready(int comp_id) {
     int next;
     hal_comp_t *comp;
 
-    rtapi_mutex_get(&(hal_data->mutex));
+    halpr_mutex_acquire();
 
     /* search component list for 'comp_id' */
     next = hal_data->comp_list_ptr;
     if (next == 0) {
 	/* list is empty - should never happen, but... */
-	rtapi_mutex_give(&(hal_data->mutex));
+	halpr_mutex_release();
 	rtapi_print_msg(RTAPI_MSG_ERR,
 	    "HAL: ERROR: component %d not found\n", comp_id);
 	return -EINVAL;
@@ -508,7 +602,7 @@ int hal_unready(int comp_id) {
 	next = comp->next_ptr;
 	if (next == 0) {
 	    /* reached end of list without finding component */
-	    rtapi_mutex_give(&(hal_data->mutex));
+	    halpr_mutex_release();
 	    rtapi_print_msg(RTAPI_MSG_ERR,
 		"HAL: ERROR: component %d not found\n", comp_id);
 	    return -EINVAL;
@@ -518,11 +612,11 @@ int hal_unready(int comp_id) {
     if(comp->ready < 1) {
         rtapi_print_msg(RTAPI_MSG_ERR,
                 "HAL: ERROR: Component '%s' already unready\n", comp->name);
-        rtapi_mutex_give(&(hal_data->mutex));
+        halpr_mutex_release();
         return -EINVAL;
     }
     comp->ready = 0;
-    rtapi_mutex_give(&(hal_data->mutex));
+    halpr_mutex_release();
     return 0;
 }
 
@@ -530,10 +624,10 @@ char *hal_comp_name(int comp_id)
 {
     hal_comp_t *comp;
     char *result = NULL;
-    rtapi_mutex_get(&(hal_data->mutex));
+    halpr_mutex_acquire();
     comp = halpr_find_comp_by_id(comp_id);
     if(comp) result = comp->name;
-    rtapi_mutex_give(&(hal_data->mutex));
+    halpr_mutex_release();
     return result;
 }
 
@@ -856,12 +950,12 @@ int hal_pin_new(const char *name, hal_type_t type, hal_pin_dir_t dir,
 
     rtapi_print_msg(RTAPI_MSG_DBG, "HAL: creating pin '%s'\n", name);
     /* get mutex before accessing shared data */
-    rtapi_mutex_get(&(hal_data->mutex));
+    halpr_mutex_acquire();
     /* validate comp_id */
     comp = halpr_find_comp_by_id(comp_id);
     if (comp == NULL) {
 	/* bad comp_id */
-	rtapi_mutex_give(&(hal_data->mutex));
+	halpr_mutex_release();
 	rtapi_print_msg(RTAPI_MSG_ERR,
 	    "HAL: ERROR: component %d not found\n", comp_id);
 	return -EINVAL;
@@ -869,7 +963,7 @@ int hal_pin_new(const char *name, hal_type_t type, hal_pin_dir_t dir,
     // Already check duplicate before allocating
     if(halpr_find_pin_by_name(name)) {
         // Duplicate pin name
-        rtapi_mutex_give(&(hal_data->mutex));
+        halpr_mutex_release();
         rtapi_print_msg(RTAPI_MSG_ERR, "HAL: ERROR: duplicate pin '%s'\n", name);
         return -EINVAL;
     }
@@ -883,13 +977,13 @@ int hal_pin_new(const char *name, hal_type_t type, hal_pin_dir_t dir,
     /* validate passed in pointer - must point to HAL shmem */
     if (! SHMCHK(data_ptr_addr)) {
 	/* bad pointer */
-	rtapi_mutex_give(&(hal_data->mutex));
+	halpr_mutex_release();
 	rtapi_print_msg(RTAPI_MSG_ERR,
 	    "HAL: ERROR: data_ptr_addr not in shared memory\n");
 	return -EINVAL;
     }
     if(comp->ready) {
-	rtapi_mutex_give(&(hal_data->mutex));
+	halpr_mutex_release();
 	rtapi_print_msg(RTAPI_MSG_ERR,
 	    "HAL: ERROR: pin_new called after hal_ready\n");
 	return -EINVAL;
@@ -898,7 +992,7 @@ int hal_pin_new(const char *name, hal_type_t type, hal_pin_dir_t dir,
     new = alloc_pin_struct();
     if (new == NULL) {
 	/* alloc failed */
-	rtapi_mutex_give(&(hal_data->mutex));
+	halpr_mutex_release();
 	rtapi_print_msg(RTAPI_MSG_ERR,
 	    "HAL: ERROR: insufficient memory for pin '%s'\n", name);
 	return -ENOMEM;
@@ -921,7 +1015,7 @@ int hal_pin_new(const char *name, hal_type_t type, hal_pin_dir_t dir,
 	    /* reached end of list, insert here */
 	    new->next_ptr = next;
 	    *prev = SHMOFF(new);
-	    rtapi_mutex_give(&(hal_data->mutex));
+	    halpr_mutex_release();
 	    return 0;
 	}
 	ptr = SHMPTR(next);
@@ -930,13 +1024,13 @@ int hal_pin_new(const char *name, hal_type_t type, hal_pin_dir_t dir,
 	    /* found the right place for it, insert here */
 	    new->next_ptr = next;
 	    *prev = SHMOFF(new);
-	    rtapi_mutex_give(&(hal_data->mutex));
+	    halpr_mutex_release();
 	    return 0;
 	}
 	if (cmp == 0) {
 	    /* name already in list, can't insert */
 	    free_pin_struct(new);
-	    rtapi_mutex_give(&(hal_data->mutex));
+	    halpr_mutex_release();
 	    rtapi_print_msg(RTAPI_MSG_ERR,
 		"HAL: ERROR: duplicate variable '%s'\n", name);
 	    return -EINVAL;
@@ -972,11 +1066,11 @@ int hal_pin_alias(const char *pin_name, const char *alias)
 	}
     }
     /* get mutex before accessing shared data */
-    rtapi_mutex_get(&(hal_data->mutex));
+    halpr_mutex_acquire();
     if (alias != NULL ) {
 	pin = halpr_find_pin_by_name(alias);
 	if ( pin != NULL ) {
-	    rtapi_mutex_give(&(hal_data->mutex));
+	    halpr_mutex_release();
 	    rtapi_print_msg(RTAPI_MSG_ERR,
 	        "HAL: ERROR: duplicate pin/alias name '%s'\n", alias);
 	    return -EINVAL;
@@ -990,7 +1084,7 @@ int hal_pin_alias(const char *pin_name, const char *alias)
        to succeed since at least one struct is on the free list. */
     oldname = halpr_alloc_oldname_struct();
     if ( oldname == NULL ) {
-	rtapi_mutex_give(&(hal_data->mutex));
+	halpr_mutex_release();
 	rtapi_print_msg(RTAPI_MSG_ERR,
 	    "HAL: ERROR: insufficient memory for pin_alias\n");
 	return -EINVAL;
@@ -1002,7 +1096,7 @@ int hal_pin_alias(const char *pin_name, const char *alias)
     while (1) {
 	if (next == 0) {
 	    /* reached end of list, not found */
-	    rtapi_mutex_give(&(hal_data->mutex));
+	    halpr_mutex_release();
 	    rtapi_print_msg(RTAPI_MSG_ERR,
 		"HAL: ERROR: pin '%s' not found\n", pin_name);
 	    return -EINVAL;
@@ -1053,7 +1147,7 @@ int hal_pin_alias(const char *pin_name, const char *alias)
 	    /* reached end of list, insert here */
 	    pin->next_ptr = next;
 	    *prev = SHMOFF(pin);
-	    rtapi_mutex_give(&(hal_data->mutex));
+	    halpr_mutex_release();
 	    return 0;
 	}
 	ptr = SHMPTR(next);
@@ -1062,7 +1156,7 @@ int hal_pin_alias(const char *pin_name, const char *alias)
 	    /* found the right place for it, insert here */
 	    pin->next_ptr = next;
 	    *prev = SHMOFF(pin);
-	    rtapi_mutex_give(&(hal_data->mutex));
+	    halpr_mutex_release();
 	    return 0;
 	}
 	/* didn't find it yet, look at next one */
@@ -1102,10 +1196,10 @@ int hal_signal_new(const char *name, hal_type_t type)
 
     rtapi_print_msg(RTAPI_MSG_DBG, "HAL: creating signal '%s'\n", name);
     /* get mutex before accessing shared data */
-    rtapi_mutex_get(&(hal_data->mutex));
+    halpr_mutex_acquire();
     /* check for an existing signal with the same name */
     if (halpr_find_sig_by_name(name) != NULL) {
-	rtapi_mutex_give(&(hal_data->mutex));
+	halpr_mutex_release();
 	rtapi_print_msg(RTAPI_MSG_ERR,
 	    "HAL: ERROR: duplicate signal '%s'\n", name);
 	return -EINVAL;
@@ -1129,7 +1223,7 @@ int hal_signal_new(const char *name, hal_type_t type)
         memset(data_addr, 0, sizeof(hal_data_u));
         break;
     default:
-	rtapi_mutex_give(&(hal_data->mutex));
+	halpr_mutex_release();
 	rtapi_print_msg(RTAPI_MSG_ERR,
 	    "HAL: ERROR: illegal signal type %d'\n", type);
 	return -EINVAL;
@@ -1138,7 +1232,7 @@ int hal_signal_new(const char *name, hal_type_t type)
     new = alloc_sig_struct();
     if ((new == NULL) || (data_addr == NULL)) {
 	/* alloc failed */
-	rtapi_mutex_give(&(hal_data->mutex));
+	halpr_mutex_release();
 	rtapi_print_msg(RTAPI_MSG_ERR,
 	    "HAL: ERROR: insufficient memory for signal '%s'\n", name);
 	return -ENOMEM;
@@ -1158,7 +1252,7 @@ int hal_signal_new(const char *name, hal_type_t type)
 	    /* reached end of list, insert here */
 	    new->next_ptr = next;
 	    *prev = SHMOFF(new);
-	    rtapi_mutex_give(&(hal_data->mutex));
+	    halpr_mutex_release();
 	    return 0;
 	}
 	ptr = SHMPTR(next);
@@ -1167,7 +1261,7 @@ int hal_signal_new(const char *name, hal_type_t type)
 	    /* found the right place for it, insert here */
 	    new->next_ptr = next;
 	    *prev = SHMOFF(new);
-	    rtapi_mutex_give(&(hal_data->mutex));
+	    halpr_mutex_release();
 	    return 0;
 	}
 	/* didn't find it yet, look at next one */
@@ -1195,7 +1289,7 @@ int hal_signal_delete(const char *name)
     
     rtapi_print_msg(RTAPI_MSG_DBG, "HAL: deleting signal '%s'\n", name);
     /* get mutex before accessing shared data */
-    rtapi_mutex_get(&(hal_data->mutex));
+    halpr_mutex_acquire();
     /* search for the signal */
     prev = &(hal_data->sig_list_ptr);
     next = *prev;
@@ -1207,7 +1301,7 @@ int hal_signal_delete(const char *name)
 	    /* and delete it */
 	    free_sig_struct(sig);
 	    /* done */
-	    rtapi_mutex_give(&(hal_data->mutex));
+	    halpr_mutex_release();
 	    return 0;
 	}
 	/* no match, try the next one */
@@ -1215,7 +1309,7 @@ int hal_signal_delete(const char *name)
 	next = *prev;
     }
     /* if we get here, we didn't find a match */
-    rtapi_mutex_give(&(hal_data->mutex));
+    halpr_mutex_release();
     rtapi_print_msg(RTAPI_MSG_ERR, "HAL: ERROR: signal '%s' not found\n",
 	name);
     return -EINVAL;
@@ -1252,12 +1346,12 @@ int hal_link(const char *pin_name, const char *sig_name)
     rtapi_print_msg(RTAPI_MSG_DBG,
 	"HAL: linking pin '%s' to '%s'\n", pin_name, sig_name);
     /* get mutex before accessing data structures */
-    rtapi_mutex_get(&(hal_data->mutex));
+    halpr_mutex_acquire();
     /* locate the pin */
     pin = halpr_find_pin_by_name(pin_name);
     if (pin == NULL) {
 	/* not found */
-	rtapi_mutex_give(&(hal_data->mutex));
+	halpr_mutex_release();
 	rtapi_print_msg(RTAPI_MSG_ERR,
 	    "HAL: ERROR: pin '%s' not found\n", pin_name);
 	return -EINVAL;
@@ -1266,21 +1360,21 @@ int hal_link(const char *pin_name, const char *sig_name)
     sig = halpr_find_sig_by_name(sig_name);
     if (sig == NULL) {
 	/* not found */
-	rtapi_mutex_give(&(hal_data->mutex));
+	halpr_mutex_release();
 	rtapi_print_msg(RTAPI_MSG_ERR,
 	    "HAL: ERROR: signal '%s' not found\n", sig_name);
 	return -EINVAL;
     }
     /* found both pin and signal, are they already connected? */
     if (SHMPTR(pin->signal) == sig) {
-	rtapi_mutex_give(&(hal_data->mutex));
+	halpr_mutex_release();
 	rtapi_print_msg(RTAPI_MSG_WARN,
 	    "HAL: Warning: pin '%s' already linked to '%s'\n", pin_name, sig_name);
 	return 0;
     }
     /* is the pin connected to something else? */
     if(pin->signal) {
-	rtapi_mutex_give(&(hal_data->mutex));
+	halpr_mutex_release();
 	sig = SHMPTR(pin->signal);
 	rtapi_print_msg(RTAPI_MSG_ERR,
 	    "HAL: ERROR: pin '%s' is linked to '%s', cannot link to '%s'\n",
@@ -1289,7 +1383,7 @@ int hal_link(const char *pin_name, const char *sig_name)
     }
     /* check types */
     if (pin->type != sig->type) {
-	rtapi_mutex_give(&(hal_data->mutex));
+	halpr_mutex_release();
 	rtapi_print_msg(RTAPI_MSG_ERR,
 	    "HAL: ERROR: type mismatch '%s' <- '%s'\n", pin_name, sig_name);
 	return -EINVAL;
@@ -1297,14 +1391,14 @@ int hal_link(const char *pin_name, const char *sig_name)
     /* linking output pin to sig that already has output or I/O pins? */
     if ((pin->dir == HAL_OUT) && ((sig->writers > 0) || (sig->bidirs > 0 ))) {
 	/* yes, can't do that */
-	rtapi_mutex_give(&(hal_data->mutex));
+	halpr_mutex_release();
 	rtapi_print_msg(RTAPI_MSG_ERR,
 	    "HAL: ERROR: signal '%s' already has output or I/O pin(s)\n", sig_name);
 	return -EINVAL;
     }
     /* linking bidir pin to sig that is a port?*/
     if ((pin->dir == HAL_IO) && (pin->type == HAL_PORT)) {
-    rtapi_mutex_give(&(hal_data->mutex));
+    halpr_mutex_release();
     rtapi_print_msg(RTAPI_MSG_ERR,
         "HAL: ERROR: signal '%s' is a port and cannot have I/O pin(s)\n", sig_name);
     return -EINVAL;
@@ -1312,7 +1406,7 @@ int hal_link(const char *pin_name, const char *sig_name)
     /* linking bidir pin to sig that already has output pin? */
     if ((pin->dir == HAL_IO) && (sig->writers > 0)) {
 	/* yes, can't do that */
-	rtapi_mutex_give(&(hal_data->mutex));
+	halpr_mutex_release();
 	rtapi_print_msg(RTAPI_MSG_ERR,
 	    "HAL: ERROR: signal '%s' already has output pin\n", sig_name);
 	return -EINVAL;
@@ -1321,7 +1415,7 @@ int hal_link(const char *pin_name, const char *sig_name)
     /* linking input pin to port sig that already has an input port? */
     if ((pin->type == HAL_PORT) && (pin->dir == HAL_IN) && (sig->readers > 0)) {
 	/* ports can only have one reader */
-	rtapi_mutex_give(&(hal_data->mutex));
+	halpr_mutex_release();
 	rtapi_print_msg(RTAPI_MSG_ERR,
 	    "HAL: ERROR: signal '%s' can only have one input pin\n", sig_name);
 	return -EINVAL;
@@ -1388,7 +1482,7 @@ int hal_link(const char *pin_name, const char *sig_name)
     /* and update the pin */
     pin->signal = SHMOFF(sig);
     /* done, release the mutex and return */
-    rtapi_mutex_give(&(hal_data->mutex));
+    halpr_mutex_release();
     return 0;
 }
 
@@ -1415,12 +1509,12 @@ int hal_unlink(const char *pin_name)
     rtapi_print_msg(RTAPI_MSG_DBG,
 	"HAL: unlinking pin '%s'\n", pin_name);
     /* get mutex before accessing data structures */
-    rtapi_mutex_get(&(hal_data->mutex));
+    halpr_mutex_acquire();
     /* locate the pin */
     pin = halpr_find_pin_by_name(pin_name);
     if (pin == NULL) {
 	/* not found */
-	rtapi_mutex_give(&(hal_data->mutex));
+	halpr_mutex_release();
 	rtapi_print_msg(RTAPI_MSG_ERR,
 	    "HAL: ERROR: pin '%s' not found\n", pin_name);
 	return -EINVAL;
@@ -1428,7 +1522,7 @@ int hal_unlink(const char *pin_name)
     /* found pin, unlink it */
     unlink_pin(pin);
     /* done, release the mutex and return */
-    rtapi_mutex_give(&(hal_data->mutex));
+    halpr_mutex_release();
     return 0;
 }
 
@@ -1598,12 +1692,12 @@ static int hal_param_new_anyapi(const char *name, hal_type_t type, hal_pdir_t di
 
     rtapi_print_msg(RTAPI_MSG_DBG, "HAL: creating parameter '%s'\n", name);
     /* get mutex before accessing shared data */
-    rtapi_mutex_get(&(hal_data->mutex));
+    halpr_mutex_acquire();
     /* validate comp_id */
     comp = halpr_find_comp_by_id(comp_id);
     if (comp == NULL) {
 	/* bad comp_id */
-	rtapi_mutex_give(&(hal_data->mutex));
+	halpr_mutex_release();
 	rtapi_print_msg(RTAPI_MSG_ERR,
 	    "HAL: ERROR: component %d not found\n", comp_id);
 	return -EINVAL;
@@ -1611,7 +1705,7 @@ static int hal_param_new_anyapi(const char *name, hal_type_t type, hal_pdir_t di
     // Already check duplicate before allocating
     if(halpr_find_param_by_name(name)) {
         // Duplicate parameter name
-        rtapi_mutex_give(&(hal_data->mutex));
+        halpr_mutex_release();
         rtapi_print_msg(RTAPI_MSG_ERR, "HAL: ERROR: duplicate parameter '%s'\n", name);
         return -EINVAL;
     }
@@ -1625,13 +1719,13 @@ static int hal_param_new_anyapi(const char *name, hal_type_t type, hal_pdir_t di
     /* validate passed in pointer - must point to HAL shmem */
     if (! SHMCHK(data_addr)) {
 	/* bad pointer */
-	rtapi_mutex_give(&(hal_data->mutex));
+	halpr_mutex_release();
 	rtapi_print_msg(RTAPI_MSG_ERR,
 	    "HAL: ERROR: data_addr not in shared memory\n");
 	return -EINVAL;
     }
     if(comp->ready) {
-	rtapi_mutex_give(&(hal_data->mutex));
+	halpr_mutex_release();
 	rtapi_print_msg(RTAPI_MSG_ERR,
 	    "HAL: ERROR: param_new called after hal_ready\n");
 	return -EINVAL;
@@ -1640,7 +1734,7 @@ static int hal_param_new_anyapi(const char *name, hal_type_t type, hal_pdir_t di
     new = alloc_param_struct();
     if (new == NULL) {
 	/* alloc failed */
-	rtapi_mutex_give(&(hal_data->mutex));
+	halpr_mutex_release();
 	rtapi_print_msg(RTAPI_MSG_ERR,
 	    "HAL: ERROR: insufficient memory for parameter '%s'\n", name);
 	return -ENOMEM;
@@ -1666,7 +1760,7 @@ static int hal_param_new_anyapi(const char *name, hal_type_t type, hal_pdir_t di
 	    /* reached end of list, insert here */
 	    new->next_ptr = next;
 	    *prev = SHMOFF(new);
-	    rtapi_mutex_give(&(hal_data->mutex));
+	    halpr_mutex_release();
 	    return 0;
 	}
 	ptr = SHMPTR(next);
@@ -1675,13 +1769,13 @@ static int hal_param_new_anyapi(const char *name, hal_type_t type, hal_pdir_t di
 	    /* found the right place for it, insert here */
 	    new->next_ptr = next;
 	    *prev = SHMOFF(new);
-	    rtapi_mutex_give(&(hal_data->mutex));
+	    halpr_mutex_release();
 	    return 0;
 	}
 	if (cmp == 0) {
 	    /* name already in list, can't insert */
 	    free_param_struct(new);
-	    rtapi_mutex_give(&(hal_data->mutex));
+	    halpr_mutex_release();
 	    rtapi_print_msg(RTAPI_MSG_ERR,
 		"HAL: ERROR: duplicate parameter '%s'\n", name);
 	    return -EINVAL;
@@ -1841,27 +1935,27 @@ int hal_param_set(const char *name, hal_type_t type, void *value_addr)
     
     rtapi_print_msg(RTAPI_MSG_DBG, "HAL: setting parameter '%s'\n", name);
     /* get mutex before accessing shared data */
-    rtapi_mutex_get(&(hal_data->mutex));
+    halpr_mutex_acquire();
 
     /* search param list for name */
     param = halpr_find_param_by_name(name);
     if (param == NULL) {
 	/* parameter not found */
-	rtapi_mutex_give(&(hal_data->mutex));
+	halpr_mutex_release();
 	rtapi_print_msg(RTAPI_MSG_ERR,
 	    "HAL: ERROR: parameter '%s' not found\n", name);
 	return -EINVAL;
     }
     /* found it, is type compatible? */
     if (param->type != type) {
-	rtapi_mutex_give(&(hal_data->mutex));
+	halpr_mutex_release();
 	rtapi_print_msg(RTAPI_MSG_ERR,
 	    "HAL: ERROR: type mismatch setting param '%s'\n", name);
 	return -EINVAL;
     }
     /* is it read only? */
     if (param->dir == HAL_RO) {
-	rtapi_mutex_give(&(hal_data->mutex));
+	halpr_mutex_release();
 	rtapi_print_msg(RTAPI_MSG_ERR,
 	    "HAL: ERROR: param '%s' is not writable\n", name);
 	return -EINVAL;
@@ -1893,12 +1987,12 @@ int hal_param_set(const char *name, hal_type_t type, void *value_addr)
 	break;
     default:
 	/* Shouldn't get here, but just in case... */
-	rtapi_mutex_give(&(hal_data->mutex));
+	halpr_mutex_release();
 	rtapi_print_msg(RTAPI_MSG_ERR,
 	    "HAL: ERROR: bad type %d setting param\n", param->type);
 	return -EINVAL;
     }
-    rtapi_mutex_give(&(hal_data->mutex));
+    halpr_mutex_release();
     return 0;
 }
 
@@ -1927,11 +2021,11 @@ int hal_param_alias(const char *param_name, const char *alias)
 	}
     }
     /* get mutex before accessing shared data */
-    rtapi_mutex_get(&(hal_data->mutex));
+    halpr_mutex_acquire();
     if (alias != NULL ) {
 	param = halpr_find_param_by_name(alias);
 	if ( param != NULL ) {
-	    rtapi_mutex_give(&(hal_data->mutex));
+	    halpr_mutex_release();
 	    rtapi_print_msg(RTAPI_MSG_ERR,
 	        "HAL: ERROR: duplicate pin/alias name '%s'\n", alias);
 	    return -EINVAL;
@@ -1945,7 +2039,7 @@ int hal_param_alias(const char *param_name, const char *alias)
        to succeed since at least one struct is on the free list. */
     oldname = halpr_alloc_oldname_struct();
     if ( oldname == NULL ) {
-	rtapi_mutex_give(&(hal_data->mutex));
+	halpr_mutex_release();
 	rtapi_print_msg(RTAPI_MSG_ERR,
 	    "HAL: ERROR: insufficient memory for param_alias\n");
 	return -EINVAL;
@@ -1957,7 +2051,7 @@ int hal_param_alias(const char *param_name, const char *alias)
     while (1) {
 	if (next == 0) {
 	    /* reached end of list, not found */
-	    rtapi_mutex_give(&(hal_data->mutex));
+	    halpr_mutex_release();
 	    rtapi_print_msg(RTAPI_MSG_ERR,
 		"HAL: ERROR: param '%s' not found\n", param_name);
 	    return -EINVAL;
@@ -2008,7 +2102,7 @@ int hal_param_alias(const char *param_name, const char *alias)
 	    /* reached end of list, insert here */
 	    param->next_ptr = next;
 	    *prev = SHMOFF(param);
-	    rtapi_mutex_give(&(hal_data->mutex));
+	    halpr_mutex_release();
 	    return 0;
 	}
 	ptr = SHMPTR(next);
@@ -2017,7 +2111,7 @@ int hal_param_alias(const char *param_name, const char *alias)
 	    /* found the right place for it, insert here */
 	    param->next_ptr = next;
 	    *prev = SHMOFF(param);
-	    rtapi_mutex_give(&(hal_data->mutex));
+	    halpr_mutex_release();
 	    return 0;
 	}
 	/* didn't find it yet, look at next one */
@@ -2138,25 +2232,25 @@ int hal_export_funct(const char *name, void (*funct) (void *, long),
     
     rtapi_print_msg(RTAPI_MSG_DBG, "HAL: exporting function '%s'\n", name);
     /* get mutex before accessing shared data */
-    rtapi_mutex_get(&(hal_data->mutex));
+    halpr_mutex_acquire();
     /* validate comp_id */
     comp = halpr_find_comp_by_id(comp_id);
     if (comp == 0) {
 	/* bad comp_id */
-	rtapi_mutex_give(&(hal_data->mutex));
+	halpr_mutex_release();
 	rtapi_print_msg(RTAPI_MSG_ERR,
 	    "HAL: ERROR: component %d not found\n", comp_id);
 	return -EINVAL;
     }
     if (comp->type == COMPONENT_TYPE_USER) {
 	/* not a realtime component */
-	rtapi_mutex_give(&(hal_data->mutex));
+	halpr_mutex_release();
 	rtapi_print_msg(RTAPI_MSG_ERR,
 	    "HAL: ERROR: component %d is not realtime\n", comp_id);
 	return -EINVAL;
     }
     if(comp->ready) {
-	rtapi_mutex_give(&(hal_data->mutex));
+	halpr_mutex_release();
 	rtapi_print_msg(RTAPI_MSG_ERR,
 	    "HAL: ERROR: export_funct called after hal_ready\n");
 	return -EINVAL;
@@ -2165,7 +2259,7 @@ int hal_export_funct(const char *name, void (*funct) (void *, long),
     new = alloc_funct_struct();
     if (new == 0) {
 	/* alloc failed */
-	rtapi_mutex_give(&(hal_data->mutex));
+	halpr_mutex_release();
 	rtapi_print_msg(RTAPI_MSG_ERR,
 	    "HAL: ERROR: insufficient memory for function '%s'\n", name);
 	return -ENOMEM;
@@ -2202,7 +2296,7 @@ int hal_export_funct(const char *name, void (*funct) (void *, long),
 	if (cmp == 0) {
 	    /* name already in list, can't insert */
 	    free_funct_struct(new);
-	    rtapi_mutex_give(&(hal_data->mutex));
+	    halpr_mutex_release();
 	    rtapi_print_msg(RTAPI_MSG_ERR,
 		"HAL: ERROR: duplicate function '%s'\n", name);
 	    return -EINVAL;
@@ -2212,7 +2306,7 @@ int hal_export_funct(const char *name, void (*funct) (void *, long),
 	next = *prev;
     }
     /* at this point we have a new function and can yield the mutex */
-    rtapi_mutex_give(&(hal_data->mutex));
+    halpr_mutex_release();
 
     /* create a pin with the function's runtime in it */
     if (hal_pin_s32_newf(HAL_OUT, &(new->runtime), comp_id,"%s.time",name)) {
@@ -2272,7 +2366,7 @@ int hal_create_thread(const char *name, unsigned long period_nsec, int uses_fp)
     }
 
     /* get mutex before accessing shared data */
-    rtapi_mutex_get(&(hal_data->mutex));
+    halpr_mutex_acquire();
     /* make sure name is unique on thread list */
     next = hal_data->thread_list_ptr;
     while (next != 0) {
@@ -2280,7 +2374,7 @@ int hal_create_thread(const char *name, unsigned long period_nsec, int uses_fp)
 	cmp = strcmp(tptr->name, name);
 	if (cmp == 0) {
 	    /* name already in list, can't insert */
-	    rtapi_mutex_give(&(hal_data->mutex));
+	    halpr_mutex_release();
 	    rtapi_print_msg(RTAPI_MSG_ERR,
 		"HAL: ERROR: duplicate thread name %s\n", name);
 	    return -EINVAL;
@@ -2292,7 +2386,7 @@ int hal_create_thread(const char *name, unsigned long period_nsec, int uses_fp)
     new = alloc_thread_struct();
     if (new == 0) {
 	/* alloc failed */
-	rtapi_mutex_give(&(hal_data->mutex));
+	halpr_mutex_release();
 	rtapi_print_msg(RTAPI_MSG_ERR,
 	    "HAL: ERROR: insufficient memory to create thread\n");
 	return -ENOMEM;
@@ -2310,7 +2404,7 @@ int hal_create_thread(const char *name, unsigned long period_nsec, int uses_fp)
 	    /* not running, start it */
 	    curr_period = rtapi_clock_set_period(period_nsec);
 	    if (curr_period < 0) {
-		rtapi_mutex_give(&(hal_data->mutex));
+		halpr_mutex_release();
 		rtapi_print_msg(RTAPI_MSG_ERR,
 		    "HAL_LIB: ERROR: clock_set_period returned %ld\n",
 		    curr_period);
@@ -2319,7 +2413,7 @@ int hal_create_thread(const char *name, unsigned long period_nsec, int uses_fp)
 	}
 	/* make sure period <= desired period (allow 1% roundoff error) */
 	if (curr_period > (long)(period_nsec + (period_nsec / 100))) {
-	    rtapi_mutex_give(&(hal_data->mutex));
+	    halpr_mutex_release();
 	    rtapi_print_msg(RTAPI_MSG_ERR,
 		"HAL_LIB: ERROR: clock period too long: %ld\n", curr_period);
 	    return -EINVAL;
@@ -2341,7 +2435,7 @@ int hal_create_thread(const char *name, unsigned long period_nsec, int uses_fp)
 	prev_priority = tptr->priority;
     }
     if ( (long)period_nsec < hal_data->base_period) {
-	rtapi_mutex_give(&(hal_data->mutex));
+	halpr_mutex_release();
 	rtapi_print_msg(RTAPI_MSG_ERR,
 	    "HAL_LIB: ERROR: new thread period %ld is less than clock period %ld\n",
 	     period_nsec, hal_data->base_period);
@@ -2351,7 +2445,7 @@ int hal_create_thread(const char *name, unsigned long period_nsec, int uses_fp)
     n = (period_nsec + hal_data->base_period / 2) / hal_data->base_period;
     new->period = hal_data->base_period * n;
     if ( new->period < prev_period ) {
-	rtapi_mutex_give(&(hal_data->mutex));
+	halpr_mutex_release();
 	rtapi_print_msg(RTAPI_MSG_ERR,
 	    "HAL_LIB: ERROR: new thread period %ld is less than existing thread period %ld\n",
 	     period_nsec, prev_period);
@@ -2364,7 +2458,7 @@ int hal_create_thread(const char *name, unsigned long period_nsec, int uses_fp)
     retval = rtapi_task_new(thread_task, new, new->priority,
 	lib_module_id, HAL_STACKSIZE, 1);
     if (retval < 0) {
-	rtapi_mutex_give(&(hal_data->mutex));
+	halpr_mutex_release();
 	rtapi_print_msg(RTAPI_MSG_ERR,
 	    "HAL_LIB: could not create task for thread %s\n", name);
 	return -EINVAL;
@@ -2373,7 +2467,7 @@ int hal_create_thread(const char *name, unsigned long period_nsec, int uses_fp)
     /* start task */
     retval = rtapi_task_start(new->task_id, new->period);
     if (retval < 0) {
-	rtapi_mutex_give(&(hal_data->mutex));
+	halpr_mutex_release();
 	rtapi_print_msg(RTAPI_MSG_ERR,
 	    "HAL_LIB: could not start task for thread %s: %d\n", name, retval);
 	return -EINVAL;
@@ -2382,7 +2476,7 @@ int hal_create_thread(const char *name, unsigned long period_nsec, int uses_fp)
     new->next_ptr = hal_data->thread_list_ptr;
     hal_data->thread_list_ptr = SHMOFF(new);
     /* done, release mutex */
-    rtapi_mutex_give(&(hal_data->mutex));
+    halpr_mutex_release();
 
     rtapi_snprintf(buf,sizeof(buf), HAL_PSEUDO_COMP_PREFIX"%s",new->name); // pseudo prefix
     new->comp_id = hal_init(buf);
@@ -2431,7 +2525,7 @@ extern int hal_thread_delete(const char *name)
     
     rtapi_print_msg(RTAPI_MSG_DBG, "HAL: deleting thread '%s'\n", name);
     /* get mutex before accessing shared data */
-    rtapi_mutex_get(&(hal_data->mutex));
+    halpr_mutex_acquire();
     /* search for the signal */
     prev = &(hal_data->thread_list_ptr);
     next = *prev;
@@ -2447,7 +2541,7 @@ extern int hal_thread_delete(const char *name)
 	    /* and delete it */
 	    free_thread_struct(thread);
 	    /* done */
-	    rtapi_mutex_give(&(hal_data->mutex));
+	    halpr_mutex_release();
 	    return 0;
 	}
 	/* no match, try the next one */
@@ -2455,7 +2549,7 @@ extern int hal_thread_delete(const char *name)
 	next = *prev;
     }
     /* if we get here, we didn't find a match */
-    rtapi_mutex_give(&(hal_data->mutex));
+    halpr_mutex_release();
     rtapi_print_msg(RTAPI_MSG_ERR, "HAL: ERROR: thread '%s' not found\n",
 	name);
     return -EINVAL;
@@ -2487,25 +2581,25 @@ int hal_add_funct_to_thread(const char *funct_name, const char *thread_name, int
 	"HAL: adding function '%s' to thread '%s'\n",
 	funct_name, thread_name);
     /* get mutex before accessing data structures */
-    rtapi_mutex_get(&(hal_data->mutex));
+    halpr_mutex_acquire();
     /* make sure position is valid */
     if (position == 0) {
 	/* zero is not allowed */
-	rtapi_mutex_give(&(hal_data->mutex));
+	halpr_mutex_release();
 	rtapi_print_msg(RTAPI_MSG_ERR, "HAL: ERROR: bad position: 0\n");
 	return -EINVAL;
     }
     /* make sure we were given a function name */
     if (funct_name == NULL) {
 	/* no name supplied */
-	rtapi_mutex_give(&(hal_data->mutex));
+	halpr_mutex_release();
 	rtapi_print_msg(RTAPI_MSG_ERR, "HAL: ERROR: missing function name\n");
 	return -EINVAL;
     }
     /* make sure we were given a thread name */
     if (thread_name == NULL) {
 	/* no name supplied */
-	rtapi_mutex_give(&(hal_data->mutex));
+	halpr_mutex_release();
 	rtapi_print_msg(RTAPI_MSG_ERR, "HAL: ERROR: missing thread name\n");
 	return -EINVAL;
     }
@@ -2513,14 +2607,14 @@ int hal_add_funct_to_thread(const char *funct_name, const char *thread_name, int
     funct = halpr_find_funct_by_name(funct_name);
     if (funct == NULL) {
 	/* function not found */
-	rtapi_mutex_give(&(hal_data->mutex));
+	halpr_mutex_release();
 	rtapi_print_msg(RTAPI_MSG_ERR,
 	    "HAL: ERROR: function '%s' not found\n", funct_name);
 	return -EINVAL;
     }
     /* found the function, is it available? */
     if ((funct->users > 0) && (funct->reentrant == 0)) {
-	rtapi_mutex_give(&(hal_data->mutex));
+	halpr_mutex_release();
 	rtapi_print_msg(RTAPI_MSG_ERR,
 	    "HAL: ERROR: function '%s' may only be added to one thread\n", funct_name);
 	return -EINVAL;
@@ -2529,7 +2623,7 @@ int hal_add_funct_to_thread(const char *funct_name, const char *thread_name, int
     thread = halpr_find_thread_by_name(thread_name);
     if (thread == NULL) {
 	/* thread not found */
-	rtapi_mutex_give(&(hal_data->mutex));
+	halpr_mutex_release();
 	rtapi_print_msg(RTAPI_MSG_ERR,
 	    "HAL: ERROR: thread '%s' not found\n", thread_name);
 	return -EINVAL;
@@ -2548,7 +2642,7 @@ int hal_add_funct_to_thread(const char *funct_name, const char *thread_name, int
 	    list_entry = list_next(list_entry);
 	    if (list_entry == list_root) {
 		/* reached end of list */
-		rtapi_mutex_give(&(hal_data->mutex));
+		halpr_mutex_release();
 		rtapi_print_msg(RTAPI_MSG_ERR,
 		    "HAL: ERROR: position '%d' is too high\n", position);
 		return -EINVAL;
@@ -2561,7 +2655,7 @@ int hal_add_funct_to_thread(const char *funct_name, const char *thread_name, int
 	    list_entry = list_prev(list_entry);
 	    if (list_entry == list_root) {
 		/* reached end of list */
-		rtapi_mutex_give(&(hal_data->mutex));
+		halpr_mutex_release();
 		rtapi_print_msg(RTAPI_MSG_ERR,
 		    "HAL: ERROR: position '%d' is too low\n", position);
 		return -EINVAL;
@@ -2574,7 +2668,7 @@ int hal_add_funct_to_thread(const char *funct_name, const char *thread_name, int
     funct_entry = alloc_funct_entry_struct();
     if (funct_entry == NULL) {
 	/* alloc failed */
-	rtapi_mutex_give(&(hal_data->mutex));
+	halpr_mutex_release();
 	rtapi_print_msg(RTAPI_MSG_ERR,
 	    "HAL: ERROR: insufficient memory for thread->function link\n");
 	return -ENOMEM;
@@ -2587,7 +2681,7 @@ int hal_add_funct_to_thread(const char *funct_name, const char *thread_name, int
     list_add_after((hal_list_t *) funct_entry, list_entry);
     /* update the function usage count */
     funct->users++;
-    rtapi_mutex_give(&(hal_data->mutex));
+    halpr_mutex_release();
     return 0;
 }
 
@@ -2626,11 +2720,11 @@ int hal_init_funct_to_thread(const char *funct_name, const char *thread_name, in
         "HAL: adding init function '%s' to thread '%s'\n",
         funct_name, thread_name);
 
-    rtapi_mutex_get(&(hal_data->mutex));
+    halpr_mutex_acquire();
 
     funct = halpr_find_funct_by_name(funct_name);
     if (funct == NULL) {
-        rtapi_mutex_give(&(hal_data->mutex));
+        halpr_mutex_release();
         rtapi_print_msg(RTAPI_MSG_ERR,
             "HAL: ERROR: function '%s' not found\n", funct_name);
         return -EINVAL;
@@ -2638,7 +2732,7 @@ int hal_init_funct_to_thread(const char *funct_name, const char *thread_name, in
 
     thread = halpr_find_thread_by_name(thread_name);
     if (thread == NULL) {
-        rtapi_mutex_give(&(hal_data->mutex));
+        halpr_mutex_release();
         rtapi_print_msg(RTAPI_MSG_ERR,
             "HAL: ERROR: thread '%s' not found\n", thread_name);
         return -EINVAL;
@@ -2648,7 +2742,7 @@ int hal_init_funct_to_thread(const char *funct_name, const char *thread_name, in
        no-op so config order doesn't depend on whether start_threads has been
        issued. Surface this with -EALREADY so halcmd can warn loudly. */
     if (thread->init_done) {
-        rtapi_mutex_give(&(hal_data->mutex));
+        halpr_mutex_release();
         rtapi_print_msg(RTAPI_MSG_WARN,
             "HAL: WARNING: thread '%s' init cycle already ran; '%s' will not be invoked\n",
             thread_name, funct_name);
@@ -2664,7 +2758,7 @@ int hal_init_funct_to_thread(const char *funct_name, const char *thread_name, in
         while (++n < position) {
             list_entry = list_next(list_entry);
             if (list_entry == list_root) {
-                rtapi_mutex_give(&(hal_data->mutex));
+                halpr_mutex_release();
                 rtapi_print_msg(RTAPI_MSG_ERR,
                     "HAL: ERROR: position '%d' is too high\n", position);
                 return -EINVAL;
@@ -2674,7 +2768,7 @@ int hal_init_funct_to_thread(const char *funct_name, const char *thread_name, in
         while (--n > position) {
             list_entry = list_prev(list_entry);
             if (list_entry == list_root) {
-                rtapi_mutex_give(&(hal_data->mutex));
+                halpr_mutex_release();
                 rtapi_print_msg(RTAPI_MSG_ERR,
                     "HAL: ERROR: position '%d' is too low\n", position);
                 return -EINVAL;
@@ -2687,7 +2781,7 @@ int hal_init_funct_to_thread(const char *funct_name, const char *thread_name, in
        referenced multiple times in the init list itself (no users-cap check) */
     funct_entry = alloc_funct_entry_struct();
     if (funct_entry == NULL) {
-        rtapi_mutex_give(&(hal_data->mutex));
+        halpr_mutex_release();
         rtapi_print_msg(RTAPI_MSG_ERR,
             "HAL: ERROR: insufficient memory for thread->init function link\n");
         return -ENOMEM;
@@ -2700,7 +2794,7 @@ int hal_init_funct_to_thread(const char *funct_name, const char *thread_name, in
 
     funct->users++;
 
-    rtapi_mutex_give(&(hal_data->mutex));
+    halpr_mutex_release();
     return 0;
 }
 
@@ -2727,18 +2821,18 @@ int hal_del_funct_from_thread(const char *funct_name, const char *thread_name)
 	"HAL: removing function '%s' from thread '%s'\n",
 	funct_name, thread_name);
     /* get mutex before accessing data structures */
-    rtapi_mutex_get(&(hal_data->mutex));
+    halpr_mutex_acquire();
     /* make sure we were given a function name */
     if (funct_name == NULL) {
 	/* no name supplied */
-	rtapi_mutex_give(&(hal_data->mutex));
+	halpr_mutex_release();
 	rtapi_print_msg(RTAPI_MSG_ERR, "HAL: ERROR: missing function name\n");
 	return -EINVAL;
     }
     /* make sure we were given a thread name */
     if (thread_name == NULL) {
 	/* no name supplied */
-	rtapi_mutex_give(&(hal_data->mutex));
+	halpr_mutex_release();
 	rtapi_print_msg(RTAPI_MSG_ERR, "HAL: ERROR: missing thread name\n");
 	return -EINVAL;
     }
@@ -2746,14 +2840,14 @@ int hal_del_funct_from_thread(const char *funct_name, const char *thread_name)
     funct = halpr_find_funct_by_name(funct_name);
     if (funct == NULL) {
 	/* function not found */
-	rtapi_mutex_give(&(hal_data->mutex));
+	halpr_mutex_release();
 	rtapi_print_msg(RTAPI_MSG_ERR,
 	    "HAL: ERROR: function '%s' not found\n", funct_name);
 	return -EINVAL;
     }
     /* found the function, is it in use? */
     if (funct->users == 0) {
-	rtapi_mutex_give(&(hal_data->mutex));
+	halpr_mutex_release();
 	rtapi_print_msg(RTAPI_MSG_ERR,
 	    "HAL: ERROR: function '%s' is not in use\n", funct_name);
 	return -EINVAL;
@@ -2762,7 +2856,7 @@ int hal_del_funct_from_thread(const char *funct_name, const char *thread_name)
     thread = halpr_find_thread_by_name(thread_name);
     if (thread == NULL) {
 	/* thread not found */
-	rtapi_mutex_give(&(hal_data->mutex));
+	halpr_mutex_release();
 	rtapi_print_msg(RTAPI_MSG_ERR,
 	    "HAL: ERROR: thread '%s' not found\n", thread_name);
 	return -EINVAL;
@@ -2773,7 +2867,7 @@ int hal_del_funct_from_thread(const char *funct_name, const char *thread_name)
     while (1) {
 	if (list_entry == list_root) {
 	    /* reached end of list, funct not found */
-	    rtapi_mutex_give(&(hal_data->mutex));
+	    halpr_mutex_release();
 	    rtapi_print_msg(RTAPI_MSG_ERR,
 		"HAL: ERROR: thread '%s' doesn't use %s\n", thread_name,
 		funct_name);
@@ -2786,7 +2880,7 @@ int hal_del_funct_from_thread(const char *funct_name, const char *thread_name)
 	    /* and delete it */
 	    free_funct_entry_struct(funct_entry);
 	    /* done */
-	    rtapi_mutex_give(&(hal_data->mutex));
+	    halpr_mutex_release();
 	    return 0;
 	}
 	/* try next one */
@@ -3298,7 +3392,7 @@ void rtapi_app_exit(void)
     rtapi_print_msg(RTAPI_MSG_DBG, "HAL_LIB: removing kernel lib\n");
     hal_proc_clean();
     /* grab mutex before manipulating list */
-    rtapi_mutex_get(&(hal_data->mutex));
+    halpr_mutex_acquire();
     /* must remove all threads before unloading this module */
     while (hal_data->thread_list_ptr != 0) {
 	/* point to a thread */
@@ -3309,7 +3403,7 @@ void rtapi_app_exit(void)
 	free_thread_struct(thread);
     }
     /* release mutex */
-    rtapi_mutex_give(&(hal_data->mutex));
+    halpr_mutex_release();
     /* release RTAPI resources */
     rtapi_shmem_delete(lib_mem_id, lib_module_id);
     rtapi_exit(lib_module_id);
@@ -3412,18 +3506,18 @@ static int init_hal_data(void)
     don't both try to initialize hal_data at the same time.  NOTE:
     The first time through, the hal_data memory buffer is fresh from
     rtapi_shmem_new(), which means it's initialized to all zero bytes.
-    This means hal_data->mutex is valid and unlocked. */
-    rtapi_mutex_get(&(hal_data->mutex));
+    This means mutex is valid and locked. */
+    halpr_mutex_acquire();
 
     if (hal_data->version != 0) {
         /* hal_data has been initialized already, verify version code */
         if (hal_data->version == HAL_VER) {
-            rtapi_mutex_give(&(hal_data->mutex));
+            halpr_mutex_release();
             return 0;
         } else {
             rtapi_print("HAL: version:%d expected:%d\n",hal_data->version,HAL_VER);
             rtapi_print_msg(RTAPI_MSG_ERR, "HAL: ERROR: version code mismatch\n");
-            rtapi_mutex_give(&(hal_data->mutex));
+            halpr_mutex_release();
             return -1;
         }
     }
@@ -3458,7 +3552,7 @@ static int init_hal_data(void)
     hal_data->shmem_top = HAL_SIZE;
     hal_data->lock = HAL_LOCK_NONE;
     /* done, release mutex */
-    rtapi_mutex_give(&(hal_data->mutex));
+    halpr_mutex_release();
     return 0;
 }
 

--- a/src/hal/hal_lib_extra.c
+++ b/src/hal/hal_lib_extra.c
@@ -1,0 +1,155 @@
+//
+// HAL non-RT support API
+//
+// Copyright 2026  B.Stultiens
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of version 2 of the GNU General
+// Public License as published by the Free Software Foundation.
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+#include "hal.h"
+#include "hal_priv.h"
+
+//
+// Allow user-land to forcefully release the HAL mutex.
+//
+// WARNING: This may crash the rest of the LCNC application(s).
+//
+int hal_mutex_force_release(void)
+{
+    if(!hal_data) {
+        // The HAL shared memory segment was not mapped, do so now
+        int comp_id = rtapi_init("hal_unlocker");
+        if(comp_id < 0) {
+            rtapi_print_msg(RTAPI_MSG_ERR, "error: hal_mutex_force_release: rtapi_init failed\n");
+            return comp_id;
+        }
+        int mem_id = rtapi_shmem_new(HAL_KEY, comp_id, HAL_SIZE);
+        if(mem_id < 0) {
+            rtapi_print_msg(RTAPI_MSG_ERR, "error: hal_mutex_force_release: could not open shared memory\n");
+            rtapi_exit(comp_id);
+            return mem_id;
+        }
+        int rv = rtapi_shmem_getptr(mem_id, (void **)&hal_shmem_base);
+        if (rv < 0) {
+            hal_shmem_base = NULL;
+            rtapi_print_msg(RTAPI_MSG_ERR, "error: hal_mutex_force_release: could not access shared memory\n");
+            rtapi_shmem_delete(mem_id, comp_id);
+            rtapi_exit(comp_id);
+            return rv;
+        }
+        hal_data = (hal_data_t *)hal_shmem_base;
+
+        halpr_mutex_force_release();
+
+        // We're done, cleanup our mapping
+        rtapi_shmem_delete(mem_id, comp_id);
+        rtapi_exit(comp_id);
+        hal_data = NULL;
+        hal_shmem_base = NULL;
+    } else {
+        // We already have a mapped segment, use it
+        halpr_mutex_force_release();
+    }
+    return 0;
+}
+
+//
+// HAL will pretend that the exact base period requested is possible.
+// This mode is not suitable for running real hardware.
+// Returns zero (0) on success or a negative -EACCES error if already set.
+//
+int hal_enforce_exact_base_period(void)
+{
+    if(NULL == hal_data) {
+        rtapi_print_msg(RTAPI_MSG_DBG, "hal_enforce_exact_base_period: HAL shared memory not mapped\n");
+        return -EFAULT;
+    }
+    halpr_mutex_acquire();
+    if(0 != hal_data->exact_base_period) {
+        halpr_mutex_release();
+        return -EACCES;
+    }
+    hal_data->exact_base_period = 1;
+    halpr_mutex_release();
+    return 0;
+}
+
+// Invoke the constructor for a new instance
+int hal_comp_invoke_make(const char *compname, const char *newname, const char *arg)
+{
+    if(NULL == hal_data) {
+        rtapi_print_msg(RTAPI_MSG_DBG, "hal_invoke_make: HAL shared memory not mapped\n");
+        return -EFAULT;
+    }
+    if(!compname || !newname || !arg) {
+        rtapi_print_msg(RTAPI_MSG_DBG, "hal_invoke_make: Invalid arguments\n");
+        return -EINVAL;
+    }
+
+    halpr_mutex_acquire();
+    hal_comp_t *comp = halpr_find_comp_by_name(compname);
+    if(!comp) {
+        halpr_mutex_release();
+        rtapi_print_msg(RTAPI_MSG_DBG, "hal_invoke_make: Component '%s' not found\n", compname);
+        return -ENOENT;
+    }
+
+    if(!comp->make) {
+        halpr_mutex_release();
+        rtapi_print_msg(RTAPI_MSG_DBG, "hal_invoke_make: Component '%s' has no contructor\n", compname);
+        return -ENOEXEC;
+    }
+    halpr_mutex_release();
+    // This is a race, but only if the module gets unloaded before we call its
+    // constructor. Luckily, this is rather unlikely. However, the original in
+    // uspace_rtapi_main.cc:so_newinst_cmd() also had this race. It is unclear
+    // how it can be prevented. Unless we want to hold the mutex while the
+    // module calls hal_init() and creates pins and the like, which is not
+    // necessarily a good idea. But with the recursive mutex, it could be made
+    // working.
+    // The code assumes that the constructor is called from the rtapi_app
+    // context (which houses all uspace RT modules). If not, then the function
+    // pointer will point into the wrong context and a crash is expected.
+    // FIXME: Remove the cast when we fix the prototype.
+    return comp->make((char *)newname, (char *)arg);
+}
+
+//
+// Set the insmod arguments in a named component
+// This call is used when loading is (nearly) done
+//
+int hal_comp_insmod_args(const char *compname, const char *args)
+{
+    if(NULL == hal_data) {
+        rtapi_print_msg(RTAPI_MSG_DBG, "hal_comp_insmod_args: HAL shared memory not mapped\n");
+        return -EFAULT;
+    }
+    if(!compname || !args) {
+        rtapi_print_msg(RTAPI_MSG_DBG, "hal_comp_insmod_args: Invalid arguments\n");
+        return -EINVAL;
+    }
+    if(!SHMCHK(args)) {
+        rtapi_print_msg(RTAPI_MSG_ERR, "hal_comp_insmod_args: 'args' not in HAL memory\n");
+        return -EINVAL;
+    }
+
+    halpr_mutex_acquire();
+    hal_comp_t *comp = halpr_find_comp_by_name(compname);
+    if(!comp) {
+        halpr_mutex_release();
+        rtapi_print_msg(RTAPI_MSG_DBG, "hal_comp_insmod_args: Component '%s' not found\n", compname);
+        return -ENOENT;
+    }
+    comp->insmod_args = SHMOFF(args);
+    halpr_mutex_release();
+    return 0;
+}

--- a/src/hal/hal_priv.h
+++ b/src/hal/hal_priv.h
@@ -118,7 +118,7 @@
 */
 
 #define HAL_KEY   0x48414C32	/* key used to open HAL shared memory */
-#define HAL_VER   0x00000012	/* version code */
+#define HAL_VER   0x00000013	/* version code */
 #define HAL_SIZE  (2*256*4096)
 #define HAL_PSEUDO_COMP_PREFIX "__" /* prefix to identify a pseudo component */
 
@@ -247,8 +247,18 @@ typedef struct hal_thread_t hal_thread_t;
 */
 typedef struct hal_data_t {
     int version;		/* version code for structs, etc */
-    rtapi_mutex_t mutex;	/* protection for linked lists, etc. */
-    hal_s32_t shmem_avail;	/* amount of shmem left free */
+
+    // WARNING: Do not touch these mutex lock fields. Only use the proper
+    // functions halpr_mutex_acquire() and halpr_mutex_release(). See comment
+    // above hal_lib.c:halpr_mutex_acquire() for functional explanation.
+    rtapi_mutex_t priv_rdmutex; // Private mutex for recursive lock
+                                // Important: the mutex uses reverse default
+                                // which means: 0==locked, 1==unlocked
+    int lockcnt;                // Lock counter (using interlocked inc/dec)
+    int locklvl;                // Lock recursion level
+    int locktid;                // Lock owner thread ID
+
+    rtapi_s32 shmem_avail;	/* amount of shmem left free */
     constructor pending_constructor;
 			/* pointer to the pending constructor function */
     char constructor_prefix[HAL_NAME_LEN+1];
@@ -499,6 +509,11 @@ extern hal_pin_t *halpr_find_pin_by_sig(hal_sig_t * sig, hal_pin_t * start);
     used with all other hal_port functions.
 */
 extern int hal_port_alloc(unsigned size, hal_port_t *port);
+
+// Recursive HAL mutex (replaces old mutex)
+int halpr_mutex_acquire(void);
+int halpr_mutex_release(void);
+void halpr_mutex_force_release(void);
 
 RTAPI_END_DECLS
 #endif /* HAL_PRIV_H */

--- a/src/hal/halmodule.cc
+++ b/src/hal/halmodule.cc
@@ -94,10 +94,10 @@ private:
 //
 struct scoped_hal_mutex {
     scoped_hal_mutex() {
-        rtapi_mutex_get(&(hal_data->mutex));
+        halpr_mutex_acquire();
     }
     ~scoped_hal_mutex() {
-        rtapi_mutex_give(&(hal_data->mutex));
+        halpr_mutex_release();
     }
 };
 

--- a/src/hal/utils/halcmd_commands.cc
+++ b/src/hal/utils/halcmd_commands.cc
@@ -163,23 +163,23 @@ int do_linkpp_cmd(char *first_pin_name, char *second_pin_name)
 	halcmd_warning("linkpp command is deprecated, use 'net'\n");
 	dep_msg_printed = 1;
     }
-    rtapi_mutex_get(&(hal_data->mutex));
+    halpr_mutex_acquire();
     /* check if the pins are there */
     first_pin = halpr_find_pin_by_name(first_pin_name);
     second_pin = halpr_find_pin_by_name(second_pin_name);
     if (first_pin == NULL) {
 	/* first pin not found*/
-	rtapi_mutex_give(&(hal_data->mutex));
+	halpr_mutex_release();
 	halcmd_error("pin '%s' not found\n", first_pin_name);
 	return -EINVAL; 
     } else if (second_pin == NULL) {
-	rtapi_mutex_give(&(hal_data->mutex));
+	halpr_mutex_release();
 	halcmd_error("pin '%s' not found\n", second_pin_name);
 	return -EINVAL; 
     }
     
     /* give the mutex, as the other functions use their own mutex */
-    rtapi_mutex_give(&(hal_data->mutex));
+    halpr_mutex_release();
     
     /* check that both pins have the same type, 
        don't want to create a sig, which after that won't be useful */
@@ -499,14 +499,14 @@ int do_net_cmd(char *signal, char *pins[]) {
     hal_sig_t *sig;
     int i, retval;
 
-    rtapi_mutex_get(&(hal_data->mutex));
+    halpr_mutex_acquire();
     /* see if signal already exists */
     sig = halpr_find_sig_by_name(signal);
 
     /* verify that everything matches up (pin types, etc) */
     retval = preflight_net_cmd(signal, sig, pins);
     if(retval < 0) {
-        rtapi_mutex_give(&(hal_data->mutex));
+        halpr_mutex_release();
         return retval;
     }
 
@@ -517,21 +517,21 @@ int do_net_cmd(char *signal, char *pins[]) {
                     "Signal name '%s' must not be the same as a pin.  "
                     "Did you omit the signal name?\n",
 		signal);
-	    rtapi_mutex_give(&(hal_data->mutex));
+	    halpr_mutex_release();
 	    return -ENOENT;
 	}
     }
     if(!sig) {
         /* Create the signal with the type of the first pin */
         hal_pin_t *pin = halpr_find_pin_by_name(pins[0]);
-        rtapi_mutex_give(&(hal_data->mutex));
+        halpr_mutex_release();
         if(!pin) {
             return -ENOENT;
         }
         retval = hal_signal_new(signal, pin->type);
     } else {
 	/* signal already exists */
-        rtapi_mutex_give(&(hal_data->mutex));
+        halpr_mutex_release();
     }
     /* add pins to signal */
     for(i=0; retval == 0 && pins[i] && *pins[i]; i++) {
@@ -583,35 +583,35 @@ int do_newinst_cmd(char *comp_name, char *inst_name) {
         return -EINVAL;
     }
 
-    rtapi_mutex_get(&(hal_data->mutex));
+    halpr_mutex_acquire();
 
     while(hal_data->pending_constructor) {
         struct timespec ts = {0, 100 * 1000 * 1000}; // 100ms
-        rtapi_mutex_give(&(hal_data->mutex));
+        halpr_mutex_release();
         nanosleep(&ts, NULL);
-        rtapi_mutex_get(&(hal_data->mutex));
+        halpr_mutex_acquire();
     }
     rtapi_strlcpy(hal_data->constructor_prefix, inst_name, HAL_NAME_LEN);
     hal_data->constructor_prefix[HAL_NAME_LEN]=0;
     hal_data->pending_constructor = comp->make;
-    rtapi_mutex_give(&(hal_data->mutex));
+    halpr_mutex_release();
 
     if(fputc(' ', f) == EOF) {
         halcmd_error( "cannot write to proc entry: %s\n",
                 strerror(errno));
         fclose(f);
-        rtapi_mutex_get(&(hal_data->mutex));
+        halpr_mutex_acquire();
         hal_data->pending_constructor = 0;
-        rtapi_mutex_give(&(hal_data->mutex));
+        halpr_mutex_release();
         return -EINVAL;
     }
     if(fclose(f) != 0) {
         halcmd_error(
                 "cannot close proc entry: %s\n",
                 strerror(errno));
-        rtapi_mutex_get(&(hal_data->mutex));
+        halpr_mutex_acquire();
         hal_data->pending_constructor = 0;
-        rtapi_mutex_give(&(hal_data->mutex));
+        halpr_mutex_release();
         return -EINVAL;
     }
 
@@ -626,7 +626,7 @@ int do_newinst_cmd(char *comp_name, char *inst_name) {
     hal_comp_t *inst = halpr_alloc_comp_struct();
     if (inst == 0) {
         /* couldn't allocate structure */
-        rtapi_mutex_give(&(hal_data->mutex));
+        halpr_mutex_release();
         halcmd_error(
             "insufficient memory for instance '%s'\n", inst_name);
         return -ENOMEM;
@@ -642,7 +642,7 @@ int do_newinst_cmd(char *comp_name, char *inst_name) {
     inst->next_ptr = hal_data->comp_list_ptr;
     hal_data->comp_list_ptr = SHMOFF(inst);
 
-    rtapi_mutex_give(&(hal_data->mutex));
+    halpr_mutex_release();
     }
     return 0;
 }
@@ -783,25 +783,25 @@ int do_setp_cmd(char *name, char *value)
 
     halcmd_info("setting parameter '%s' to '%s'\n", name, value);
     /* get mutex before accessing shared data */
-    rtapi_mutex_get(&(hal_data->mutex));
+    halpr_mutex_acquire();
     /* search param list for name */
     param = halpr_find_param_by_name(name);
     if (param == NULL) {
         pin = halpr_find_pin_by_name(name);
         if(pin == NULL) {
-            rtapi_mutex_give(&(hal_data->mutex));
+            halpr_mutex_release();
             halcmd_error("parameter or pin '%s' not found\n", name);
             return -EINVAL;
         } else {
             /* found it */
             type = pin->type;
             if(pin->dir == HAL_OUT) {
-                rtapi_mutex_give(&(hal_data->mutex));
+                halpr_mutex_release();
                 halcmd_error("pin '%s' is not writable\n", name);
                 return -EINVAL;
             }
             if(pin->signal != 0) {
-                rtapi_mutex_give(&(hal_data->mutex));
+                halpr_mutex_release();
                 halcmd_error("pin '%s' is connected to a signal\n", name);
                 return -EINVAL;
             }
@@ -813,7 +813,7 @@ int do_setp_cmd(char *name, char *value)
         type = param->type;
         /* is it read only? */
         if (param->dir == HAL_RO) {
-            rtapi_mutex_give(&(hal_data->mutex));
+            halpr_mutex_release();
             halcmd_error("param '%s' is not writable\n", name);
             return -EINVAL;
         }
@@ -822,7 +822,7 @@ int do_setp_cmd(char *name, char *value)
 
     retval = set_common(type, d_ptr, value);
 
-    rtapi_mutex_give(&(hal_data->mutex));
+    halpr_mutex_release();
     if (retval == 0) {
 	/* print success message */
         if(param) {
@@ -851,14 +851,14 @@ int do_ptype_cmd(char *name)
     
     rtapi_print_msg(RTAPI_MSG_DBG, "getting parameter '%s'\n", name);
     /* get mutex before accessing shared data */
-    rtapi_mutex_get(&(hal_data->mutex));
+    halpr_mutex_acquire();
     /* search param list for name */
     param = halpr_find_param_by_name(name);
     if (param) {
         /* found it */
         type = param->type;
         halcmd_output("%s\n", data_type2(type));
-        rtapi_mutex_give(&(hal_data->mutex));
+        halpr_mutex_release();
         return 0;
     }
         
@@ -868,11 +868,11 @@ int do_ptype_cmd(char *name)
         /* found it */
         type = pin->type;
         halcmd_output("%s\n", data_type2(type));
-        rtapi_mutex_give(&(hal_data->mutex));
+        halpr_mutex_release();
         return 0;
     }   
     
-    rtapi_mutex_give(&(hal_data->mutex));
+    halpr_mutex_release();
     halcmd_error("pin or parameter '%s' not found\n", name);
     return -EINVAL;
 }
@@ -888,7 +888,7 @@ int do_getp_cmd(char *name)
     
     rtapi_print_msg(RTAPI_MSG_DBG, "getting parameter '%s'\n", name);
     /* get mutex before accessing shared data */
-    rtapi_mutex_get(&(hal_data->mutex));
+    halpr_mutex_acquire();
     /* search param list for name */
     param = halpr_find_param_by_name(name);
     if (param) {
@@ -896,7 +896,7 @@ int do_getp_cmd(char *name)
         type = param->type;
         d_ptr = SHMPTR(param->data_ptr);
         halcmd_output("%s\n", data_value2((int) type, d_ptr));
-        rtapi_mutex_give(&(hal_data->mutex));
+        halpr_mutex_release();
         return 0;
     }
         
@@ -913,11 +913,11 @@ int do_getp_cmd(char *name)
             d_ptr = &(pin->dummysig);
         }
         halcmd_output("%s\n", data_value2((int) type, d_ptr));
-        rtapi_mutex_give(&(hal_data->mutex));
+        halpr_mutex_release();
         return 0;
     }   
     
-    rtapi_mutex_give(&(hal_data->mutex));
+    halpr_mutex_release();
     halcmd_error("pin or parameter '%s' not found\n", name);
     return -EINVAL;
 }
@@ -931,17 +931,17 @@ int do_sets_cmd(char *name, char *value)
 
     rtapi_print_msg(RTAPI_MSG_DBG, "setting signal '%s'\n", name);
     /* get mutex before accessing shared data */
-    rtapi_mutex_get(&(hal_data->mutex));
+    halpr_mutex_acquire();
     /* search signal list for name */
     sig = halpr_find_sig_by_name(name);
     if (sig == NULL) {
-	rtapi_mutex_give(&(hal_data->mutex));
+	halpr_mutex_release();
 	halcmd_error("signal '%s' not found\n", name);
 	return -EINVAL;
     }
     /* found it - it have a writer? if it is a port we can set its buffer size */
     if ((sig->type != HAL_PORT) && (sig->writers > 0)) {
-	rtapi_mutex_give(&(hal_data->mutex));
+	halpr_mutex_release();
 	halcmd_error("signal '%s' already has writer(s)\n", name);
 	return -EINVAL;
     }
@@ -949,7 +949,7 @@ int do_sets_cmd(char *name, char *value)
     type = sig->type;
     d_ptr = SHMPTR(sig->data_ptr);
     retval = set_common(type, d_ptr, value);
-    rtapi_mutex_give(&(hal_data->mutex));
+    halpr_mutex_release();
     if (retval == 0) {
 	/* print success message */
 	halcmd_info("Signal '%s' set to %s\n", name, value);
@@ -967,18 +967,18 @@ int do_stype_cmd(char *name)
 
     rtapi_print_msg(RTAPI_MSG_DBG, "getting signal '%s'\n", name);
     /* get mutex before accessing shared data */
-    rtapi_mutex_get(&(hal_data->mutex));
+    halpr_mutex_acquire();
     /* search signal list for name */
     sig = halpr_find_sig_by_name(name);
     if (sig == NULL) {
-	rtapi_mutex_give(&(hal_data->mutex));
+	halpr_mutex_release();
 	halcmd_error("signal '%s' not found\n", name);
 	return -EINVAL;
     }
     /* found it */
     type = sig->type;
     halcmd_output("%s\n", data_type2(type));
-    rtapi_mutex_give(&(hal_data->mutex));
+    halpr_mutex_release();
     return 0;
 }
 
@@ -990,11 +990,11 @@ int do_gets_cmd(char *name)
 
     rtapi_print_msg(RTAPI_MSG_DBG, "getting signal '%s'\n", name);
     /* get mutex before accessing shared data */
-    rtapi_mutex_get(&(hal_data->mutex));
+    halpr_mutex_acquire();
     /* search signal list for name */
     sig = halpr_find_sig_by_name(name);
     if (sig == NULL) {
-	rtapi_mutex_give(&(hal_data->mutex));
+	halpr_mutex_release();
 	halcmd_error("signal '%s' not found\n", name);
 	return -EINVAL;
     }
@@ -1002,7 +1002,7 @@ int do_gets_cmd(char *name)
     type = sig->type;
     d_ptr = SHMPTR(sig->data_ptr);
     halcmd_output("%s\n", data_value2((int) type, d_ptr));
-    rtapi_mutex_give(&(hal_data->mutex));
+    halpr_mutex_release();
     return 0;
 }
 
@@ -1242,17 +1242,17 @@ int do_loadrt_cmd(char *mod_name, char *args[])
     /* copy string to shmem */
     strcpy(cp1, arg_string);
     /* get mutex before accessing shared data */
-    rtapi_mutex_get(&(hal_data->mutex));
+    halpr_mutex_acquire();
     /* search component list for the newly loaded component */
     comp = halpr_find_comp_by_name(mod_name);
     if (comp == NULL) {
-	rtapi_mutex_give(&(hal_data->mutex));
+	halpr_mutex_release();
 	halcmd_error("module '%s' not loaded\n", mod_name);
 	return -EINVAL;
     }
     /* link args to comp struct */
     comp->insmod_args = SHMOFF(cp1);
-    rtapi_mutex_give(&(hal_data->mutex));
+    halpr_mutex_release();
     /* print success message */
     halcmd_info("Realtime module '%s' loaded\n", mod_name);
     return 0;
@@ -1276,7 +1276,7 @@ int do_delsig_cmd(char *mod_name)
     } else {
 	/* build a list of signal(s) to delete */
 	n = 0;
-	rtapi_mutex_get(&(hal_data->mutex));
+	halpr_mutex_acquire();
 
 	next = hal_data->sig_list_ptr;
 	while (next != 0) {
@@ -1288,7 +1288,7 @@ int do_delsig_cmd(char *mod_name)
 	    }
 	    next = sig->next_ptr;
 	}
-	rtapi_mutex_give(&(hal_data->mutex));
+	halpr_mutex_release();
 	sigs[n][0] = '\0';
 
 	if ( sigs[0][0] == '\0' ) {
@@ -1334,7 +1334,7 @@ int do_unloadusr_cmd(char *mod_name)
 	all = 0;
     }
     /* build a list of component(s) to unload */
-    rtapi_mutex_get(&(hal_data->mutex));
+    halpr_mutex_acquire();
     next = hal_data->comp_list_ptr;
     while (next != 0) {
 	comp = SHMPTR(next);
@@ -1347,7 +1347,7 @@ int do_unloadusr_cmd(char *mod_name)
 	}
 	next = comp->next_ptr;
     }
-    rtapi_mutex_give(&(hal_data->mutex));
+    halpr_mutex_release();
     return 0;
 }
 
@@ -1371,7 +1371,7 @@ int do_unloadrt_cmd(char *mod_name)
        comps[] in newest-to-oldest order. The unload loop below relies
        on that invariant: do not change one without the other. */
     n = 0;
-    rtapi_mutex_get(&(hal_data->mutex));
+    halpr_mutex_acquire();
     next = hal_data->comp_list_ptr;
     while (next != 0) {
 	comp = SHMPTR(next);
@@ -1387,7 +1387,7 @@ int do_unloadrt_cmd(char *mod_name)
 	}
 	next = comp->next_ptr;
     }
-    rtapi_mutex_give(&(hal_data->mutex));
+    halpr_mutex_release();
     /* mark end of list */
     comps[n][0] = '\0';
     if ( !all && ( comps[0][0] == '\0' )) {
@@ -1465,10 +1465,10 @@ int do_unload_cmd(char *mod_name) {
     } else {
         hal_comp_t *comp;
         component_type_t type = COMPONENT_TYPE_UNKNOWN;
-        rtapi_mutex_get(&(hal_data->mutex));
+        halpr_mutex_acquire();
         comp = halpr_find_comp_by_name(mod_name);
         if(comp) type = comp->type;
-        rtapi_mutex_give(&(hal_data->mutex));
+        halpr_mutex_release();
         if(type == COMPONENT_TYPE_UNKNOWN) {
             halcmd_error("component '%s' is not loaded\n",
                 mod_name);
@@ -1626,12 +1626,12 @@ int do_loadusr_cmd(const char *args[])
 	        }
 	    }
 	    /* check for program becoming ready */
-            rtapi_mutex_get(&(hal_data->mutex));
+            halpr_mutex_acquire();
             comp = halpr_find_comp_by_name(new_comp_name);
             if(comp && comp->ready) {
                 ready = 1;
             }
-            rtapi_mutex_give(&(hal_data->mutex));
+            halpr_mutex_release();
 	    /* pacify the user */
             count++;
             if(count == 200) {
@@ -1699,19 +1699,19 @@ int do_waitusr_cmd(char *comp_name)
 	halcmd_error("component name missing\n");
 	return -EINVAL;
     }
-    rtapi_mutex_get(&(hal_data->mutex));
+    halpr_mutex_acquire();
     comp = halpr_find_comp_by_name(comp_name);
     if (comp == NULL) {
-	rtapi_mutex_give(&(hal_data->mutex));
+	halpr_mutex_release();
 	halcmd_info("component '%s' not found or already exited\n", comp_name);
 	return 0;
     }
     if (comp->type != COMPONENT_TYPE_USER) {
-	rtapi_mutex_give(&(hal_data->mutex));
+	halpr_mutex_release();
 	halcmd_error("'%s' is not a userspace component\n", comp_name);
 	return -EINVAL;
     }
-    rtapi_mutex_give(&(hal_data->mutex));
+    halpr_mutex_release();
     /* let the user know what is going on */
     halcmd_info("Waiting for component '%s'\n", comp_name);
     exited = 0;
@@ -1720,12 +1720,12 @@ int do_waitusr_cmd(char *comp_name)
 	struct timespec ts = {0, 200 * 1000 * 1000};
 	nanosleep(&ts, NULL);
 	/* check for component still around */
-	rtapi_mutex_get(&(hal_data->mutex));
+	halpr_mutex_acquire();
 	comp = halpr_find_comp_by_name(comp_name);
 	if(comp == NULL) {
 		exited = 1;
 	}
-	rtapi_mutex_give(&(hal_data->mutex));
+	halpr_mutex_release();
     }
     halcmd_info("Component '%s' finished\n", comp_name);
     return 0;
@@ -1741,7 +1741,7 @@ static void print_comp_info(char **patterns)
 	halcmd_output("Loaded HAL Components:\n");
 	halcmd_output("ID      Type  %-*s PID   State\n", HAL_NAME_LEN, "Name");
     }
-    rtapi_mutex_get(&(hal_data->mutex));
+    halpr_mutex_acquire();
     next = hal_data->comp_list_ptr;
     while (next != 0) {
 	comp = SHMPTR(next);
@@ -1767,7 +1767,7 @@ static void print_comp_info(char **patterns)
 	}
 	next = comp->next_ptr;
     }
-    rtapi_mutex_give(&(hal_data->mutex));
+    halpr_mutex_release();
     halcmd_output("\n");
 }
 
@@ -1783,7 +1783,7 @@ static void print_pin_info(int type, char **patterns)
 	halcmd_output("Component Pins:\n");
 	halcmd_output("Owner   Type  Dir                 Value  Name\n");
     }
-    rtapi_mutex_get(&(hal_data->mutex));
+    halpr_mutex_acquire();
     next = hal_data->pin_list_ptr;
     while (next != 0) {
 	pin = SHMPTR(next);
@@ -1819,7 +1819,7 @@ static void print_pin_info(int type, char **patterns)
 	}
 	next = pin->next_ptr;
     }
-    rtapi_mutex_give(&(hal_data->mutex));
+    halpr_mutex_release();
     halcmd_output("\n");
 }
 
@@ -1833,7 +1833,7 @@ static void print_pin_aliases(char **patterns)
 	halcmd_output("Pin Aliases:\n");
 	halcmd_output(" %-*s  %s\n", HAL_NAME_LEN, "Alias", "Original Name");
     }
-    rtapi_mutex_get(&(hal_data->mutex));
+    halpr_mutex_acquire();
     next = hal_data->pin_list_ptr;
     while (next != 0) {
 	pin = SHMPTR(next);
@@ -1850,7 +1850,7 @@ static void print_pin_aliases(char **patterns)
 	}
 	next = pin->next_ptr;
     }
-    rtapi_mutex_give(&(hal_data->mutex));
+    halpr_mutex_release();
     halcmd_output("\n");
 }
 
@@ -1867,7 +1867,7 @@ static void print_sig_info(int type, char **patterns)
     }
     halcmd_output("Signals:\n");
     halcmd_output("Type                  Value  Name     (linked to)\n");
-    rtapi_mutex_get(&(hal_data->mutex));
+    halpr_mutex_acquire();
     next = hal_data->sig_list_ptr;
     while (next != 0) {
 	sig = SHMPTR(next);
@@ -1885,7 +1885,7 @@ static void print_sig_info(int type, char **patterns)
 	}
 	next = sig->next_ptr;
     }
-    rtapi_mutex_give(&(hal_data->mutex));
+    halpr_mutex_release();
     halcmd_output("\n");
 }
 
@@ -1899,7 +1899,7 @@ static void print_script_sig_info(int type, char **patterns)
     if (scriptmode == 0) {
     	return;
     }
-    rtapi_mutex_get(&(hal_data->mutex));
+    halpr_mutex_acquire();
     next = hal_data->sig_list_ptr;
     while (next != 0) {
 	sig = SHMPTR(next);
@@ -1918,7 +1918,7 @@ static void print_script_sig_info(int type, char **patterns)
 	}
 	next = sig->next_ptr;
     }
-    rtapi_mutex_give(&(hal_data->mutex));
+    halpr_mutex_release();
     halcmd_output("\n");
 }
 
@@ -1932,7 +1932,7 @@ static void print_param_info(int type, char **patterns)
 	halcmd_output("Parameters:\n");
 	halcmd_output("Owner   Type  Dir                 Value  Name\n");
     }
-    rtapi_mutex_get(&(hal_data->mutex));
+    halpr_mutex_acquire();
     next = hal_data->param_list_ptr;
     while (next != 0) {
 	param = SHMPTR(next);
@@ -1954,7 +1954,7 @@ static void print_param_info(int type, char **patterns)
 	}
 	next = param->next_ptr;
     }
-    rtapi_mutex_give(&(hal_data->mutex));
+    halpr_mutex_release();
     halcmd_output("\n");
 }
 
@@ -1968,7 +1968,7 @@ static void print_param_aliases(char **patterns)
 	halcmd_output("Parameter Aliases:\n");
 	halcmd_output(" %-*s  %s\n", HAL_NAME_LEN, "Alias", "Original Name");
     }
-    rtapi_mutex_get(&(hal_data->mutex));
+    halpr_mutex_acquire();
     next = hal_data->param_list_ptr;
     while (next != 0) {
 	param = SHMPTR(next);
@@ -1985,7 +1985,7 @@ static void print_param_aliases(char **patterns)
 	}
 	next = param->next_ptr;
     }
-    rtapi_mutex_give(&(hal_data->mutex));
+    halpr_mutex_release();
     halcmd_output("\n");
 }
 
@@ -1999,7 +1999,7 @@ static void print_funct_info(char **patterns)
 	halcmd_output("Exported Functions:\n");
 	halcmd_output("Owner   CodeAddr      Arg           FP   Users   Name\n");
     }
-    rtapi_mutex_get(&(hal_data->mutex));
+    halpr_mutex_acquire();
     next = hal_data->funct_list_ptr;
     while (next != 0) {
 	fptr = SHMPTR(next);
@@ -2021,7 +2021,7 @@ static void print_funct_info(char **patterns)
 	}
 	next = fptr->next_ptr;
     }
-    rtapi_mutex_give(&(hal_data->mutex));
+    halpr_mutex_release();
     halcmd_output("\n");
 }
 
@@ -2038,7 +2038,7 @@ static void print_thread_info(char **patterns)
 	halcmd_output("Realtime Threads:\n");
 	halcmd_output("     Period  FP     Name               (     Time, Max-Time )\n");
     }
-    rtapi_mutex_get(&(hal_data->mutex));
+    halpr_mutex_acquire();
     next_thread = hal_data->thread_list_ptr;
     while (next_thread != 0) {
 	tptr = SHMPTR(next_thread);
@@ -2102,7 +2102,7 @@ static void print_thread_info(char **patterns)
 	}
 	next_thread = tptr->next_ptr;
     }
-    rtapi_mutex_give(&(hal_data->mutex));
+    halpr_mutex_release();
     halcmd_output("\n");
 }
 
@@ -2111,7 +2111,7 @@ static void print_comp_names(char **patterns)
     SHMFIELD(hal_comp_t) next;
     hal_comp_t *comp;
 
-    rtapi_mutex_get(&(hal_data->mutex));
+    halpr_mutex_acquire();
     next = hal_data->comp_list_ptr;
     while (next != 0) {
 	comp = SHMPTR(next);
@@ -2120,7 +2120,7 @@ static void print_comp_names(char **patterns)
 	}
 	next = comp->next_ptr;
     }
-    rtapi_mutex_give(&(hal_data->mutex));
+    halpr_mutex_release();
     halcmd_output("\n");
 }
 
@@ -2129,7 +2129,7 @@ static void print_pin_names(char **patterns)
     SHMFIELD(hal_pin_t) next;
     hal_pin_t *pin;
 
-    rtapi_mutex_get(&(hal_data->mutex));
+    halpr_mutex_acquire();
     next = hal_data->pin_list_ptr;
     while (next != 0) {
 	pin = SHMPTR(next);
@@ -2138,7 +2138,7 @@ static void print_pin_names(char **patterns)
 	}
 	next = pin->next_ptr;
     }
-    rtapi_mutex_give(&(hal_data->mutex));
+    halpr_mutex_release();
     halcmd_output("\n");
 }
 
@@ -2147,7 +2147,7 @@ static void print_sig_names(char **patterns)
     SHMFIELD(hal_sig_t) next;
     hal_sig_t *sig;
 
-    rtapi_mutex_get(&(hal_data->mutex));
+    halpr_mutex_acquire();
     next = hal_data->sig_list_ptr;
     while (next != 0) {
 	sig = SHMPTR(next);
@@ -2156,7 +2156,7 @@ static void print_sig_names(char **patterns)
 	}
 	next = sig->next_ptr;
     }
-    rtapi_mutex_give(&(hal_data->mutex));
+    halpr_mutex_release();
     halcmd_output("\n");
 }
 
@@ -2165,7 +2165,7 @@ static void print_param_names(char **patterns)
     SHMFIELD(hal_param_t) next;
     hal_param_t *param;
 
-    rtapi_mutex_get(&(hal_data->mutex));
+    halpr_mutex_acquire();
     next = hal_data->param_list_ptr;
     while (next != 0) {
 	param = SHMPTR(next);
@@ -2174,7 +2174,7 @@ static void print_param_names(char **patterns)
 	}
 	next = param->next_ptr;
     }
-    rtapi_mutex_give(&(hal_data->mutex));
+    halpr_mutex_release();
     halcmd_output("\n");
 }
 
@@ -2183,7 +2183,7 @@ static void print_funct_names(char **patterns)
     SHMFIELD(hal_funct_t) next;
     hal_funct_t *fptr;
 
-    rtapi_mutex_get(&(hal_data->mutex));
+    halpr_mutex_acquire();
     next = hal_data->funct_list_ptr;
     while (next != 0) {
 	fptr = SHMPTR(next);
@@ -2192,7 +2192,7 @@ static void print_funct_names(char **patterns)
 	}
 	next = fptr->next_ptr;
     }
-    rtapi_mutex_give(&(hal_data->mutex));
+    halpr_mutex_release();
     halcmd_output("\n");
 }
 
@@ -2201,7 +2201,7 @@ static void print_thread_names(char **patterns)
     SHMFIELD(hal_thread_t) next_thread;
     hal_thread_t *tptr;
 
-    rtapi_mutex_get(&(hal_data->mutex));
+    halpr_mutex_acquire();
     next_thread = hal_data->thread_list_ptr;
     while (next_thread != 0) {
 	tptr = SHMPTR(next_thread);
@@ -2210,7 +2210,7 @@ static void print_thread_names(char **patterns)
 	}
 	next_thread = tptr->next_ptr;
     }
-    rtapi_mutex_give(&(hal_data->mutex));
+    halpr_mutex_release();
     halcmd_output("\n");
 }
 
@@ -2241,14 +2241,14 @@ int count_list(SHMFIELD(T) list_root)
     int n;
     SHMFIELD(T) next;
 
-    rtapi_mutex_get(&(hal_data->mutex));
+    halpr_mutex_acquire();
     next = list_root;
     n = 0;
     while (next != 0) {
 	n++;
 	next = SHMPTR(next)->next_ptr;
     }
-    rtapi_mutex_give(&(hal_data->mutex));
+    halpr_mutex_release();
     return n;
 }
 
@@ -2273,7 +2273,7 @@ static void print_mem_status()
     recycled = count_list(hal_data->param_free_ptr);
     halcmd_output("  active/recycled parameters: %d/%d\n", active, recycled);
     // count aliases
-    rtapi_mutex_get(&(hal_data->mutex));
+    halpr_mutex_acquire();
     {
     SHMFIELD(hal_pin_t) next = hal_data->pin_list_ptr;
     active = 0;
@@ -2291,7 +2291,7 @@ static void print_mem_status()
 	next = param->next_ptr;
     }
     }
-    rtapi_mutex_give(&(hal_data->mutex));
+    halpr_mutex_release();
     recycled = count_list(hal_data->oldname_free_ptr);
     halcmd_output("  active/recycled aliases:    %d/%d\n", active, recycled);
     // count signals
@@ -2632,7 +2632,7 @@ static void save_comps(FILE *dst)
     hal_comp_t *comp;
 
     fprintf(dst, "# components\n");
-    rtapi_mutex_get(&(hal_data->mutex));
+    halpr_mutex_acquire();
 
     int ncomps = 0;
     next = hal_data->comp_list_ptr;
@@ -2646,7 +2646,7 @@ static void save_comps(FILE *dst)
 
     if(!ncomps) {
         // No components found, bail
-        rtapi_mutex_give(&(hal_data->mutex));
+        halpr_mutex_release();
         return;
 	}
 
@@ -2684,7 +2684,7 @@ static void save_comps(FILE *dst)
 	next = comp->next_ptr;
     }
 #endif
-    rtapi_mutex_give(&(hal_data->mutex));
+    halpr_mutex_release();
 }
 
 static void save_aliases(FILE *dst)
@@ -2694,7 +2694,7 @@ static void save_aliases(FILE *dst)
     hal_oldname_t *oldname;
 
     fprintf(dst, "# pin aliases\n");
-    rtapi_mutex_get(&(hal_data->mutex));
+    halpr_mutex_acquire();
     {
     SHMFIELD(hal_pin_t) next;
     next = hal_data->pin_list_ptr;
@@ -2722,7 +2722,7 @@ static void save_aliases(FILE *dst)
 	next = param->next_ptr;
     }
     }
-    rtapi_mutex_give(&(hal_data->mutex));
+    halpr_mutex_release();
 }
 
 static void save_signals(FILE *dst, int only_unlinked)
@@ -2731,14 +2731,14 @@ static void save_signals(FILE *dst, int only_unlinked)
     hal_sig_t *sig;
 
     fprintf(dst, "# signals\n");
-    rtapi_mutex_get(&(hal_data->mutex));
+    halpr_mutex_acquire();
     
     for( next = hal_data->sig_list_ptr; next; next = sig->next_ptr) {
 	sig = SHMPTR(next);
         if(only_unlinked && (sig->readers || sig->writers)) continue;
 	fprintf(dst, "newsig %s %s\n", sig->name, data_type((int) sig->type));
     }
-    rtapi_mutex_give(&(hal_data->mutex));
+    halpr_mutex_release();
 }
 
 static void save_links(FILE *dst, int arrow)
@@ -2749,7 +2749,7 @@ static void save_links(FILE *dst, int arrow)
     const char *arrow_str;
 
     fprintf(dst, "# links\n");
-    rtapi_mutex_get(&(hal_data->mutex));
+    halpr_mutex_acquire();
     next = hal_data->pin_list_ptr;
     while (next != 0) {
 	pin = SHMPTR(next);
@@ -2764,7 +2764,7 @@ static void save_links(FILE *dst, int arrow)
 	}
 	next = pin->next_ptr;
     }
-    rtapi_mutex_give(&(hal_data->mutex));
+    halpr_mutex_release();
 }
 
 static void save_nets(FILE *dst, int arrow)
@@ -2775,7 +2775,7 @@ static void save_nets(FILE *dst, int arrow)
     const char *arrow_str;
 
     fprintf(dst, "# nets\n");
-    rtapi_mutex_get(&(hal_data->mutex));
+    halpr_mutex_acquire();
     
     for (next = hal_data->sig_list_ptr; next != 0; next = sig->next_ptr) {
 	sig = SHMPTR(next);
@@ -2847,7 +2847,7 @@ static void save_nets(FILE *dst, int arrow)
             }
         }
     }
-    rtapi_mutex_give(&(hal_data->mutex));
+    halpr_mutex_release();
 }
 
 static void save_params(FILE *dst)
@@ -2856,7 +2856,7 @@ static void save_params(FILE *dst)
     hal_param_t *param;
 
     fprintf(dst, "# parameter values\n");
-    rtapi_mutex_get(&(hal_data->mutex));
+    halpr_mutex_acquire();
     next = hal_data->param_list_ptr;
     while (next != 0) {
 	param = SHMPTR(next);
@@ -2867,7 +2867,7 @@ static void save_params(FILE *dst)
 	}
 	next = param->next_ptr;
     }
-    rtapi_mutex_give(&(hal_data->mutex));
+    halpr_mutex_release();
 }
 
 static void save_threads(FILE *dst)
@@ -2879,7 +2879,7 @@ static void save_threads(FILE *dst)
     hal_funct_t *funct;
 
     fprintf(dst, "# realtime thread/function links\n");
-    rtapi_mutex_get(&(hal_data->mutex));
+    halpr_mutex_acquire();
     next_thread = hal_data->thread_list_ptr;
     while (next_thread != 0) {
 	tptr = SHMPTR(next_thread);
@@ -2894,7 +2894,7 @@ static void save_threads(FILE *dst)
 	}
 	next_thread = tptr->next_ptr;
     }
-    rtapi_mutex_give(&(hal_data->mutex));
+    halpr_mutex_release();
 }
 
 static void save_unconnected_input_pin_values(FILE *dst)
@@ -2918,7 +2918,7 @@ static void save_unconnected_input_pin_values(FILE *dst)
 
 int do_setexact_cmd() {
     int retval = 0;
-    rtapi_mutex_get(&(hal_data->mutex));
+    halpr_mutex_acquire();
     if(hal_data->base_period) {
         halcmd_error(
             "HAL_LIB: Cannot run 'setexact'"
@@ -2931,7 +2931,7 @@ int do_setexact_cmd() {
             "This mode is not suitable for running real hardware.\n");
         hal_data->exact_base_period = 1;
     }
-    rtapi_mutex_give(&(hal_data->mutex));
+    halpr_mutex_release();
     return retval;
 }
 

--- a/src/hal/utils/halcmd_completion.c
+++ b/src/hal/utils/halcmd_completion.c
@@ -592,7 +592,7 @@ char **halcmd_completer(const char *text, int start, int end, hal_completer_func
     match_writers = -1;
     match_direction = -1;
 
-    rtapi_mutex_get(&(hal_data->mutex));
+    halpr_mutex_acquire();
 
     if(startswith(buffer, "delsig ") && argno == 1) {
         result = func(text, signal_generator);
@@ -722,18 +722,18 @@ char **halcmd_completer(const char *text, int start, int end, hal_completer_func
     } else if(startswith(buffer, "unload ") && argno == 1) {
         result = func(text, comp_generator);
     } else if(startswith(buffer, "source ") && argno == 1) {
-        rtapi_mutex_give(&(hal_data->mutex));
+        halpr_mutex_release();
         // leaves rl_attempted_completion_over = 0 to complete from filesystem
         return NULL;
     } else if(startswith(buffer, "loadusr ") && argno < 3) {
-        rtapi_mutex_give(&(hal_data->mutex));
+        halpr_mutex_release();
         // leaves rl_attempted_completion_over = 0 to complete from filesystem
         return func(text, loadusr_generator);
     } else if(startswith(buffer, "loadrt ") && argno == 1) {
         result = func(text, loadrt_generator);
     }
 
-    rtapi_mutex_give(&(hal_data->mutex));
+    halpr_mutex_release();
 
     rl_attempted_completion_over = 1;
     return result;

--- a/src/hal/utils/halcmd_main.c
+++ b/src/hal/utils/halcmd_main.c
@@ -340,42 +340,7 @@ int main(int argc, char **argv)
 */
 static int release_HAL_mutex(void)
 {
-    int comp_id, mem_id, retval;
-    void *mem;
-    hal_data_t *hal_data;
-
-    /* do RTAPI init */
-    comp_id = rtapi_init("hal_unlocker");
-    if (comp_id < 0) {
-        rtapi_print_msg(RTAPI_MSG_ERR, "ERROR: rtapi init failed\n");
-        return -EINVAL;
-    }
-    /* get HAL shared memory block from RTAPI */
-    mem_id = rtapi_shmem_new(HAL_KEY, comp_id, HAL_SIZE);
-    if (mem_id < 0) {
-        rtapi_print_msg(RTAPI_MSG_ERR,
-            "ERROR: could not open shared memory\n");
-        rtapi_exit(comp_id);
-        return -EINVAL;
-    }
-    /* get address of shared memory area */
-    retval = rtapi_shmem_getptr(mem_id, &mem);
-    if (retval < 0) {
-        rtapi_print_msg(RTAPI_MSG_ERR,
-            "ERROR: could not access shared memory\n");
-        rtapi_exit(comp_id);
-        return -EINVAL;
-    }
-    /* set up internal pointers to shared mem and data structure */
-    hal_data = (hal_data_t *) mem;
-    /* release mutex  */
-    rtapi_mutex_give(&(hal_data->mutex));
-    /* release RTAPI resources */
-    rtapi_shmem_delete(mem_id, comp_id);
-    rtapi_exit(comp_id);
-    /* done */
-    return 0;
-
+    return hal_mutex_force_release() == 0 ? 0 : -EINVAL;
 }
 
 static char **completion_callback(const char *text, hal_generator_func cb) {

--- a/src/hal/utils/halrmt.c
+++ b/src/hal/utils/halrmt.c
@@ -579,42 +579,7 @@ int hal_systemv(char *const argv[], connectionRecType *context) {
 */
 static int release_HAL_mutex(void)
 {
-    int comp_id, mem_id, retval;
-    void *mem;
-    hal_data_t *hal_data;
-
-    /* do RTAPI init */
-    comp_id = rtapi_init("hal_unlocker");
-    if (comp_id < 0) {
-        rtapi_print_msg(RTAPI_MSG_ERR, "ERROR: rtapi init failed\n");
-        return -EINVAL;
-    }
-    /* get HAL shared memory block from RTAPI */
-    mem_id = rtapi_shmem_new(HAL_KEY, comp_id, HAL_SIZE);
-    if (mem_id < 0) {
-        rtapi_print_msg(RTAPI_MSG_ERR,
-            "ERROR: could not open shared memory\n");
-        rtapi_exit(comp_id);
-        return -EINVAL;
-    }
-    /* get address of shared memory area */
-    retval = rtapi_shmem_getptr(mem_id, &mem);
-    if (retval < 0) {
-        rtapi_print_msg(RTAPI_MSG_ERR,
-            "ERROR: could not access shared memory\n");
-        rtapi_exit(comp_id);
-        return -EINVAL;
-    }
-    /* set up internal pointers to shared mem and data structure */
-    hal_data = (hal_data_t *) mem;
-    /* release mutex  */
-    rtapi_mutex_give(&(hal_data->mutex));
-    /* release RTAPI resources */
-    rtapi_shmem_delete(mem_id, comp_id);
-    rtapi_exit(comp_id);
-    /* done */
-    return 0;
-
+    return hal_mutex_force_release() == 0 ? 0 : -EINVAL;
 }
 
 static int doLock(char *command, connectionRecType *context)
@@ -667,27 +632,27 @@ static int doLinkpp(char *first_pin_name, char *second_pin_name, connectionRecTy
     hal_pin_t *first_pin, *second_pin;
     const char *nakStr = "SET LINKPP NAK";
 
-    rtapi_mutex_get(&(hal_data->mutex));
+    halpr_mutex_acquire();
     /* check if the pins are there */
     first_pin = halpr_find_pin_by_name(first_pin_name);
     second_pin = halpr_find_pin_by_name(second_pin_name);
     if (first_pin == NULL) {
 	/* first pin not found*/
-      rtapi_mutex_give(&(hal_data->mutex));
+      halpr_mutex_release();
       snprintf(errorStr, sizeof(errorStr), "HAL:%d: ERROR: pin '%s' not found\n", linenumber, first_pin_name);
       sockWriteError(nakStr, context);
       return -EINVAL; 
       } 
     else 
       if (second_pin == NULL) {
-	rtapi_mutex_give(&(hal_data->mutex));
+	halpr_mutex_release();
         snprintf(errorStr, sizeof(errorStr), "HAL:%d: ERROR: pin '%s' not found", linenumber, second_pin_name);
         sockWriteError(nakStr, context);
 	return -EINVAL; 
         }
     
     /* give the mutex, as the other functions use their own mutex */
-    rtapi_mutex_give(&(hal_data->mutex));
+    halpr_mutex_release();
     
     /* check that both pins have the same type, 
        don't want to create a sig, which after that won't be useful */
@@ -812,14 +777,14 @@ int doNet(char *signal, char *pins[], connectionRecType *context)
     int i, retval;
     const char *nakStr = "SET NET NAK";
 
-    rtapi_mutex_get(&(hal_data->mutex));
+    halpr_mutex_acquire();
     /* see if signal already exists */
     sig = halpr_find_sig_by_name(signal);
 
     /* verify that everything matches up (pin types, etc) */
     retval = preflightNet(signal, sig, pins, context);
     if(retval < 0) {
-        rtapi_mutex_give(&(hal_data->mutex));
+        halpr_mutex_release();
         return retval;
     }
 
@@ -829,21 +794,21 @@ int doNet(char *signal, char *pins[], connectionRecType *context)
 //	    halcmd_error("Signal name '%s' must not be the same as a pin.\n", signal);
             snprintf(errorStr, sizeof(errorStr), "Signal name '%s' must not be the same as a pin.", signal);
             sockWriteError(nakStr, context);
-	    rtapi_mutex_give(&(hal_data->mutex));
+	    halpr_mutex_release();
 	    return -ENOENT;
 	}
     }
     if(!sig) {
         /* Create the signal with the type of the first pin */
         hal_pin_t *pin = halpr_find_pin_by_name(pins[0]);
-        rtapi_mutex_give(&(hal_data->mutex));
+        halpr_mutex_release();
         if(!pin) {
             return -ENOENT;
         }
         retval = hal_signal_new(signal, pin->type);
     } else {
 	/* signal already exists */
-        rtapi_mutex_give(&(hal_data->mutex));
+        halpr_mutex_release();
     }
     /* add pins to signal */
     for(i=0; retval == 0 && pins[i] && *pins[i]; i++) {
@@ -967,13 +932,13 @@ static int doSetp(char *name, char *value, connectionRecType *context)
     void *d_ptr;
 
     /* get mutex before accessing shared data */
-    rtapi_mutex_get(&(hal_data->mutex));
+    halpr_mutex_acquire();
     /* search param list for name */
     param = halpr_find_param_by_name(name);
     if (param == NULL) {
         pin = halpr_find_pin_by_name(name);
         if(pin == NULL) {
-            rtapi_mutex_give(&(hal_data->mutex));
+            halpr_mutex_release();
             snprintf(errorStr, sizeof(errorStr),
                 "HAL:%d: ERROR: parameter or pin '%s' not found\n", linenumber, name);
             sockWriteError(nakStr, context);
@@ -982,14 +947,14 @@ static int doSetp(char *name, char *value, connectionRecType *context)
             /* found it */
             type = pin->type;
             if(pin->dir == HAL_OUT) {
-                rtapi_mutex_give(&(hal_data->mutex));
+                halpr_mutex_release();
                 snprintf(errorStr, sizeof(errorStr),
                     "HAL:%d: ERROR: pin '%s' is not writable\n", linenumber, name);
                 sockWriteError(nakStr, context);
                 return -EINVAL;
             }
             if(pin->signal != 0) {
-                rtapi_mutex_give(&(hal_data->mutex));
+                halpr_mutex_release();
                 snprintf(errorStr, sizeof(errorStr),
                     "HAL:%d: ERROR: pin '%s' is connected to a signal\n", linenumber, name);
                 sockWriteError(nakStr, context);
@@ -1003,7 +968,7 @@ static int doSetp(char *name, char *value, connectionRecType *context)
         type = param->type;
         /* is it read only? */
         if (param->dir == HAL_RO) {
-            rtapi_mutex_give(&(hal_data->mutex));
+            halpr_mutex_release();
             rtapi_print_msg(RTAPI_MSG_ERR,
                 "HAL:%d: ERROR: param '%s' is not writable\n", linenumber, name);
             return -EINVAL;
@@ -1013,7 +978,7 @@ static int doSetp(char *name, char *value, connectionRecType *context)
 
     retval = set_common(type, d_ptr, value, context);
 
-    rtapi_mutex_give(&(hal_data->mutex));
+    halpr_mutex_release();
     if (retval != 0) {
 	snprintf(errorStr, sizeof(errorStr), "HAL:%d: setp failed\n", linenumber);
         sockWriteError(nakStr, context);
@@ -1030,11 +995,11 @@ static int doSets(char *name, char *value, connectionRecType *context)
     void *d_ptr;
 
     /* get mutex before accessing shared data */
-    rtapi_mutex_get(&(hal_data->mutex));
+    halpr_mutex_acquire();
     /* search signal list for name */
     sig = halpr_find_sig_by_name(name);
     if (sig == NULL) {
-	rtapi_mutex_give(&(hal_data->mutex));
+	halpr_mutex_release();
 	snprintf(errorStr, sizeof(errorStr),
 	    "HAL:%d: ERROR: signal '%s' not found\n", linenumber, name);
         sockWriteError(nakStr, context);
@@ -1042,7 +1007,7 @@ static int doSets(char *name, char *value, connectionRecType *context)
     }
     /* found it - does it have a writer? */
     if (sig->writers > 0) {
-	rtapi_mutex_give(&(hal_data->mutex));
+	halpr_mutex_release();
 	snprintf(errorStr, sizeof(errorStr),
 	    "HAL:%d: ERROR: signal '%s' already has writer(s)\n", linenumber, name);
         sockWriteError(nakStr, context);
@@ -1052,7 +1017,7 @@ static int doSets(char *name, char *value, connectionRecType *context)
     type = sig->type;
     d_ptr = SHMPTR(sig->data_ptr);
     retval = set_common(type, d_ptr, value, context);
-    rtapi_mutex_give(&(hal_data->mutex));
+    halpr_mutex_release();
     if (retval != 0) {
       snprintf(errorStr, sizeof(errorStr), "HAL:%d: sets failed\n", linenumber);
       sockWriteError(nakStr, context);
@@ -1221,18 +1186,18 @@ static int doLoadRt(char *mod_name, char *args[], connectionRecType *context)
     /* copy string to shmem */
     strcpy (cp1, arg_string);
     /* get mutex before accessing shared data */
-    rtapi_mutex_get(&(hal_data->mutex));
+    halpr_mutex_acquire();
     /* search component list for the newly loaded component */
     comp = halpr_find_comp_by_name(mod_name);
     if (comp == NULL) {
-	rtapi_mutex_give(&(hal_data->mutex));
+	halpr_mutex_release();
         snprintf(errorStr, sizeof(errorStr), "module '%s' not loaded", mod_name);
         sockWriteError(nakStr, context);
 	return -EINVAL;
     }
     /* link args to comp struct */
     comp->insmod_args = SHMOFF(cp1);
-    rtapi_mutex_give(&(hal_data->mutex));
+    halpr_mutex_release();
     /* print success message */
 //    halcmd_info("Realtime module '%s' loaded\n", mod_name);
     return 0;
@@ -1253,7 +1218,7 @@ static int doDelsig(char *mod_name, connectionRecType *context)
     else {
       /* build a list of signal(s) to delete */
       n = 0;
-      rtapi_mutex_get(&(hal_data->mutex));
+      halpr_mutex_acquire();
 
       next = hal_data->sig_list_ptr;
       while (next != 0) {
@@ -1265,7 +1230,7 @@ static int doDelsig(char *mod_name, connectionRecType *context)
 	  }
         next = sig->next_ptr;
 	}
-      rtapi_mutex_give(&(hal_data->mutex));
+      halpr_mutex_release();
       sigs[n][0] = '\0';
 
       if (sigs[0][0] == '\0') {
@@ -1306,7 +1271,7 @@ static int doUnload(char *mod_name, connectionRecType *context)
     }
     /* build a list of component(s) to unload */
     n = 0;
-    rtapi_mutex_get(&(hal_data->mutex));
+    halpr_mutex_acquire();
     next = hal_data->comp_list_ptr;
     while (next != 0) {
 	comp = SHMPTR(next);
@@ -1323,7 +1288,7 @@ static int doUnload(char *mod_name, connectionRecType *context)
 	}
 	next = comp->next_ptr;
     }
-    rtapi_mutex_give(&(hal_data->mutex));
+    halpr_mutex_release();
     /* mark end of list */
     comps[n][0] = '\0';
     if ( !all && ( comps[0][0] == '\0' )) {
@@ -1623,7 +1588,7 @@ static int doLoadUsr(char *args[])
             retval = waitpid( pid, &status, WNOHANG );
             if(retval != 0) goto wait_common;
 
-            rtapi_mutex_get(&(hal_data->mutex));
+            halpr_mutex_acquire();
             next = hal_data->comp_list_ptr;
             while(next) {
                 hal_comp_t *comp = SHMPTR(next);
@@ -1633,7 +1598,7 @@ static int doLoadUsr(char *args[])
                     break;
                 }
             }
-            rtapi_mutex_give(&(hal_data->mutex));
+            halpr_mutex_release();
 
             count++;
             if(count == 100) {
@@ -1687,7 +1652,7 @@ static void getCompInfo(char *pattern, connectionRecType *context)
     int next, len;
     hal_comp_t *comp;
 
-    rtapi_mutex_get(&(hal_data->mutex));
+    halpr_mutex_acquire();
     len = strlen(pattern);
     next = hal_data->comp_list_ptr;
     while (next != 0) {
@@ -1698,7 +1663,7 @@ static void getCompInfo(char *pattern, connectionRecType *context)
 	}
       next = comp->next_ptr;
       }
-    rtapi_mutex_give(&(hal_data->mutex));
+    halpr_mutex_release();
 }
 
 
@@ -1710,7 +1675,7 @@ static void getPinInfo(char *pattern, int valuesOnly, connectionRecType *context
     hal_sig_t *sig;
     void *dptr;
 
-    rtapi_mutex_get(&(hal_data->mutex));
+    halpr_mutex_acquire();
     len = strlen(pattern);
     next = hal_data->pin_list_ptr;
     while (next != 0) {
@@ -1740,7 +1705,7 @@ static void getPinInfo(char *pattern, int valuesOnly, connectionRecType *context
 	} 
       next = pin->next_ptr;
     }
-    rtapi_mutex_give(&(hal_data->mutex));
+    halpr_mutex_release();
 }
 
 
@@ -1750,7 +1715,7 @@ static void getSigInfo(char *pattern, int valuesOnly, connectionRecType *context
     hal_sig_t *sig;
     void *dptr;
 
-    rtapi_mutex_get(&(hal_data->mutex));
+    halpr_mutex_acquire();
     len = strlen(pattern);
     next = hal_data->sig_list_ptr;
     while (next != 0) {
@@ -1768,7 +1733,7 @@ static void getSigInfo(char *pattern, int valuesOnly, connectionRecType *context
         }
       next = sig->next_ptr;
       }
-    rtapi_mutex_give(&(hal_data->mutex));
+    halpr_mutex_release();
 }
 
 static void getParamInfo(char *pattern, int valuesOnly, connectionRecType *context)
@@ -1777,7 +1742,7 @@ static void getParamInfo(char *pattern, int valuesOnly, connectionRecType *conte
     hal_param_t *param;
     hal_comp_t *comp;
 
-    rtapi_mutex_get(&(hal_data->mutex));
+    halpr_mutex_acquire();
     len = strlen(pattern);
     next = hal_data->param_list_ptr;
     while (next != 0) {
@@ -1799,7 +1764,7 @@ static void getParamInfo(char *pattern, int valuesOnly, connectionRecType *conte
 	}
       next = param->next_ptr;
       }
-    rtapi_mutex_give(&(hal_data->mutex));
+    halpr_mutex_release();
 }
 
 static void getFunctInfo(char *pattern, connectionRecType *context)
@@ -1808,7 +1773,7 @@ static void getFunctInfo(char *pattern, connectionRecType *context)
     hal_funct_t *fptr;
     hal_comp_t *comp;
 
-    rtapi_mutex_get(&(hal_data->mutex));
+    halpr_mutex_acquire();
     len = strlen(pattern);
     next = hal_data->funct_list_ptr;
     while (next != 0) {
@@ -1826,7 +1791,7 @@ static void getFunctInfo(char *pattern, connectionRecType *context)
 	}
       next = fptr->next_ptr;
     }
-    rtapi_mutex_give(&(hal_data->mutex));
+    halpr_mutex_release();
 }
 
 static void getThreadInfo(char *pattern, connectionRecType *context)
@@ -1837,7 +1802,7 @@ static void getThreadInfo(char *pattern, connectionRecType *context)
     hal_funct_entry_t *fentry;
     hal_funct_t *funct;
 
-    rtapi_mutex_get(&(hal_data->mutex));
+    halpr_mutex_acquire();
     len = strlen(pattern);
     next_thread = hal_data->thread_list_ptr;
     while (next_thread != 0) {
@@ -1896,7 +1861,7 @@ static void getThreadInfo(char *pattern, connectionRecType *context)
 	}
       next_thread = tptr->next_ptr;
       }
-    rtapi_mutex_give(&(hal_data->mutex));
+    halpr_mutex_release();
 }
 
 
@@ -2146,7 +2111,7 @@ static void save_comps(FILE *dst)
     hal_comp_t *comp;
 
     fprintf(dst, "# components\n");
-    rtapi_mutex_get(&(hal_data->mutex));
+    halpr_mutex_acquire();
     next = hal_data->comp_list_ptr;
     while (next != 0) {
 	comp = SHMPTR(next);
@@ -2161,7 +2126,7 @@ static void save_comps(FILE *dst)
 	}
 	next = comp->next_ptr;
     }
-    rtapi_mutex_give(&(hal_data->mutex));
+    halpr_mutex_release();
 }
 
 static void save_signals(FILE *dst)
@@ -2170,14 +2135,14 @@ static void save_signals(FILE *dst)
     hal_sig_t *sig;
 
     fprintf(dst, "# signals\n");
-    rtapi_mutex_get(&(hal_data->mutex));
+    halpr_mutex_acquire();
     next = hal_data->sig_list_ptr;
     while (next != 0) {
 	sig = SHMPTR(next);
 	fprintf(dst, "newsig %s %s\n", sig->name, data_type((int) sig->type));
 	next = sig->next_ptr;
     }
-    rtapi_mutex_give(&(hal_data->mutex));
+    halpr_mutex_release();
 }
 
 static void save_links(FILE *dst, int arrow)
@@ -2188,7 +2153,7 @@ static void save_links(FILE *dst, int arrow)
     const char *arrow_str;
 
     fprintf(dst, "# links\n");
-    rtapi_mutex_get(&(hal_data->mutex));
+    halpr_mutex_acquire();
     next = hal_data->pin_list_ptr;
     while (next != 0) {
 	pin = SHMPTR(next);
@@ -2203,7 +2168,7 @@ static void save_links(FILE *dst, int arrow)
 	}
 	next = pin->next_ptr;
     }
-    rtapi_mutex_give(&(hal_data->mutex));
+    halpr_mutex_release();
 }
 
 static void save_nets(FILE *dst, int arrow)
@@ -2214,7 +2179,7 @@ static void save_nets(FILE *dst, int arrow)
     const char *arrow_str;
 
     fprintf(dst, "# nets\n");
-    rtapi_mutex_get(&(hal_data->mutex));
+    halpr_mutex_acquire();
     next = hal_data->sig_list_ptr;
     while (next != 0) {
 	sig = SHMPTR(next);
@@ -2231,7 +2196,7 @@ static void save_nets(FILE *dst, int arrow)
 	}
 	next = sig->next_ptr;
     }
-    rtapi_mutex_give(&(hal_data->mutex));
+    halpr_mutex_release();
 }
 
 static void save_params(FILE *dst)
@@ -2240,7 +2205,7 @@ static void save_params(FILE *dst)
     hal_param_t *param;
 
     fprintf(dst, "# parameter values\n");
-    rtapi_mutex_get(&(hal_data->mutex));
+    halpr_mutex_acquire();
     next = hal_data->param_list_ptr;
     while (next != 0) {
 	param = SHMPTR(next);
@@ -2251,7 +2216,7 @@ static void save_params(FILE *dst)
 	}
 	next = param->next_ptr;
     }
-    rtapi_mutex_give(&(hal_data->mutex));
+    halpr_mutex_release();
 }
 
 static void save_threads(FILE *dst)
@@ -2263,7 +2228,7 @@ static void save_threads(FILE *dst)
     hal_funct_t *funct;
 
     fprintf(dst, "# realtime thread/function links\n");
-    rtapi_mutex_get(&(hal_data->mutex));
+    halpr_mutex_acquire();
     next_thread = hal_data->thread_list_ptr;
     while (next_thread != 0) {
 	tptr = SHMPTR(next_thread);
@@ -2278,7 +2243,7 @@ static void save_threads(FILE *dst)
 	}
 	next_thread = tptr->next_ptr;
     }
-    rtapi_mutex_give(&(hal_data->mutex));
+    halpr_mutex_release();
 }
 
 static int do_help_cmd(char *command)

--- a/src/hal/utils/meter.c
+++ b/src/hal/utils/meter.c
@@ -417,7 +417,7 @@ void popup_probe_window(GtkWidget * widget, gpointer data)
     clear_list(probe->lists[1]);
     clear_list(probe->lists[2]);
 
-    rtapi_mutex_get(&(hal_data->mutex));
+    halpr_mutex_acquire();
     next = hal_data->pin_list_ptr;
     match_tab = 0;
     match_row = 0;
@@ -468,7 +468,7 @@ void popup_probe_window(GtkWidget * widget, gpointer data)
         row++;
     }
 
-    rtapi_mutex_give(&(hal_data->mutex));
+    halpr_mutex_release();
     gtk_widget_show_all(probe->window);
 
     if (probe->pickname != NULL) {
@@ -507,12 +507,12 @@ static int refresh_value(gpointer data)
 	}
     }
 
-    rtapi_mutex_get(&(hal_data->mutex));
+    halpr_mutex_acquire();
     if (probe->pin != NULL) {
 	if (probe->pin->name[0] == '\0') {
 	    /* pin has been deleted, can't display it any more */
 	    probe->pin = NULL;
-	    rtapi_mutex_give(&(hal_data->mutex));
+	    halpr_mutex_release();
 	    return 1;
 	}
 	name_str = probe->pin->name;
@@ -528,7 +528,7 @@ static int refresh_value(gpointer data)
 	if (probe->sig->name[0] == '\0') {
 	    /* signal has been deleted, can't display it any more */
 	    probe->sig = NULL;
-	    rtapi_mutex_give(&(hal_data->mutex));
+	    halpr_mutex_release();
 	    return 1;
 	}
 	name_str = probe->sig->name;
@@ -538,7 +538,7 @@ static int refresh_value(gpointer data)
 	if (probe->param->name[0] == '\0') {
 	    /* parameter has been deleted, can't display it any more */
 	    probe->param = NULL;
-	    rtapi_mutex_give(&(hal_data->mutex));
+	    halpr_mutex_release();
 	    return 1;
 	}
 	name_str = probe->param->name;
@@ -548,7 +548,7 @@ static int refresh_value(gpointer data)
 	name_str = "-----";
 	value_str = "---";
     }
-    rtapi_mutex_give(&(hal_data->mutex));
+    halpr_mutex_release();
     gtk_label_set_text(GTK_LABEL(meter->value_label), value_str);
     if (!small) {
 	gtk_label_set_text(GTK_LABEL(meter->name_label), name_str);

--- a/src/hal/utils/scope_horiz.c
+++ b/src/hal/utils/scope_horiz.c
@@ -240,7 +240,7 @@ static void init_acquire_function(void)
 	return;
     }
     /* function is in use, find out which thread it is linked to */
-    rtapi_mutex_get(&(hal_data->mutex));
+    halpr_mutex_acquire();
     next_thread = hal_data->thread_list_ptr;
     while (next_thread != 0) {
 	thread = SHMPTR(next_thread);
@@ -253,7 +253,7 @@ static void init_acquire_function(void)
 		horiz->thread_name = thread->name;
 		horiz->thread_period_ns = thread->period;
 		/* done with hal data */
-		rtapi_mutex_give(&(hal_data->mutex));
+		halpr_mutex_release();
 		/* reset watchdog to give RT code some time */
 		ctrl_shm->watchdog = 1;
 		return;
@@ -263,7 +263,7 @@ static void init_acquire_function(void)
 	next_thread = thread->next_ptr;
     }
     /* didn't find a linked thread - should never get here, but... */
-    rtapi_mutex_give(&(hal_data->mutex));
+    halpr_mutex_release();
     return;
 }
 
@@ -590,7 +590,7 @@ static void dialog_realtime_not_linked(void)
             G_CALLBACK(acquire_selection_made), horiz);
 
     /* get mutex before traversing list */
-    rtapi_mutex_get(&(hal_data->mutex));
+    halpr_mutex_acquire();
     n = 0;
     sel_row = -1;
     next = hal_data->thread_list_ptr;
@@ -619,7 +619,7 @@ static void dialog_realtime_not_linked(void)
 	next = thread->next_ptr;
     }
 
-    rtapi_mutex_give(&(hal_data->mutex));
+    halpr_mutex_release();
 
     /* set up the the layout for the multiplier spinbutton */
     hbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 5);

--- a/src/hal/utils/scope_vert.c
+++ b/src/hal/utils/scope_vert.c
@@ -959,7 +959,7 @@ static gboolean dialog_select_source(int chan_num)
             G_CALLBACK(change_page), vert);
 
     /* populate the pin, signal, and parameter lists */
-    rtapi_mutex_get(&(hal_data->mutex));
+    halpr_mutex_acquire();
     next = hal_data->pin_list_ptr;
     match_tab = -1;
     match_row = 0;
@@ -1010,7 +1010,7 @@ static gboolean dialog_select_source(int chan_num)
         row++;
     }
 
-    rtapi_mutex_give(&(hal_data->mutex));
+    halpr_mutex_release();
 
     gtk_widget_show_all(dialog);
 


### PR DESCRIPTION
Change the HAL mutex from a simple mutex to a recursive mutex. This is necessary to support coming changes in the HAL API.

Many changes in the PR are simply to replace the old mutex get/give with a halpr_mutex_acquire/halpr_mutex_release call. This is actually a hal_lib private API, but removing access to hal_priv.h would require a huge change-set. This way it will be done gradually.
The forced mutex release function (used in halcmd) is now part of hal_lib so that the caller no longer needs to access library internals. Anyway, when you need to force-release the mutex, then all bets are off and you should restart anyway.

<strike>The rtapi_app is now cleared of accessing the HAL private API. The newinst code (if anybody is using it) now uses a call into a specially published hal_lib function to call the constructor instead of extracting a halpr_xxx function.</strike>
The has been postponed because it changes a prototype that may give a problem. However, it is unlikely that anyone is using constructable components since this is (already since 2.2) an experimental feature.