### PR TITLE
Gmoccapy: File extension tweaks

### DIFF
--- a/docs/src/gui/gmoccapy.adoc
+++ b/docs/src/gui/gmoccapy.adoc
@@ -1370,7 +1370,13 @@ To avoid that any program is loaded at start up, just press the None button.
 
 The file selection screen will use the filters you have set in the INI file,
 if there aren't any filters given, you will only see *NGC files*.
-The path will be set according to the INI settings in `[DISPLAY] PROGRAM_PREFIX`.
+The path will be set according to the INI settings in `[DISPLAY] PROGRAM_PREFIX`. +
+NGC files can be explicitly excluded from the file selection screen by passing *no_ngc* instead of an extension:
+
+[source,ini]
+----
+PROGRAM_EXTENSION = no_ngc Exclude ngc files from selection screen
+----
 
 .Jump to dir
 

--- a/src/emc/usr_intf/gmoccapy/getiniinfo.py
+++ b/src/emc/usr_intf/gmoccapy/getiniinfo.py
@@ -343,10 +343,13 @@ class GetIniInfo:
                 raw_ext = data.split(",")
                 for extension in raw_ext:
                     ext = extension.split()
-                    ext_list.append(ext[0].replace(".", "*."))
+                    if ext[0] == "no_ngc":
+                        ext_list.remove("*.ngc")
+                    else:
+                        ext_list.append(ext[0].replace(".", "*."))
         else:
-            LOG.warning("Error converting the file extensions from INI file [FILTER]PROGRAM_PREFIX, "
-            "using as default '*.ngc'")
+            LOG.warning("Error converting the file extensions from INI file [FILTER]PROGRAM_EXTENSION, "
+            "Using default '.ngc'")
             ext_list = ["*.ngc"]
         return ext_list
 


### PR DESCRIPTION
Addresses https://github.com/LinuxCNC/linuxcnc/issues/4225

- Fixes wrong INI key descriptor in warning message
- Minor rewording of warning message
- Adds option to exclude *.ngc files from file selection screen
- Updates the Gmoccapy adoc 

<img width="1014" height="188" alt="doc update" src="https://github.com/user-attachments/assets/f05daa00-bfaf-4a57-ae42-0cd531372da9" />

