### PR TITLE
hal: Introduce HAL query API and add/update man-pages

### DIFF
--- a/docs/src/man/man3/hal.3.adoc
+++ b/docs/src/man/man3/hal.3.adoc
@@ -1,3 +1,5 @@
+:manvolnum: 3
+
 = hal(3)
 
 == NAME
@@ -67,12 +69,102 @@ so that realtime components and non-realtime programs can access the data.
 
 == REALTIME CONSIDERATIONS
 
-For an explanation of realtime considerations, see *rtapi(3)*.
+For an explanation of realtime considerations, see rtapi(3).
 
 == HAL STATUS CODES
 
 Except as noted in specific manual pages, HAL returns negative errno
 values for errors, and non-negative values for success.
+
+== EXAMPLE
+
+A simple component with two pins that copies data from one to the other:
+
+[source,c]
+----
+#include <rtapi.h>
+#include <rtapi_app.h>
+#include <hal.h>
+
+static const char cname[] = "mycomp";
+static int comp_id;
+
+// Container structure type for our pins
+typedef struct {
+    hal_real_t pino;
+    hal_sint_t pini;
+    hal_sint_t offs;
+    hal_real_t mult;
+} mycomp_hal_t;
+
+static mycomp_hal_t *pins;
+
+// Macro to make error checking easier
+#define CHKP(x,p) do {  \
+        int _rv = (x);  \
+        if(_rv < 0) {   \
+            rtapi_print_msg(RTAPI_MSG_ERR, "%s: Failed to create '%s.%s', err=%d\n", \
+                            cname, cname, (p), _rv); \
+            return _rv; \
+        }               \
+    } while(0)
+
+static void process(void *arg, long period)
+{
+    (void)arg;    // Unused
+    (void)period; // Unused
+
+    // pino = (pini - offs) * mult
+    // Also converts from signed integer input to floating point output
+    rtapi_sint sint = hal_get_sint(pins->pini) - hal_get_sint(pins->offs);
+    hal_set_real(pins->pino, sint * hal_get_real(pins->mult));
+}
+
+int rtapi_app_main(void)
+{
+    // Get memory for the pins
+    pins = (mycomp_hal_t *)hal_malloc(sizeof(*pins));
+    if(!pins) {
+        rtapi_print_msg(RTAPI_MSG_ERR, "%s: Failed to allocate HAL memory\n", cname);
+        return -ENOMEM;
+    }
+
+    // Initialize HAL for this component
+    if((comp_id = hal_init(cname)) < 0) {
+        rtapi_print_msg(RTAPI_MSG_ERR, "%s: hal_init() failed err=%d\n", cname, comp_id);
+        return comp_id;
+    }
+
+    // Create some pins
+    CHKP(hal_pin_new_real(comp_id, HAL_OUT, &pins->pino, 3.14, "%s.pino", cname), "pino");
+    CHKP(hal_pin_new_sint(comp_id, HAL_IN,  &pins->pini, 3,    "%s.pini", cname), "pini");
+
+    // Create some parameters
+    CHKP(hal_param_new_real(comp_id, HAL_RW, &pins->mult, 0, "%s.scale",  cname), "scale");
+    CHKP(hal_param_new_sint(comp_id, HAL_RW, &pins->offs, 0, "%s.offset", cname), "offset");
+
+    // Export our function
+    int rv = hal_export_functf(process, NULL, 1, 0, comp_id, "%s.process", cname);
+    if(rv < 0) {
+        rtapi_print_msg(RTAPI_MSG_ERR, "%s: Failed export of 'process' err=%d\n", cname, rv);
+        return rv;
+    }
+
+    // Mark us ready
+    if((rv = hal_ready(comp_id)) < 0) {
+        rtapi_print_msg(RTAPI_MSG_ERR, "%s: hal_ready() failed err=%d\n", cname, rv);
+        return rv;
+    }
+
+    return 0;
+}
+
+void rtapi_app_exit(void)
+{
+    if(comp_id > 0)
+        hal_exit(comp_id);
+}
+----
 
 == SEE ALSO
 

--- a/docs/src/man/man3/hal_add_funct_to_thread.3.adoc
+++ b/docs/src/man/man3/hal_add_funct_to_thread.3.adoc
@@ -6,12 +6,14 @@
 
 hal_add_funct_to_thread, hal_del_funct_from_thread - cause a function to be executed at regular intervals
 
-== SYNTAX
+== SYNOPSIS
 
 [source,c]
 ----
-int hal_add_funct_to_thread(const char* funct_name, const char* thread_name, int position)
-int hal_del_funct_from_thread(const char* funct_name, const char* thread_name)
+#include <hal.h>
+
+int hal_add_funct_to_thread(const char* funct_name, const char* thread_name, int position);
+int hal_del_funct_from_thread(const char* funct_name, const char* thread_name);
 ----
 
 == ARGUMENTS
@@ -31,10 +33,10 @@ position::
 
 == DESCRIPTION
 
-The function *hal_add_funct_to_thread* adds another function that is exported by a realtime HAL component to a realtime thread.
+The function *hal_add_funct_to_thread()* adds another function that is exported by a realtime HAL component to a realtime thread.
 This determines how often and in what order functions are executed.
 
-The function *hal_del_funct_from_thread* removes a function from a thread.
+The function *hal_del_funct_from_thread()* removes a function from a thread.
 
 == RETURN VALUE
 

--- a/docs/src/man/man3/hal_comp_by_name.3.adoc
+++ b/docs/src/man/man3/hal_comp_by_name.3.adoc
@@ -1,0 +1,47 @@
+:manvolnum: 3
+
+= hal_comp_by_name(3)
+
+== NAME
+
+hal_comp_by_name, hal_comp_by_id - Retrieve information about a named component
+
+== SYNOPSIS
+
+[source,c]
+----
+#include <hal.h>
+
+int hal_comp_by_name(const char *comp, hal_query_t *query);
+int hal_comp_by_id(int comp_id, hal_query_t *query);
+----
+
+== ARGUMENTS
+
+comp::
+  A HAL component name.
+comp_id::
+  A HAL component identifier.
+query::
+  A query structure that will receive the component's information.
+  May be NULL if no information is required, besides determining whether the component exists.
+
+== DESCRIPTION
+
+The *hal_comp_by_name()* and *hal_comp_by_id()* functions retrieve component information by name or ID.
+
+If no component was found, then *-ENOENT* is returned.
+If the _query_ argument is not NULL, then the query structure will contain all available information about the component.
+
+== RETURN VALUE
+
+Returns zero (0) on success or a negative errno code:
+
+[horizontal]
+-EFAULT:: The shared memory was not mapped.
+-EINVAL:: An invalid argument was passed.
+-ENOENT:: The component does not exist.
+
+== SEE ALSO
+
+hal_query_t(3)

--- a/docs/src/man/man3/hal_create_thread.3.adoc
+++ b/docs/src/man/man3/hal_create_thread.3.adoc
@@ -1,14 +1,20 @@
+:manvolnum: 3
+
 = hal_create_thread(3)
 
 == NAME
 
 hal_create_thread - Create a HAL thread
 
-== SYNTAX
+== SYNOPSIS
 
-int hal_create_thread(const char* _name_, unsigned long _period_, int _uses_fp_)
+[source,c]
+----
+#include <hal.h>
 
-int hal_thread_delete(const char* _name_)
+int hal_create_thread(const char *name, unsigned long period, int uses_fp);
+int hal_thread_delete(const char *name);
+----
 
 == ARGUMENTS
 
@@ -41,6 +47,14 @@ Call only from realtime init code, not from other realtime or non-realtime code.
 == RETURN VALUE
 
 Returns a HAL status code.
+
+[horizontal]
+-EFAULT:: The shared memory was not mapped.
+-EINVAL:: An invalid argument was passed.
+-EPERM:: HAL is config locked.
+-EEXIST:: The thread name already exists (hal_create_thread).
+-ENOMEM:: Failed to allocate memory for thread registration.
+-ENOENT:: The thread does not exist (hal_thread_delete).
 
 == SEE ALSO
 

--- a/docs/src/man/man3/hal_exit.3.adoc
+++ b/docs/src/man/man3/hal_exit.3.adoc
@@ -1,12 +1,19 @@
+:manvolnum: 3
+
 = hal_exit(3)
 
 == NAME
 
 hal_exit - Shut down HAL
 
-== SYNTAX
+== SYNOPSIS
 
-int hal_exit(int _comp_id_)
+[source,c]
+----
+#include <hal.h>
+
+int hal_exit(int comp_id);
+----
 
 == ARGUMENTS
 
@@ -15,8 +22,12 @@ comp_id::
 
 == DESCRIPTION
 
-The function *hal_exit* shuts down and cleans up HAL and RTAPI.
-It must be called prior to exit by any module that called *hal_init*.
+The function *hal_exit()* shuts down and cleans up HAL and RTAPI.
+It must be called prior to exit by any module that called hal_init(3).
+
+Each hal_init(3) call must be matched with a *hal_exit()* call.
+Failing to do so will leak resources in HAL memory and may hamper proper shutdown.
+Usually you'd call *hal_exit()* in rtapi_app_exit(3).
 
 == REALTIME CONSIDERATIONS
 
@@ -24,4 +35,13 @@ Call only from within non-realtime or init/cleanup code, not from realtime tasks
 
 == RETURN VALUE
 
-Returns a HAL status code.
+Returns zero (0) on success or a HAL status code:
+
+[horizontal]
+-EFAULT:: The shared memory was not mapped.
+-ENOENT:: The component does not exist.
+
+== SEE ALSO
+
+hal_init(3),
+rtapi_app_exit(3)

--- a/docs/src/man/man3/hal_export_funct.3.adoc
+++ b/docs/src/man/man3/hal_export_funct.3.adoc
@@ -6,11 +6,17 @@
 
 hal_export_funct, hal_export_functf - create a realtime function callable from a thread
 
-== SYNTAX
+== SYNOPSIS
 
-typedef void(*hal_funct_t)(void* _arg_, long _period_)
+[source,c]
+----
+#include <hal.h>
 
-int hal_export_funct(const char* _name_, hal_funct_t _funct_, void* _arg_, int _uses_fp_, int _reentrant_, int _comp_id_)
+typedef void(*hal_funct_t)(void *arg, long period);
+
+int hal_export_funct(const char *name, hal_funct_t funct, void *arg, int uses_fp, int reentrant, int comp_id);
+int hal_export_functf(hal_funct_t funct, void *arg, int uses_fp, int reentrant, int comp_id, const char *fmt, ...);
+----
 
 == ARGUMENTS
 
@@ -27,18 +33,21 @@ reentrant::
   If reentrant is non-zero, the function may be preempted and called again before the first call completes.
   Otherwise, it may only be added to one thread.
 comp_id::
-  A HAL component identifier returned by an earlier call to *hal_init*.
+  A HAL component identifier returned by an earlier call to hal_init(3).
+fmt, ...::
+  A printf-style format string and arguments
 
 == DESCRIPTION
 
-*hal_export_funct* makes a realtime function provided by a component available to the system.
-A subsequent call to *hal_add_funct_to_thread* can be used to schedule the
+The *hal_export_funct()* function makes a realtime function provided by a component available to the system.
+A subsequent call to hal_add_funct_to_thread(3) can be used to schedule the
 execution of the function as needed by the system.
 
 When this function is placed on a HAL thread, and HAL threads are started,
 _funct_ is called repeatedly with two arguments:
-_void *arg_ is the same value that was given to *hal_export_funct*,
-and _long period_ is the interval between calls in nanoseconds.
+[horizontal]
+_void *arg_:: is the same value that was given to *hal_export_funct()*,
+_long period_:: is the interval between calls in nanoseconds.
 
 Each call to the function should do a small amount of work and return.
 

--- a/docs/src/man/man3/hal_get_p.3.adoc
+++ b/docs/src/man/man3/hal_get_p.3.adoc
@@ -1,0 +1,133 @@
+:manvolnum: 3
+
+= hal_get_p(3)
+
+== NAME
+
+hal_get_p, hal_getref_p - Get HAL pin or param value and information
+
+== SYNOPSIS
+
+[source,c]
+----
+#include <hal.h>
+
+typedef int (*hal_query_cb)(hal_query_t *query, void *arg);
+
+int hal_get_p(hal_query_t *query, hal_query_cb callback, void *arg);
+int hal_getref_p(hal_query_t *query);
+----
+
+== ARGUMENTS
+
+query::
+  The query structure containing the data to search for and returns all data found.
+
+callback::
+  The callback function to invoke when the data has been found or NULL if no callback is required.
+
+arg::
+  A user defined pointer to a user defined data structure.
+  The _arg_ pointer is passed verbatim to the _callback_ function.
+
+== DESCRIPTION
+
+The *hal_get_p()* function will retrieve the value of a pin or param, including its data reference.
+The value of a pin, if connected, is the signal's value.
+The _query_ structure should be set to zero before the call, except for the fields noted here.
+
+The _query.name_ must be set to the name of the pin or parameter you want to get.
+Optionally, you can enforce to look exclusively for a pin or param by setting _query.qtype_ before the call to:
+
+* `0` - look for either pin or param
+* `HAL_QTYPE_PIN` - only look for a pin
+* `HAL_QTYPE_PARAM` - only look for a param
+
+Note that both pins and params share one namespace and cannot overlap.
+
+You can further limit the search by setting _query.pp.type_ to the HAL type you want to find.
+If the pin or param is found, but has a different type, then *-EEXIST* is returned.
+
+The _callback_ is called with all fields set appropriately, including value and data reference.
+You must to demultiplex the _query.pp.value_ according to the _query.pp.type_ field.
+
+The *hal_getref_p()* function will only retrieve the data reference of the pin or param.
+No callback is used and no value is retrieved.
+The reference of a pin, if connected, is the signal's value.
+All query fields, expect _query.pp.value_ are set upon return.
+The *hal_getref_p()* function is preferable if you do not need the actual pin or param value, like testing for existence.
+
+If found, both *hal_get_p()* and *hal_getref_p()* set the _query.name_ field to the actual live pin or param name.
+Also, both functions set _query.qtype_ to the actual query type found.
+
+== RETURN VALUE
+
+Both functions return zero (0) on success.
+The return value of the _callback_ is returned if it got called.
+A negative errno code is returned if any problem is detected:
+
+[horizontal]
+-EFAULT:: The shared memory was not mapped.
+-EINVAL:: An invalid argument was passed.
+-ENOENT:: The pin or param does not exist.
+-EEXIST:: The pin or param exists but is of different type (*hal_get_p()* only).
+-EIO:: The internal data pointer is missing.
+-EBADF:: An invalid type was detected.
+
+== EXAMPLES
+
+[source,c]
+----
+int have_p(const char *ppname)
+{
+    hal_query_t query = {};
+    query.name = ppname;
+
+    int rv = hal_getref_p(&query);
+
+    if(-ENOENT == rv)
+        return 0;  // Does not exist
+
+    if(0 == rv)
+        return 1;  // Does exist
+
+    return rv;     // An error occured
+}
+----
+
+[source,c]
+----
+int print_p_val(const char *ppname)
+{
+    hal_query_t query = {};
+    query.name = ppname;
+
+    int rv = hal_get_p(&query, NULL, NULL);
+
+    if(-ENOENT == rv) {
+        printf("%s: not found\n", ppname);
+    } else if(0 != rv) {
+        return rv;  // Let upstream handle any errors
+    }
+
+    if(HAL_QTYPE_PIN == query.qtype) {
+        printf("%s (%s): ", ppname, query.pp.signal ? query.pp.signal : "no signal");
+    } else {
+        printf("%s (param): ", ppname);
+    }
+
+    switch(query.pp.type) {
+    case HAL_BOOL: printf("%s\n",  query.pp.value.b ? "true" : "false"); break;
+    case HAL_REAL: printf("%f\n",  query.pp.value.r); break;
+    case HAL_SINT: printf("%ld\n", query.pp.value.s); break;
+    case HAL_UINT: printf("%lu\n", query.pp.value.u); break;
+    default: printf("unsupported value type %d\n", (int)query.pp.type); break;
+    }
+
+    return 0;
+}
+----
+
+== SEE ALSO
+
+hal_query_t(3), hal_set_p(3)

--- a/docs/src/man/man3/hal_get_realtime_type.3.adoc
+++ b/docs/src/man/man3/hal_get_realtime_type.3.adoc
@@ -6,16 +6,29 @@
 
 hal_get_realtime_type - Get the type of the running realtime
 
-== SYNTAX
+== SYNOPSIS
 
-hal_realtime_type_t hal_get_realtime_type()
+[source,c]
+----
+#include <hal.h>
+
+hal_realtime_type_t hal_get_realtime_type();
+----
+
+== DESCRIPTION
+
+Retrieve the realtype type of the LinuxCNC instance currently running.
+
+For uspace, this returns *REALTIME_TYPE_UNINITIALIZED* if *rtapi_app* is not running.
+It is safe to assume this never happens in realtime components.
+But userspace components can be loaded without *rtapi_app* being started.
+
+For rtai, this always returns *REALTIME_TYPE_RTAI*.
 
 == RETURN VALUE
 
-*hal_get_realtime_type* returns the type of the running realtime system or a HAL status code on failure.
+Returns the type of the running realtime system. Returns *-EFAULT* if HAL is not initialized.
 
-For uspace, this returns *REALTIME_TYPE_UNINITIALIZED* if *rtapi_app* is not running. It is safe to assume
-this never happens in realtime components. But userspace components can be loaded without *rtapi_app* being
-started.
+== SEE ALSO
 
-For rtai, this always returns *REALTIME_TYPE_RTAI*.
+rtapi(3)

--- a/docs/src/man/man3/hal_get_s.3.adoc
+++ b/docs/src/man/man3/hal_get_s.3.adoc
@@ -1,0 +1,119 @@
+:manvolnum: 3
+
+= hal_get_s(3)
+
+== NAME
+
+hal_get_s, hal_getref_s - Get HAL signal value and information
+
+== SYNOPSIS
+
+[source,c]
+----
+#include <hal.h>
+
+typedef int (*hal_query_cb)(hal_query_t *query, void *arg);
+
+int hal_get_s(hal_query_t *query, hal_query_cb callback, void *arg);
+int hal_getref_s(hal_query_t *query);
+----
+
+== ARGUMENTS
+
+query::
+  The query structure containing the data to search for and returns all data found.
+
+callback::
+  The callback function to invoke when the data has been found or NULL if no callback is required.
+
+arg::
+  A user defined pointer to a user defined data structure.
+  The _arg_ pointer is passed verbatim to the _callback_ function.
+
+== DESCRIPTION
+
+The *hal_get_s()* function will retrieve the value of a signal, including its data reference.
+The _query_ structure should be set to zero before the call, except for the fields noted here.
+
+The _query.name_ must be set to the name of the signal you want to get.
+
+You can further limit the search by setting _query.sig.type_ to the HAL type you want to find.
+If the signal is found, but has a different type, then *-EEXIST* is returned.
+
+The _callback_ is called with all fields set appropriately, including value and data reference.
+You must to demultiplex the _query.sig.value_ according to the _query.sig.type_ field.
+
+The *hal_getref_s()* function will only retrieve the data reference of the signal.
+No callback is used and no value is retrieved.
+All query fields, expect _query.sig.value_ are set upon return.
+The *hal_getref_s()* function is preferable if you do not need the actual signal, like testing for existence.
+
+If found, both *hal_get_s()* and *hal_getref_s()* set the _query.name_ field to the actual live signal name.
+Also, both functions set _query.qtype_ to `HAL_QTYPE_SIGNAL`.
+
+== RETURN VALUE
+
+Both functions return zero (0) on success.
+The return value of the _callback_ is returned if it got called.
+A negative errno code is returned if any problem is detected:
+
+[horizontal]
+-EFAULT:: The shared memory was not mapped.
+-EINVAL:: An invalid argument was passed.
+-ENOENT:: The signal does not exist.
+-EEXIST:: The signal exists but is of different type (*hal_get_s()* only).
+-EIO:: The internal data pointer is missing.
+-EBADF:: An invalid type was detected.
+
+== EXAMPLES
+
+[source,c]
+----
+int have_s(const char *signame)
+{
+    hal_query_t query = {};
+    query.name = signame;
+    int rv = hal_getref_s(&query);
+
+    if(-ENOENT == rv)
+        return 0;  // Does not exist
+
+    if(0 == rv)
+        return 1;  // Does exist
+
+    return rv;     // An error occured
+}
+----
+
+[source,c]
+----
+int print_s_val(const char *signame)
+{
+    hal_query_t query = {};
+    query.name = signame;
+
+    int rv = hal_get_s(&query, NULL, NULL);
+
+    if(-ENOENT == rv) {
+        printf("%s: not found\n", signame);
+    } else if(0 != rv) {
+        return rv;  // Let upstream handle any errors
+    }
+
+    printf("%s (%s): ", signame, query.sig.writers ? "driven" : "not driven");
+
+    switch(query.sig.type) {
+    case HAL_BOOL: printf("%s\n",  query.sig.value.b ? "true" : "false"); break;
+    case HAL_REAL: printf("%f\n",  query.sig.value.r); break;
+    case HAL_SINT: printf("%ld\n", query.sig.value.s); break;
+    case HAL_UINT: printf("%lu\n", query.sig.value.u); break;
+    default: printf("unsupported value type %d\n", (int)query.sig.type); break;
+    }
+
+    return 0;
+}
+----
+
+== SEE ALSO
+
+hal_query_t(3), hal_set_s(3)

--- a/docs/src/man/man3/hal_getter.3.adoc
+++ b/docs/src/man/man3/hal_getter.3.adoc
@@ -1,0 +1,42 @@
+:manvolnum: 3
+
+= hal_getter(3)
+
+== NAME
+
+hal_getter, hal_get_bool, hal_get_real, hal_get_sint, hal_get_uint,
+hal_get_si32, hal_get_ui32, hal_get_si32_clamped, hal_get_ui32_clamped - HAL pin and param data reader
+
+== SYNOPSIS
+
+[source,c]
+----
+#include <hal.h>
+
+rtapi_bool hal_get_bool(hal_bool_t refp);
+rtapi_real hal_get_real(hal_real_t refp);
+rtapi_sint hal_get_sint(hal_sint_t refp);
+rtapi_uint hal_get_uint(hal_uint_t refp);
+
+rtapi_s32 hal_get_si32(hal_sint_t refp);
+rtapi_u32 hal_get_ui32(hal_uint_t refp);
+rtapi_s32 hal_get_si32_clamped(hal_sint_t refp);
+rtapi_u32 hal_get_ui32_clamped(hal_uint_t refp);
+----
+
+== ARGUMENTS
+
+refp::
+  Pin, param or signal data reference.
+
+== DESCRIPTION
+
+The **hal_get_*()** family of functions will get the value of a pin, param or signal from its data reference.
+
+Reading 32-bit values normally truncates the value from the underlying storage.
+The *hal_get_si32_clamped()* and *hal_get_ui32_clamped()* functions will clamp the read value based on type.
+The ranges are `RTAPI_INT32_MIN`...`RTAPI_INT32_MAX` for signed and `0`...`RTAPI_UINT32_MAX` for unsigned values.
+
+== SEE ALSO
+
+hal_setter(3), hal_type_t(3), hal_pin_new(3), hal_param_new(3)

--- a/docs/src/man/man3/hal_init.3.adoc
+++ b/docs/src/man/man3/hal_init.3.adoc
@@ -1,24 +1,32 @@
+:manvolnum: 3
+
 = hal_init(3)
 
 == NAME
 
 hal_init - Sets up HAL and RTAPI
 
-== SYNTAX
+== SYNOPSIS
 
-int hal_init(const char* _modname_)
+[source,c]
+----
+#include <hal.h>
+
+int hal_init(const char *modname);
+----
 
 == ARGUMENTS
 
+[horizontal]
 modname::
   The name of this HAL module.
 
 == DESCRIPTION
 
-*hal_init* sets up HAL and RTAPI. It must be called by any module
-that intends to use the API, before any other RTAPI calls.
+The *hal_init()* function sets up HAL and RTAPI.
+It must be called by any module that intends to use the API, before any other RTAPI calls.
 
-_modname_ must point to a string that identifies the module.
+The _modname_ argument must point to a string that identifies the module.
 The string may be no longer than *HAL_NAME_LEN* characters.
 
 == REALTIME CONSIDERATIONS
@@ -27,6 +35,17 @@ Call only from within non-realtime or init/cleanup code, not from realtime tasks
 
 == RETURN VALUE
 
-On success, returns a positive integer module ID, which is used for
-subsequent calls to HAL and rtapi APIs. On failure, returns a HAL error
-code.
+Returns a positive non-zero integer component ID on success.
+The component ID is used for subsequent calls to HAL and rtapi APIs.
+On failure, returns a negative errno value:
+
+[horizontal]
+-EINVAL:: The name argument was too long.
+-EEXIST:: The component name already exists.
+-EMFILE:: Too many modules (rtapi error).
+-ENOMEM:: Failed to allocate memory for component registration.
+-EPROTO:: HAL data version mismatch.
+
+== SEE ALSO
+
+hal_exit(3)

--- a/docs/src/man/man3/hal_init_funct_to_thread.3.adoc
+++ b/docs/src/man/man3/hal_init_funct_to_thread.3.adoc
@@ -1,0 +1,65 @@
+:manvolnum: 3
+
+= hal_init_funct_to_thread(3)
+
+== NAME
+
+hal_init_funct_to_thread - cause an initialization function to be executed at the start of the thread
+
+== SYNOPSIS
+
+[source,c]
+----
+#include <hal.h>
+
+int hal_init_funct_to_thread(const char *funct_name, const char *thread_name, int position);
+----
+
+== ARGUMENTS
+
+funct_name::
+  The name of the function.
+thread_name::
+  The name of the thread.
+position::
+  The desired location within the thread.
+  This determines the init order of the running the functions in the thread at startup.
+  A positive number indicates the desired location as measured from the beginning of the thread.
+  A negative number indicated the desired location as measured from the end.
+  A value of +1 means this function will become the first one to run, +5 means it will be the fifth one to run.
+  A value of -2 means it will be next to last, and -1 means it will be last.
+  Zero (0) is an illegal position value.
+
+== DESCRIPTION
+
+The *hal_init_funct_to_thread()* function registers _funcname_ to run exactly once in the realtime context of _thread_name_.
+Init functions run before the thread executes any cyclic (addf-registered) function.
+The init list is invoked in a dedicated "special cycle" the first time the thread observes `threads_running == 1`.
+The cyclic function list is skipped during that cycle.
+After the init list returns, the thread's period is re-anchored.
+The next cyclic cycle wakes one full period later.
+This avoids both spurious "unexpected realtime delay" and assures a clean starting boundary for long/slow init functions.
+
+Calls made to *hal_init_funct_to_thread()* after the init cycle has already run fail with -EALREADY.
+
+== RETURN VALUE
+
+Returns zero (0) on success.
+Returns a negative errno code on failure:
+
+[horizontal]
+-EPERM:: HAL is config locked.
+-EINVAL:: An invalid argument was passed.
+-EFAULT:: The shared memory was not mapped.
+-ENOENT:: The function or thread does not exist.
+-EALREADY:: if the thread is already running.
+-ENOMEM:: Failed to allocate memory for function registration.
+
+
+== REALTIME CONSIDERATIONS
+
+Call only from realtime init code, not from other realtime or non-realtime code.
+
+== SEE ALSO
+
+hal_add_funct_to_thread(3), hal_thread_new(3), hal_export_funct(3)

--- a/docs/src/man/man3/hal_list_comp.3.adoc
+++ b/docs/src/man/man3/hal_list_comp.3.adoc
@@ -1,0 +1,89 @@
+:manvolnum: 3
+
+= hal_list_comp(3)
+
+== NAME
+
+hal_list_comp - Iterate HAL components
+
+== SYNOPSIS
+
+[source,c]
+----
+#include <hal.h>
+
+typedef int (*hal_query_cb)(hal_query_t *query, void *arg);
+
+int hal_list_comp(hal_query_t *query, hal_query_cb callback, void *arg);
+----
+
+== ARGUMENTS
+
+query::
+  The query structure that returns all data found.
+
+callback::
+  The callback function to invoke for each signal found.
+
+arg::
+  A user defined pointer to a user defined data structure.
+  The _arg_ pointer is passed verbatim to the _callback_ function.
+
+== DESCRIPTION
+
+The *hal_list_comp()* function will iterate all registered components and call the _callback_ for each.
+The _query_ structure should be set to zero before the call.
+
+The _callback_ is called with all fields set appropriately.
+The _query.qtype_ is set to `HAL_QTYPE_COMP`.
+
+The iteration continues until no more components are available or the _callback_ returns non-zero.
+You can return a positive value from the _callback_ to signal termination of iteration without triggering an error.
+The return value from the _callback_ is returned from the *hal_list_comp()* function as is.
+
+== RETURN VALUE
+
+Returns zero (0) on success.
+The return value of the _callback_ is returned if it was non-zero.
+A negative errno code is returned if any problem is detected:
+
+[horizontal]
+-EFAULT:: The shared memory was not mapped.
+-EINVAL:: An invalid argument was passed.
+
+== EXAMPLES
+
+[source,c]
+----
+static int print_comps_cb(hal_query_t *query, void *arg)
+{
+    const char *pattern = (const char *)arg;
+
+    if(!fnmatch(pattern, query->name, FNM_NOESCAPE|FNM_CASEFOLD)) {
+        printf("%s(%d) %s %d %s (%s)\n",
+            query->name,
+            query->comp.comp_id,
+            query->comp.type == HAL_COMP_TYPE_REALTIME ? "RT" : "User",
+            query->comp.pid,
+            query->comp.ready ? "ready" : "notready",
+            query->comp.insmod ? query->comp.insmod : "");
+    }
+    return 0; // Keep on going
+}
+
+// Print components that match a pattern
+int print_comps(const char *pattern)
+{
+    hal_query_t query = {};
+
+    int rv = hal_list_comp(&query, print_comps_cb, (void *)pattern);
+
+    if(0 != rv)
+        printf("Iteration failure: %s", hal_strerror(rv));
+    return rv;
+}
+----
+
+== SEE ALSO
+
+hal_query_t(3)

--- a/docs/src/man/man3/hal_list_funct.3.adoc
+++ b/docs/src/man/man3/hal_list_funct.3.adoc
@@ -1,0 +1,88 @@
+:manvolnum: 3
+
+= hal_list_funct(3)
+
+== NAME
+
+hal_list_funct - Iterate HAL functions
+
+== SYNOPSIS
+
+[source,c]
+----
+#include <hal.h>
+
+typedef int (*hal_query_cb)(hal_query_t *query, void *arg);
+
+int hal_list_funct(hal_query_t *query, hal_query_cb callback, void *arg);
+----
+
+== ARGUMENTS
+
+query::
+  The query structure that returns all data found.
+
+callback::
+  The callback function to invoke for each signal found.
+
+arg::
+  A user defined pointer to a user defined data structure.
+  The _arg_ pointer is passed verbatim to the _callback_ function.
+
+== DESCRIPTION
+
+The *hal_list_funct()* function will iterate all registered components and call the _callback_ for each.
+The _query_ structure should be set to zero before the call.
+
+The _callback_ is called with all fields set appropriately.
+The _query.qtype_ is set to `HAL_QTYPE_FUNCT`.
+
+The iteration continues until no more components are available or the _callback_ returns non-zero.
+You can return a positive value from the _callback_ to signal termination of iteration without triggering an error.
+The return value from the _callback_ is returned from the *hal_list_comp()* function as is.
+
+== RETURN VALUE
+
+Returns zero (0) on success.
+The return value of the _callback_ is returned if it was non-zero.
+A negative errno code is returned if any problem is detected:
+
+[horizontal]
+-EFAULT:: The shared memory was not mapped.
+-EINVAL:: An invalid argument was passed.
+
+== EXAMPLES
+
+[source,c]
+----
+static int print_functs_cb(hal_query_t *query, void *arg)
+{
+    const char *pattern = (const char *)arg;
+
+    if(!fnmatch(pattern, query->name, FNM_NOESCAPE|FNM_CASEFOLD)) {
+        printf("%s %s(%d) %d %s\n",
+            query->name,
+            query->funct.comp,
+            query->funct.comp_id,
+            query->funct.users,
+            query->funct.reentrant ? "reentrant" : "non-reentrant");
+    }
+    return 0; // Keep on going
+}
+
+// Print functions that match a pattern
+int print_functs(const char *pattern)
+{
+    hal_query_t query = {};
+
+    int rv = hal_list_funct(&query, print_functs_cb, (void *)pattern);
+
+    if(0 != rv)
+        printf("Iteration failure: %s", hal_strerror(rv));
+    return rv;
+}
+----
+
+== SEE ALSO
+
+hal_query_t(3)

--- a/docs/src/man/man3/hal_list_p.3.adoc
+++ b/docs/src/man/man3/hal_list_p.3.adoc
@@ -1,0 +1,104 @@
+:manvolnum: 3
+
+= hal_list_p(3)
+
+== NAME
+
+hal_list_p - Iterate HAL pins and params
+
+== SYNOPSIS
+
+[source,c]
+----
+#include <hal.h>
+
+typedef int (*hal_query_cb)(hal_query_t *query, void *arg);
+
+int hal_list_p(hal_query_t *query, hal_query_cb callback, void *arg);
+----
+
+== ARGUMENTS
+
+query::
+  The query structure containing the data to search for and returns all data found.
+
+callback::
+  The callback function to invoke for each signal found.
+
+arg::
+  A user defined pointer to a user defined data structure.
+  The _arg_ pointer is passed verbatim to the _callback_ function.
+
+== DESCRIPTION
+
+The *hal_list_p()* function will iterate all registered pins and param and call the _callback_ for each.
+The _query_ structure should be set to zero before the call, except for the fields noted here.
+
+You can enforce to look exclusively for a pin or param by setting _query.qtype_ before the call to:
+
+* `0` - look for either pin or param
+* `HAL_QTYPE_PIN` - only look for a pin
+* `HAL_QTYPE_PARAM` - only look for a param
+
+Note that both pins and params share one namespace and cannot overlap.
+
+The _callback_ is called with all fields set appropriately, including value and data reference.
+The _query.qtype_ is set to `HAL_QTYPE_PIN` or `HAL_QTYPE_PARAM` according to the item found.
+You must demultiplex the _query.pp.value_ and _query.pp.ref_ according to the _query.pp.type_ field in the callback function.
+
+The iteration continues until no more pins or params are available or the _callback_ returns non-zero.
+You can return a positive value from the _callback_ to signal termination of iteration without triggering an error.
+The return value from the _callback_ is returned from the *hal_list_p()* function as is.
+
+== RETURN VALUE
+
+Returns zero (0) on success.
+The return value of the _callback_ is returned if it was non-zero.
+A negative errno code is returned if any problem is detected:
+
+[horizontal]
+-EFAULT:: The shared memory was not mapped.
+-EINVAL:: An invalid argument was passed.
+-EBADF:: An invalid type was detected.
+
+== EXAMPLES
+
+[source,c]
+----
+static int print_pins_cb(hal_query_t *query, void *arg)
+{
+    const char *pattern = (const char *)arg;
+
+    if(!fnmatch(pattern, query->name, FNM_NOESCAPE|FNM_CASEFOLD)) {
+        printf("%s: ", query->name);
+        switch(query->pp.type) {
+        case HAL_BOOL: printf("%s\n",  query->pp.value.b ? "true" : "false"); break;
+        case HAL_REAL: printf("%f\n",  query->pp.value.r); break;
+        case HAL_SINT: printf("%ld\n", query->pp.value.s); break;
+        case HAL_PORT:
+        case HAL_UINT: printf("%lu\n", query->pp.value.u); break;
+        default: printf("unsupported value type %d\n", (int)query->pp.type); break;
+        }
+    }
+    return 0; // Keep on going
+}
+
+// Print only pins that match a pattern
+int print_pins(const char *pattern)
+{
+    hal_query_t query = {};
+    query.qtype = HAL_QTYPE_PIN;
+
+    int rv = hal_list_p(&query, print_pins_cb, (void *)pattern);
+
+    if(0 != rv)
+        printf("Iteration failure: %s", hal_strerror(rv));
+    return rv;
+}
+----
+
+== SEE ALSO
+
+hal_query_t(3),
+hal_list_s(3), hal_list_p_s(3),
+hal_get_p(3)

--- a/docs/src/man/man3/hal_list_p_s.3.adoc
+++ b/docs/src/man/man3/hal_list_p_s.3.adoc
@@ -1,0 +1,104 @@
+:manvolnum: 3
+
+= hal_list_p_s(3)
+
+== NAME
+
+hal_list_p_s - Iterate HAL pins connected to a specific signal
+
+== SYNOPSIS
+
+[source,c]
+----
+#include <hal.h>
+
+typedef int (*hal_query_cb)(hal_query_t *query, void *arg);
+
+int hal_list_p_s(hal_query_t *query, hal_query_cb callback, void *arg);
+----
+
+== ARGUMENTS
+
+query::
+  The query structure containing the data to search for and returns all data found.
+
+callback::
+  The callback function to invoke for each signal found.
+
+arg::
+  A user defined pointer to a user defined data structure.
+  The _arg_ pointer is passed verbatim to the _callback_ function.
+
+== DESCRIPTION
+
+The *hal_list_p_s()* function will iterate all pins connected to a specific signal and call the _callback_ for each.
+The _query_ structure should be set to zero before the call, except the _query.name_ field.
+The _query.name_ must be set to the signal to search for.
+
+The _callback_ is called with all fields set appropriately, including value and data reference.
+The _query.qtype_ is set to `HAL_QTYPE_PIN` for each pin found.
+You must demultiplex the _query.pp.value_ and _query.pp.ref_ according to the _query.pp.type_ field in the callback function.
+However, the pin type is always the same as the signal type or they could not be connected.
+If you know the signal type, then you could use that for the pins too.
+
+The iteration continues until no more connected pins are found or the _callback_ returns non-zero.
+You can return a positive value from the _callback_ to signal termination of iteration without triggering an error.
+The return value from the _callback_ is returned from the *hal_list_p_s()* function as is.
+
+== RETURN VALUE
+
+Returns zero (0) on success.
+The return value of the _callback_ is returned if it was non-zero.
+A negative errno code is returned if any problem is detected:
+
+[horizontal]
+-EFAULT:: The shared memory was not mapped.
+-EINVAL:: An invalid argument was passed.
+-ENOENT:: The signal is not found.
+-EBADF:: An invalid type was detected.
+
+== EXAMPLES
+
+[source,c]
+----
+static int print_sigpins_cb(hal_query_t *query, void *arg)
+{
+    (void)arg; // Not used in this example
+
+    printf("%s: %s: ", query->pp.signal, query->name);
+    if(HAL_OUT == query->pp.dir)
+        printf("out: ");
+    else if(HAL_IN == query->pp.dir)
+        printf("in : ");
+    else
+        printf("io : ");
+    switch(query->pp.type) {
+    case HAL_BOOL: printf("%s\n",  query->pp.value.b ? "true" : "false"); break;
+    case HAL_REAL: printf("%f\n",  query->pp.value.r); break;
+    case HAL_SINT: printf("%ld\n", query->pp.value.s); break;
+    case HAL_PORT:
+    case HAL_UINT: printf("%lu\n", query->pp.value.u); break;
+    default: printf("unsupported value type %d\n", (int)query->pp.type); break;
+    }
+    return 0; // Keep on going
+}
+
+// Print only pins that match a pattern
+int print_sigpins(const char *signame)
+{
+    hal_query_t query = {};
+    query.name = signame;
+
+    int rv = hal_list_p_s(&query, print_sigpins_cb, NULL);
+
+    if(0 != rv)
+        printf("Iteration failure: %s", hal_strerror(rv));
+    return rv;
+}
+----
+
+== SEE ALSO
+
+hal_query_t(3),
+hal_list_p(3), hal_list_s(3),
+hal_get_p(3), hal_get_s(3)

--- a/docs/src/man/man3/hal_list_s.3.adoc
+++ b/docs/src/man/man3/hal_list_s.3.adoc
@@ -1,0 +1,95 @@
+:manvolnum: 3
+
+= hal_list_s(3)
+
+== NAME
+
+hal_list_s - Iterate HAL signals
+
+== SYNOPSIS
+
+[source,c]
+----
+#include <hal.h>
+
+typedef int (*hal_query_cb)(hal_query_t *query, void *arg);
+
+int hal_list_s(hal_query_t *query, hal_query_cb callback, void *arg);
+----
+
+== ARGUMENTS
+
+query::
+  The query structure that returns all data found.
+
+callback::
+  The callback function to invoke for each signal found.
+
+arg::
+  A user defined pointer to a user defined data structure.
+  The _arg_ pointer is passed verbatim to the _callback_ function.
+
+== DESCRIPTION
+
+The *hal_list_s()* function will iterate all registered signals and call the _callback_ for each.
+The _query_ structure should be set to zero before the call.
+
+The _callback_ is called with all fields set appropriately, including value and data reference.
+The _query.qtype_ is set to `HAL_QTYPE_SIGNAL`.
+You must demultiplex the _query.sig.value_ and _query.sig.ref_ according to the _query.sig.type_ field in the callback function.
+
+The iteration continues until no more signals are available or the _callback_ returns non-zero.
+You can return a positive value from the _callback_ to signal termination of iteration without triggering an error.
+The return value from the _callback_ is returned from the *hal_list_s()* function as is.
+
+== RETURN VALUE
+
+Returns zero (0) on success.
+The return value of the _callback_ is returned if it was non-zero.
+A negative errno code is returned if any problem is detected:
+
+[horizontal]
+-EFAULT:: The shared memory was not mapped.
+-EINVAL:: An invalid argument was passed.
+-EBADF:: An invalid type was detected.
+
+== EXAMPLES
+
+[source,c]
+----
+static int print_sigs_cb(hal_query_t *query, void *arg)
+{
+    const char *pattern = (const char *)arg;
+
+    if(!fnmatch(pattern, query->name, FNM_NOESCAPE|FNM_CASEFOLD)) {
+        printf("%s (%s): ", query->name, query->sig.writers ? "driven" : "not driven");
+        switch(query->sig.type) {
+        case HAL_BOOL: printf("%s\n",  query->sig.value.b ? "true" : "false"); break;
+        case HAL_REAL: printf("%f\n",  query->sig.value.r); break;
+        case HAL_SINT: printf("%ld\n", query->sig.value.s); break;
+        case HAL_UINT: printf("%lu\n", query->sig.value.u); break;
+        /* case HAL_PORT: could also happen, but that is left to the reader */
+        default: printf("unsupported value type %d\n", (int)query->sig.type); break;
+        }
+    }
+    return 0; // Keep on going
+}
+
+// Print signals that match a pattern
+int print_sigs(const char *pattern)
+{
+    hal_query_t query = {};
+
+    int rv = hal_list_s(&query, print_sigs_cb, (void *)pattern);
+
+    if(0 != rv)
+        printf("Iteration failure: %s", hal_strerror(rv));
+    return rv;
+}
+----
+
+== SEE ALSO
+
+hal_query_t(3),
+hal_list_p(3), hal_list_p_s(3),
+hal_get_s(3)

--- a/docs/src/man/man3/hal_list_thread.3.adoc
+++ b/docs/src/man/man3/hal_list_thread.3.adoc
@@ -1,0 +1,129 @@
+:manvolnum: 3
+
+= hal_list_thread(3)
+
+== NAME
+
+hal_list_thread - Iterate HAL threads and their functions
+
+== SYNOPSIS
+
+[source,c]
+----
+#include <hal.h>
+
+typedef int (*hal_query_cb)(hal_query_t *query, void *arg);
+
+int hal_list_thread(hal_query_t *query, hal_query_cb callback, void *arg);
+----
+
+== ARGUMENTS
+
+query::
+  The query structure that returns all data found.
+
+callback::
+  The callback function to invoke for each signal found.
+
+arg::
+  A user defined pointer to a user defined data structure.
+  The _arg_ pointer is passed verbatim to the _callback_ function.
+
+== DESCRIPTION
+
+The *hal_list_thread()* function will iterate all registered components and call the _callback_ for each.
+The _query_ structure should be set to zero before the call, except for the _query.qtype_ field.
+
+The _query_qtype_ field can be set to:
+
+* `0` or `HAL_QTYPE_THREAD` - to iterate only threads
+* `HAL_QTYPE_THREAD_FUNCT` - to iterate threads and the functions of each thread
+
+The _callback_ is called with all fields set appropriately.
+The _query.qtype_ is set to `HAL_QTYPE_THREAD` when the callback is regarding a thread's information.
+The _query.qtype_ is set to `HAL_QTYPE_THREAD_FUNCT` when the callback is regarding a thread's function information.
+For functions, fields _query.thread.functidx_, _query.thread.funct_ and _query.thread.is_init_ are set.
+
+Iteration using `HAL_QTYPE_THREAD_FUNCT` will first invoke the _callback_ with _query.qtype_ set to `HAL_QTYPE_THREAD` to indicate the start of a new thread.
+Then, if the thread contains functions, subsequent invocations will have _query.qtype_ set to `HAL_QTYPE_THREAD_FUNCT` until no more functions are in that thread.
+
+The iteration continues until no more components are available or the _callback_ returns non-zero.
+You can return a positive value from the _callback_ to signal termination of iteration without triggering an error.
+The return value from the _callback_ is returned from the *hal_list_comp()* function as is.
+
+== RETURN VALUE
+
+Returns zero (0) on success.
+The return value of the _callback_ is returned if it was non-zero.
+A negative errno code is returned if any problem is detected:
+
+[horizontal]
+-EFAULT:: The shared memory was not mapped.
+-EINVAL:: An invalid argument was passed.
+
+== EXAMPLES
+
+[source,c]
+----
+static int print_threadfuncts_cb(hal_query_t *query, void *arg)
+{
+    const char *pattern = (const char *)arg;
+
+    if(!fnmatch(pattern, query->name, FNM_NOESCAPE|FNM_CASEFOLD)) {
+        if(HAL_QTYPE_THREAD == query->qtype) {
+            // Thread callback
+            printf("%s %s(%d) %ld\n", query->name,
+                query->thread.comp, query->thread.comp_id, query->thread.period);
+        } else {
+            // Thread function callback
+            printf("--> %d %s%s\n", query->thread.functidx,
+                query->thread.funct, query->thread.is_init ? " (init)" : "");
+        }
+    }
+    return 0; // Keep on going
+}
+
+// Print threads and functions that match a pattern
+int print_threadfuncts(const char *pattern)
+{
+    hal_query_t query = {};
+    query.qtype = HAL_QTYPE_THREAD_FUNCT;
+
+    int rv = hal_list_thread(&query, print_threadfuncts_cb, (void *)pattern);
+
+    if(0 != rv)
+        printf("Iteration failure: %s", hal_strerror(rv));
+    return rv;
+}
+----
+
+[source,c]
+----
+static int print_threads_cb(hal_query_t *query, void *arg)
+{
+    const char *pattern = (const char *)arg;
+
+    if(!fnmatch(pattern, query->name, FNM_NOESCAPE|FNM_CASEFOLD)) {
+        printf("%s %s(%d) %ld\n", query->name,
+            query->thread.comp, query->thread.comp_id, query->thread.period);
+    }
+    return 0; // Keep on going
+}
+
+// Print threads that match a pattern
+int print_threads(const char *pattern)
+{
+    hal_query_t query = {};
+    query.qtype = HAL_QTYPE_THREAD;
+
+    int rv = hal_list_thread(&query, print_threads_cb, (void *)pattern);
+
+    if(0 != rv)
+        printf("Iteration failure: %s", hal_strerror(rv));
+    return rv;
+}
+----
+
+== SEE ALSO
+
+hal_query_t(3)

--- a/docs/src/man/man3/hal_malloc.3.adoc
+++ b/docs/src/man/man3/hal_malloc.3.adoc
@@ -1,12 +1,19 @@
+:manvolnum: 3
+
 = hal_malloc(3)
 
 == NAME
 
 hal_malloc - Allocate space in the HAL shared memory area
 
-== SYNTAX
+== SYNOPSIS
 
-void *hal_malloc(long int _size_)
+[source,c]
+----
+#include <hal.h>
+
+void *hal_malloc(long int size);
+----
 
 == ARGUMENTS
 
@@ -15,19 +22,18 @@ size::
 
 == DESCRIPTION
 
-*hal_malloc* allocates a block of memory from the main HAL shared memory
-area. It should be used by all components to allocate memory for HAL
-pins and parameters. It allocates `size' bytes, and returns a pointer to
-the allocated space, or NULL (0) on error. The returned pointer will be
-properly aligned for any type HAL supports. A component should allocate
-during initialization all the memory it needs.
+The *hal_malloc()* function allocates a block of memory from the main HAL shared memory area.
+It should be used by all components to allocate memory for HAL pins and parameters.
+It allocates _size_ bytes, and returns a pointer to the allocated space, or NULL (0) on error.
+The returned pointer will be properly aligned for any type HAL supports.
+A component should allocate during initialization all the memory it needs.
 
-The allocator is very simple, and there is no `free'. The entire HAL
-shared memory area is freed when the last component calls *hal_exit*.
+The allocator is very simple, and there is no `free'.
+The entire HAL shared memory area is freed when the last component calls hal_exit(3).
 This means that if you continuously install and remove one component
 while other components are present, you eventually will fill up the
-shared memory and an install will fail. Removing all components
-completely clears memory and you start fresh.
+shared memory and an install will fail.
+Removing all components and shared memory mappings completely clears memory and you start fresh.
 
 == RETURN VALUE
 

--- a/docs/src/man/man3/hal_param_alias.3.adoc
+++ b/docs/src/man/man3/hal_param_alias.3.adoc
@@ -1,12 +1,19 @@
+:manvolnum: 3
+
 = hal_param_alias(3)
 
 == NAME
 
 hal_param_alias - create an alternate name for a param
 
-== SYNTAX
+== SYNOPSIS
 
-int *hal_param_alias*(const char **original_name*, const char **alias*);
+[source,c]
+----
+#include <hal.h>
+
+int hal_param_alias(const char original_name, const char alias);
+----
 
 == ARGUMENTS
 
@@ -18,7 +25,7 @@ alias::
 == DESCRIPTION
 
 A param may have two names: the original name
-(the one that was passed to a *hal_param_new* function) and an alias.
+(the one that was passed to a hal_param_new(3) function) and an alias.
 
 Usually, aliases are for the convenience of users and should be created and destroyed via halcmd.
 However, in some cases it is sensible to create aliases directly in a component.

--- a/docs/src/man/man3/hal_param_new-legacy.3.adoc
+++ b/docs/src/man/man3/hal_param_new-legacy.3.adoc
@@ -1,0 +1,62 @@
+:manvolnum: 3
+
+= hal_param_new-legacy(3)
+
+== NAME
+
+hal_param_new-legacy, hal_param_bit_new-legacy, hal_param_float_new-legacy, hal_param_u32_new-legacy,
+hal_param_s32_new-legacy, hal_param_bit_newf-legacy, hal_param_float_newf-legacy, hal_param_u32_newf-legacy,
+hal_param_s32_newf-legacy - creates a HAL parameter
+
+== SYNTAX
+
+int hal_param_bit_new(const char* _name_, hal_param_dir_t _dir_, hal_bit_t* _data_addr_, int _comp_id_)
+
+int hal_param_float_new(const char* _name_, hal_param_dir_t _dir_, hal_float_t* _data_addr_, int _comp_id_)
+
+int hal_param_u32_new(const char* _name_, hal_param_dir_t _dir_, hal_u32_t* _data_addr_, int _comp_id_)
+
+int hal_param_s32_new(const char* _name_, hal_param_dir_t _dir_, hal_s32_t* _data_addr_, int _comp_id_)
+
+int hal_param_bit_newf(hal_param_dir_t _dir_, hal_bit_t* _data_addr_, int _comp_id_, const char* _fmt_, _..._)
+
+int hal_param_float_newf(hal_param_dir_t _dir_, hal_float_t* _data_addr_, int _comp_id_, const char* _fmt_, _..._)
+
+int hal_param_u32_newf(hal_param_dir_t _dir_, hal_u32_t * _data_addr_, int _comp_id_, const char* _fmt_, _..._)
+
+int hal_param_s32_newf(hal_param_dir_t _dir_, hal_s32_t * _data_addr_, int _comp_id_, const char* _fmt_, _..._)
+
+int hal_param_new(const char* _name_, hal_type_t _type_, hal_param_dir_t _dir_, void* _data_addr_, int _comp_id_)
+
+== ARGUMENTS
+
+_name_::
+  The name to give to the created parameter.
+_dir_::
+  The direction of the parameter, from the viewpoint of the component.
+  It may be one of *HAL_RO*, or *HAL_RW*.
+  A component may assign a value to any parameter,
+  but other programs (such as halcmd) may only assign a value to a parameter that is *HAL_RW*.
+_data_addr_::
+  The address of the data, which must lie within memory allocated by *hal_malloc*.
+_comp_id_::
+  A HAL component identifier returned by an earlier call to *hal_init*.
+_fmt, ..._::
+  A printf-style format string and arguments.
+_type_::
+  The type of the parameter, as specified in *hal_type_t(3)*.
+
+== DESCRIPTION
+
+The *hal_param_new* family of functions create a new _param_ object.
+
+There are functions for each of the data types that the HAL supports.
+Pins may only be linked to signals of the same type.
+
+== RETURN VALUE
+
+Returns a HAL status code.
+
+== SEE ALSO
+
+hal_type_t(3)

--- a/docs/src/man/man3/hal_param_new.3.adoc
+++ b/docs/src/man/man3/hal_param_new.3.adoc
@@ -4,57 +4,65 @@
 
 == NAME
 
-hal_param_new, hal_param_bit_new, hal_param_float_new, hal_param_u32_new, hal_param_s32_new, hal_param_bit_newf, hal_param_float_newf, hal_param_u32_newf, hal_param_s32_newf - creates a HAL parameter
+hal_param_new, hal_param_new_bool, hal_param_new_real,
+hal_param_new_sint, hal_param_new_uint, hal_param_new_fake - creates a HAL parameter
 
-== SYNTAX
+== SYNOPSIS
 
-int hal_param_bit_new(const char* _name_, hal_param_dir_t _dir_, hal_bit_t* _data_addr_, int _comp_id_)
+[source,c]
+----
+#include <hal.h>
 
-int hal_param_float_new(const char* _name_, hal_param_dir_t _dir_, hal_float_t* _data_addr_, int _comp_id_)
-
-int hal_param_u32_new(const char* _name_, hal_param_dir_t _dir_, hal_u32_t* _data_addr_, int _comp_id_)
-
-int hal_param_s32_new(const char* _name_, hal_param_dir_t _dir_, hal_s32_t* _data_addr_, int _comp_id_)
-
-int hal_param_bit_newf(hal_param_dir_t _dir_, hal_bit_t* _data_addr_, int _comp_id_, const char* _fmt_, _..._)
-
-int hal_param_float_newf(hal_param_dir_t _dir_, hal_float_t* _data_addr_, int _comp_id_, const char* _fmt_, _..._)
-
-int hal_param_u32_newf(hal_param_dir_t _dir_, hal_u32_t * _data_addr_, int _comp_id_, const char* _fmt_, _..._)
-
-int hal_param_s32_newf(hal_param_dir_t _dir_, hal_s32_t * _data_addr_, int _comp_id_, const char* _fmt_, _..._)
-
-int hal_param_new(const char* _name_, hal_type_t _type_, hal_param_dir_t _dir_, void* _data_addr_, int _comp_id_)
+int hal_param_new_bool(int comp_id, hal_pdir_t dir, hal_bool_t *param_ptr, rtapi_bool dflt, const char *fmt, ...);
+int hal_param_new_real(int comp_id, hal_pdir_t dir, hal_real_t *param_ptr, rtapi_real dflt, const char *fmt, ...);
+int hal_param_new_sint(int comp_id, hal_pdir_t dir, hal_sint_t *param_ptr, rtapi_sint dflt, const char *fmt, ...);
+int hal_param_new_uint(int comp_id, hal_pdir_t dir, hal_uint_t *param_ptr, rtapi_uint dflt, const char *fmt, ...);
+int hal_param_new_fake(int comp_id, hal_refs_t *param_ptr);
+----
 
 == ARGUMENTS
 
-_name_::
-  The name to give to the created parameter.
-_dir_::
+comp_id::
+  A HAL component identifier returned by an earlier call to hal_init(3).
+dir::
   The direction of the parameter, from the viewpoint of the component.
-  It may be one of *HAL_RO*, or *HAL_RW*.
+  It may be one of `HAL_RO`, or `HAL_RW`.
   A component may assign a value to any parameter,
-  but other programs (such as halcmd) may only assign a value to a parameter that is *HAL_RW*.
-_data_addr_::
-  The address of the data, which must lie within memory allocated by *hal_malloc*.
-_comp_id_::
-  A HAL component identifier returned by an earlier call to *hal_init*.
-_fmt, ..._::
+  but other programs (such as halcmd) may only assign a value to a parameter that is `HAL_RW`.
+param_ptr::
+  The address of the opaque param data storage reference, which must lie within memory allocated by hal_malloc(3).
+dflt::
+  The default assigned parameter value when the param is created.
+fmt, ...::
   A printf-style format string and arguments.
-_type_::
-  The type of the parameter, as specified in *hal_type_t(3)*.
 
 == DESCRIPTION
 
-The *hal_param_new* family of functions create a new _param_ object.
+The **hal_param_new_*()** family of functions create a new _param_ object.
 
 There are functions for each of the data types that the HAL supports.
-Pins may only be linked to signals of the same type.
+Parameters cannot be linked to signals.
+They serve as static configuration and informational status for LinuxCNC.
+
+The *hal_param_new_fake()* function will allocate backing storage for the parameter but not export a name.
+The storage size is guaranteed to be large enough to hold any hal_type_t(3) value.
+You can set and get the value using the getters and setters using any of the unionized hal_type_t fields.
+
+Allocating a fake parameter is added for compatibility with older code that used local parameter storage.
+All parameters behave like pins now and you can no longer use local storage for parameter values.
+All access to parameters changed to use getters and setters.
+But old code may still (ab)use these parameters as very expensive variables.
+There can be initialization cases where the actual parameter is not exported but it is still used as a variable.
+For the getters and setters to work in this case, you need to allocate storage.
+Changing the code path may prove very difficult and *hal_param_new_fake()* may then provide a way around the problem.
+You can allocate a fake parameter in the initialization path so that storage is present and all getters and setters will work as expected.
 
 == RETURN VALUE
 
-Returns a HAL status code.
+Returns zero (0) on success, or a negative errno value on failure.
 
 == SEE ALSO
 
-hal_type_t(3)
+hal_pin_new(3),
+hal_type_t(3), hal_pdir_t(3),
+hal_getter(3), hal_setter(3)

--- a/docs/src/man/man3/hal_parport.3.adoc
+++ b/docs/src/man/man3/hal_parport.3.adoc
@@ -1,21 +1,27 @@
+:manvolnum: 3
+
 = hal_parport(3)
 
 == NAME
 
 hal_parport - portable access to PC-style parallel ports
 
-== SYNTAX
+== SYNOPSIS
 
-....
+Obsolete: Please use the rtapi_parport(3) interface instead.
+
+[source,c]
+----
 #include "hal_parport.h"
-int hal_parport_get(int _comp_id_, hal_parport_t* _port_, unsigned short _base_, unsigned short _base_hi_, unsigned int _modes_)
-void hal_parport_release(hal_parport_t* _port_)
-....
+
+int hal_parport_get(int comp_id, hal_parport_t *port, unsigned short base, unsigned short base_hi, unsigned int modes);
+void hal_parport_release(hal_parport_t *port);
+----
 
 == ARGUMENTS
 
 comp_id::
-  A HAL component identifier returned by an earlier call to *hal_init*.
+  A HAL component identifier returned by an earlier call to hal_init(3).
 port::
   A pointer to a hal_parport_t structure.
 base::
@@ -33,7 +39,7 @@ modes::
 == DESCRIPTION
 
 *hal_parport_get* allocates a parallel port for exclusive use of the named HAL component.
-The port must be released with *hal_parport_release* before the component exits with *hal_exit*.
+The port must be released with *hal_parport_release()* before the component exits with hal_exit(3).
 
 == HIGH ADDRESS PROBING
 
@@ -44,14 +50,15 @@ If no high address is detected, port->base_hi is 0.
 
 == PARPORT STRUCTURE
 
-....
+[source,c]
+----
 typedef struct
 {
     unsigned short base;
     unsigned short base_hi;
     .... // and further unspecified fields
 } hal_parport_t;
-....
+----
 
 == RETURN VALUE
 

--- a/docs/src/man/man3/hal_pdir_t.3.adoc
+++ b/docs/src/man/man3/hal_pdir_t.3.adoc
@@ -1,0 +1,38 @@
+:manvolnum: 3
+
+= hal_pdir_t(3)
+
+== NAME
+
+hal_pdir_t - HAL data direction enumeration
+
+== DESCRIPTION
+
+typedef enum *hal_pdir_t*;::
+  HAL_IN;;
+    An input pin.
+    The owning component can only read the pin.
+    Multiple input pins can be connected to the same signal.
+  HAL_OUT;;
+    An output pin.
+    The owning component can read and write the pin.
+    Only one (1) output pin can be connected to a signal.
+  HAL_IO;;
+    A bidirectional pin.
+    The owning component can read and write the pin.
+    Multiple bidirectional pins can be connected to the same signal.
+    It must be ensured that _at least_ one component will be writing data onto the signal.
+  HAL_RW;;
+    A bidirectional parameter.
+    User-space programs can read and write the parameter.
+    The owning component can read and write the parameter.
+    Parameters cannot be connected to signals.
+  HAL_RO;;
+    An output parameter.
+    User-space programs can only read the parameter.
+    The component can read and write the parameter.
+    Parameters cannot be connected to signals.
+
+== SEE ALSO
+
+hal_pin_new(3), hal_param_new(3)

--- a/docs/src/man/man3/hal_pin_alias.3.adoc
+++ b/docs/src/man/man3/hal_pin_alias.3.adoc
@@ -1,12 +1,19 @@
+:manvolnum: 3
+
 = hal_pin_alias(3)
 
 == NAME
 
 hal_pin_alias - creates an alternate name for a pin
 
-== SYNTAX
+== SYNOPSIS
 
-int *hal_pin_alias*(const char* _original_name_, const char* _alias_);
+[source,c]
+----
+#include <hal.h>
+
+int hal_pin_alias(const char *original_name, const char *alias);
+----
 
 == ARGUMENTS
 
@@ -19,7 +26,7 @@ alias::
 == DESCRIPTION
 
 A pin may have two names: the original name (the one that was passed to
-a *hal_pin_new* function) and an alias.
+a hal_pin_new(3) function) and an alias.
 
 Usually, aliases are for the convenience of users and should be created and destroyed via halcmd.
 However, in some cases it is sensible to create aliases directly in a component.

--- a/docs/src/man/man3/hal_pin_new-legacy.3.adoc
+++ b/docs/src/man/man3/hal_pin_new-legacy.3.adoc
@@ -1,0 +1,74 @@
+:manvolnum: 3
+
+= hal_pin_new-legacy(3)
+
+== NAME
+
+hal_pin_new-legacy, hal_pin_bit_new-legacy, hal_pin_float_new-legacy, hal_pin_u32_new-legacy,
+hal_pin_s32_new-legacy, hal_pin_port_new-legacy, hal_pin_bit_newf-legacy,
+hal_pin_float_newf-legacy, hal_pin_u32_newf-legacy, hal_pin_s32_newf-legacy,
+hal_pin_port_newf-legacy - creates a HAL pin
+
+== SYNTAX
+
+int hal_pin_bit_new(const char* _name_, hal_pin_dir_t _dir_, hal_bit_t** _data_ptr_addr_, int _comp_id_)
+
+int hal_pin_float_new(const char* _name_, hal_pin_dir_t _dir_, hal_float_t** _data_ptr_addr_, int _comp_id_)
+
+int hal_pin_u32_new(const char* _name_, hal_pin_dir_t _dir_, hal_u32_t** _data_ptr_addr_, int _comp_id_)
+
+int hal_pin_s32_new(const char* _name_, hal_pin_dir_t _dir_, hal_s32_t** _data_ptr_addr_, int _comp_id_)
+
+int hal_pin_port_new(const char* _name_, hal_pin_dir_t _dir_, hal_port_t** _data_ptr_addr_, int _comp_id_)
+
+int hal_pin_bit_newf(hal_pin_dir_t _dir_, hal_bit_t** _data_ptr_addr_, int _comp_id_, const char* _fmt_, _..._)
+
+int hal_pin_float_newf(hal_pin_dir_t _dir_, hal_float_t** _data_ptr_addr_, int _comp_id_, const char* _fmt_, _..._)
+
+int hal_pin_u32_newf(hal_pin_dir_t _dir_, hal_u32_t** _data_ptr_addr_, int _comp_id_, const char* _fmt_, _..._)
+
+int hal_pin_s32_newf(hal_pin_dir_t _dir_, hal_s32_t** _data_ptr_addr_, int _comp_id_, const char* _fmt_, _..._)
+
+int hal_pin_port_newf(hal_pin_dir_t _dir_, hal_port_t** _data_ptr_addr_, int _comp_id_, const char* _fmt_, _..._)
+
+int hal_pin_new(const char* _name_, hal_type_t _type_, hal_pin_dir_t _dir_, void** _data_ptr_addr_, int _comp_id_)
+
+== ARGUMENTS
+
+name::
+  Name of the pin.
+dir::
+  The direction of the pin, from the viewpoint of the component.
+  It may be one of *HAL_IN*, *HAL_OUT*, or *HAL_IO*.
+  Any number of *HAL_IN* or *HAL_IO* pins may be connected to the same signal,
+  but at most one *HAL_OUT* pin is permitted.
+  A component may assign a value to a pin that is *HAL_OUT* or *HAL_IO*,
+  but may not assign a value to a pin that is *HAL_IN*.
+data_ptr_addr::
+  The address of the pointer-to-data, which must lie within memory
+  allocated by *hal_malloc*.
+comp_id::
+  HAL component identifier returned by an earlier call to *hal_init*.
+fmt,::
+  printf-style format string and arguments
+type::
+  The type of the param, as specified in *hal_type_t(3)*.
+
+== DESCRIPTION
+
+The *hal_pin_new* family of functions create a new _pin_ object.
+Once a pin has been created, it can be linked to a signal object using *hal_link*.
+A pin contains a pointer, and the component that owns the pin
+can dereference the pointer to access whatever signal is linked to the pin.
+(If no signal is linked, it points to a dummy signal.)
+
+There are functions for each of the data types that the HAL supports.
+Pins may only be linked to signals of the same type.
+
+== RETURN VALUE
+
+Returns 0 on success, or a negative errno value on failure.
+
+== SEE ALSO
+
+hal_type_t(3), hal_link(3)

--- a/docs/src/man/man3/hal_pin_new.3.adoc
+++ b/docs/src/man/man3/hal_pin_new.3.adoc
@@ -4,71 +4,65 @@
 
 == NAME
 
-hal_pin_new, hal_pin_bit_new, hal_pin_float_new, hal_pin_u32_new,
-hal_pin_s32_new, hal_pin_port_new, hal_pin_bit_newf,
-hal_pin_float_newf, hal_pin_u32_newf, hal_pin_s32_newf,
-hal_pin_port_newf - creates a HAL pin
+hal_pin_new, hal_pin_new_bool, hal_pin_new_real, hal_pin_new_sint, hal_pin_new_uint, hal_pin_new_port - creates a HAL pin
 
-== SYNTAX
+== SYNOPSIS
 
-int hal_pin_bit_new(const char* _name_, hal_pin_dir_t _dir_, hal_bit_t** _data_ptr_addr_, int _comp_id_)
+[source,c]
+----
+#include <hal.h>
 
-int hal_pin_float_new(const char* _name_, hal_pin_dir_t _dir_, hal_float_t** _data_ptr_addr_, int _comp_id_)
-
-int hal_pin_u32_new(const char* _name_, hal_pin_dir_t _dir_, hal_u32_t** _data_ptr_addr_, int _comp_id_)
-
-int hal_pin_s32_new(const char* _name_, hal_pin_dir_t _dir_, hal_s32_t** _data_ptr_addr_, int _comp_id_)
-
-int hal_pin_port_new(const char* _name_, hal_pin_dir_t _dir_, hal_port_t** _data_ptr_addr_, int _comp_id_)
-
-int hal_pin_bit_newf(hal_pin_dir_t _dir_, hal_bit_t** _data_ptr_addr_, int _comp_id_, const char* _fmt_, _..._)
-
-int hal_pin_float_newf(hal_pin_dir_t _dir_, hal_float_t** _data_ptr_addr_, int _comp_id_, const char* _fmt_, _..._)
-
-int hal_pin_u32_newf(hal_pin_dir_t _dir_, hal_u32_t** _data_ptr_addr_, int _comp_id_, const char* _fmt_, _..._)
-
-int hal_pin_s32_newf(hal_pin_dir_t _dir_, hal_s32_t** _data_ptr_addr_, int _comp_id_, const char* _fmt_, _..._)
-
-int hal_pin_port_newf(hal_pin_dir_t _dir_, hal_port_t** _data_ptr_addr_, int _comp_id_, const char* _fmt_, _..._)
-
-int hal_pin_new(const char* _name_, hal_type_t _type_, hal_pin_dir_t _dir_, void** _data_ptr_addr_, int _comp_id_)
+int hal_pin_new_bool(int comp_id, hal_pdir_t dir, hal_bool_t *pin_ptr, rtapi_bool dflt, const char *fmt, ...);
+int hal_pin_new_real(int comp_id, hal_pdir_t dir, hal_real_t *pin_ptr, rtapi_real dflt, const char *fmt, ...);
+int hal_pin_new_sint(int comp_id, hal_pdir_t dir, hal_sint_t *pin_ptr, rtapi_sint dflt, const char *fmt, ...);
+int hal_pin_new_uint(int comp_id, hal_pdir_t dir, hal_uint_t *pin_ptr, rtapi_uint dflt, const char *fmt, ...);
+int hal_pin_new_port(int comp_id, hal_pdir_t dir, hal_port_t *pin_ptr, const char *fmt, ...);
+----
 
 == ARGUMENTS
 
-name::
-  Name of the pin.
+comp_id::
+  HAL component identifier returned by an earlier call to hal_init(3).
 dir::
   The direction of the pin, from the viewpoint of the component.
-  It may be one of *HAL_IN*, *HAL_OUT*, or *HAL_IO*.
-  Any number of *HAL_IN* or *HAL_IO* pins may be connected to the same signal,
-  but at most one *HAL_OUT* pin is permitted.
-  A component may assign a value to a pin that is *HAL_OUT* or *HAL_IO*,
-  but may not assign a value to a pin that is *HAL_IN*.
-data_ptr_addr::
-  The address of the pointer-to-data, which must lie within memory
-  allocated by *hal_malloc*.
-comp_id::
-  HAL component identifier returned by an earlier call to *hal_init*.
-fmt,::
-  printf-style format string and arguments
-type::
-  The type of the param, as specified in *hal_type_t(3)*.
+  It may be one of `HAL_IN`, `HAL_OUT`, or `HAL_IO`.
+  Any number of `HAL_IN` or `HAL_IO` pins may be connected to the same signal,
+  but at most one `HAL_OUT` pin is permitted.
+  A component may assign a value to a pin that is `HAL_OUT` or `HAL_IO`.
+  Components may not assign a value to a pin that is `HAL_IN`.
+pin_ptr::
+  The address of the opaque pin data storage reference, which must lie within memory allocated by hal_malloc(3).
+dflt::
+  The default assigned pin value when the pin is created.
+fmt, ...::
+  A printf-style format string and arguments
 
 == DESCRIPTION
 
-The *hal_pin_new* family of functions create a new _pin_ object.
-Once a pin has been created, it can be linked to a signal object using *hal_link*.
-A pin contains a pointer, and the component that owns the pin
-can dereference the pointer to access whatever signal is linked to the pin.
-(If no signal is linked, it points to a dummy signal.)
+The **hal_pin_new_*()** family of functions create a new _pin_ object.
+The type of the pin corresponds to one of the hal_type_t(3) types.
+Once a pin has been created, it can be linked to a signal object using hal_link(3).
+A pin contains an opaque reference, which can be dereferenced the appropriate getter/setter.
+Pins of type `HAL_IN` only can use the appropriate getter **hal_get_*()**.
+Pins of type `HAL_OUT` and `HAL_IO` and use the getter and the setter **hal_set_*()**.
+Getting and settin a pin's value will address the value of the signal if the pin is connected.
+If no signal is linked, it gets/sets a dummy signal.
 
 There are functions for each of the data types that the HAL supports.
 Pins may only be linked to signals of the same type.
 
+The *hal_pin_new_port()* functions is special in that it does not have a default.
+Exact two `HAL_PORT` port pins, one `HAL_IN` and one `HAL_OUT`, must be connected to a `HAL_PORT` type signal.
+You cannot call hal_set_p(3) or hal_get_p(3) on a `HAL_PORT` pin.
+A call to hal_set_s(3) on the port signal will set the queue size.
+
 == RETURN VALUE
 
-Returns 0 on success, or a negative errno value on failure.
+Returns zero (0) on success, or a negative errno value on failure.
 
 == SEE ALSO
 
-hal_type_t(3), hal_link(3)
+hal_param_new(3),
+hal_getter(3), hal_setter(3),
+hal_type_t(3), hal_pdir_t(3),
+hal_link(3)

--- a/docs/src/man/man3/hal_port.3.adoc
+++ b/docs/src/man/man3/hal_port.3.adoc
@@ -1,14 +1,19 @@
+:manvolnum: 3
+
 = hal_port(3)
 
 == NAME
 
-hal_port - a HAL pin type that acts as an asynchronous one way byte
-stream
+hal_port, hal_port_read, hal_port_peek, hal_port_peek_commit, hal_port_readable,
+hal_port_clear, hal_port_write, hal_port_writable,
+hal_port_buffer_size - a HAL pin type that acts as an asynchronous one way byte stream
 
 == SYNOPSIS
 
-....
+[source,c]
+----
 #include <hal.h>
+
 bool hal_port_read(hal_port_t port, char* dest, unsigned count);
 bool hal_port_peek(hal_port_t port, char* dest, unsigned count);
 bool hal_port_peek_commit(hal_port_t port, unsigned count);
@@ -24,7 +29,7 @@ unsigned hal_port_buffer_size(hal_port_t port);
 void hal_port_wait_readable(hal_port_t** port, unsigned count, sig_atomic_t* stop);
 void hal_port_wait_writable(hal_port_t** port, unsigned count, sig_atomic_t* stop);
 #endif
-....
+----
 
 == DESCRIPTION
 
@@ -37,66 +42,56 @@ link only a single writer and a single reader.
 A port also buffers data. Users should determine the proper buffer size
 based upon their intended application.
 
-=== *hal_port_read*
+hal_port_read()::
+  Reads count bytes from the port into destination buffer dest.
+  A call to *hal_port_read()* will read _count_ bytes if and only if _count_
+  bytes are available for reading and otherwise it will leave the port unaffected.
+  Returns true if count bytes were read and false otherwise. This function
+  should only be called by the component that owns the IN PORT pin.
 
-Reads count bytes from the port into destination buffer dest.
-hal_port_read will read _count_ bytes if and only if _count_ bytes are
-available for reading and otherwise it will leave the port unaffected.
-Returns true if count bytes were read and false otherwise. This function
-should only be called by the component that owns the IN PORT pin.
+hal_port_peek()::
+  Behaves the same as *hal_port_read()*, however it does not consume bytes
+  from the HAL port. Repeated calls to *hal_port_peek()* will return the same
+  data. Returns true if count bytes were read and false otherwise. This
+  function should only be called by the component that owns the IN PORT
+  pin.
 
-=== *hal_port_peek*
+hal_port_peek_commit()::
+  Advances the read position in the port buffer by count bytes.
+  A *hal_port_peek()* followed by a *hal_port_peek_commit()* would function
+  equivalently to *hal_port_read()* given the same count value. Returns true
+  if count readable bytes were skipped and are no longer accessible and
+  false if no bytes wer skipped. This function should only be called by
+  the component that owns the IN PORT pin.
 
-Behaves the same as hal_port_read, however it does not consume bytes
-from the HAL port. Repeated calls to hal_port_peek will return the same
-data. Returns true if count bytes were read and false otherwise. This
-function should only be called by the component that owns the IN PORT
-pin.
+hal_port_readable()::
+  Returns the number of bytes available for reading from port.
+  It is safe to call this function from any component.
 
-=== *hal_port_peek_commit*
+hal_port_clear()::
+  Emptys a given port of all data. hal_port_clear should only be called by
+  the component that owns the IN PORT pin.
 
-Advances the read position in the port buffer by count bytes.
-A hal_port_peek followed by a hal_port_peek_commit would function
-equivalently to hal_port_read given the same count value. Returns true
-if count readable bytes were skipped and are no longer accessible and
-false if no bytes wer skipped. This function should only be called by
-the component that owns the IN PORT pin.
+hal_port_write()::
+  Writes count bytes from src into the port. Returns true if count bytes
+  were written and false otherwise. This function should only be called by
+  the component that owns the OUT PORT pin.
 
-=== *hal_port_readable*
+hal_port_writable()::
+  Returns the number of bytes that can be written into the port.
+  It is safe to call this function from any component.
 
-Returns the number of bytes available for reading from port. It is safe
-to call this function from any component.
+hal_port_buffer_size()::
+  Returns the maximum number of bytes that a port can buffer.
+  It is safe to call this function from any component.
 
-=== *hal_port_clear*
+hal_port_wait_readable()::
+  Waits until the port has count bytes or more available for reading or the stop flag is set. +
+  This function cannot be called from realtime code.
 
-Emptys a given port of all data. hal_port_clear should only be called by
-the component that owns the IN PORT pin.
-
-=== *hal_port_write*
-
-Writes count bytes from src into the port. Returns true if count bytes
-were written and false otherwise. This function should only be called by
-the component that owns the OUT PORT pin.
-
-=== *hal_port_writable*
-
-Returns the number of bytes that can be written into the port. It is
-safe to call this function from any component.
-
-=== *hal_port_buffer_size*
-
-Returns the maximum number of bytes that a port can buffer. It is safe
-to call this function from any component.
-
-=== *hal_port_wait_readable*
-
-Waits until the port has count bytes or more available for reading or
-the stop flag is set.
-
-=== *hal_port_wait_writable*
-
-Waits until the port has count bytes or more available for writing or
-the stop flag is set.
+hal_port_wait_writable()::
+  Waits until the port has count bytes or more available for writing or the stop flag is set. +
+  This function cannot be called from realtime code.
 
 == ARGUMENTS
 
@@ -124,11 +119,9 @@ that also programs the raster component from Python.
 
 == REALTIME CONSIDERATIONS
 
-*hal_port_read*, *hal_port_peek*, *hal_port_peek_commit*,
-*hal_port_readable*, *hal_port_clear*, *hal_port_write*,
-*hal_port_writable*, *hal_port_buffer_size* may be called from realtime code.
+Most **hal_port_*()** functions can be called from realtime code.
 
-*hal_port_wait_writable*, *hal_port_wait_readable* may be called from ULAPI code.
+The exceptions are *hal_port_wait_writable()* and *hal_port_wait_readable()*, which may be only called from ULAPI code.
 
 == SEE ALSO
 

--- a/docs/src/man/man3/hal_query_t.3.adoc
+++ b/docs/src/man/man3/hal_query_t.3.adoc
@@ -1,0 +1,414 @@
+:manvolnum: 3
+
+= hal_query_t(3)
+
+== NAME
+
+hal_query_t - HAL query API and data structure
+
+== DESCRIPTION
+
+The HAL query API is an interface to retrieve information about:
+
+* pins
+* params
+* signals
+* components
+* functions
+* threads
+
+Additionally, the query API can set the value of pins, params and signals.
+The query API uses a standard structure to capture both input and output.
+Most query API functions use a callback function with the following signature:
+
+[source,c]
+----
+typedef int (*hal_query_cb)(hal_query_t *query, void *arg);
+----
+
+It is important to remember that the HAL mutex is held while the callback function is executing.
+You may call other query API functions from within the callback (the HAL mutex is recursive).
+
+[WARNING]
+====
+You should **never** exit your program from within a callback.
+Doing so would keep HAL locked and all other programs are forever blocked from performing actions.
+Beware of OS signals during callbacks (see signal(2) and signal(7)).
+
+You should also beware of performing blocking I/O.
+Taking a long time in callbacks may be problematic for performance.
+It may be better to collect data in the callback and handle the slow operations outside of it.
+====
+
+A query's details is defined by the query structure;
+
+[source,c]
+----
+typedef struct {
+    const char *name;
+    hal_qtype_t qtype;
+    union {
+        void           *vpval;
+        const void     *cpval;
+        rtapi_intptr_t  ipval;
+        rtapi_uintptr_t upval;
+        rtapi_sint      sival;
+        rtapi_uint      uival;
+    } callerdata;
+    union {
+        hal_query_pp_t     pp;
+        hal_query_sig_t    sig;
+        hal_query_comp_t   comp;
+        hal_query_funct_t  funct;
+        hal_query_thread_t thread;
+    };
+} hal_query_t;
+
+typedef enum {
+    HAL_QTYPE_ANY = 0,
+    HAL_QTYPE_PIN,
+    HAL_QTYPE_PARAM,
+    HAL_QTYPE_SIGNAL,
+    HAL_QTYPE_COMP,
+    HAL_QTYPE_FUNCT,
+    HAL_QTYPE_THREAD,
+    HAL_QTYPE_THREAD_FUNCT,
+} hal_qtype_t;
+----
+
+The fields _name_ and _qtype_ are used as a selector.
+The user may use the _callerdata_ fields to propagate additional data to the callback.
+The _callerdata_ fields are never altered by any query function.
+
+Data is returned in the individual sub-field.
+
+[horizontal]
+pp::
+  Pin and param data.
+  The _qtype_ field is set to `HAL_QTYPE_PIN` when the data relates to a pin and `HAL_QTYPE_PARAM` for a param.
+sig::
+  Signal data.
+  The _qtype_ field is set to `HAL_QTYPE_SIGNAL`
+comp::
+  Component data.
+  The _qtype_ field is set to `HAL_QTYPE_COMP`
+funct::
+  Function data.
+  The _qtype_ field is set to `HAL_QTYPE_FUNCT`
+thread::
+  Thread data.
+  The _qtype_ field is set to `HAL_QTYPE_THREAD` if it was set at call start.
+  If the _qtype_ was set to `HAL_QTYPE_THREAD_FUNCT`,
+  then it will alternate between `HAL_QTYPE_THREAD` and `HAL_QTYPE_THREAD_FUNCT`,
+  depending whether the callback is about the thread or an attached function.
+
+== QUERY FUNCTIONS
+
+hal_get_p, hal_getref_p, hal_set_p::
+  Retrieve or set the value of a pin or param. +
+  The value and opaque reference is retrieved with *hal_get_p*.
+  Only the opaque reference is retrieved with *hal_getref_p* (useful for existence test).
+  Setting a pin or param can be done with *hal_set_p*.
+
+hal_get_s, hal_getref_s, hal_set_s::
+  Retrieve or set the value of a signal. +
+  The value and opaque reference is retrieved with *hal_get_s*.
+  Only the opaque reference is retrieved with *hal_getref_s* (useful for existence test).
+  Setting a signal can be done with *hal_set_s*.
+
+hal_list_p::
+  Iterate all pins or params registered with HAL.
+  You can limit the search to pins, params or both.
+  The pin and param values, including reference, can be accessed in the callback.
+
+hal_list_s::
+  Iterate all signals registered with HAL.
+  The signal values, including reference, can be accessed in the callback.
+
+hal_list_p_s::
+  Iterate all pins connected to a specific signal.
+  The pin values, including reference, can be accessed in the callback.
+
+hal_list_comp::
+  Iterate all components registered with HAL
+
+hal_list_funct::
+  Iterate all functions registered with HAL
+
+hal_list_thread::
+  Iterate all threads registered with HAL. +
+  You can select to iterate the functions attached to a threads while iterating threads.
+
+== PINS AND PARAMS
+
+Query data for pins and param is handled by the *hal_query_pp_t* structure:
+
+[source,c]
+----
+typedef struct {
+    hal_type_t type;
+    hal_refs_u ref;
+    hal_query_value_u value;
+    hal_pdir_t dir;
+    const char *alias;
+    const char *signal;
+    const char *comp;
+    int comp_id;
+} hal_query_pp_t;
+----
+
+The *hal_query_t* fields _name_ and _qtype_ will be set before the callback is invoked.
+The _name_ fields will point to the actual live pin or parameter name.
+The _qtype_ field will indicate whether the data contains a pin (`HAL_QTYPE_PIN`) or a param (`HAL_QTYPE_PARAM`).
+
+[horizontal]
+type::
+  The pin/param type as described in *hal_type_t(3)*. +
+  The _type_ field may be used as a selector/filter and set before calling *hal_set_p(3)*, *hal_get_p(3)*.
+
+ref::
+  The opaque reference as described in *hal_refs_u(3)*.
+
+anchor:hal_query_value_u[]value::
+  The value is a union *hal_query_value_u* of supported values, shown below.
+  The _type_ field indicates which value you should select from the union.
+  You should make sure to use the proper field. +
+  Must be set, including _type_ above, before the call to *hal_set_p(3)* when no callback is specified.
++
+[source,c]
+----
+typedef union {
+    rtapi_bool b;
+    rtapi_sint s;
+    rtapi_uint u;
+    rtapi_real r;
+} hal_query_value_u;
+----
+
+dir::
+  The direction of the pin or param as described in *hal_pdir_t(3)*.
+
+alias::
+  An pin/param name alias (also know as 'oldname') or NULL if none exists.
+
+signal::
+  Pins only:
+  Set to the name of the signal the pin is connected to or NULL if not connected.
+
+comp::
+  The name of the owner component of the pin/param.
+
+comp_id::
+  The numerical ID of the owner component of the pin/param.
+
+== SIGNALS
+
+Query data for signals is handled by the *hal_query_sig_t* structure:
+
+[source,c]
+----
+typedef struct {
+    hal_type_t type;
+    hal_refs_u ref;
+    hal_query_value_u value;
+    int writers;
+    int readers;
+    int bidirs;
+} hal_query_sig_t;
+----
+
+The *hal_query_t* field _name_ will be set before the callback is invoked.
+The _name_ fields will point to the actual live signal name.
+
+[horizontal]
+type::
+  The signal type as described in *hal_type_t(3)*. +
+  The _type_ field may be used as a selector/filter and set before calling *hal_set_s(3)*, *hal_get_s(3)*.
+
+ref::
+  The opaque reference as described in *hal_refs_u(3)*.
+
+value::
+  The value is a union *hal_query_value_u* of supported values.
+  The _type_ field indicates which value you should select from the union.
+  You should make sure to use the proper field.
+  See above under link:#hal_query_value_u[pins and parameters] for details. +
+  Must be set, including _type_ above, before the call to *hal_set_s(3)* when no callback is specified.
+
+writers::
+  The number of `HAL_OUT` pins connected.
+  This value is either zero (0) when no `HAL_OUT` pin is connected or one (1) if a `HAL_OUT` pin is connected.
+
+readers::
+  The number of `HAL_IN` pins connected to the signal.
+  Signals of type `HAL_PORT` can only have one (1) reader.
+
+bidirs::
+  The number of `HAL_IO` pins connected to the signal.
+  Note that there is no guarantee that a value is ever written to the signal.
+  Writing bidirectional pins is only by the component's discretion.
+
+== COMPONENTS
+
+Query data for components is handled by the *hal_query_comp_t* structure:
+
+[source,c]
+----
+typedef struct {
+    int comp_id;
+    hal_comp_type_t type;
+    int pid;
+    bool ready;
+    const char *insmod;
+} hal_query_comp_t;
+----
+
+The *hal_query_t* field _name_ will be set before the callback is invoked.
+The _name_ fields will point to the actual live component name.
+
+[horizontal]
+comp_id::
+  The component ID assigned to the component (returned by *hal_init(3)*).
+
+type::
+  The component type (`typedef enum hal_comp_type_t`)
+  HAL_COMP_TYPE_UNKNOWN;;
+    No additional information is available.
+  HAL_COMP_TYPE_USER;;
+    A user-space program's component loaded with `loadusr`.
+    The _pid_ field will indicate the program's process ID.
+  HAL_COMP_TYPE_REALTIME;;
+    A realtime component loaded as a kernel module or uspace realtime application using `loadrt`.
+  HAL_COMP_TYPE_OTHER;;
+    An unknown type of component.
+    This should not happen...famous...last...words.
+
+pid::
+  The process ID of the user-space program that created the component.
+
+ready::
+  True if the component is in the ready state.
+
+insmod::
+  The `loadrt` arguments passed to the realtime module at load time.
+  User-space programs will have this field set to NULL.
+
+== FUNCTIONS
+
+Query data for functions is handled by the *hal_query_funct_t* structure:
+
+[source,c]
+----
+typedef struct {
+    int comp_id;
+    const char *comp;
+    int users;
+    rtapi_intptr_t arg;
+    rtapi_intptr_t funct;
+    bool reentrant;
+} hal_query_funct_t;
+----
+
+The *hal_query_t* field _name_ will be set before the callback is invoked.
+The _name_ fields will point to the actual live function name.
+
+[horizontal]
+comp_id::
+  The owning component's ID.
+  This is set by the calls to *hal_export_functf(3)*.
+
+comp::
+  The owning component's name.
+
+users::
+  The number of times the function is in use by one or more threads.
+
+arg::
+  Internal reference to the argument passed to the function when executed.
+  You cannot dereference this value as it's address belongs to a different process.
+
+funct::
+  Internal reference to the functions location in memory.
+  You cannot dereference this value as it's address belongs to a different process.
+
+reentrant::
+  Set to true if the function has no static references and can be called twice or more at the same time.
+
+== THREADS
+
+Query data for threads is handled by the *hal_query_thread_t* structure:
+
+[source,c]
+----
+typedef struct {
+    int comp_id;
+    const char *comp;
+    int priority;
+    long int period;
+    int functidx;
+    const char *funct;
+    bool is_init;
+} hal_query_thread_t;
+----
+
+The *hal_query_t* field _name_ will be set before the callback is invoked.
+The _name_ fields will point to the actual live thread name.
+
+[horizontal]
+comp_id::
+  The owning component's ID.
+
+comp::
+  The owning component's name.
+
+priority::
+  Internal priority of the thread.
+
+period::
+  The cycle time of the thread in nanoseconds.
+
+functidx::
+  Only set if iterating a thread's functions (HAL_QTYPE_THREAD_FUNCT). +
+  The zero-based call index/sequence of the function as executed by the thread.
+
+funct::
+  Only set if iterating a thread's functions (HAL_QTYPE_THREAD_FUNCT). +
+  The function name at the _functidx_.
+
+is_init::
+  Only set if iterating a thread's functions (HAL_QTYPE_THREAD_FUNCT). +
+  Set to true is this is an initialization function in the thread.
+  See *hal_init_funct_to_thread(3)* for details.
+  Iterating init functions is only possible if the thread is not running and has never been started.
+
+== REALTIME CONSIDERATIONS
+
+The query API functions are not available from realtime.
+The HAL library query functions are not exported to realtime modules.
+Only non-realtime user-space programs linking to HAL library can use the query functions.
+
+== RETURN VALUE
+
+All functions returns zero (0) on success.
+A negative errno code is returned when an error is encountered.
+The callback's return value is returned verbatim.
+
+== SEE ALSO
+
+hal_set_p(3),
+hal_set_s(3),
+hal_get_p(3),
+hal_get_s(3),
+hal_getref_p(3),
+hal_getref_s(3),
+hal_list_p(3),
+hal_list_s(3),
+hal_list_p_s(3),
+hal_list_comp(3),
+hal_list_funct(3),
+hal_list_thread(3),
+hal_comp_by_name(3),
+hal_comp_by_id(3),
+hal_statistics(3),
+hal_type_t(3),
+hal_refs_u(3).

--- a/docs/src/man/man3/hal_ready.3.adoc
+++ b/docs/src/man/man3/hal_ready.3.adoc
@@ -1,25 +1,43 @@
+:manvolnum: 3
+
 = hal_ready(3)
 
 == NAME
 
-hal_ready - indicates that this component is ready
+hal_ready, hal_unready - Set the operational ready state of the component
 
-== SYNTAX
+== SYNOPSIS
 
-hal_ready(int _comp_id_)
+[source,c]
+----
+#include <hal.h>
+
+int hal_ready(int comp_id);
+int hal_unready(int comp_id);
+----
 
 == ARGUMENTS
 
 comp_id::
-  A HAL component identifier returned by an earlier call to *hal_init*.
+  A HAL component identifier returned by an earlier call to hal_init(3).
 
 == DESCRIPTION
 
-*hal_ready* indicates that this component is ready (has created all its
-pins, parameters, and functions). This must be called in any realtime
-HAL component before its *rtapi_app_init* exits, and in any non-realtime
-component before it enters its main loop.
+Calling hal_ready(3) indicates that the component is ready for operation.
+Creation of pins, parameters, and functions is not allowed when the component is ready.
+This must be called in any realtime HAL component before its rtapi_app_main(3) exits.
+In any non-realtime component it should be called before it enters its main loop.
+
+You can call hal_unready(3) to again allow modifications of pins, params and functions.
+This should only be done in non real-time applications.
+After the modifications are done, you must call hal_ready(3) again.
 
 == RETURN VALUE
 
-Returns a HAL status code.
+Returns zero (0) on success, or a negative errno value to indicate the error.
+
+== SEE ALSO
+
+rtapi_app_main(3),
+hal_init(3),
+hal_exit(3)

--- a/docs/src/man/man3/hal_refs_u.3.adoc
+++ b/docs/src/man/man3/hal_refs_u.3.adoc
@@ -1,0 +1,32 @@
+:manvolnum: 3
+
+= hal_refs_u(3)
+
+== NAME
+
+hal_refs_u - Combined pin, param and signal opaque data reference
+
+== DESCRIPTION
+
+A union of opaque references to all hal_type_t(3) types.
+You need to have access to the type enumeration to select the correct union field.
+
+[source,c]
+----
+typedef union {
+    hal_bool_t b;
+    hal_sint_t s;
+    hal_uint_t u;
+    hal_real_t r;
+    hal_port_t p;
+} hal_refs_u;
+----
+
+HAL data cannot be read or written directly.
+The *hal_refs_u* contains opaque structures that reference a value of the type indicated by the name.
+Reading and writing HAL types is performed with getters and setters.
+
+== SEE ALSO
+
+hal_query_t(3),
+hal_setter(3), hal_getter(3)

--- a/docs/src/man/man3/hal_set_constructor.3.adoc
+++ b/docs/src/man/man3/hal_set_constructor.3.adoc
@@ -1,17 +1,24 @@
+:manvolnum: 3
+
 = hal_set_constructor(3)
 
 == NAME
 
 hal_set_constructor - sets the constructor function for this component
 
-== SYNTAX
+== SYNOPSIS
+
+[source,c]
+----
+#include <hal.h>
 
 typedef int (*hal_constructor_t)(const char* prefix, const char* arg);
-int hal_set_constructor(int _comp_id_, hal_constructor_t _constructor_)
+int hal_set_constructor(int comp_id, hal_constructor_t constructor);
+----
 
 == ARGUMENTS
 
-_comp_id_:: A HAL component identifier returned by an earlier call to *hal_init*.
+_comp_id_:: A HAL component identifier returned by an earlier call to hal_init(3).
 
 _prefix_:: The prefix to be given to the pins, parameters, and functions in the new instance.
 

--- a/docs/src/man/man3/hal_set_lock.3.adoc
+++ b/docs/src/man/man3/hal_set_lock.3.adoc
@@ -6,20 +6,31 @@
 
 hal_set_lock, hal_get_lock - Set or get the HAL lock level
 
-== SYNTAX
+== SYNOPSIS
 
-int hal_set_lock(unsigned char _lock_type_)
+[source,c]
+----
+#include <hal.h>
 
-int hal_get_lock()
+int hal_set_lock(unsigned char lock_type);
+int hal_get_lock();
+----
 
 == ARGUMENTS
 
 lock_type::
   The desired lock type, which may be a bitwise combination of:
-  *HAL_LOCK_LOAD*, *HAL_LOCK_CONFIG*, *HAL_LOCK_PARAMS*, or *HAL_LOCK_PARAMS*.
-  *HAL_LOCK_NONE* or 0 locks nothing, and *HAL_LOCK_ALL locks everything.*
++
+* `HAL_LOCK_LOAD` - Lock creating new pins, params and functions.
+* `HAL_LOCK_CONFIG` - Lock creating or altering threads.
+* `HAL_LOCK_PARAMS` - Lock altering parameters (only partly functional).
+* `HAL_LOCK_RUN` - Lock starting/stopping threads.
+* `HAL_LOCK_NONE` - locks nothing (unlocks all).
+* `HAL_LOCK_ALL` - Lock everything.
 
 == RETURN VALUE
 
-*hal_set_lock* returns a HAL status code.
-*hal_get_lock* returns the current HAL lock level or a HAL status code.
+Function *hal_set_lock()* returns zero (0) on success or *-EFAULT* if HAL is not initialized.
+
+Function *hal_get_lock()* returns the current HAL lock level.
+If HAL is not initialized, *hal_get_lock()* returns `HAL_LOCK_ALL`.

--- a/docs/src/man/man3/hal_set_p.3.adoc
+++ b/docs/src/man/man3/hal_set_p.3.adoc
@@ -1,0 +1,134 @@
+:manvolnum: 3
+
+= hal_set_p(3)
+
+== NAME
+
+hal_set_p - Set a HAL pin or param value
+
+== SYNOPSIS
+
+[source,c]
+----
+#include <hal.h>
+
+typedef int (*hal_query_cb)(hal_query_t *query, void *arg);
+
+int hal_set_p(hal_query_t *query, hal_query_cb callback, void *arg);
+----
+
+== ARGUMENTS
+
+query::
+  The query structure containing the name to search for and value to set.
+
+callback::
+  The callback function to invoke when the pin or param has been found to get the value to set.
+  This can also be NULL if no callback is required.
+  Both _query.pp.value_ *and* _query.pp.type_ must be appropriately set if _callback_ is NULL.
+
+arg::
+  A user defined pointer to a user defined data structure.
+  The _arg_ pointer is passed verbatim to the _callback_ function.
+
+== DESCRIPTION
+
+The *hal_set_p()* function will find the named pin or param and set its value to the user supplied value.
+The _query_ structure should be set to zero before the call, except for the fields noted below.
+
+The _query.name_ must be set to the name of the pin or parameter you want to set.
+Optionally, you can enforce to look exclusively for a pin or param by setting _query.qtype_ before the call to:
+
+* `0` - look for either pin or param
+* `HAL_QTYPE_PIN` - only look for a pin
+* `HAL_QTYPE_PARAM` - only look for a param
+
+Note that both pins and params share one namespace and cannot overlap.
+
+You can further limit the search by setting _query.pp.type_ to the HAL type you want to set.
+If the pin or param is found, but has a different type, then *-EEXIST* is returned.
+
+Setting a pin connected to a signal or a pin of direction `HAL_OUT` will fail with an *-EACCES* error.
+Setting a param of direction `HAL_RO` will fail with an *-EACCES* error.
+
+The _callback_ is called with all fields set appropriately, including data reference.
+You must set the correct _query.pp.value_ subfield in the callback according to the _query.pp.type_ field.
+The pin's or param's value will be set if the callback returns with zero (0).
+
+If you do not wish to use a callback, then you must set both _query.pp.type_ and _query.pp.value_ beforehand.
+The actual type will be checked against what is found and a mismatch will result in an *-EEXIST* error.
+
+If found, *hal_set_p()* sets the _query.name_ field to the actual live pin or param name.
+The _query.qtype_ field is set accordingly to whether a pin or a param was found.
+
+== RETURN VALUE
+
+The *hal_set_p()* function returns zero (0) on success.
+The return value of the _callback_ is returned if it got called and was non-zero.
+A negative errno code is returned if any problem is detected:
+
+[horizontal]
+-EFAULT:: The shared memory was not mapped.
+-EINVAL:: An invalid argument was passed.
+-ENOENT:: The pin or param does not exist.
+-EEXIST:: The pin or param exists but is of different type.
+-EACCES:: Trying to write a `HAL_OUT` pin, a connected pin or a `HAL_RO` param.
+-EBADF:: Attempt to set a `HAL_PORT` pin.
+-EIO:: The internal data pointer is missing.
+
+== EXAMPLES
+
+[source,c]
+----
+int set_pin_fpval(const char *ppname, rtapi_real val)
+{
+    hal_query_t query = {};
+    query.name = ppname;
+    query.qtype = HAL_QTYPE_PIN; // Only look for pins
+    query.pp.type = HAL_REAL;    // We want to set a floating point value
+    query.pp.value.r = val;      // This is the value
+
+    int rv = hal_set_p(&query, NULL, NULL);
+
+    if(0 != rv)
+        printf("Failed to set '%s': %s\n", ppname, hal_strerror(rv));
+    return rv;
+}
+----
+
+[source,c]
+----
+static int ppsetter_cb(hal_query_t *query, void *arg)
+{
+    const char *str = (const char *)arg;
+
+    // Perform conversion based on type
+    switch(query->pp.type) {
+    case HAL_BOOL: query->pp.value.b = str2bool(str); break;
+    case HAL_REAL: query->pp.value.r = str2real(str); break;
+    case HAL_SINT: query->pp.value.s = str2sint(str); break;
+    case HAL_UINT: query->pp.value.u = str2uint(str); break;
+    default:
+        printf("unsupported value type %d\n", (int)query->pp.type);
+        return -EBADF;
+    }
+
+    return 0;
+}
+
+int set_p_val(const char *ppname, const char *str)
+{
+    hal_query_t query = {};
+    query.name = ppname;
+
+    int rv = hal_set_p(&query, ppsetter_cb, (void *)str);
+
+    if(0 != rv)
+        printf("Failed to set '%s' to '%s': %s\n", ppname, str, hal_strerror(rv));
+    return rv;
+}
+----
+
+== SEE ALSO
+
+hal_query_t(3), hal_get_p(3), hal_set_s(3)

--- a/docs/src/man/man3/hal_set_s.3.adoc
+++ b/docs/src/man/man3/hal_set_s.3.adoc
@@ -1,0 +1,132 @@
+:manvolnum: 3
+
+= hal_set_s(3)
+
+== NAME
+
+hal_set_s - Set a HAL signal value
+
+== SYNOPSIS
+
+[source,c]
+----
+#include <hal.h>
+
+typedef int (*hal_query_cb)(hal_query_t *query, void *arg);
+
+int hal_set_s(hal_query_t *query, hal_query_cb callback, void *arg);
+----
+
+== ARGUMENTS
+
+query::
+  The query structure containing the name to search for and value to set.
+
+callback::
+  The callback function to invoke when the signal has been found to get the value to set.
+  This can also be NULL if no callback is required.
+  Both _query.sig.value_ *and* _query.sig.type_ must be appropriately set if _callback_ is NULL.
+
+arg::
+  A user defined pointer to a user defined data structure.
+  The _arg_ pointer is passed verbatim to the _callback_ function.
+
+== DESCRIPTION
+
+The *hal_set_s()* function will find the named signal and set its value to the user supplied value.
+The _query_ structure should be set to zero before the call, except for the fields noted below.
+
+The _query.name_ must be set to the name of the signal you want to set.
+
+You can further limit the search by setting _query.sig.type_ to the HAL type you want to set.
+If the signal is found, but has a different type, then *-EEXIST* is returned.
+
+Setting a signal with a writer pin connected will fail with an *-EACCES* error.
+
+The _callback_ is called with all fields set appropriately, including data reference.
+You must set the correct _query.sig.value_ subfield in the callback according to the _query.sig.type_ field.
+The signal's value will be set if the callback returns with zero (0).
+
+If you do not wish to use a callback, then you must set both _query.sig.type_ and _query.sig.value_ beforehand.
+The actual type will be checked against what is found and a mismatch will result in an *-EEXIST* error.
+
+If found, *hal_set_s()* sets the _query.name_ field to the actual live signal name.
+
+Setting a signal of type `HAL_PORT` will allocate the port's message queue.
+The size of the queue is determined by the value passed in _query.sig.value.u_.
+A port's queue size cannot be larger than 65536 bytes.
+Trying to reallocate a port's queue will fail with an *-EISCONN* error.
+
+== RETURN VALUE
+
+The *hal_set_s()* function returns zero (0) on success.
+The return value of the _callback_ is returned if it got called and was non-zero.
+A negative errno code is returned if any problem is detected:
+
+[horizontal]
+-EFAULT:: The shared memory was not mapped.
+-EINVAL:: An invalid argument was passed.
+-ENOENT:: The signal does not exist.
+-EEXIST:: The signal exists but is of different type.
+-EACCES:: Trying to write a signal with `HAL_OUT` a pin connected.
+-EISCONN:: Attempt to set a `HAL_PORT` signal with an allocated queue.
+-EBADF:: The signal type is not supported.
+-EIO:: The internal data pointer is missing.
+
+== EXAMPLES
+
+[source,c]
+----
+int set_sig_fpval(const char *signame, rtapi_real val)
+{
+    hal_query_t query = {};
+    query.name = signame;
+    query.sig.type = HAL_REAL;  // We want to set a floating point value
+    query.sig.value.r = val;    // This is the value
+
+    int rv = hal_set_s(&query, NULL, NULL);
+
+    if(0 != rv)
+        printf("Failed to set '%s': %s\n", signame, hal_strerror(rv));
+    return rv;
+}
+----
+
+[source,c]
+----
+static int sigsetter_cb(hal_query_t *query, void *arg)
+{
+    const char *str = (const char *)arg;
+
+    // Perform conversion based on type
+    switch(query->sig.type) {
+    case HAL_BOOL: query->sig.value.b = str2bool(str); break;
+    case HAL_REAL: query->sig.value.r = str2real(str); break;
+    case HAL_SINT: query->sig.value.s = str2sint(str); break;
+    case HAL_UINT: query->sig.value.u = str2uint(str); break;
+
+    case HAL_PORT: // This you'd normally handle as a special case in your code
+    default:
+        printf("unsupported value type %d\n", (int)query->sig.type);
+        return -EBADF;
+    }
+
+    return 0;
+}
+
+int set_s_val(const char *signame, const char *str)
+{
+    hal_query_t query = {};
+    query.name = signame;
+
+    int rv = hal_set_s(&query, sigsetter_cb, (void *)str);
+
+    if(0 != rv)
+        printf("Failed to set '%s' to '%s': %s\n", signame, str, hal_strerror(rv));
+    return rv;
+}
+----
+
+== SEE ALSO
+
+hal_query_t(3), hal_get_p(3), hal_set_s(3)

--- a/docs/src/man/man3/hal_setter.3.adoc
+++ b/docs/src/man/man3/hal_setter.3.adoc
@@ -1,0 +1,38 @@
+:manvolnum: 3
+
+= hal_setter(3)
+
+== NAME
+
+hal_setter, hal_set_bool, hal_set_real, hal_set_sint, hal_set_uint,
+hal_set_si32, hal_set_ui32 - HAL pin and param data writer
+
+== SYNOPSIS
+
+[source,c]
+----
+#include <hal.h>
+
+rtapi_bool hal_set_bool(hal_bool_t refp, rtapi_bool value);
+rtapi_real hal_set_real(hal_real_t refp, rtapi_real value);
+rtapi_sint hal_set_sint(hal_sint_t refp, rtapi_sint value);
+rtapi_uint hal_set_uint(hal_uint_t refp, rtapi_uint value);
+rtapi_s32 hal_set_si32(hal_sint_t refp, rtapi_s32 value);
+rtapi_u32 hal_set_ui32(hal_uint_t refp, rtapi_u32 value);
+----
+
+== ARGUMENTS
+
+refp::
+  Pin or param opaque reference.
+value::
+  The pin or parameter value to set according to the type of the function.
+
+== DESCRIPTION
+
+The **hal_set_*()** family of functions will set a pin or param to the value of the argument.
+The setter ensures that booleans and 32-bit values are properly extended for the underlying storage.
+
+== SEE ALSO
+
+hal_getter(), hal_type_t(3), hal_pin_new(3), hal_param_new(3)

--- a/docs/src/man/man3/hal_signal_new.3.adoc
+++ b/docs/src/man/man3/hal_signal_new.3.adoc
@@ -7,15 +7,17 @@
 hal_signal_new, hal_signal_delete, hal_link, hal_unlink - Manipulate HAL
 signals
 
-== SYNTAX
+== SYNOPSIS
 
-int hal_signal_new(const char* _signal_name_, hal_type_t _type_)
+[source,c]
+----
+#include <hal.h>
 
-int hal_signal_delete(const char* _signal_name_)
-
-int hal_link(const char* _pin_name_, const char* _signal_name_)
-
-int hal_unlink(const char* _pin_name_)
+int hal_signal_new(const char *signal_name, hal_type_t type);
+int hal_signal_delete(const char *signal_name);
+int hal_link(const char *pin_name, const char *signal_name);
+int hal_unlink(const char pin_name);
+----
 
 == ARGUMENTS
 
@@ -28,25 +30,25 @@ type::
 
 == DESCRIPTION
 
-*hal_signal_new* creates a new signal object. Once a signal has been
-created, pins can be linked to it with *hal_link*. The signal object
-contains the actual storage for the signal data. Pin objects linked to
-the signal have pointers that point to the data. 'name' is the name of
-the new signal. It may be no longer than HAL_NAME_LEN characters. If
-there is already a signal with the same name the call will fail.
+The *hal_signal_new()* function creates a new signal object.
+Once a signal has been created, pins can be linked to it with *hal_link()*.
+The signal object contains the actual storage for the signal data.
+Pin objects linked to the signal have pointers that point to the data.
+The _signal_name_ cannot be longer than HAL_NAME_LEN characters.
+If there is already a signal with the same name the call will fail.
 
-*hal_link* links a pin to a signal. If the pin is already linked to the
-desired signal, the command succeeds. If the pin is already linked to
-some other signal, it is an error. In either case, the existing
-connection is not modified. (Use 'hal_unlink' to break an existing
-connection.) If the signal already has other pins linked to it, they are
-unaffected - one signal can be linked to many pins, but a pin can be
-linked to only one signal.
+The *hal_link()* function links a pin to a signal.
+If the pin is already linked to the desired signal, the command succeeds.
+If the pin is already linked to some other signal, it is an error.
+In either case, the existing connection is not modified.
+(Use *hal_unlink()* to break an existing connection.)
+If the signal already has other pins linked to it, they are unaffected.
+One signal can be linked to many pins, but a pin can be linked to only one signal.
 
-*hal_unlink* unlinks any signal from the specified pin.
+The *hal_unlink()* functions unlinks any signal from the specified pin.
 
-*hal_signal_delete* deletes a signal object. Any pins linked to the
-object are unlinked.
+The *hal_signal_delete()* function deletes a signal object.
+Any pins linked to the signal object are unlinked.
 
 == RETURN VALUE
 

--- a/docs/src/man/man3/hal_start_threads.3.adoc
+++ b/docs/src/man/man3/hal_start_threads.3.adoc
@@ -1,21 +1,27 @@
+:manvolnum: 3
+
 = hal_start_threads(3)
 
 == NAME
 
 hal_start_threads - Allow HAL threads to begin executing
 
-== SYNTAX
+== SYNOPSIS
 
-int hal_start_threads()
+[source,c]
+----
+#include <hal.h>
 
-int hal_stop_threads()
+int hal_start_threads();
+int hal_stop_threads();
+----
 
 == DESCRIPTION
 
-*hal_start_threads* starts all threads that have been created.
+The *hal_start_threads()* function starts all threads that have been created.
 This is the point at which realtime functions start being called.
 
-*hal_stop_threads* stops all threads that were previously started by *hal_start_threads*.
+The *hal_stop_threads()* function stops all threads that were previously started by *hal_start_threads()*.
 It should be called before any component that is part of a system exits.
 
 == RETURN VALUE

--- a/docs/src/man/man3/hal_statistics.3.adoc
+++ b/docs/src/man/man3/hal_statistics.3.adoc
@@ -1,0 +1,74 @@
+:manvolnum: 3
+
+= hal_statistics(3)
+
+== NAME
+
+hal_statistics - Retrieve statistical information about HAL
+
+== SYNOPSIS
+
+[source,c]
+----
+#include <hal.h>
+
+int hal_statistics(hal_statistics_t *sts);
+----
+
+== ARGUMENTS
+
+sts::
+  A pointer to a `hal_statistics_t` variable that will receive the data.
+
+== DESCRIPTION
+
+Retrieve the current statistics about memory, pin, param, signal, etc. usage.
+
+The data is provided in a structure with following layout:
+
+[source,c]
+----
+typedef struct {
+    long mem_total;
+    long mem_free;
+    int ncomps;
+    int ncomps_free;
+    int npins;
+    int npins_free;
+    int nparams;
+    int nparams_free;
+    int naliases;
+    int naliases_free;
+    int nsignals;
+    int nsignals_free;
+    int nthreads;
+    int nthreads_free;
+    int nfuncts;
+    int nfuncts_free;
+} hal_statistics_t;
+----
+
+Fields:
+
+[horizontal]
+mem_total;; The shared memory segment's size.
+mem_free;; The remaining amount of shared memory free for allocation.
+ncomps, ncomps_free;; Component count and number of component reserve structures for reuse.
+npins, npins_free;; Pin count and number of pin reserve structures for reuse.
+nparams, nparams_free;; Param count and number of param reserve structures for reuse.
+naliases, naliases_free;; Alias count (oldname) and number of alias reserve structures for reuse.
+nsignals, nsignals_free;; Signal count and number of signal reserve structures for reuse.
+nthreads, nthreads_free;; Thread count and number of thread reserve structures for reuse.
+nfuncts, nfuncts_free;; Function count and number of function reserve structures for reuse.
+
+== RETURN VALUE
+
+Returns zero (0) on success or a negative errno code:
+
+[horizontal]
+-EFAULT:: The shared memory was not mapped.
+-EINVAL:: An invalid argument was passed.
+
+== SEE ALSO
+
+hal_query_t(3)

--- a/docs/src/man/man3/hal_stream.3.adoc
+++ b/docs/src/man/man3/hal_stream.3.adoc
@@ -1,3 +1,5 @@
+:manvolnum: 3
+
 = hal_stream(3)
 
 == NAME
@@ -9,6 +11,7 @@ hal_stream - non-blocking realtime streams
 [source,c]
 ----
 #include <hal.h>
+
 int hal_stream_create(hal_stream_t* stream, int comp_id, int key, int depth, const char* typestring);
 void hal_stream_destroy(hal_stream_t* stream);
 int hal_stream_attach(hal_stream_t* stream, int comp_id, int key, const char* typestring);
@@ -42,73 +45,82 @@ and a data structure specified by _typestring_.
 They must also agree which component (the first one loaded) will *hal_stream_create* the stream,
 and which component (the second one loaded) will *hal_stream_attach* to the already-created stream.
 
-The non-realtime part can be *halstreamer* or *halsampler*.
-In the case of *halstreamer* the key is 0x48535430 plus the channel number.
-In the case of *halsampler* the key is 0x48534130 plus the channel number.
+The non-realtime part can be halstreamer(1) or halsampler(1).
+In the case of halstreamer(1) the key is 0x48535430 plus the channel number.
+In the case of halsampler(1)* the key is 0x48534130 plus the channel number.
 
-*hal_stream_create*::
+hal_stream_create()::
   Create the given stream, initializing the _stream_ which is passed by reference.
   It is an undiagnosed error if a stream has already been created with the same _key_.
 
-*hal_stream_destroy*::
+hal_stream_destroy()::
   Destroy the given stream. It is an undiagnosed error if the stream is
   still attached by another component. It is an undiagnosed error if the
-  stream was attached with *hal_stream_attach* rather than created with
-  *hal_stream_create*. It is an undiagnosed error if the call to
-  *hal_stream_destroy* is omitted.
+  stream was attached with *hal_stream_attach()* rather than created with
+  *hal_stream_create()*. It is an undiagnosed error if the call to
+  *hal_stream_destroy()* is omitted.
 
-*hal_stream_attach*::
-  Attach the given stream, which was already created by *hal_stream_create*.
+hal_stream_attach()::
+  Attach the given stream, which was already created by *hal_stream_create()*.
   If the typestring is specified, this call fails if it does not match the typestring the stream was created with.
   If the typestring argument is NULL, then any typestring is accepted.
 
-*hal_stream_detach*::
+hal_stream_detach()::
   Detach the given stream. It is an undiagnosed error if the stream was
-  created with *hal_stream_create* rather than attached with *hal_stream_attach*.
-  It is an undiagnosed error if the call to *hal_stream_detach* is omitted.
+  created with *hal_stream_create()* rather than attached with *hal_stream_attach()*.
+  It is an undiagnosed error if the call to *hal_stream_detach()* is omitted.
 
-*hal_stream_element_count*:: Returns the number of pins.
+hal_stream_element_count():: Returns the number of pins.
 
-*hal_stream_element_type*:: Returns the type of the given pin number.
+hal_stream_element_type():: Returns the type of the given pin number.
 
-*hal_stream_readable*:: Returns true if the stream has at least one sample to read
+hal_stream_readable():: Returns true if the stream has at least one sample to read
 
-*hal_stream_read*:: If the stream has one sample to read, stores it in buf.
+hal_stream_read():: If the stream has one sample to read, stores it in buf.
 
-*hal_stream_writable*:: Returns true if the stream has room for at least one sample to be written.
+hal_stream_writable():: Returns true if the stream has room for at least one sample to be written.
 
-*hal_stream_depth*:: Returns the number of samples waiting to be read.
+hal_stream_depth():: Returns the number of samples waiting to be read.
 
-*hal_stream_maxdepth*:: Returns the *depth* argument that the stream was created with.
+hal_stream_maxdepth():: Returns the _depth_ argument that the stream was created with.
 
-*hal_stream_num_overruns*:: Returns a number which is incremented each time *hal_stream_write* is called without space available.
+hal_stream_num_overruns()::
+  Returns a number which is incremented each time *hal_stream_write()* is called without space available.
 
-*hal_stream_num_underruns*:: Returns a number which is incremented each time *hal_stream_read* is called without a sample available.
+hal_stream_num_underruns()::
+  Returns a number which is incremented each time *hal_stream_read()* is called without a sample available.
 
-*hal_stream_wait_readable*:: Waits until the stream is readable or the stop flag is set.
+hal_stream_wait_readable()::
+  Waits until the stream is readable or the stop flag is set. +
+  This function cannot be called from realtime.
 
-*hal_stream_wait_writable*:: Waits until the stream is writable or the stop flag is set.
+hal_stream_wait_writable()::
+  Waits until the stream is writable or the stop flag is set. +
+  This function cannot be called from realtime.
 
-*hal_stream_read*:: Reads a record from stream.
+hal_stream_read()::
+  Reads a record from stream.
   If successful, it is stored in the given buffer.
-  Optionally, the sample number can be retrieved. If no sample is available, _num_underruns_ is incremented.
-  It is an undetected error if more than one component or real-time function calls *hal_stream_read* concurrently.
+  Optionally, the sample number can be retrieved.
+  If no sample is available, _num_underruns_ is incremented.
+  It is an undetected error if more than one component or real-time function calls *hal_stream_read()* concurrently.
 
-*hal_stream_write*:: Writes a record to the stream.
+hal_stream_write()::
+  Writes a record to the stream.
   If successful, it copied from the given buffer.
   If no room is available, _num_overruns_ is incremented.
   In either case, the internal _sampleno_ value is incremented.
-  It is an undetected error if more than one component or real-time function calls *hal_stream_write* concurrently.
+  It is an undetected error if more than one component or real-time function calls *hal_stream_write()* concurrently.
 
 == ARGUMENTS
 
 stream::
-  A pointer to a stream object. In the case of *hal_stream_create* and
-  *hal_stream_attach* this is an uninitialized stream; in other cases,
+  A pointer to a stream object. In the case of *hal_stream_create()* and
+  *hal_stream_attach()* this is an uninitialized stream; in other cases,
   it must be a stream created or attached by an earlier call and not yet
   detached or destroyed.
 hal_id::
-  An HAL component identifier returned by an earlier call to *hal_init*.
+  An HAL component identifier returned by an earlier call to hal_init(3).
 key::
   The key for the shared memory segment.
 depth::
@@ -145,19 +157,14 @@ In the source tree under `src/hal/components`, *sampler.c* and
 
 == REALTIME CONSIDERATIONS
 
-*hal_stream_read*, *hal_stream_readable*, *hal_stream_write*,
-*hal_stream_writable*, *hal_stream_element_count*, *hal_tream_pin_type*,
-*hal_stream_depth*, *hal_stream_maxdepth*, *hal_stream_num_underruns*,
-*hal_stream_number_overruns* may be called from realtime code.
-
-*hal_stream_wait_writable*, *hal_stream_wait_writable* may be called from ULAPI code.
+The *hal_stream_wait_readable()* and *hal_stream_wait_writable()* cannot be called from realtime.
 
 Other functions may be called in any context, including realtime contexts.
 
 == RETURN VALUE
 
-The functions *hal_stream_create*, *hal_stream_attach*, *hal_stream_read*,
-*hal_stream_write*, *hal_stream_detach* and *hal_stream_destroy* return
+The functions *hal_stream_create()*, *hal_stream_attach()*, *hal_stream_read()*,
+*hal_stream_write()*, *hal_stream_detach()* and *hal_stream_destroy()* return
 an RTAPI status code. Other functions' return values are explained above.
 
 == BUGS

--- a/docs/src/man/man3/hal_type_t-legacy.3.adoc
+++ b/docs/src/man/man3/hal_type_t-legacy.3.adoc
@@ -1,0 +1,66 @@
+:manvolnum: 3
+
+= hal_type_t-legacy(3)
+
+== NAME
+
+hal_type_t-legacy, hal_bool-legacy, hal_bit_t-legacy, hal_s32_t-legacy, hal_u32_t-legacy,
+hal_port_t-legacy, hal_float_t-legacy, real_t-legacy, ireal_t-legacy - typedefs for HAL datatypes
+
+== DESCRIPTION
+
+typedef ... *hal_bool;*::
+  A type which may have a value of 0 or nonzero.
+typedef ... *hal_bit_t;*::
+  A volatile type which may have a value of 0 or nonzero.
+typedef ... *hal_s32_t*;::
+  A volatile type which may have a value from -2147483648 to 2147483647.
+typedef ... *hal_u32_t*;::
+  A volatile type which may have a value from 0 to 4294967295.
+typedef ... *hal_port_t*;::
+  A volatile handle to a port object. Used with hal_port* functions.
+typedef ... *hal_float_t*;::
+  A volatile floating-point type, which typically has the same precision
+  and range as the C type *double*.
+typedef ... *real_t*;::
+  A nonvolatile floating-point type with at least as much precision as
+  *hal_float_t*.
+typedef ... *ireal_t*;::
+  A nonvolatile unsigned integral type the same size as *hal_float_t*.
+typedef enum *hal_type_t*;::
+
+  *HAL_BIT*;;
+    Corresponds to the type *hal_bit_t*.
+  *HAL_FLOAT*;;
+    Corresponds to the type *hal_float_t*.
+  *HAL_S32*;;
+    Corresponds to the type *hal_s32_t*.
+  *HAL_U32*;;
+    Corresponds to the type *hal_u32_t*.
+
+== NOTES
+
+*hal_bit_t* is typically a typedef to an integer type whose range is
+larger than just 0 and 1. When testing the value of a *hal_bit_t*, never
+compare it to 1. Prefer one of the following:
+
+* if(b)
+* if(b != 0)
+
+It is often useful to refer to a type that can represent all the values
+as a HAL type, but without the volatile qualifier. The following types
+correspond with the HAL types:
+
+hal_bit_t:: int
+hal_s32_t:: __s32
+hal_u32_t:: __u32
+hal_float_t:: hal_real_t
+hal_port_t:: int
+
+Take care not to use the types *s32* and *u32*. These will compile in
+kernel modules but not in userspace, and not for realtime components
+when using uspace realtime.
+
+== SEE ALSO
+
+hal_pin_new(3), hal_param_new(3)

--- a/docs/src/man/man3/hal_type_t.3.adoc
+++ b/docs/src/man/man3/hal_type_t.3.adoc
@@ -4,62 +4,41 @@
 
 == NAME
 
-hal_type_t, hal_bool, hal_bit_t, hal_s32_t, hal_u32_t, hal_port_t, hal_float_t, real_t, ireal_t - typedefs for HAL datatypes
+hal_type_t, hal_bool_t, hal_real_t, hal_sint_t, hal_uint_t, hal_port_t - typedefs for HAL data types
 
 == DESCRIPTION
 
-typedef ... *hal_bool;*::
-  A type which may have a value of 0 or nonzero.
-typedef ... *hal_bit_t;*::
-  A volatile type which may have a value of 0 or nonzero.
-typedef ... *hal_s32_t*;::
-  A volatile type which may have a value from -2147483648 to 2147483647.
-typedef ... *hal_u32_t*;::
-  A volatile type which may have a value from 0 to 4294967295.
+typedef ... *hal_bool_t*;::
+  An opaque type reference for a boolean with a value of zero/false (0) or one/true (1).
+typedef ... *hal_real_t*;::
+  An opaque type reference for a floating-point value with the same precision as a C double type.
+typedef ... *hal_sint_t*;::
+  An opaque type reference for a value from -2^63^ ... +2^63^-1.
+typedef ... *hal_uint_t*;::
+  An opaque type reference for a value from 0 ... +2^64^-1.
 typedef ... *hal_port_t*;::
-  A volatile handle to a port object. Used with hal_port* functions.
-typedef ... *hal_float_t*;::
-  A volatile floating-point type, which typically has the same precision
-  and range as the C type *double*.
-typedef ... *real_t*;::
-  A nonvolatile floating-point type with at least as much precision as
-  *hal_float_t*.
-typedef ... *ireal_t*;::
-  A nonvolatile unsigned integral type the same size as *hal_float_t*.
+  An opaque type reference as a handle to a port object. Used with hal_port*() functions.
 typedef enum *hal_type_t*;::
-  
-  *HAL_BIT*;;
-    Corresponds to the type *hal_bit_t*.
-  *HAL_FLOAT*;;
-    Corresponds to the type *hal_float_t*.
-  *HAL_S32*;;
-    Corresponds to the type *hal_s32_t*.
-  *HAL_U32*;;
-    Corresponds to the type *hal_u32_t*.
+  *HAL_BOOL*;;
+    Corresponds to the type *hal_bool_t*.
+  *HAL_REAL*;;
+    Corresponds to the type *hal_real_t*.
+  *HAL_SINT*;;
+    Corresponds to the type *hal_sint_t*.
+  *HAL_UINT*;;
+    Corresponds to the type *hal_uint_t*.
+  *HAL_PORT*;;
+    Corresponds to the type *hal_port_t*.
 
 == NOTES
 
-*hal_bit_t* is typically a typedef to an integer type whose range is
-larger than just 0 and 1. When testing the value of a *hal_bit_t*, never
-compare it to 1. Prefer one of the following:
-
-* if(b)
-* if(b != 0)
-
-It is often useful to refer to a type that can represent all the values
-as a HAL type, but without the volatile qualifier. The following types
-correspond with the HAL types:
-
-hal_bit_t:: int
-hal_s32_t:: __s32
-hal_u32_t:: __u32
-hal_float_t:: hal_real_t
-hal_port_t:: int
-
-Take care not to use the types *s32* and *u32*. These will compile in
-kernel modules but not in userspace, and not for realtime components
-when using uspace realtime.
+HAL types cannot be read or written directly.
+They are opaque structures that reference a value of the type indicated by the name.
+Reading and writing HAL types is done with getters and setters.
+There are 32-bit compatibility getters and setters to handle smaller coding types.
 
 == SEE ALSO
 
-hal_pin_new(3), hal_param_new(3)
+hal_pin_new(3), hal_param_new(3),
+hal_query_t(3),
+hal_setter(3), hal_getter(3)

--- a/src/hal/Submakefile
+++ b/src/hal/Submakefile
@@ -3,7 +3,7 @@
 ../include/hal.h: ./hal/hal.h
 	cp $^ $@
 
-HALLIBSRCS := hal/hal_lib.c hal/hal_lib_extra.c $(ULAPISRCS)
+HALLIBSRCS := hal/hal_lib.c hal/hal_lib_query.c hal/hal_lib_extra.c $(ULAPISRCS)
 $(call TOOBJSDEPS, $(HALLIBSRCS)): EXTRAFLAGS += -fPIC $(ULAPI_CFLAGS)
 USERSRCS += $(HALLIBSRCS)
 ifeq ($(BUILD_SYS),uspace)

--- a/src/hal/hal.h
+++ b/src/hal/hal.h
@@ -159,6 +159,42 @@ RTAPI_BEGIN_DECLS
 *                   GENERAL PURPOSE FUNCTIONS                          *
 ************************************************************************/
 
+// hal_is_init() returns the current state of HAL for the calling process. It
+// determines whether hal_init() has been called by checking whether the shared
+// memory segment is present.
+// The return value is one (1) if HAL is initialized and zero (0) if not.
+int hal_is_init(void);
+
+#ifdef ULAPI
+// 'hal_lib_init()' will register an rtapi application (HAL_LIB_<pid>) and map
+// the shared HAL memory segment.
+// Only user-space applications linking to hal_lib can initialize the library
+// in this way. This is useful for any program wishing to do set[ps], get[ps]
+// and the like, which do not need a component. Any hal_lib function that does
+// not require an associated component can be executed with HAL shared memory
+// mapped.
+// Note: A caller who creates a component with hal_init() does not need to call
+//       hal_lib_init(). The initialization is automatically performed on
+//       component creation.
+//
+// 'hal_lib_exit()' will unmap the shared HAL memory segment and de-register
+// the rtapi application (HAL_LIB_<pid>).
+// The de-initialization will only occur if no references are left in this
+// instance. A reference is any call to hal_init() with an unmatched hal_exit()
+// (i.e. a component exists). An error message will be emitted when you call
+// hal_lib_exit() while there still are components referenced.
+//
+// Only user-space applications linking to hal_lib can de-init the library.
+// This is useful for any program that accesses HAL constructs but does itself
+// not need any components.
+// Note: A caller is not required to call hal_lib_exit() when the library was
+//       finalized through a call matching call pair to hal_init()/hal_exit.
+//       The last component exit will invoke hal_lib_exit() automatically.
+//
+int  hal_lib_init(void);
+void hal_lib_exit(void);
+#endif
+
 /** 'hal_init()' is called by a HAL component before any other hal
     function is called, to open the HAL shared memory block and
     do other initialization.
@@ -1359,6 +1395,202 @@ typedef enum {
 
 // Only enable the query API when we are compiling the user-land HAL library
 #ifdef ULAPI
+
+// Query type of a HAL item
+typedef enum {
+    HAL_QTYPE_ANY = 0,
+    HAL_QTYPE_PIN,
+    HAL_QTYPE_PARAM,
+    HAL_QTYPE_SIGNAL,
+    HAL_QTYPE_COMP,
+    HAL_QTYPE_FUNCT,
+    HAL_QTYPE_THREAD,
+    HAL_QTYPE_THREAD_FUNCT,
+} hal_qtype_t;
+
+typedef struct {
+    int comp_id;          // Return: Component ID (RTAPI module id)
+    hal_comp_type_t type; // Return: Component type (name in query struct)
+    int pid;              // Return: PID of component (user components only)
+    bool ready;           // Return: True if ready, false if not
+    const char *insmod;   // Return: Arguments passed via insmod or NULL if none present
+} hal_query_comp_t;
+
+typedef struct {
+    int comp_id;          // Return: Component ID
+    const char *comp;     // Return: Component's name
+    int users;            // Return: Number of threads using function
+    rtapi_intptr_t funct; // Return: Pointer to function code
+    rtapi_intptr_t arg;   // Return: Argument for function
+    bool reentrant;       // Return: True if function is re-entrant
+} hal_query_funct_t;
+
+typedef struct {
+    int comp_id;          // Return: Owning component
+    const char *comp;     // Return: Component's name
+    int priority;         // Return: Thread priority
+    long int period;      // Return: Thread period in nsec
+    int functidx;         // Return: Function iteration counter
+    const char *funct;    // Return: Attached function name
+    bool is_init;         // Return: True if funct is an init function
+} hal_query_thread_t;
+
+typedef union {
+    rtapi_bool b;   // values used in hal_[gs]et_[ps]
+    rtapi_sint s;
+    rtapi_uint u;
+    rtapi_real r;
+} hal_query_value_u;
+
+typedef struct {
+    hal_type_t type;    // Request: Enforce specific type (any when == 0);
+                        // Return: HAL_XXX type
+    hal_refs_u ref;     // Return: Value reference
+    hal_query_value_u value; // Request: Set in the callback or in advance for set_p with enforced type;
+                             // Return(get_p): value read
+    hal_pdir_t dir;     // Return: pin/param direction
+    const char *alias;  // Return: non-NULL if there is an alias name
+    const char *signal; // Return: get_p/getref_p/list_p signal name if connected
+    const char *comp;   // Return: Owner's name (component name)
+    int comp_id;        // Return: Owner ID
+} hal_query_pp_t;
+
+typedef struct {
+    hal_type_t type;    // Request: Enforce specific type (any when == 0);
+                        // Return: HAL_XXX type
+    hal_refs_u ref;     // Return: Value reference
+    hal_query_value_u value; // Request: Set in the callback or in advance for set_s with enforced type;
+                             // Return(get_s): value read
+    int writers;        // Return: Number of writer pins attached to the signal
+    int readers;        // Return: Number of reader pins attached to the signal
+    int bidirs;         // Return: Number of bidirectional pins attached to the signal
+} hal_query_sig_t;
+
+//
+// HAL query structure used both for input and output
+//
+typedef struct {
+    const char *name;              // Request: name to search for;
+                                   // Return: name found (live pointer)
+    hal_qtype_t qtype;             // Request: limit search;
+                                   // Return: Connection type found
+    union {
+        void *vpval;         // Generic pointer
+        const void *cpval;   // const pointer (for easier cast'ability)
+        rtapi_intptr_t ipval;
+        rtapi_uintptr_t upval;
+        rtapi_sint sival;
+        rtapi_uint uival;
+    } callerdata;                  // Caller private data additional to 'arg'
+    union {
+        // Query data specific according to 'qtype'
+        // See details above
+        hal_query_pp_t     pp;     // Pins, params
+        hal_query_sig_t    sig;    // Signals
+        hal_query_comp_t   comp;   // Components
+        hal_query_funct_t  funct;  // Functions
+        hal_query_thread_t thread; // Threads
+    };
+} hal_query_t;
+
+// Callback prototype
+// A callback is invoked while holding the HAL mutex. You are allowed to call
+// back into the HAL library from within the callback (the mutex is recursive).
+// A fair warning:
+//    You should not take too long in callbacks and _MUST_NOT_ terminate the
+//    program inside a callback. Doing so will keep the mutex locked and other
+//    processes will hang indefinitely when they call into the HAL library.
+// Returning non-zero will automatically break any iteration loop. Use negative
+// return values to signal error conditions and positive return values to
+// simply terminate any iteration loop. The callback's return value is used as
+// the iteration function's return value.
+typedef int (*hal_query_cb)(hal_query_t *query, void *arg);
+
+// Pin/Param/Signal setters based on name
+// get_p/set_p - get or set pin or param
+// get_s/set_s - get or set signal
+// getref_p    - return only the pin/param reference
+// getref_s    - return only the signal reference
+//
+// set_s(): If the type is HAL_PORT, then the action sets the port's
+//          queue size according to the `query->value.u` setting.
+//
+// set_p/set_s: The callback function is called after it is determined that the
+// name exists and optionally if the type matches. If the setter 'cb' callback
+// is NULL, then it is required that you set both the query->{pp,sig}.type to
+// the proper type and the matching query->{pp,sig}.value field to its
+// associated value.
+//
+// get_p/get_s: The callback function is called after it is determined that
+// the name exists and optionally if the type matches. The getter calls the
+// callback with the appropriate query->{pp,sig}.value field set to the value
+// read, according to the type. If the getter 'cb' callback is NULL, then it is
+// simply skipped and the value is still available in the query structure.
+//
+// For all query functions: The callback should return zero when it succeeds
+// and a negative errno value on error. If the callback returns with a non-zero
+// value, then that value is returned.
+// Returning a positive value from a callback function in iterations terminates
+// the iteration loop. The caller can determine from the return value's sign
+// whether it was an error or an intentional iteration loop termination.
+//
+int hal_getref_p(hal_query_t *query);
+int hal_get_p(hal_query_t *query, hal_query_cb cb, void *arg);
+int hal_set_p(hal_query_t *query, hal_query_cb cb, void *arg);
+
+int hal_getref_s(hal_query_t *query);
+int hal_get_s(hal_query_t *query, hal_query_cb cb, void *arg);
+int hal_set_s(hal_query_t *query, hal_query_cb cb, void *arg);
+
+//
+// *** HAL structure iteration functions ***
+//
+// Each function will invoke the callback on each of the HAL structures
+// of interest:
+//   hal_list_p      - callback on pins and/or params
+//   hal_list_p_s    - callback on pins connected to named signal
+//   hal_list_s      - callback on signals
+//   hal_list_comp   - callback on components
+//   hal_list_funct  - callback on registered functions
+//   hal_list_thread - callback on registered threads (and its functions)
+//
+int hal_list_p(hal_query_t *q, hal_query_cb cb, void *arg);
+int hal_list_p_s(hal_query_t *q, hal_query_cb cb, void *arg);
+int hal_list_s(hal_query_t *q, hal_query_cb cb, void *arg);
+int hal_list_comp(hal_query_t *q, hal_query_cb cb, void *arg);
+int hal_list_funct(hal_query_t *q, hal_query_cb cb, void *arg);
+int hal_list_thread(hal_query_t *q, hal_query_cb cb, void *arg);
+
+//
+// *** Component queries ***
+//
+// Query components by name or ID
+int hal_comp_by_name(const char *name, hal_query_t *q);
+int hal_comp_by_id(int comp_id, hal_query_t *q);
+
+//
+// *** General HAL statistics ***
+//
+typedef struct {
+    long mem_total;
+    long mem_free;
+    int ncomps;
+    int ncomps_free;
+    int npins;
+    int npins_free;
+    int nparams;
+    int nparams_free;
+    int naliases;
+    int naliases_free;
+    int nsignals;
+    int nsignals_free;
+    int nthreads;
+    int nthreads_free;
+    int nfuncts;
+    int nfuncts_free;
+} hal_statistics_t;
+
+int hal_statistics(hal_statistics_t *sts);
 
 //
 // *** Special functions for rtapi_app and halcmd ***

--- a/src/hal/hal_lib.c
+++ b/src/hal/hal_lib.c
@@ -259,13 +259,123 @@ void halpr_mutex_force_release(void)
 
 static int ref_cnt = 0;
 
+#ifdef ULAPI
+static int init_cnt = 0; // Reference count on hal_lib_init()/hal_lib_exit()
+
+// Only user-space applications linking to hal_lib have access to this part.
+// Especially halmodule will call it on import to map the shared memory.
+int hal_lib_init(void)
+{
+    init_cnt++;  // Reference count init calls
+
+    if(0 != lib_mem_id)
+        return 0;  // Already initialized and mapped
+
+    rtapi_print_msg(RTAPI_MSG_DBG, "HAL: initializing hal_lib\n");
+    char rtapi_name[RTAPI_NAME_LEN + 1];
+    rtapi_snprintf(rtapi_name, RTAPI_NAME_LEN, "HAL_LIB_%d", (int)getpid());
+    lib_module_id = rtapi_init(rtapi_name);
+    if (lib_module_id < 0) {
+        rtapi_print_msg(RTAPI_MSG_ERR, "HAL: ERROR: could not initialize RTAPI\n");
+        init_cnt--;
+        return lib_module_id;
+    }
+
+    /* get HAL shared memory block from RTAPI */
+    lib_mem_id = rtapi_shmem_new(HAL_KEY, lib_module_id, HAL_SIZE);
+    if (lib_mem_id < 0) {
+        rtapi_print_msg(RTAPI_MSG_ERR, "HAL: ERROR: could not open shared memory\n");
+        rtapi_exit(lib_module_id);
+        // Reset the 'lib_mem_id' because it is used as a key in the test to
+        // perform the memory mapping at the start of the function.
+        lib_mem_id = 0;
+        lib_module_id = -1;
+        init_cnt--;
+        return -EINVAL;
+    }
+    /* get address of shared memory area */
+    void *mem;
+    int retval = rtapi_shmem_getptr(lib_mem_id, &mem);
+    if (retval < 0) {
+        rtapi_print_msg(RTAPI_MSG_ERR, "HAL: ERROR: could not access shared memory\n");
+        rtapi_shmem_delete(lib_mem_id, lib_module_id);
+        rtapi_exit(lib_module_id);
+        lib_mem_id = 0;
+        lib_module_id = -1;
+        init_cnt--;
+        return -EINVAL;
+    }
+    /* set up internal pointers to shared mem and data structure */
+    hal_shmem_base = (char *)mem;
+    hal_data = (hal_data_t *)mem;
+    /* perform a global init if needed */
+    retval = init_hal_data();
+    if (0 != retval) {
+        rtapi_print_msg(RTAPI_MSG_ERR, "HAL: ERROR: could not init shared memory\n");
+        rtapi_shmem_delete(lib_mem_id, lib_module_id);
+        rtapi_exit(lib_module_id);
+        hal_shmem_base = NULL;
+        hal_data = NULL;
+        lib_mem_id = 0;
+        lib_module_id = -1;
+        init_cnt--;
+        return -EINVAL;
+    }
+    return 0;
+}
+
+static int dangling_comp_cb(hal_query_t *q, void *arg)
+{
+    (void)arg;
+    if(q->callerdata.sival == q->comp.pid) {
+        rtapi_print_msg(RTAPI_MSG_ERR, "  dangling component: '%s' id=%d pid=%d ready=%d insmod='%s'\n",
+            q->name, q->comp.comp_id, q->comp.pid, (int)q->comp.ready, q->comp.insmod ? q->comp.insmod : "(null)");
+    }
+    return 0;
+}
+
+void hal_lib_exit(void)
+{
+    if(init_cnt <= 0) {
+        rtapi_print_msg(RTAPI_MSG_ERR, "HAL: ERROR: hal_lib_exit() called too often (init_cnt=%d)\n", init_cnt);
+        return;
+    }
+
+    init_cnt--;  // Decrease the ref count
+
+    if(init_cnt > 0) {
+        return;  // Not yet final exit.
+    }
+
+    // We check the hal_init() refcount. We can't delete until hal_exit() was
+    // called on all of them. We alse check whether we actually have been
+    // initialized and have a valid shared memory ID. This ID is non-zero when
+    // we sucessfully initialized.
+    if(0 == ref_cnt) {
+        if(0 != lib_mem_id) {
+            rtapi_print_msg(RTAPI_MSG_DBG, "HAL: releasing RTAPI resources\n");
+            /* release RTAPI resources */
+            rtapi_shmem_delete(lib_mem_id, lib_module_id);
+            rtapi_exit(lib_module_id);
+            lib_mem_id = 0;
+            lib_module_id = -1;
+            hal_shmem_base = NULL;
+            hal_data = NULL;
+        } // else it is a no-op
+    } else {
+        int pid = (int)getpid();
+        rtapi_print_msg(RTAPI_MSG_ERR, "HAL: ERROR: hal_lib_exit() called"
+                        " while holding %d component references (pid=%d)\n", ref_cnt, pid);
+        hal_query_t q = {};
+        q.callerdata.sival = pid;
+        hal_list_comp(&q, dangling_comp_cb, NULL);
+    }
+}
+#endif /* ULAPI */
+
 int hal_init(const char *name)
 {
     int comp_id;
-#ifdef ULAPI
-    int retval;
-    void *mem;
-#endif
     char rtapi_name[RTAPI_NAME_LEN + 1];
     char hal_name[HAL_NAME_LEN + 1];
     hal_comp_t *comp;
@@ -281,43 +391,10 @@ int hal_init(const char *name)
     }
 
 #ifdef ULAPI
-    if(!lib_mem_id) {
-	rtapi_print_msg(RTAPI_MSG_DBG, "HAL: initializing hal_lib\n");
-	rtapi_snprintf(rtapi_name, RTAPI_NAME_LEN, "HAL_LIB_%d", (int)getpid());
-	lib_module_id = rtapi_init(rtapi_name);
-	if (lib_module_id < 0) {
-	    rtapi_print_msg(RTAPI_MSG_ERR,
-		"HAL: ERROR: could not initialize RTAPI\n");
-	    return -EINVAL;
-	}
-
-	/* get HAL shared memory block from RTAPI */
-	lib_mem_id = rtapi_shmem_new(HAL_KEY, lib_module_id, HAL_SIZE);
-	if (lib_mem_id < 0) {
-	    rtapi_print_msg(RTAPI_MSG_ERR,
-		"HAL: ERROR: could not open shared memory\n");
-	    rtapi_exit(lib_module_id);
-	    return -EINVAL;
-	}
-	/* get address of shared memory area */
-	retval = rtapi_shmem_getptr(lib_mem_id, &mem);
-	if (retval < 0) {
-	    rtapi_print_msg(RTAPI_MSG_ERR,
-		"HAL: ERROR: could not access shared memory\n");
-	    rtapi_exit(lib_module_id);
-	    return -EINVAL;
-	}
-	/* set up internal pointers to shared mem and data structure */
-        hal_shmem_base = (char *) mem;
-        hal_data = (hal_data_t *) mem;
-	/* perform a global init if needed */
-	retval = init_hal_data();
-	if ( retval ) {
-	    rtapi_print_msg(RTAPI_MSG_ERR,
-		"HAL: ERROR: could not init shared memory\n");
-	    rtapi_exit(lib_module_id);
-	    return -EINVAL;
-	}
+    if(ref_cnt == 0) {
+        int retval = hal_lib_init();
+        if (0 != retval)
+            return retval;
     }
 #endif
     rtapi_print_msg(RTAPI_MSG_DBG, "HAL: initializing component '%s'\n",
@@ -329,7 +406,7 @@ int hal_init(const char *name)
     comp_id = rtapi_init(rtapi_name);
     if (comp_id < 0) {
 	rtapi_print_msg(RTAPI_MSG_ERR, "HAL: ERROR: rtapi init failed\n");
-	return -EINVAL;
+	return comp_id;
     }
     /* get mutex before manipulating the shared data */
     halpr_mutex_acquire();
@@ -340,7 +417,7 @@ int hal_init(const char *name)
 	rtapi_print_msg(RTAPI_MSG_ERR,
 	    "HAL: ERROR: duplicate component name '%s'\n", hal_name);
 	rtapi_exit(comp_id);
-	return -EINVAL;
+	return -EEXIST;
     }
     /* allocate a new component structure */
     comp = halpr_alloc_comp_struct();
@@ -386,7 +463,7 @@ int hal_exit(int comp_id)
     if (hal_data == NULL) {
 	rtapi_print_msg(RTAPI_MSG_ERR,
 	    "HAL: ERROR: exit called before init\n");
-	return -EINVAL;
+	return -EFAULT;
     }
     rtapi_print_msg(RTAPI_MSG_DBG, "HAL: removing component %02d\n", comp_id);
     /* grab mutex before manipulating list */
@@ -399,7 +476,7 @@ int hal_exit(int comp_id)
 	halpr_mutex_release();
 	rtapi_print_msg(RTAPI_MSG_ERR,
 	    "HAL: ERROR: component %d not found\n", comp_id);
-	return -EINVAL;
+	return -ENOENT;
     }
     comp = SHMPTR(next);
     while (comp->comp_id != comp_id) {
@@ -411,7 +488,7 @@ int hal_exit(int comp_id)
 	    halpr_mutex_release();
 	    rtapi_print_msg(RTAPI_MSG_ERR,
 		"HAL: ERROR: component %d not found\n", comp_id);
-	    return -EINVAL;
+	    return -ENOENT;
 	}
 	comp = SHMPTR(next);
     }
@@ -442,15 +519,10 @@ int hal_exit(int comp_id)
     halpr_mutex_release();
     --ref_cnt;
 #ifdef ULAPI
-    if(ref_cnt == 0) {
-        rtapi_print_msg(RTAPI_MSG_DBG, "HAL: releasing RTAPI resources\n");
-	/* release RTAPI resources */
-	rtapi_shmem_delete(lib_mem_id, lib_module_id);
-	rtapi_exit(lib_module_id);
-	lib_mem_id = 0;
-	lib_module_id = -1;
-	hal_shmem_base = NULL;
-	hal_data = NULL;
+    if (0 == ref_cnt) {
+        hal_lib_exit();
+    } else if(ref_cnt < 0) {
+        rtapi_print_msg(RTAPI_MSG_ERR, "HAL: ERROR: hal_exit() made reference count negative\n");
     }
 #endif
     rtapi_exit(comp_id);
@@ -678,10 +750,10 @@ char *hal_comp_name(int comp_id)
 }
 
 hal_realtime_type_t hal_get_realtime_type() {
-    if (hal_data == 0) {
+    if (hal_data == NULL) {
         rtapi_print_msg(RTAPI_MSG_ERR,
             "HAL: ERROR: hal_get_realtime_type called before init\n");
-        return -EINVAL;
+        return -EFAULT;
     }
     return hal_data->realtime_type;
 }
@@ -696,7 +768,7 @@ int hal_set_lock(unsigned char lock_type) {
     if (hal_data == NULL) {
 	rtapi_print_msg(RTAPI_MSG_ERR,
 	    "HAL: ERROR: set_lock called before init\n");
-	return -EINVAL;
+	return -EFAULT;
     }
     hal_data->lock = lock_type;
     return 0;
@@ -961,7 +1033,7 @@ int hal_pin_new(const char *name, hal_type_t type, hal_pin_dir_t dir,
     if (hal_data == NULL) {
 	rtapi_print_msg(RTAPI_MSG_ERR,
 	    "HAL: ERROR: pin_new called before init\n");
-	return -EINVAL;
+	return -EFAULT;
     }
 
     if(*data_ptr_addr) 
@@ -1100,7 +1172,7 @@ int hal_pin_alias(const char *pin_name, const char *alias)
     if (hal_data == NULL) {
 	rtapi_print_msg(RTAPI_MSG_ERR,
 	    "HAL: ERROR: pin_alias called before init\n");
-	return -EINVAL;
+	return -EFAULT;
     }
     if (hal_data->lock & HAL_LOCK_CONFIG)  {
 	rtapi_print_msg(RTAPI_MSG_ERR,
@@ -1229,7 +1301,7 @@ int hal_signal_new(const char *name, hal_type_t type)
     if (hal_data == NULL) {
 	rtapi_print_msg(RTAPI_MSG_ERR,
 	    "HAL: ERROR: signal_new called before init\n");
-	return -EINVAL;
+	return -EFAULT;
     }
 
     if (strlen(name) > HAL_NAME_LEN) {
@@ -1260,12 +1332,12 @@ int hal_signal_new(const char *name, hal_type_t type)
      * See: #421 and https://github.com/machinekit/machinekit/issues/524
      */
     switch (type) {
-    case HAL_BIT:
+    case HAL_BOOL:
     case HAL_S32:
     case HAL_U32:
-    case HAL_S64:
-    case HAL_U64:
-    case HAL_FLOAT:
+    case HAL_SINT:
+    case HAL_UINT:
+    case HAL_REAL:
     case HAL_PORT:
         data_addr = shmalloc_up(sizeof(hal_data_u));
         // Initialize the signal value
@@ -1327,7 +1399,7 @@ int hal_signal_delete(const char *name)
     if (hal_data == NULL) {
 	rtapi_print_msg(RTAPI_MSG_ERR,
 	    "HAL: ERROR: signal_delete called before init\n");
-	return -EINVAL;
+	return -EFAULT;
     }
     
     if (hal_data->lock & HAL_LOCK_CONFIG)  {
@@ -1374,7 +1446,7 @@ int hal_link(const char *pin_name, const char *sig_name)
     if (hal_data == NULL) {
 	rtapi_print_msg(RTAPI_MSG_ERR,
 	    "HAL: ERROR: link called before init\n");
-	return -EINVAL;
+	return -EFAULT;
     }
 
     if (hal_data->lock & HAL_LOCK_CONFIG)  {
@@ -1542,7 +1614,7 @@ int hal_unlink(const char *pin_name)
     if (hal_data == NULL) {
 	rtapi_print_msg(RTAPI_MSG_ERR,
 	    "HAL: ERROR: unlink called before init\n");
-	return -EINVAL;
+	return -EFAULT;
     }
 
     if (hal_data->lock & HAL_LOCK_CONFIG)  {
@@ -1713,7 +1785,7 @@ static int hal_param_new_anyapi(const char *name, hal_type_t type, hal_pdir_t di
     if (hal_data == NULL) {
 	rtapi_print_msg(RTAPI_MSG_ERR,
 	    "HAL: ERROR: param_new called before init\n");
-	return -EINVAL;
+	return -EFAULT;
     }
 
     if (type != HAL_BIT && type != HAL_FLOAT && type != HAL_S32 && type != HAL_U32 && type != HAL_S64 && type != HAL_U64) {
@@ -1863,7 +1935,7 @@ int hal_param_new_bool(int compid, hal_pdir_t dir, hal_bool_t *ref, rtapi_bool d
 {
     va_list ap;
     va_start(ap, fmt);
-    int ret = hal_param_new_newapi(HAL_BIT, dir, (void**)ref, compid, fmt, ap);
+    int ret = hal_param_new_newapi(HAL_BIT, dir, ref, compid, fmt, ap);
     va_end(ap);
     if(ret)
         return ret;
@@ -1875,7 +1947,7 @@ int hal_param_new_si32(int compid, hal_pdir_t dir, hal_sint_t *ref, rtapi_s32 de
 {
     va_list ap;
     va_start(ap, fmt);
-    int ret = hal_param_new_newapi(HAL_S32, dir, (void**)ref, compid, fmt, ap);
+    int ret = hal_param_new_newapi(HAL_S32, dir, ref, compid, fmt, ap);
     va_end(ap);
     if(ret)
         return ret;
@@ -1887,7 +1959,7 @@ int hal_param_new_ui32(int compid, hal_pdir_t dir, hal_uint_t *ref, rtapi_u32 de
 {
     va_list ap;
     va_start(ap, fmt);
-    int ret = hal_param_new_newapi(HAL_U32, dir, (void**)ref, compid, fmt, ap);
+    int ret = hal_param_new_newapi(HAL_U32, dir, ref, compid, fmt, ap);
     va_end(ap);
     if(ret)
         return ret;
@@ -1899,7 +1971,7 @@ int hal_param_new_sint(int compid, hal_pdir_t dir, hal_sint_t *ref, rtapi_sint d
 {
     va_list ap;
     va_start(ap, fmt);
-    int ret = hal_param_new_newapi(HAL_S64, dir, (void**)ref, compid, fmt, ap);
+    int ret = hal_param_new_newapi(HAL_S64, dir, ref, compid, fmt, ap);
     va_end(ap);
     if(ret)
         return ret;
@@ -1911,7 +1983,7 @@ int hal_param_new_uint(int compid, hal_pdir_t dir, hal_uint_t *ref, rtapi_uint d
 {
     va_list ap;
     va_start(ap, fmt);
-    int ret = hal_param_new_newapi(HAL_U64, dir, (void**)ref, compid, fmt, ap);
+    int ret = hal_param_new_newapi(HAL_U64, dir, ref, compid, fmt, ap);
     va_end(ap);
     if(ret)
         return ret;
@@ -1923,7 +1995,7 @@ int hal_param_new_real(int compid, hal_pdir_t dir, hal_real_t *ref, rtapi_real d
 {
     va_list ap;
     va_start(ap, fmt);
-    int ret = hal_param_new_newapi(HAL_FLOAT, dir, (void**)ref, compid, fmt, ap);
+    int ret = hal_param_new_newapi(HAL_FLOAT, dir, ref, compid, fmt, ap);
     va_end(ap);
     if(ret)
         return ret;
@@ -1990,7 +2062,7 @@ int hal_param_set(const char *name, hal_type_t type, void *value_addr)
     if (hal_data == NULL) {
 	rtapi_print_msg(RTAPI_MSG_ERR,
 	    "HAL: ERROR: param_set called before init\n");
-	return -EINVAL;
+	return -EFAULT;
     }
     
     if (hal_data->lock & HAL_LOCK_PARAMS)  {
@@ -2072,7 +2144,7 @@ int hal_param_alias(const char *param_name, const char *alias)
     if (hal_data == NULL) {
 	rtapi_print_msg(RTAPI_MSG_ERR,
 	    "HAL: ERROR: param_alias called before init\n");
-	return -EINVAL;
+	return -EFAULT;
     }
     if (hal_data->lock & HAL_LOCK_CONFIG)  {
 	rtapi_print_msg(RTAPI_MSG_ERR,
@@ -2279,10 +2351,10 @@ int hal_export_funct(const char *name, void (*funct) (void *, long),
     hal_comp_t *comp;
     char buf[HAL_NAME_LEN + 1];
 
-    if (hal_data == 0) {
+    if (hal_data == NULL) {
 	rtapi_print_msg(RTAPI_MSG_ERR,
 	    "HAL: ERROR: export_funct called before init\n");
-	return -EINVAL;
+	return -EFAULT;
     }
 
     if (strlen(name) > HAL_NAME_LEN) {
@@ -2409,10 +2481,10 @@ int hal_create_thread(const char *name, unsigned long period_nsec, int uses_fp)
 
     rtapi_print_msg(RTAPI_MSG_DBG,
 	"HAL: creating thread %s, %ld nsec\n", name, period_nsec);
-    if (hal_data == 0) {
+    if (hal_data == NULL) {
 	rtapi_print_msg(RTAPI_MSG_ERR,
 	    "HAL: ERROR: create_thread called before init\n");
-	return -EINVAL;
+	return -EFAULT;
     }
     if (period_nsec == 0) {
 	rtapi_print_msg(RTAPI_MSG_ERR,
@@ -2443,7 +2515,7 @@ int hal_create_thread(const char *name, unsigned long period_nsec, int uses_fp)
 	    halpr_mutex_release();
 	    rtapi_print_msg(RTAPI_MSG_ERR,
 		"HAL: ERROR: duplicate thread name %s\n", name);
-	    return -EINVAL;
+	    return -EEXIST;
 	}
 	/* didn't find it yet, look at next one */
 	next = tptr->next_ptr;
@@ -2549,7 +2621,7 @@ int hal_create_thread(const char *name, unsigned long period_nsec, int uses_fp)
     if (new->comp_id < 0) {
         rtapi_print_msg(RTAPI_MSG_ERR,
            "HAL: ERROR: fail to create pseudo comp for thread: '%s'\n", new->name);
-        return -EINVAL;
+        return new->comp_id;
     }
 
     rtapi_snprintf(buf, sizeof(buf), "%s.tmax", new->name);
@@ -2577,10 +2649,10 @@ extern int hal_thread_delete(const char *name)
     hal_thread_t *thread;
     rtapi_intptr_t *prev, next;
 
-    if (hal_data == 0) {
+    if (hal_data == NULL) {
 	rtapi_print_msg(RTAPI_MSG_ERR,
 	    "HAL: ERROR: thread_delete called before init\n");
-	return -EINVAL;
+	return -EFAULT;
     }
 
     if (hal_data->lock & HAL_LOCK_CONFIG) {
@@ -2618,7 +2690,7 @@ extern int hal_thread_delete(const char *name)
     halpr_mutex_release();
     rtapi_print_msg(RTAPI_MSG_ERR, "HAL: ERROR: thread '%s' not found\n",
 	name);
-    return -EINVAL;
+    return -ENOENT;
 }
 
 #endif /* RTAPI */
@@ -2634,7 +2706,7 @@ int hal_add_funct_to_thread(const char *funct_name, const char *thread_name, int
     if (hal_data == NULL) {
 	rtapi_print_msg(RTAPI_MSG_ERR,
 	    "HAL: ERROR: add_funct called before init\n");
-	return -EINVAL;
+	return -EFAULT;
     }
 
     if (hal_data->lock & HAL_LOCK_CONFIG) {
@@ -2762,7 +2834,7 @@ int hal_init_funct_to_thread(const char *funct_name, const char *thread_name, in
     if (hal_data == NULL) {
         rtapi_print_msg(RTAPI_MSG_ERR,
             "HAL: ERROR: init_funct called before init\n");
-        return -EINVAL;
+        return -EFAULT;
     }
 
     if (hal_data->lock & HAL_LOCK_CONFIG) {
@@ -2793,7 +2865,7 @@ int hal_init_funct_to_thread(const char *funct_name, const char *thread_name, in
         halpr_mutex_release();
         rtapi_print_msg(RTAPI_MSG_ERR,
             "HAL: ERROR: function '%s' not found\n", funct_name);
-        return -EINVAL;
+        return -ENOENT;
     }
 
     thread = halpr_find_thread_by_name(thread_name);
@@ -2801,7 +2873,7 @@ int hal_init_funct_to_thread(const char *funct_name, const char *thread_name, in
         halpr_mutex_release();
         rtapi_print_msg(RTAPI_MSG_ERR,
             "HAL: ERROR: thread '%s' not found\n", thread_name);
-        return -EINVAL;
+        return -ENOENT;
     }
 
     /* once the special init cycle has executed, further initf calls are a
@@ -2874,7 +2946,7 @@ int hal_del_funct_from_thread(const char *funct_name, const char *thread_name)
     if (hal_data == NULL) {
 	rtapi_print_msg(RTAPI_MSG_ERR,
 	    "HAL: ERROR: del_funct called before init\n");
-	return -EINVAL;
+	return -EFAULT;
     }
 
     if (hal_data->lock & HAL_LOCK_CONFIG) {
@@ -2960,7 +3032,7 @@ int hal_start_threads(void)
     if (hal_data == NULL) {
 	rtapi_print_msg(RTAPI_MSG_ERR,
 	    "HAL: ERROR: start_threads called before init\n");
-	return -EINVAL;
+	return -EFAULT;
     }
 
     if (hal_data->lock & HAL_LOCK_RUN) {
@@ -2981,7 +3053,7 @@ int hal_stop_threads(void)
     if (hal_data == NULL) {
 	rtapi_print_msg(RTAPI_MSG_ERR,
 	    "HAL: ERROR: stop_threads called before init\n");
-	return -EINVAL;
+	return -EFAULT;
     }
 
     if (hal_data->lock & HAL_LOCK_RUN) {
@@ -3584,10 +3656,10 @@ static int init_hal_data(void)
             halpr_mutex_release();
             return 0;
         } else {
+            halpr_mutex_release();
             rtapi_print("HAL: version:%d expected:%d\n",hal_data->version,HAL_VER);
             rtapi_print_msg(RTAPI_MSG_ERR, "HAL: ERROR: version code mismatch\n");
-            halpr_mutex_release();
-            return -1;
+            return -EPROTO;
         }
     }
 
@@ -4022,7 +4094,7 @@ static void unlink_pin(hal_pin_t * pin)
     dummy_addr = (hal_data_u *)(hal_shmem_base + SHMOFF(&(pin->dummysig)));
 
     switch (pin->type) {
-    case HAL_BIT:
+    case HAL_BOOL:
         dummy_addr->b = sig_data_addr->b;
         break;
     case HAL_S32:
@@ -4031,13 +4103,13 @@ static void unlink_pin(hal_pin_t * pin)
     case HAL_U32:
         dummy_addr->u = sig_data_addr->u;
         break;
-    case HAL_S64:
+    case HAL_SINT:
         dummy_addr->s = sig_data_addr->s;
         break;
-    case HAL_U64:
+    case HAL_UINT:
         dummy_addr->u = sig_data_addr->u;
         break;
-    case HAL_FLOAT:
+    case HAL_REAL:
         dummy_addr->f = sig_data_addr->f;
         break;
     case HAL_PORT:
@@ -4392,7 +4464,15 @@ static bool hal_port_compute_copy(unsigned read,
 }
 
 
-int hal_port_alloc(unsigned size, hal_port_t *port) {
+// hal_port_alloc() is DEPRECATED
+// Access to port allocation is done by hal_set_s() on the signal that has the
+// port pins connected.
+int hal_port_alloc(unsigned size, hal_port_t *port)
+{
+    return halpr_port_alloc(size, port);
+}
+
+int halpr_port_alloc(unsigned size, hal_port_t *port) {
     if(!port || size < 1 || size > HAL_PORT_SIZE_MAX)
         return -EINVAL;
 

--- a/src/hal/hal_lib_query.c
+++ b/src/hal/hal_lib_query.c
@@ -1,0 +1,1111 @@
+//
+// HAL non-RT query API
+//
+// Copyright 2026  B.Stultiens
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of version 2 of the GNU General
+// Public License as published by the Free Software Foundation.
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+#include "hal.h"
+#include "hal_priv.h"
+
+//=====================================================
+//
+// HAL query API implementation of gets/sets and getp/setp
+//
+// Additionally adds retrieving the pin/param/signal
+// reference for reading and writing using hal_getref_[ps].
+//
+// Replaces all (re-)implementations in other programs as
+// one standard and unified API.
+//
+// NOTE: This API is not exported in the kernel.
+//       It is a user-land thing and should only
+//       be called from non-RT applications.
+//
+// Iteration of HAL's internal data structures is done using
+// the hal_list_* functions. These iterate over any and all
+// HAL structure with a user provided callback and may be
+// used to extract useful data.
+//
+//=====================================================
+
+static int set_common(hal_type_t type, const hal_query_value_u *v, hal_refs_u u, bool setport, bool isparam)
+{
+    // This is a special case because compatibility requires us to write to the
+    // smaller field when addressing parameters. An old-style param has a
+    // user-defined storage that may not be large enough for our new types and
+    // would overwrite other memory.
+    // FIXME: This code must be retired when we do the API break.
+    if(isparam) {
+        switch(type) {
+        case HAL_BOOL: ((hal_data_u *)u.b)->b  = v->b; break;
+        case HAL_S32:  ((hal_data_u *)u.s)->s  = v->s; break;
+        case HAL_U32:  ((hal_data_u *)u.u)->u  = v->u; break;
+        case HAL_SINT: ((hal_data_u *)u.s)->ls = v->s; break;
+        case HAL_UINT: ((hal_data_u *)u.u)->lu = v->u; break;
+        case HAL_REAL: ((hal_data_u *)u.r)->f  = v->r; break;
+        default:
+        case HAL_PORT: return -EBADF;
+        }
+        return 0;
+    }
+    switch(type) {
+    case HAL_BOOL: hal_set_bool(u.b, v->b); break;
+    case HAL_S32:  hal_set_si32(u.s, v->s); break;
+    case HAL_U32:  hal_set_ui32(u.u, v->u); break;
+    case HAL_SINT: hal_set_sint(u.s, v->s); break;
+    case HAL_UINT: hal_set_uint(u.u, v->u); break;
+    case HAL_REAL: hal_set_real(u.r, v->r); break;
+    case HAL_PORT: {
+        if(!setport)
+            return -EBADF;
+        // FIXME: This needs to be changed when the old API is removed
+        rtapi_port port = hal_get_sint(u.s);
+        if(0 != port && hal_port_buffer_size((hal_port_t *)u.s) > 0) {
+            return -EISCONN;
+        }
+        int rv = halpr_port_alloc(v->u, (hal_port_t *)u.s);
+        if(rv)
+            return rv;
+        } break;
+    default:
+        return -EBADF;
+    }
+    return 0;
+}
+
+//
+// hal_set_s() - Set the value of a signal
+//
+// Query inputs:
+//   q->name      - Signal to set
+//   q->sig.type  - Optional: must match specific HAL_X type
+//                  The q->sig.value must be set to the proper value,
+//                  which will be used, if there is no callback set.
+//                  The type is mandatory if no callback is specified.
+//   q->sig.value - Mandatory if no callback is specified.
+//
+int hal_set_s(hal_query_t *q, hal_query_cb cb, void *arg)
+{
+    if(NULL == hal_data) {
+        rtapi_print_msg(RTAPI_MSG_ERR, "hal_set_s: HAL shared memory not mapped\n");
+        return -EFAULT;
+    }
+    if(!q || !q->name) {
+        rtapi_print_msg(RTAPI_MSG_ERR, "hal_set_s: Invalid query arguments\n");
+        return -EINVAL;
+    }
+    if(0 == q->sig.type && !cb) {
+        rtapi_print_msg(RTAPI_MSG_ERR, "hal_set_s: Must have callback if type is not specified\n");
+        return -EINVAL;
+    }
+
+    // Grab the mutex to keep the data stable
+    halpr_mutex_acquire();
+
+    hal_type_t qtp = q->sig.type; // Save original request signal type
+    hal_sig_t *sig = halpr_find_sig_by_name(q->name);
+    if(!sig) {
+        // Signal name not found
+        halpr_mutex_release();
+        return -ENOENT;
+    }
+    if(HAL_PORT != sig->type && sig->writers > 0) {
+        // Signal is not a port and has writers
+        halpr_mutex_release();
+        return -EACCES;
+    }
+
+    // Setup callback data
+    q->qtype       = HAL_QTYPE_SIGNAL; // Handling a signal
+    q->name        = sig->name;
+    q->sig.type    = sig->type;       // of this type
+    q->sig.writers = sig->writers;    // Signals have no direction
+    q->sig.readers = sig->readers;    // Signals have no alias
+    q->sig.bidirs  = sig->bidirs;     // Only relevant for pins
+
+    if(!sig->data_ptr) {
+        // Signal's data pointer is invalid
+        halpr_mutex_release();
+        rtapi_print_msg(RTAPI_MSG_ERR, "hal_set_s: Signal '%s' has no data target\n", q->name);
+        return -EIO;
+    }
+    q->sig.ref = (hal_refs_u)(hal_sint_t)SHMPTR(sig->data_ptr);
+
+    if(0 != qtp && qtp != sig->type) {
+        // Specific type requested and it didn't match
+        halpr_mutex_release();
+        return -EEXIST;
+    }
+
+    int rv = cb ? cb(q, arg) : 0;  // Callback to get the value
+
+    if(!rv) {
+        // Success, data to write must be in the value union
+        hal_refs_u u = (hal_refs_u)(hal_sint_t)SHMPTR(sig->data_ptr);
+        if((rv = set_common(sig->type, &q->sig.value, u, 1, 0)) < 0) {
+            halpr_mutex_release();
+            if(-EBADF == rv)
+                rtapi_print_msg(RTAPI_MSG_ERR, "hal_set_s: Signal '%s' has bad type %d\n", q->name, sig->type);
+            return rv;
+        }
+    } // else something went wrong in the callback
+
+    halpr_mutex_release();
+    return rv;
+}
+
+//
+// hal_set_p() - Set the value of a pin/param
+//
+// Returns an error if it matches a pin and it is connected.
+//
+// Query inputs:
+//   q->name     - Pin/param to set
+//   q->qtype    - Optional: HAL_QTYPE_PIN or HAL_QTYPE_PARAM to limit type
+//   q->pp.type  - Optional: must match specific HAL_X type
+//                 The q->pp.value must be set to the proper value,
+//                 which will be used, if there is no callback set.
+//                 The type is mandatory if no callback is specified.
+//   q->pp.value - Mandatory if no callback is specified.
+//
+int hal_set_p(hal_query_t *q, hal_query_cb cb, void *arg)
+{
+    if(NULL == hal_data) {
+        rtapi_print_msg(RTAPI_MSG_ERR, "hal_set_p: HAL shared memory not mapped\n");
+        return -EFAULT;
+    }
+    if(!q || !q->name) {
+        rtapi_print_msg(RTAPI_MSG_ERR, "hal_set_p: Invalid query arguments\n");
+        return -EINVAL;
+    }
+    if(0 == q->pp.type && !cb) {
+        rtapi_print_msg(RTAPI_MSG_ERR, "hal_set_p: Must have callback if type is not specified\n");
+        return -EINVAL;
+    }
+    // Grab the mutex to keep the data stable
+    halpr_mutex_acquire();
+
+    hal_type_t qtp = q->pp.type; // Save original request pin/param type
+    hal_type_t t;
+    hal_pin_t *pin = NULL;
+    hal_refs_u u;
+    bool isparam;
+    // If only parameters requested, don't look for pins
+    if(HAL_QTYPE_PARAM != q->qtype)
+        pin = halpr_find_pin_by_name(q->name);
+    if(!pin) {
+        if(HAL_QTYPE_PIN == q->qtype) {
+            // Only pin search requested and it was not found
+            halpr_mutex_release();
+            return -ENOENT;
+        }
+        // Not a pin, try param
+        hal_param_t *param = halpr_find_param_by_name(q->name);
+        if(!param) {
+            // Neither pin nor param name found
+            halpr_mutex_release();
+            return -ENOENT;
+        }
+        // We have the param, copy the data, but we still can fail
+        q->qtype     = HAL_QTYPE_PARAM;
+        q->name      = param->name;
+        q->pp.type   = t = param->type;
+        q->pp.ref    = (hal_refs_u)(hal_sint_t)SHMPTR(param->data_ptr);
+        q->pp.dir    = param->dir;
+        q->pp.alias  = param->oldname ? ((hal_oldname_t *)SHMPTR(param->oldname))->name : NULL;
+        q->pp.signal = NULL;
+        hal_comp_t *comp = (hal_comp_t *)SHMPTR(param->owner_ptr);
+        q->pp.comp       = comp->name;
+        q->pp.comp_id    = comp->comp_id;
+
+        if(0 != qtp && qtp != param->type) {
+            // Specific type requested and it didn't match
+            halpr_mutex_release();
+            return -EEXIST;
+        }
+        if(HAL_RO == param->dir) {
+            // Param not writable
+            halpr_mutex_release();
+            return -EACCES;
+        }
+        if(!param->data_ptr) {
+            // Param's data pointer is invalid
+            halpr_mutex_release();
+            rtapi_print_msg(RTAPI_MSG_ERR, "hal_set_p: Param '%s' has no data target\n", q->name);
+            return -EIO;
+        }
+        // FIXME: This can be targeted to param's data when the old API is retired
+        u = (hal_refs_u)(hal_sint_t)SHMPTR(param->data_ptr);
+        isparam = 1;
+    } else {
+        // We have a pin, copy the data, but we still can fail
+        q->qtype     = HAL_QTYPE_PIN;
+        q->name      = pin->name;
+        q->pp.type   = t = pin->type;
+        q->pp.ref    = (hal_refs_u)(hal_sint_t)&pin->dummysig;
+        q->pp.dir    = pin->dir;
+        q->pp.alias  = pin->oldname ? ((hal_oldname_t *)SHMPTR(pin->oldname))->name : NULL;
+        q->pp.signal = NULL;
+        hal_comp_t *comp = (hal_comp_t *)SHMPTR(pin->owner_ptr);
+        q->pp.comp       = comp->name;
+        q->pp.comp_id    = comp->comp_id;
+
+        // We still record the signal, even if we fail to write
+        if(0 != pin->signal) {
+            hal_sig_t *sig = (hal_sig_t *)SHMPTR(pin->signal);
+            q->pp.signal = sig->name;
+        }
+        if(0 != qtp && qtp != pin->type) {
+            // Specific type requested and it didn't match
+            halpr_mutex_release();
+            return -EEXIST;
+        }
+        if(HAL_OUT == pin->dir || 0 != pin->signal) {
+            // Pin not writable
+            halpr_mutex_release();
+            return -EACCES;
+        }
+        u = (hal_refs_u)(hal_sint_t)&pin->dummysig;
+        isparam = 0;
+    }
+
+    // Note: the callback is called while holding the mutex
+    int rv = cb ? cb(q, arg) : 0; // Callback to get the value
+
+    if(!rv) {
+        // Success, data to write must be in the value union
+        if((rv = set_common(t, &q->pp.value, u, 0, isparam)) < 0) {
+            halpr_mutex_release();
+            if(-EBADF == rv)
+                rtapi_print_msg(RTAPI_MSG_ERR, "hal_set_p: %s '%s' has bad type %d\n", pin ? "Pin" : "Param", q->name, t);
+            return rv;
+        }
+    } // else something went wrong in the callback
+
+    halpr_mutex_release();
+    return rv;
+}
+
+static int get_common(hal_type_t type, hal_query_value_u *v, hal_refs_u u, bool getport)
+{
+    switch(type) {
+    case HAL_BOOL: v->b = hal_get_bool(u.b); break;
+    case HAL_S32:  v->s = hal_get_si32(u.s); break;
+    case HAL_U32:  v->u = hal_get_ui32(u.u); break;
+    case HAL_SINT: v->s = hal_get_sint(u.s); break;
+    case HAL_UINT: v->u = hal_get_uint(u.u); break;
+    case HAL_REAL: v->r = hal_get_real(u.r); break;
+    case HAL_PORT:
+        if(!getport) {
+            v->u = 0;
+        } else {
+            // FIXME: This needs to be changed when the old API is removed
+            v->u = hal_port_buffer_size((hal_port_t *)u.s);
+        }
+        break;
+    default:
+        return -EBADF;
+    }
+    return 0;
+}
+
+//
+// hal_get_s() - Retrieve the value of a signal
+//
+// Query inputs:
+//   q->name     - Signal to get
+//   q->sig.type - Optional: must match specific HAL_X type
+//
+int hal_get_s(hal_query_t *q, hal_query_cb cb, void *arg)
+{
+    if(NULL == hal_data) {
+        rtapi_print_msg(RTAPI_MSG_ERR, "hal_get_s: HAL shared memory not mapped\n");
+        return -EFAULT;
+    }
+    if(!q || !q->name) {
+        rtapi_print_msg(RTAPI_MSG_ERR, "hal_get_s: Invalid query arguments\n");
+        return -EINVAL;
+    }
+    // Grab the mutex to keep the data stable
+    halpr_mutex_acquire();
+
+    hal_type_t qtp = q->sig.type; // Save original request signal type
+    hal_sig_t *sig = halpr_find_sig_by_name(q->name);
+    if(!sig) {
+        // No signal by that name found
+        halpr_mutex_release();
+        return -ENOENT;
+    }
+    q->qtype       = HAL_QTYPE_SIGNAL;
+    q->name        = sig->name;
+    q->sig.type    = sig->type;
+    q->sig.writers = sig->writers;
+    q->sig.readers = sig->readers;
+    q->sig.bidirs  = sig->bidirs;
+
+    if(!sig->data_ptr) {
+        // Signal's data pointer is invalid
+        halpr_mutex_release();
+        rtapi_print_msg(RTAPI_MSG_ERR, "hal_get_s: Signal '%s' has no data target\n", q->name);
+        return -EIO;
+    }
+    q->sig.ref = (hal_refs_u)(hal_sint_t)SHMPTR(sig->data_ptr);
+
+    // We have the primary data copied, but fail if there is a type mismatch.
+    if(0 != qtp && qtp != sig->type) {
+        // A specific signal type was requested and it didn't match
+        halpr_mutex_release();
+        return -EEXIST;
+    }
+    int rv = get_common(sig->type, &q->sig.value, q->sig.ref, 1);
+    if(!rv && cb)
+        rv = cb(q, arg);
+    halpr_mutex_release();
+    return rv;
+}
+
+//
+// hal_get_p() - Retrieve the value of a pin/param
+//
+// Returns the signal's value if a pin matches and it is connected.
+//
+// Query inputs:
+//   q->name    - Pin/param to get
+//   q->qtype   - Optional: HAL_QTYPE_PIN or HAL_QTYPE_PARAM to limit type
+//   q->pp.type - Optional: must match specific HAL_X type
+//
+int hal_get_p(hal_query_t *q, hal_query_cb cb, void *arg)
+{
+    if(NULL == hal_data) {
+        rtapi_print_msg(RTAPI_MSG_ERR, "hal_get_p: HAL shared memory not mapped\n");
+        return -EFAULT;
+    }
+    if(!q || !q->name) {
+        rtapi_print_msg(RTAPI_MSG_ERR, "hal_get_p: Invalid query arguments\n");
+        return -EINVAL;
+    }
+    // Grab the mutex to keep the data stable
+    halpr_mutex_acquire();
+
+    hal_type_t qtp = q->pp.type; // Save original request pin/param type
+    hal_type_t t;
+    hal_refs_u u;
+    hal_pin_t *pin = NULL;
+    // Only search for pins when requested
+    if(HAL_QTYPE_PARAM != q->qtype)
+        pin = halpr_find_pin_by_name(q->name);
+    if(!pin) {
+        if(HAL_QTYPE_PIN == q->qtype) {
+            // Only pin search requested and it was not found
+            halpr_mutex_release();
+            return -ENOENT;
+        }
+        // Not a pin, try param
+        hal_param_t *param = halpr_find_param_by_name(q->name);
+        if(!param) {
+            // Neither pin nor param name found
+            halpr_mutex_release();
+            return -ENOENT;
+        }
+        // We have the param, copy the data
+        q->qtype     = HAL_QTYPE_PARAM;
+        q->name      = param->name;
+        q->pp.type   = t = param->type;
+        q->pp.dir    = param->dir;
+        q->pp.alias  = param->oldname ? ((hal_oldname_t *)SHMPTR(param->oldname))->name : NULL;
+        q->pp.signal = NULL;
+        hal_comp_t *comp = (hal_comp_t *)SHMPTR(param->owner_ptr);
+        q->pp.comp       = comp->name;
+        q->pp.comp_id    = comp->comp_id;
+
+        if(!param->data_ptr) {
+            // Param's data pointer is invalid
+            halpr_mutex_release();
+            rtapi_print_msg(RTAPI_MSG_ERR, "hal_get_p: Param '%s' has no data target\n", q->name);
+            return -EIO;
+        }
+        // FIXME: This can be targeted to param's data when the old API is retired
+        q->pp.ref = u = (hal_refs_u)(hal_sint_t)SHMPTR(param->data_ptr);
+    } else {
+        // We have the pin, copy the data
+        q->qtype    = HAL_QTYPE_PIN;
+        q->name     = pin->name;
+        q->pp.type  = t = pin->type;
+        q->pp.dir   = pin->dir;
+        q->pp.alias = pin->oldname ? ((hal_oldname_t *)SHMPTR(pin->oldname))->name : NULL;
+        hal_comp_t *comp = (hal_comp_t *)SHMPTR(pin->owner_ptr);
+        q->pp.comp       = comp->name;
+        q->pp.comp_id    = comp->comp_id;
+        if(0 != pin->signal) {
+            // Pin is connected, use the signal value
+            hal_sig_t *sig = (hal_sig_t *)SHMPTR(pin->signal);
+            q->pp.ref = u = (hal_refs_u)(hal_sint_t)SHMPTR(sig->data_ptr);
+            q->pp.signal = sig->name;
+        } else {
+            // Unconnected, use the dummy value
+            q->pp.ref = u = (hal_refs_u)(hal_sint_t)&pin->dummysig;
+            q->pp.signal = NULL;
+        }
+    }
+
+    // We have the primary data copied, but fail if there is a type mismatch.
+    if(0 != qtp && qtp != t) {
+        // Specific type requested and it didn't match
+        halpr_mutex_release();
+        return -EEXIST;
+    }
+
+    int rv = get_common(t, &q->pp.value, u, 0);
+    if(!rv && cb)
+        rv = cb(q, arg);
+    halpr_mutex_release();
+    return rv;
+}
+
+//
+// hal_getref_s() - Retrieve the pin reference to read/write the signal
+//
+// Query inputs:
+//   q->name    - Signal to get
+//
+int hal_getref_s(hal_query_t *q)
+{
+    if(NULL == hal_data) {
+        rtapi_print_msg(RTAPI_MSG_ERR, "hal_getref_s: HAL shared memory not mapped\n");
+        return -EFAULT;
+    }
+    if(!q || !q->name) {
+        rtapi_print_msg(RTAPI_MSG_ERR, "hal_getref_s: Invalid query arguments\n");
+        return -EINVAL;
+    }
+    // Grab the mutex to keep the data stable
+    halpr_mutex_acquire();
+
+    hal_sig_t *sig = halpr_find_sig_by_name(q->name);
+    if(!sig) {
+        // Signal name not found
+        halpr_mutex_release();
+        return -ENOENT;
+    }
+    if(!sig->data_ptr) {
+        // Signal's data pointer is invalid
+        halpr_mutex_release();
+        rtapi_print_msg(RTAPI_MSG_ERR, "hal_getref_s: Signal '%s' has no data target\n", q->name);
+        return -EIO;
+    }
+    // We have a signal. We don't really care whether it is writable or
+    // readable. That is the caller's responsibility. This API is rather
+    // low-level and only hides the HAL private stuff. The data access is
+    // public as long as you use the hal_[gs]et_xxxx() interface.
+    // Setup return data
+    q->qtype       = HAL_QTYPE_SIGNAL; // Handling a signal
+    q->name        = sig->name;
+    q->sig.type    = sig->type;        // of this type
+    q->sig.writers = sig->writers;
+    q->sig.readers = sig->readers;
+    q->sig.bidirs  = sig->bidirs;
+    q->sig.ref     = (hal_refs_u)(hal_sint_t)SHMPTR(sig->data_ptr);
+    halpr_mutex_release();
+    return 0;
+}
+
+//
+// hal_getref_p() - Retrieve the pin reference to read/write the pin/param
+//
+// It will return the signal reference if the pin is connected.
+//
+// Query inputs:
+//   q->name    - Pin/param to get
+//
+int hal_getref_p(hal_query_t *q)
+{
+    if(NULL == hal_data) {
+        rtapi_print_msg(RTAPI_MSG_ERR, "hal_getref_p: HAL shared memory not mapped\n");
+        return -EFAULT;
+    }
+    if(!q || !q->name) {
+        rtapi_print_msg(RTAPI_MSG_ERR, "hal_getref_p: Invalid query arguments\n");
+        return -EINVAL;
+    }
+    // Grab the mutex to keep the data stable
+    halpr_mutex_acquire();
+
+    hal_pin_t *pin = NULL;
+    // If only parameters requested, don't look for pins
+    if(q->qtype != HAL_QTYPE_PARAM)
+        pin = halpr_find_pin_by_name(q->name);
+    if(!pin) {
+        if(q->qtype == HAL_QTYPE_PIN) {
+            // Only pin search requested and it was not found
+            halpr_mutex_release();
+            return -ENOENT;
+        }
+        // Not a pin, try param
+        hal_param_t *param = halpr_find_param_by_name(q->name);
+        if(!param) {
+            // Neither pin nor param name found
+            halpr_mutex_release();
+            return -ENOENT;
+        }
+        // We have the param, copy the data, but we still can fail
+        q->qtype     = HAL_QTYPE_PARAM;
+        q->name      = param->name;
+        q->pp.type   = param->type;
+        q->pp.dir    = param->dir;
+        q->pp.alias  = param->oldname ? ((hal_oldname_t *)SHMPTR(param->oldname))->name : NULL;
+        q->pp.signal = NULL;
+        hal_comp_t *comp = (hal_comp_t *)SHMPTR(param->owner_ptr);
+        q->pp.comp       = comp->name;
+        q->pp.comp_id    = comp->comp_id;
+
+        if(!param->data_ptr) {
+            // Param's data pointer is invalid
+            halpr_mutex_release();
+            rtapi_print_msg(RTAPI_MSG_ERR, "hal_getref_p: Param '%s' has no data target\n", q->name);
+            return -EIO;
+        }
+        // FIXME: This can be targeted to param's data when the old API is retired
+        q->pp.ref = (hal_refs_u)(hal_sint_t)SHMPTR(param->data_ptr);
+    } else {
+        // We have a pin, copy the data
+        q->qtype    = HAL_QTYPE_PIN;
+        q->name     = pin->name;
+        q->pp.type  = pin->type;
+        q->pp.dir   = pin->dir;
+        q->pp.alias = pin->oldname ? ((hal_oldname_t *)SHMPTR(pin->oldname))->name : NULL;
+        hal_comp_t *comp = (hal_comp_t *)SHMPTR(pin->owner_ptr);
+        q->pp.comp       = comp->name;
+        q->pp.comp_id    = comp->comp_id;
+
+        if(0 != pin->signal) {
+            // The pin is connected, return the signal ref
+            hal_sig_t *sig = (hal_sig_t *)SHMPTR(pin->signal);
+            q->pp.ref      = (hal_refs_u)(hal_sint_t)SHMPTR(sig->data_ptr);
+            q->pp.signal   = sig->name;
+        } else {
+            // Just the dummy value
+            q->pp.ref    = (hal_refs_u)(hal_sint_t)&pin->dummysig;
+            q->pp.signal = NULL;
+        }
+    }
+
+    halpr_mutex_release();
+    return 0;
+}
+
+//
+// Iterate all pins/params with a callback
+//
+// Query inputs:
+//   q->qtype   - Optional: HAL_QTYPE_PIN or HAL_QTYPE_PARAM to limit type
+//
+int hal_list_p(hal_query_t *q, hal_query_cb cb, void *arg)
+{
+    if(NULL == hal_data) {
+        rtapi_print_msg(RTAPI_MSG_ERR, "hal_list_p: HAL shared memory not mapped\n");
+        return -EFAULT;
+    }
+    if(!q || !cb || (0 != q->qtype && !(HAL_QTYPE_PIN == q->qtype || HAL_QTYPE_PARAM == q->qtype))) {
+        rtapi_print_msg(RTAPI_MSG_ERR, "hal_list_p: Invalid query arguments\n");
+        return -EINVAL;
+    }
+    // Grab the mutex to keep the data stable
+    halpr_mutex_acquire();
+
+    hal_qtype_t qtype = q->qtype; // Need to cache because field is reused
+
+    // FIXME: this can be mostly merged once we merge pin/param structures
+    if(!qtype || HAL_QTYPE_PIN == qtype) {
+        rtapi_intptr_t pinref = hal_data->pin_list_ptr;
+        while(pinref) {
+            hal_pin_t *pin = (hal_pin_t *)SHMPTR(pinref);
+            q->name     = pin->name;
+            q->qtype    = HAL_QTYPE_PIN;
+            q->pp.type  = pin->type;
+            q->pp.dir   = pin->dir;
+            q->pp.alias = pin->oldname ? ((hal_oldname_t *)SHMPTR(pin->oldname))->name : NULL;
+            hal_comp_t *comp = (hal_comp_t *)SHMPTR(pin->owner_ptr);
+            q->pp.comp       = comp->name;
+            q->pp.comp_id    = comp->comp_id;
+            if(pin->signal) {
+                hal_sig_t *sig = (hal_sig_t *)SHMPTR(pin->signal);
+                q->pp.ref = (hal_refs_u)(hal_sint_t)SHMPTR(sig->data_ptr);
+                q->pp.signal = sig->name;
+            } else {
+                q->pp.ref = (hal_refs_u)(hal_sint_t)&pin->dummysig;
+                q->pp.signal = NULL;
+            }
+            int rv = get_common(q->pp.type, &q->pp.value, q->pp.ref, 0);
+            if(0 != rv) {
+                // Non-zero return from get_common means inconsistent pin
+                halpr_mutex_release();
+                return rv;
+            }
+            if(0 != (rv = cb(q, arg))) {
+                // Non-zero return from the callback breaks the loop and we're done
+                halpr_mutex_release();
+                return rv;
+            }
+            pinref = pin->next_ptr;
+        }
+    }
+    if(!qtype || HAL_QTYPE_PARAM == qtype) {
+        rtapi_intptr_t paramref = hal_data->param_list_ptr;
+        while(paramref) {
+            hal_param_t *param = (hal_param_t *)SHMPTR(paramref);
+            q->name      = param->name;
+            q->qtype     = HAL_QTYPE_PARAM;
+            q->pp.type   = param->type;
+            q->pp.dir    = param->dir;
+            q->pp.alias  = param->oldname ? ((hal_oldname_t *)SHMPTR(param->oldname))->name : NULL;
+            q->pp.signal = NULL;
+            q->pp.ref    = (hal_refs_u)(hal_sint_t)SHMPTR(param->data_ptr);
+            hal_comp_t *comp = (hal_comp_t *)SHMPTR(param->owner_ptr);
+            q->pp.comp       = comp->name;
+            q->pp.comp_id    = comp->comp_id;
+            int rv = get_common(q->pp.type, &q->pp.value, q->pp.ref, 0);
+            if(0 != rv) {
+                // Non-zero return from get_common means inconsistent param
+                halpr_mutex_release();
+                return rv;
+            }
+            if(0 != (rv = cb(q, arg))) {
+                // Non-zero return from the callback breaks the loop and we're done
+                halpr_mutex_release();
+                return rv;
+            }
+            paramref = param->next_ptr;
+        }
+    }
+
+    halpr_mutex_release();
+    return 0;
+}
+
+//
+// Iterate all pins and find those connected to the signal specified
+//
+// Query inputs:
+//   q->name   - Signal to search for
+//
+int hal_list_p_s(hal_query_t *q, hal_query_cb cb, void *arg)
+{
+    if(NULL == hal_data) {
+        rtapi_print_msg(RTAPI_MSG_ERR, "hal_list_p_s: HAL shared memory not mapped\n");
+        return -EFAULT;
+    }
+    if(!q || !q->name || !cb) {
+        rtapi_print_msg(RTAPI_MSG_ERR, "hal_list_p_s: Invalid query arguments\n");
+        return -EINVAL;
+    }
+
+    // Grab the mutex to keep the data stable
+    halpr_mutex_acquire();
+
+    hal_sig_t *sig = halpr_find_sig_by_name(q->name);
+    if(!sig) {
+        halpr_mutex_release();
+        return -ENOENT; // Signal not found
+    }
+
+    int rv = 0;
+    hal_pin_t *pin = halpr_find_pin_by_sig(sig, NULL);  // Find first
+    while(NULL != pin) {
+        q->name      = pin->name;
+        q->qtype     = HAL_QTYPE_PIN;
+        q->pp.type   = pin->type;
+        q->pp.dir    = pin->dir;
+        q->pp.alias  = pin->oldname ? ((hal_oldname_t *)SHMPTR(pin->oldname))->name : NULL;
+        q->pp.signal = sig->name;
+        q->pp.ref    = (hal_refs_u)(hal_sint_t)SHMPTR(sig->data_ptr);
+        hal_comp_t *comp = (hal_comp_t *)SHMPTR(pin->owner_ptr);
+        q->pp.comp       = comp->name;
+        q->pp.comp_id    = comp->comp_id;
+ 
+        rv = get_common(q->pp.type, &q->pp.value, q->pp.ref, 0);
+        if(0 != rv) {
+            // Non-zero return from get_common means inconsistent pin
+            break;
+        }
+        if(0 != (rv = cb(q, arg))) {
+            // Callback requested exit
+            break;
+        }
+        pin = halpr_find_pin_by_sig(sig, pin);  // Find next
+    }
+
+    halpr_mutex_release();
+    return rv;
+}
+
+//
+// Iterate all signals with a callback
+//
+// Query inputs: None
+//
+int hal_list_s(hal_query_t *q, hal_query_cb cb, void *arg)
+{
+    if(NULL == hal_data) {
+        rtapi_print_msg(RTAPI_MSG_ERR, "hal_list_s: HAL shared memory not mapped\n");
+        return -EFAULT;
+    }
+    if(!q || !cb) {
+        rtapi_print_msg(RTAPI_MSG_ERR, "hal_list_s: Invalid query arguments\n");
+        return -EINVAL;
+    }
+    // Grab the mutex to keep the data stable
+    halpr_mutex_acquire();
+
+    int rv = 0;
+    rtapi_intptr_t sigref = hal_data->sig_list_ptr;
+    while(sigref) {
+        hal_sig_t *sig = (hal_sig_t *)SHMPTR(sigref);
+        q->name        = sig->name;
+        q->qtype       = HAL_QTYPE_SIGNAL;
+        q->sig.type    = sig->type;
+        q->sig.writers = sig->writers;
+        q->sig.readers = sig->readers;
+        q->sig.bidirs  = sig->bidirs;
+        // If someone wants to find the connected pins, then call
+        // hal_list_p_s() to get the full list.
+        q->sig.ref     = (hal_refs_u)(hal_sint_t)SHMPTR(sig->data_ptr);
+        rv = get_common(q->sig.type, &q->sig.value, q->sig.ref, 1);
+        if(0 != rv) {
+            // Non-zero return from get_common means inconsistent signal
+            break;
+        }
+        if(0 != (rv = cb(q, arg))) {
+            // Non-zero return from the callback breaks the loop and we're done
+            break;
+        }
+        sigref = sig->next_ptr;
+    }
+
+    halpr_mutex_release();
+    return rv;
+}
+
+//
+// Iterate all components with a callback
+//
+// Query inputs: None
+//
+int hal_list_comp(hal_query_t *q, hal_query_cb cb, void *arg)
+{
+    if(NULL == hal_data) {
+        rtapi_print_msg(RTAPI_MSG_ERR, "hal_list_comp: HAL shared memory not mapped\n");
+        return -EFAULT;
+    }
+    if(!q || !cb) {
+        rtapi_print_msg(RTAPI_MSG_ERR, "hal_list_comp: Invalid query arguments\n");
+        return -EINVAL;
+    }
+    // Grab the mutex to keep the data stable
+    halpr_mutex_acquire();
+
+    int rv = 0;
+    rtapi_intptr_t compref = hal_data->comp_list_ptr;
+    while(compref) {
+        hal_comp_t *comp = (hal_comp_t *)SHMPTR(compref);
+        q->name         = comp->name;
+        q->qtype        = HAL_QTYPE_COMP;
+        q->comp.type    = comp->type;
+        q->comp.comp_id = comp->comp_id;
+        q->comp.pid     = comp->pid;
+        q->comp.ready   = !!comp->ready;
+        q->comp.insmod  = comp->insmod_args ? (const char *)SHMPTR(comp->insmod_args) : NULL;
+        if(0 != (rv = cb(q, arg))) {
+            // Non-zero return from the callback breaks the loop and we're done
+            break;
+        }
+        compref = comp->next_ptr;
+    }
+
+    halpr_mutex_release();
+    return rv;
+}
+
+//
+// Iterate all functions with a callback
+//
+// Query inputs: None
+//
+int hal_list_funct(hal_query_t *q, hal_query_cb cb, void *arg)
+{
+    if(NULL == hal_data) {
+        rtapi_print_msg(RTAPI_MSG_ERR, "hal_list_funct: HAL shared memory not mapped\n");
+        return -EFAULT;
+    }
+    if(!q || !cb) {
+        rtapi_print_msg(RTAPI_MSG_ERR, "hal_list_funct: Invalid query arguments\n");
+        return -EINVAL;
+    }
+    // Grab the mutex to keep the data stable
+    halpr_mutex_acquire();
+
+    int rv = 0;
+    rtapi_intptr_t functref = hal_data->funct_list_ptr;
+    while(functref) {
+        hal_funct_t *funct = (hal_funct_t *)SHMPTR(functref);
+        q->name          = funct->name;
+        q->qtype         = HAL_QTYPE_FUNCT;
+        hal_comp_t *comp = (hal_comp_t *)SHMPTR(funct->owner_ptr);
+        q->funct.comp_id = comp->comp_id;
+        q->funct.comp    = comp->name;
+        q->funct.users   = funct->users;
+        q->funct.arg     = (rtapi_intptr_t)funct->arg;   // Purely informational
+        q->funct.funct   = (rtapi_intptr_t)funct->funct; // Purely informational
+        q->funct.reentrant = !!funct->reentrant;
+        if(0 != (rv = cb(q, arg))) {
+            // Non-zero return from the callback breaks the loop and we're done
+            break;
+        }
+        functref = funct->next_ptr;
+    }
+
+    halpr_mutex_release();
+    return rv;
+}
+
+//
+// Iterate all threads with a callback
+//
+// Query inputs:
+//   q->qtype - Optional: HAL_QTYPE_THREAD to only iterate threads or
+//              HAL_QTYPE_THREAD_FUNCT to iterate threads *and* the functions
+//              attached to the thread.
+//
+// Iteration of threads and its functions will call the callback with the
+// thread's name first and the q->qtype set to HAL_QTYPE_THREAD. Then it will
+// call the callback with q->qtype set to HAL_QTYPE_THREAD_FUNCT for each
+// function attached to the thread.
+//
+int hal_list_thread(hal_query_t *q, hal_query_cb cb, void *arg)
+{
+    if(NULL == hal_data) {
+        rtapi_print_msg(RTAPI_MSG_ERR, "hal_list_thread: HAL shared memory not mapped\n");
+        return -EFAULT;
+    }
+    if(!q || !cb) {
+        rtapi_print_msg(RTAPI_MSG_ERR, "hal_list_thread: Invalid query arguments\n");
+        return -EINVAL;
+    }
+    bool dofuncts = q->qtype == HAL_QTYPE_THREAD_FUNCT;
+    // Grab the mutex to keep the data stable
+    halpr_mutex_acquire();
+
+    int rv = 0;
+    rtapi_intptr_t threadref = hal_data->thread_list_ptr;
+    while(threadref) {
+        hal_thread_t *thread = (hal_thread_t *)SHMPTR(threadref);
+        q->name            = thread->name;
+        q->thread.comp_id  = thread->comp_id;
+        hal_comp_t *comp = halpr_find_comp_by_id(thread->comp_id);
+        const char *compname = comp ? comp->name : "?";
+        q->thread.comp = compname;
+        q->thread.priority = thread->priority;
+        q->thread.period   = thread->period;
+        q->thread.functidx = 0;
+        q->thread.funct    = NULL;
+        q->thread.is_init  = 0;
+        q->qtype           = HAL_QTYPE_THREAD;
+        // Callback on the thread
+        if(0 != (rv = cb(q, arg))) {
+            // Non-zero return from the callback breaks the loop and we're done
+            break;
+        }
+        if(dofuncts) {
+            // Callback on the thread's normal functions
+            hal_funct_entry_t *froot = (hal_funct_entry_t *)&thread->funct_list;
+            hal_funct_entry_t *entry = (hal_funct_entry_t *)SHMPTR(froot->links.next);
+            for(int cnt = 0; entry != froot; cnt++) {
+                hal_funct_t *funct = (hal_funct_t *)SHMPTR(entry->funct_ptr);
+                // Make sure all data is set
+                q->name            = thread->name;
+                q->thread.comp_id  = thread->comp_id;
+                q->thread.comp = compname;
+                q->thread.priority = thread->priority;
+                q->thread.period   = thread->period;
+                // Function level data
+                q->qtype           = HAL_QTYPE_THREAD_FUNCT;
+                q->thread.functidx = cnt;
+                q->thread.funct    = funct->name;
+                q->thread.is_init  = 0;
+                if(0 != (rv = cb(q, arg))) {
+                    // Non-zero return from the callback quits and we're done
+                    halpr_mutex_release();
+                    return rv;
+                }
+                entry = (hal_funct_entry_t *)SHMPTR(entry->links.next);
+            }
+            // Callback on the thread's init functions
+            froot = (hal_funct_entry_t *)&thread->init_funct_list;
+            entry = (hal_funct_entry_t *)SHMPTR(froot->links.next);
+            for(int cnt = 0; entry != froot; cnt++) {
+                hal_funct_t *funct = (hal_funct_t *)SHMPTR(entry->funct_ptr);
+                // Make sure all data is set
+                q->name            = thread->name;
+                q->thread.comp_id  = thread->comp_id;
+                q->thread.comp = compname;
+                q->thread.priority = thread->priority;
+                q->thread.period   = thread->period;
+                // Function level data
+                q->qtype           = HAL_QTYPE_THREAD_FUNCT;
+                q->thread.functidx = cnt;
+                q->thread.funct    = funct->name;
+                q->thread.is_init  = 1;
+                if(0 != (rv = cb(q, arg))) {
+                    // Non-zero return from the callback quits and we're done
+                    halpr_mutex_release();
+                    return rv;
+                }
+                entry = (hal_funct_entry_t *)SHMPTR(entry->links.next);
+            }
+        }
+        threadref = thread->next_ptr;
+    }
+
+    halpr_mutex_release();
+    return rv;
+}
+
+//
+// Return HAL statistics
+//
+static int count_list(rtapi_intptr_t ptr)
+{
+    int n = 0;
+    while(0 != ptr) {
+        n++;
+        // The first field in the structure is the 'next_ptr' field
+        ptr = *((rtapi_intptr_t *)SHMPTR(ptr));
+    }
+    return n;
+}
+
+int hal_statistics(hal_statistics_t *sts)
+{
+    if(NULL == hal_data) {
+        rtapi_print_msg(RTAPI_MSG_ERR, "hal_statistics: HAL shared memory not mapped\n");
+        return -EFAULT;
+    }
+    if(!sts) {
+        rtapi_print_msg(RTAPI_MSG_ERR, "hal_statistics: Missing statistics structure pointer argument\n");
+        return -EINVAL;
+    }
+    // Grab the mutex to keep the data stable
+    // (list access and iteration may otherwise fail)
+    halpr_mutex_acquire();
+
+    sts->mem_total = HAL_SIZE;
+    sts->mem_free  = hal_data->shmem_avail;
+
+    sts->ncomps        = count_list(hal_data->comp_list_ptr);
+    sts->ncomps_free   = count_list(hal_data->comp_free_ptr);
+    sts->nsignals      = count_list(hal_data->sig_list_ptr);
+    sts->nsignals_free = count_list(hal_data->sig_free_ptr);
+    sts->nfuncts       = count_list(hal_data->funct_list_ptr);
+    sts->nfuncts_free  = count_list(hal_data->funct_free_ptr);
+    sts->nthreads      = count_list(hal_data->thread_list_ptr);
+    sts->nthreads_free = count_list(hal_data->thread_free_ptr);
+
+    // Count pins, params and aliases in use
+    int nalias = 0;
+    int npin = 0;
+    int nparam = 0;
+    rtapi_intptr_t ptr = hal_data->pin_list_ptr;
+    while(0 != ptr) {
+        npin++;
+        hal_pin_t *pin = (hal_pin_t *)SHMPTR(ptr);
+        if(0 != pin->oldname)
+            nalias++;
+        ptr = pin->next_ptr;
+    }
+    ptr = hal_data->param_list_ptr;
+    while(0 != ptr) {
+        nparam++;
+        hal_param_t *param = (hal_param_t *)SHMPTR(ptr);
+        if(0 != param->oldname)
+            nalias++;
+        ptr = param->next_ptr;
+    }
+    sts->naliases      = nalias;
+    sts->naliases_free = count_list(hal_data->oldname_free_ptr);
+    sts->npins         = npin;
+    sts->npins_free    = count_list(hal_data->pin_free_ptr);
+    sts->nparams       = nparam;
+    sts->nparams_free  = count_list(hal_data->param_free_ptr);
+
+    halpr_mutex_release();
+    return 0;
+}
+
+//
+// Return the status of a component by ID
+//
+int hal_comp_by_id(int comp_id, hal_query_t *q)
+{
+    if(NULL == hal_data) {
+        rtapi_print_msg(RTAPI_MSG_ERR, "hal_comp_by_id: HAL shared memory not mapped\n");
+        return -EFAULT;
+    }
+    if(comp_id <= 0) {
+        rtapi_print_msg(RTAPI_MSG_ERR, "hal_comp_by_id: Invalid query arguments\n");
+        return -EINVAL;
+    }
+    // Grab the mutex to keep the data stable
+    halpr_mutex_acquire();
+    hal_comp_t *comp = halpr_find_comp_by_id(comp_id);
+
+    if(NULL != comp && NULL != q) {
+        q->name         = comp->name;
+        q->qtype        = HAL_QTYPE_COMP;
+        q->comp.type    = comp->type;
+        q->comp.comp_id = comp->comp_id;
+        q->comp.pid     = comp->pid;
+        q->comp.ready   = !!comp->ready;
+        q->comp.insmod  = comp->insmod_args ? (const char *)SHMPTR(comp->insmod_args) : NULL;
+    }
+    halpr_mutex_release();
+    return NULL != comp ? 0 : -ENOENT;
+}
+
+//
+// Return the status of a named component
+//
+int hal_comp_by_name(const char *name, hal_query_t *q)
+{
+    if(NULL == hal_data) {
+        rtapi_print_msg(RTAPI_MSG_ERR, "hal_comp_by_name: HAL shared memory not mapped\n");
+        return -EFAULT;
+    }
+    if(!name) {
+        rtapi_print_msg(RTAPI_MSG_ERR, "hal_comp_by_name: Missing name argument\n");
+        return -EINVAL;
+    }
+    halpr_mutex_acquire();
+    hal_comp_t *comp = halpr_find_comp_by_name(name);
+
+    if(NULL != comp && NULL != q) {
+        q->name         = comp->name;
+        q->qtype        = HAL_QTYPE_COMP;
+        q->comp.type    = comp->type;
+        q->comp.comp_id = comp->comp_id;
+        q->comp.pid     = comp->pid;
+        q->comp.ready   = !!comp->ready;
+        q->comp.insmod  = comp->insmod_args ? (const char *)SHMPTR(comp->insmod_args) : NULL;
+    }
+    halpr_mutex_release();
+    return NULL != comp ? 0 : -ENOENT;
+}

--- a/src/hal/hal_priv.h
+++ b/src/hal/hal_priv.h
@@ -298,9 +298,13 @@ typedef struct hal_data_t {
     unsigned char lock;         /* hal locking, can be one of the HAL_LOCK_* types */
 } hal_data_t;
 
-/** HAL 'component' type.
-    Assigned according to RTAPI and ULAPI definitions.
- */
+//
+// HAL 'component' type.
+// It now lives in hal.h as 'hal_comp_type_t' and the old code that included
+// HALs privates and used 'compoment_type_t' will be kept alive with this
+// typedef for as long as hal_priv.h is available.
+// FIXME: This should be declared deprecated and retired after a grace period.
+//
 typedef hal_comp_type_t component_type_t;
 
 /** HAL 'component' data structure.
@@ -511,8 +515,12 @@ extern hal_pin_t *halpr_find_pin_by_sig(hal_sig_t * sig, hal_pin_t * start);
     Returns a negative value on failure. On success zero (0) is returned and
     the newly allocated hal_port_t is returned in the port argument and can be
     used with all other hal_port functions.
+    This is supposed to be private. The public function is deprecated and you
+    should use hal_set_s() to allocate the port once the pins are connected to
+    the signal.
 */
 extern int hal_port_alloc(unsigned size, hal_port_t *port);
+int halpr_port_alloc(unsigned size, hal_port_t *port);
 
 // Recursive HAL mutex (replaces old mutex)
 int halpr_mutex_acquire(void);

--- a/src/hal/utils/setps_util.c
+++ b/src/hal/utils/setps_util.c
@@ -1,0 +1,115 @@
+/*
+ * Common set_p and set_s callback for consistent value parsing
+ *
+ * Copyright (c) 2026  B.Stultiens
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+#include <stdlib.h>
+#include <string.h>
+#include <ctype.h>
+#include <locale.h>
+
+#include "setps_util.h"
+
+//
+// Common callback parsing the string argument as a value. The actual prototype
+// is:
+//     int setps_common_cb(hal_query_t *q, const char *value)
+//
+// It expects the q->name to be set to allow error signalling of the HAL_PORT
+// type that is not allowed in signals.
+//
+// Returns zero (0) on success or an appropriate negative errno value on error:
+//   -EINVAL  - unsupported/illegal value
+//   -ERANGE  - value out of range
+//   -EBADF   - setting of q->pp.type/q->sig.type not supported
+//   -ENOMEM  - failed to allocate memory for locale switching
+//
+int setps_common_cb(hal_query_t *q, void *arg)
+{
+    const char *value = (const char *)arg;
+    hal_query_value_u *qvp = HAL_QTYPE_SIGNAL == q->qtype ? &q->sig.value : &q->pp.value;
+    hal_type_t type = HAL_QTYPE_SIGNAL == q->qtype ? q->sig.type : q->pp.type;
+    char *eptr;
+    static const struct {
+        const char *name;
+        bool value;
+    } boolvals[] = {
+        {"TRUE",  1}, {"FALSE", 0},
+        {"1",     1}, {"0",     0},
+        {"ON",    1}, {"OFF",   0},
+        {"YES",   1}, {"NO",    0},
+        {NULL, 0}
+    };
+    switch(type) {
+    case HAL_BOOL:
+        for(int i = 0; boolvals[i].name; i++) {
+            if(!strcasecmp(boolvals[i].name, value)) {
+                qvp->b = boolvals[i].value;
+                return 0;
+            }
+        }
+        return -EINVAL;
+    case HAL_S32:
+    case HAL_SINT:
+        errno = 0;
+        qvp->s = strtoll(value, &eptr, 0);
+        if(HAL_S32 == type && (qvp->s < RTAPI_INT32_MIN || qvp->s > RTAPI_INT32_MAX))
+            return -ERANGE;
+        if(0 != errno)
+            return -errno;
+        if(value == eptr || (('\0' != *eptr) && !isspace((unsigned char)*eptr)))
+            return -EINVAL;  // No data in string or trailing junk
+        break;
+    case HAL_PORT:
+        if(HAL_QTYPE_SIGNAL != q->qtype) {
+            // This is a setp call, don't allow port
+            return -EBADF;
+        }
+        /* Fallthrough */
+    case HAL_U32:
+    case HAL_UINT:
+        errno = 0;
+        qvp->u = strtoull(value, &eptr, 0);
+        if((HAL_U32 == type || HAL_PORT == type) && qvp->u > RTAPI_UINT32_MAX)
+            return -ERANGE;
+        if(0 != errno)
+            return -errno;
+        if(value == eptr || (('\0' != *eptr) && !isspace((unsigned char)*eptr)))
+            return -EINVAL;  // No data in string or trailing junk
+        break;
+    case HAL_REAL: {
+        // Switch locale so we always use decimal point
+        locale_t olc = uselocale((locale_t)0);
+        locale_t nlc = newlocale(LC_NUMERIC_MASK, "C", (locale_t)0);
+        if((locale_t)0 == nlc)
+            return -ENOMEM;
+        uselocale(nlc);
+        errno = 0;
+        qvp->r = strtod(value, &eptr);
+        int errnosave = errno;
+        uselocale(olc);
+        freelocale(nlc);
+        if(0 != errnosave)
+            return -errnosave;
+        if(value == eptr || (('\0' != *eptr) && !isspace((unsigned char)*eptr)))
+            return -EINVAL;  // No data in string or trailing junk
+        break; }
+    default:
+        return -EBADF;
+    }
+    return 0;
+}

--- a/src/hal/utils/setps_util.h
+++ b/src/hal/utils/setps_util.h
@@ -1,0 +1,35 @@
+/*
+ * Common set_p and set_s callback for consistent value parsing
+ *
+ * Copyright (c) 2026  B.Stultiens
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+#ifndef __HAL_UTILS_SETPS_UTIL_H
+#define __HAL_UTILS_SETPS_UTIL_H
+
+#include <hal.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+int setps_common_cb(hal_query_t *q, void *arg);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif


### PR DESCRIPTION
This PR introduces the HAL query API as part of hal_lib. It is only available in user-land because it is non-RT code. It should be used by all user-land applications and interfaces that need to query HAL for pins, params, signals, components, functions and threads. It provides a single API for, for example, setp/sets and getp/gets, including much more, without having to duplicate complex parsing code. Current programs will be updated in following PRs.

The library initialization and finalization has been taken out of hal_init and hal_exit so that you may now use the HAL _user-space_ library API without having to create a (fake/temporary) component. Both hal_init and hal_exit call to hal_lib_init and hal_lib_exit at the appropriate time so that existing code will not see any difference.

The patch-set includes man(3) pages for the new functions and updates a lot of the old as well. The format of all has been unified to follow the same structure. There may still be required some adjustment to the docs, but that can and will be handled later.

The query API also adds a common string-to-value parser (setps_common_cb()) that does consistent conversion of values according to the type requested. Booleans accept true/false/1/0/yes/no/on/off and floating point parsing always sets the C locale for parsing with decimal point.