### PR TITLE
Pncconf: Add P value message when servo period is changed

### DIFF
--- a/src/emc/usr_intf/pncconf/pages.py
+++ b/src/emc/usr_intf/pncconf/pages.py
@@ -301,6 +301,12 @@ class Pages:
         elif self.d.axes == 2: self.d.available_axes = ['x','z','s']
         self.d.include_spindle = self.w.include_spindle_checkbutton.get_active()
         self.d.units = self.w.units.get_active()
+        self.d.adjust_p_values = False
+        if not self.w.createconfig.get_active() and not self.d.servoperiod == self.w.servoperiod.get_value():
+            msg1 = _("You have changed the Servo Period\n")
+            msg2 = _("This will influence the PID performance for motors driven by step/dir signals \n\n")
+            msg3 = _("Do you want the P values of the PID settings for step/dir driven motors to be changed to the recommended values?")
+            self.d.adjust_p_values = self.a.warning_dialog(msg1 + msg2 + msg3,False)
         self.d.servoperiod = self.w.servoperiod.get_value()
         self.page_set_state('mesa1',self.w.mesa1_checkbutton.get_active())
         for let in ['x','y','z','a']:

--- a/src/emc/usr_intf/pncconf/pncconf.py
+++ b/src/emc/usr_intf/pncconf/pncconf.py
@@ -4194,13 +4194,9 @@ Clicking 'existing custom program' will avoid this warning. "),False):
         # stepper vrs servo configs. But we still want to allow user setting it.
         # If the value is None then we should set a default value, if not then
         # that means it's been set to something already...hopefully right.
-        # TODO this should be smarter - after going thru a config once it
-        # always uses the value set here - if it is set to a default value
-        # if should keep checking that the value is still right.
-        # but that's a bigger change then we want now.
         # We check for None and 'None' because when None is saved 
         # it's saved as a string
-        if not d[axis + "P"] == None and not d[axis + "P"] == 'None':
+        if not d[axis + "P"] == None and not d[axis + "P"] == 'None' and (stepdriven and not self.d.adjust_p_values):
             set_value("P")
         elif stepdriven == True:
             w[axis + "P"].set_value(1/(d.servoperiod/1000000000))


### PR DESCRIPTION
The P value in the motor PID settings is recommended to be set according to the servo period value. If a config is changed using pncconf tool and the servo period is changed the P values should usually be adjusted as well. This PR adds a popup so the user can choose to have the P values adjusted accordingly.

Adresses https://forum.linuxcnc.org/39-pncconf/59018-if-servo-period-is-changed-the-coresponding-p-values-for-pid-do-not-change#348002

<img width="632" height="361" alt="Screenshot from 2026-07-23 18-04-38" src="https://github.com/user-attachments/assets/96d44871-4ca1-404f-8e3f-baab3477d188" />

cc: @c-morley 