### PR TITLE
hal: Update halmeter and halscope removing access to hal_priv.h.

### DIFF
--- a/src/hal/utils/meter.c
+++ b/src/hal/utils/meter.c
@@ -59,7 +59,6 @@
 
 #include <rtapi.h>		/* RTAPI realtime OS API */
 #include <hal.h>		/* HAL public API decls */
-#include "../hal_priv.h"	/* private HAL decls */
 #include <rtapi_mutex.h>
 
 #include <gtk/gtk.h>
@@ -79,9 +78,12 @@
 typedef struct {
     int listnum;		/* 0 = pin, 1 = signal, 2 = parameter */
     char *pickname;		/* name from list, not validated */
-    hal_pin_t *pin;		/* metadata (if it's a pin) */
-    hal_sig_t *sig;		/* metadata (if it's a signal) */
-    hal_param_t *param;		/* metadata (if it's a parameter) */
+    hal_query_t qpin;		/* metadata (if it's a pin) */
+    hal_query_t qsig;		/* metadata (if it's a signal) */
+    hal_query_t qparam;		/* metadata (if it's a parameter) */
+    hal_query_t *pin;
+    hal_query_t *param;
+    hal_query_t *sig;
     GtkWidget *window;		/* selection dialog window */
     GtkWidget *notebook;	/* pointer to the notebook */
     GtkWidget *lists[3];	/* lists for pins, sigs, and params */
@@ -133,7 +135,7 @@ static void popup_probe_window(GtkWidget * widget, gpointer data);
 static void quit(int sig);
 static void exit_from_hal(void);
 static int refresh_value(gpointer data);
-static char *data_value(int type, void *valptr);
+static const char *data_value(hal_type_t type, hal_refs_u ref);
 
 static void create_probe_window(probe_t * probe);
 static void apply_selection(GtkWidget * widget, gpointer data);
@@ -382,17 +384,35 @@ probe_t *probe_new(char *probe_name)
     return new;
 }
 
+// for the callback data
+typedef struct {
+    probe_t *probe;
+    const char *name;
+    int row;
+    int tab;
+    int match_row;
+    int match_tab;
+} rowcolref_t;
+
+static int rowcol_cb(hal_query_t *q, void *arg)
+{
+    rowcolref_t *rcr = (rowcolref_t *)arg;
+    const char *name[2] = {};
+    name[0] = q->name;
+
+    add_to_list(rcr->probe->lists[rcr->tab], name, NUM_COLS);
+    if (rcr->name && !strcmp(q->name, rcr->name)) {
+        rcr->match_tab = rcr->tab;
+        rcr->match_row = rcr->row;
+    }
+    rcr->row++;
+    return 0;
+}
+
 void popup_probe_window(GtkWidget * widget, gpointer data)
 {
     (void)widget;
     probe_t *probe;
-    hal_pin_t *pin;
-    hal_sig_t *sig;
-    hal_param_t *param;
-
-    int next, row, match_row, tab, match_tab;
-    char *name[HAL_NAME_LEN + 1];
-
 
     /* get a pointer to the probe data structure */
     probe = (probe_t *) data;
@@ -417,63 +437,33 @@ void popup_probe_window(GtkWidget * widget, gpointer data)
     clear_list(probe->lists[1]);
     clear_list(probe->lists[2]);
 
-    halpr_mutex_acquire();
-    next = hal_data->pin_list_ptr;
-    match_tab = 0;
-    match_row = 0;
-    row = 0;
-    tab = 0;
-    while (next != 0) {
-        pin = SHMPTR(next);
-        *name = pin->name;
+    rowcolref_t rcr = {};
+    rcr.probe = probe;
+    hal_query_t q = {};
 
-        add_to_list(probe->lists[tab], name, NUM_COLS);
-        if (probe->pin == pin) {
-            match_tab = tab;
-            match_row = row;
-        }
-        next = pin->next_ptr;
-        row++;
-    }
+    q.qtype = HAL_QTYPE_PIN;
+    rcr.name = probe->pin ? probe->pin->name : NULL;
+    hal_list_p(&q, rowcol_cb, &rcr);
 
-    next = hal_data->sig_list_ptr;
-    row = 0;
-    tab = 1;
-    while (next != 0) {
-        sig = SHMPTR(next);
-        *name = sig->name;
+    memset(&q, 0, sizeof(q));
+    q.qtype = HAL_QTYPE_SIGNAL;
+    rcr.name = probe->sig ? probe->sig->name : NULL;
+    rcr.tab = 1;
+    rcr.row = 0;
+    hal_list_s(&q, rowcol_cb, &rcr);
 
-        add_to_list(probe->lists[tab], name, NUM_COLS);
-        if (probe->sig == sig) {
-            match_tab = tab;
-            match_row = row;
-        }
-        next = sig->next_ptr;
-        row++;
-    }
+    memset(&q, 0, sizeof(q));
+    q.qtype = HAL_QTYPE_PARAM;
+    rcr.name = probe->param ? probe->param->name : NULL;
+    rcr.tab = 2;
+    rcr.row = 0;
+    hal_list_p(&q, rowcol_cb, &rcr);
 
-    next = hal_data->param_list_ptr;
-    row = 0;
-    tab = 2;
-    while (next != 0) {
-        param = SHMPTR(next);
-        *name = param->name;
-
-        add_to_list(probe->lists[tab], name, NUM_COLS);
-        if (probe->param == param) {
-            match_tab = tab;
-            match_row = row;
-        }
-        next = param->next_ptr;
-        row++;
-    }
-
-    halpr_mutex_release();
     gtk_widget_show_all(probe->window);
 
     if (probe->pickname != NULL) {
-        gtk_notebook_set_current_page(GTK_NOTEBOOK(probe->notebook), match_tab);
-        mark_selected_row(probe->lists[match_tab], match_row);
+        gtk_notebook_set_current_page(GTK_NOTEBOOK(probe->notebook), rcr.match_tab);
+        mark_selected_row(probe->lists[rcr.match_tab], rcr.match_row);
     }
 }
 
@@ -493,8 +483,7 @@ static int refresh_value(gpointer data)
 {
     meter_t *meter;
     probe_t *probe;
-    char *value_str, *name_str;
-    hal_sig_t *sig;
+    const char *value_str, *name_str;
     static int first = 1;
 
     meter = (meter_t *) data;
@@ -507,48 +496,34 @@ static int refresh_value(gpointer data)
 	}
     }
 
-    halpr_mutex_acquire();
-    if (probe->pin != NULL) {
-	if (probe->pin->name[0] == '\0') {
-	    /* pin has been deleted, can't display it any more */
-	    probe->pin = NULL;
-	    halpr_mutex_release();
-	    return 1;
-	}
-	name_str = probe->pin->name;
-	if (probe->pin->signal == 0) {
-	    /* pin is unlinked, get data from dummysig */
-	    value_str = data_value(probe->pin->type, &(probe->pin->dummysig));
-	} else {
-	    /* pin is linked to a signal */
-	    sig = SHMPTR(probe->pin->signal);
-	    value_str = data_value(probe->pin->type, SHMPTR(sig->data_ptr));
-	}
-    } else if (probe->sig != NULL) {
-	if (probe->sig->name[0] == '\0') {
-	    /* signal has been deleted, can't display it any more */
-	    probe->sig = NULL;
-	    halpr_mutex_release();
-	    return 1;
-	}
-	name_str = probe->sig->name;
-	value_str =
-	    data_value(probe->sig->type, SHMPTR(probe->sig->data_ptr));
-    } else if (probe->param != NULL) {
-	if (probe->param->name[0] == '\0') {
-	    /* parameter has been deleted, can't display it any more */
-	    probe->param = NULL;
-	    halpr_mutex_release();
-	    return 1;
-	}
-	name_str = probe->param->name;
-	value_str =
-	    data_value(probe->param->type, SHMPTR(probe->param->data_ptr));
+    if(NULL != probe->pin) {
+        if(0 != hal_getref_p(probe->pin)) {
+            // Pin no longer exists
+            probe->pin = NULL;
+            return 1;
+        }
+        name_str = probe->pin->name;
+        value_str = data_value(probe->pin->pp.type, probe->pin->pp.ref);
+    } else if(NULL != probe->sig) {
+        if(0 != hal_getref_s(probe->sig)) {
+            // Signal no longer exists
+            probe->sig = NULL;
+            return 1;
+        }
+        name_str = probe->sig->name;
+        value_str = data_value(probe->sig->sig.type, probe->sig->sig.ref);
+    } else if(NULL != probe->param) {
+        if(0 != hal_getref_p(probe->param)) {
+            // Param no longer exists
+            probe->param = NULL;
+            return 1;
+        }
+        name_str = probe->param->name;
+        value_str = data_value(probe->param->pp.type, probe->param->pp.ref);
     } else {
 	name_str = "-----";
 	value_str = "---";
     }
-    halpr_mutex_release();
     gtk_label_set_text(GTK_LABEL(meter->value_label), value_str);
     if (!small) {
 	gtk_label_set_text(GTK_LABEL(meter->name_label), name_str);
@@ -557,30 +532,37 @@ static int refresh_value(gpointer data)
 }
 
 /* Switch function to return var value for the print_*_list functions  */
-static char *data_value(int type, void *valptr)
+static const char *data_value(hal_type_t type, hal_refs_u ref)
 {
     char *value_str;
-    static char buf[25];
+    static char buf[64];
 
     switch (type) {
-    case HAL_BIT:
-	if (*((char *) valptr) == 0)
-	    value_str = "FALSE";
-	else
-	    value_str = "TRUE";
-	break;
-    case HAL_FLOAT:
-	snprintf(buf, 14, "%.7g", (double)*((hal_float_t *) valptr));
+    case HAL_BOOL:
+        return hal_get_bool(ref.b) ? "TRUE" : "FALSE";
+    case HAL_REAL:
+	snprintf(buf, sizeof(buf), "%.7g", (double)hal_get_real(ref.r));
 	value_str = buf;
 	break;
     case HAL_S32:
-	snprintf(buf, 24, "%10ld", (long)*((hal_s32_t *) valptr));
+	snprintf(buf, sizeof(buf), "%10ld", (long)hal_get_si32(ref.s));
 	value_str = buf;
 	break;
-    case HAL_U32:
-	snprintf(buf, 24, "%10lu (0x%08lX)", (unsigned long)*((hal_u32_t *) valptr),
-	    *((unsigned long *) valptr));
+    case HAL_U32: {
+        unsigned long v = hal_get_ui32(ref.u);
+	snprintf(buf, sizeof(buf), "%10lu (0x%08lX)", v, v);
 	value_str = buf;
+        }
+	break;
+    case HAL_SINT:
+	snprintf(buf, sizeof(buf), "%10lld", (long long)hal_get_sint(ref.s));
+	value_str = buf;
+	break;
+    case HAL_UINT: {
+        unsigned long long v = hal_get_uint(ref.u);
+	snprintf(buf, sizeof(buf), "%10llu (0x%08llX)", v, v);
+	value_str = buf;
+        }
 	break;
     default:
 	/* Shouldn't get here, but just in case... */
@@ -597,7 +579,7 @@ static void create_probe_window(probe_t * probe)
     GtkWidget *scrolled_window;
     GtkTreeSelection *selection;
 
-    char *tab_label_text[3];
+    const char *tab_label_text[3];
     int n;
 
     /* create window, set size and title */
@@ -677,14 +659,32 @@ static void apply_selection(GtkWidget * widget, gpointer data)
 	return;
     }
     if (probe->listnum == 0) {
-	/* search the pin list */
-	probe->pin = halpr_find_pin_by_name(probe->pickname);
+        /* search the pin list */
+        memset(&probe->qpin, 0, sizeof(probe->qpin));
+        probe->qpin.name = probe->pickname;
+        probe->qpin.qtype = HAL_QTYPE_PIN;
+        if(0 == hal_getref_p(&probe->qpin))
+            probe->pin = &probe->qpin;
+        else
+            probe->pin = NULL;
     } else if (probe->listnum == 1) {
 	/* search the signal list */
-	probe->sig = halpr_find_sig_by_name(probe->pickname);
+        memset(&probe->qsig, 0, sizeof(probe->qsig));
+        probe->qsig.name = probe->pickname;
+        probe->qsig.qtype = HAL_QTYPE_SIGNAL;
+        if(0 == hal_getref_s(&probe->qsig))
+            probe->sig = &probe->qsig;
+        else
+            probe->sig = NULL;
     } else if (probe->listnum == 2) {
 	/* search the parameter list */
-	probe->param = halpr_find_param_by_name(probe->pickname);
+        memset(&probe->qparam, 0, sizeof(probe->qparam));
+        probe->qparam.name = probe->pickname;
+        probe->qparam.qtype = HAL_QTYPE_PARAM;
+        if(0 == hal_getref_p(&probe->qparam))
+            probe->param = &probe->qparam;
+        else
+            probe->param = NULL;
     }
     /* at this point, the probe structure contain a pointer to the item we
        wish to display, or all three are NULL if the item doesn't exist */

--- a/src/hal/utils/miscgtk.c
+++ b/src/hal/utils/miscgtk.c
@@ -183,7 +183,7 @@ void gtk_label_size_to_fit(GtkLabel * label, const gchar * str)
     return;
 }
 
-void add_to_list(GtkWidget *list, char *strs[], const int num_cols)
+void add_to_list(GtkWidget *list, const char *strs[], const int num_cols)
 {
     GtkListStore *store;
     GtkTreeIter iter;
@@ -201,7 +201,7 @@ void add_to_list(GtkWidget *list, char *strs[], const int num_cols)
     }
 }
 
-void init_list(GtkWidget *list, char *titles[], const int len)
+void init_list(GtkWidget *list, const char *titles[], const int len)
 {
     GtkCellRenderer *renderer;
     GtkListStore *store;

--- a/src/hal/utils/miscgtk.h
+++ b/src/hal/utils/miscgtk.h
@@ -90,10 +90,10 @@ void gtk_label_set_text_if(GtkWidget * label, const gchar * text);
 void gtk_label_size_to_fit(GtkLabel * label, const gchar * str);
 
 /* Initialize a TreeView. */
-void init_list(GtkWidget *list, char *titles[], const int num_cols);
+void init_list(GtkWidget *list, const char *titles[], const int num_cols);
 
 /* Add new row to a TreeView. */
-void add_to_list(GtkWidget *list, char *strs[], const int num);
+void add_to_list(GtkWidget *list, const char *strs[], const int num);
 
 /* Clears all elements from a TreeView list. */
 void clear_list(GtkWidget *list);

--- a/src/hal/utils/scope.c
+++ b/src/hal/utils/scope.c
@@ -50,7 +50,6 @@ static char *license = \
 #include "config.h"
 #include <rtapi.h>		/* RTAPI realtime OS API */
 #include <hal.h>		/* HAL public API decls */
-#include "../hal_priv.h"	/* HAL private API decls */
 
 #include <gtk/gtk.h>
 #include "miscgtk.h"		/* generic GTK stuff */
@@ -200,7 +199,8 @@ int main(int argc, gchar * argv[])
 	return -1;
     }
 
-    if (!halpr_find_funct_by_name("scope.sample")) {
+    int rv = hal_comp_by_name("scope.sample", NULL);
+    if (-ENOENT == rv) {
 	char buf[1000];
 	snprintf(buf, sizeof(buf), EMC2_BIN_DIR "/halcmd loadrt scope_rt num_samples=%d",
 		num_samples);
@@ -211,8 +211,10 @@ int main(int argc, gchar * argv[])
 	}
     } else {
 	/* scope_rt already loaded - we'll check if sample count matches later */
-	rtapi_print_msg(RTAPI_MSG_DBG,
-	    "SCOPE: scope_rt already loaded, requested %d samples\n", num_samples);
+        if(0 == rv)
+            rtapi_print_msg(RTAPI_MSG_DBG, "SCOPE: scope_rt already loaded, requested %d samples\n", num_samples);
+        else
+            rtapi_print_msg(RTAPI_MSG_DBG, "SCOPE: hal_comp_by_name() returned error %d\n", rv);
     }
     /* set up a shared memory region for the scope data */
     shm_id = rtapi_shmem_new(SCOPE_SHM_KEY, comp_id, sizeof(scope_shm_control_t));
@@ -332,9 +334,6 @@ void start_capture(void)
 {
     int n;
     scope_chan_t *chan;
-    hal_pin_t *pin;
-    hal_sig_t *sig;
-    hal_param_t *param;
 
     if (ctrl_shm->state != IDLE) {
 	/* already running! */
@@ -372,46 +371,48 @@ void start_capture(void)
 	chan = &(ctrl_usr->chan[n]);
 	/* find address of data in shared memory */
 	if ( chan->data_source_type == 0 ) {
-	    /* channel source is a pin, point at it */
-	    pin = SHMPTR(chan->data_source);
+	    /* channel source is a pin */
 	    /* make sure it's still valid */
-	    if ( pin->name[0] == '\0' ) {
-		/* pin has been deleted */
-		chan->data_source_type = -1;
-		chan->data_len = 0;
-		break;
-	    }
-	    /* point at pin data */
-	    if (pin->signal == 0) {
-		/* pin is unlinked, get data from dummysig */
-		ctrl_shm->data_offset[n] = SHMOFF(&(pin->dummysig));
-	    } else {
-		/* pin is linked to a signal */
-		sig = SHMPTR(pin->signal);
-		ctrl_shm->data_offset[n] = sig->data_ptr;
-	    }
+            hal_query_t q = {};
+            q.name = chan->name;
+            q.qtype = HAL_QTYPE_PIN;
+            if(0 == hal_getref_p(&q)) {
+               /* point at pin data */
+	       ctrl_shm->data_offset[n] = hal_reference_unmap(q.pp.ref.u);
+            } else {
+	        /* pin no longer available */
+	        chan->data_source_type = -1;
+	        chan->data_len = 0;
+	        break;
+            }
 	} else if ( chan->data_source_type == 1 ) {
-	    /* channel source is a signal, point at it */
-	    sig = SHMPTR(chan->data_source);
+	    /* channel source is a signal */
 	    /* make sure it's still valid */
-	    if ( sig->name[0] == '\0' ) {
-		/* signal has been deleted */
+            hal_query_t q = {};
+            q.name = chan->name;
+            if(0 == hal_getref_s(&q)) {
+	        ctrl_shm->data_offset[n] = hal_reference_unmap(q.sig.ref.u);
+            } else {
+		/* signal no longer available */
 		chan->data_source_type = -1;
 		chan->data_len = 0;
 		break;
 	    }
-	    ctrl_shm->data_offset[n] = sig->data_ptr;
 	} else if ( chan->data_source_type == 2 ) {
-	    /* channel source is a parameter, point at it */
-	    param = SHMPTR(chan->data_source);
+	    /* channel source is a parameter */
 	    /* make sure it's still valid */
-	    if ( param->name[0] == '\0' ) {
-		/* param has been deleted */
-		chan->data_source_type = -1;
-		chan->data_len = 0;
-		break;
-	    }
-	    ctrl_shm->data_offset[n] = param->data_ptr;
+            hal_query_t q = {};
+            q.name = chan->name;
+            q.qtype = HAL_QTYPE_PARAM;
+            if(0 == hal_getref_p(&q)) {
+               /* point at param data */
+	       ctrl_shm->data_offset[n] = hal_reference_unmap(q.pp.ref.u);
+            } else {
+	        /* param no longer available */
+	        chan->data_source_type = -1;
+	        chan->data_len = 0;
+	        break;
+            }
 	} else {
 	    /* channel source is invalid */
 	    chan->data_len = 0;
@@ -510,8 +511,8 @@ static void init_usr_control_struct(void *shmem)
 
     /* save pointer to shared control structure */
     ctrl_shm = shmem;
-    /* round size of shared struct up to a multiple of 4 for alignment */
-    skip = (sizeof(scope_shm_control_t) + 3) & ~3;
+    /* round size of shared struct up to a multiple of 8 for alignment */
+    skip = (sizeof(scope_shm_control_t) + 7) & ~7;
     /* the rest of the shared memory area is the data buffer */
     ctrl_usr->buffer = (scope_data_t *) (((char *) (shmem)) + skip);
     /* is the realtime component loaded already? */

--- a/src/hal/utils/scope_disp.c
+++ b/src/hal/utils/scope_disp.c
@@ -42,7 +42,6 @@
 
 #include <rtapi.h>		/* RTAPI realtime OS API */
 #include <hal.h>		/* HAL public API decls */
-#include "../hal_priv.h"	/* private HAL decls */
 
 #include <gtk/gtk.h>
 #include "miscgtk.h"		/* generic GTK stuff */
@@ -155,21 +154,27 @@ static void calculate_offset(int chan_num) {
 
     for(n=0; n < ctrl_usr->samples; n++) {
 	switch (type) {
-	case HAL_BIT:
-	    if (dptr->d_u8) {
+	case HAL_BOOL:
+	    if (dptr->b) {
 		value = 1.0;
 	    } else {
 		value = 0.0;
 	    };
 	    break;
-	case HAL_FLOAT:
-	    value = dptr->d_real;
+	case HAL_REAL:
+	    value = dptr->r;
 	    break;
 	case HAL_S32:
-	    value = dptr->d_s32;
+	    value = dptr->s;
 	    break;
 	case HAL_U32:
-	    value = dptr->d_u32;
+	    value = dptr->u;
+	    break;
+	case HAL_SINT:
+	    value = dptr->s;
+	    break;
+	case HAL_UINT:
+	    value = dptr->u;
 	    break;
 	default:
 	    value = 0.0;
@@ -719,7 +724,7 @@ void draw_triggerline(int chan_num, int highlight) {
     if(dx < 5) dx = 5;
     if(dy < dx + 1) dy = dx + 1;
 
-    if(chan->data_type == HAL_BIT)
+    if(chan->data_type == HAL_BOOL)
         y1 = ypoffset;
 
     if(ctrl_shm->trig_edge) dy = -dy;
@@ -814,21 +819,27 @@ void draw_waveform(int chan_num, int highlight)
 	x2 = (n * xscale) - xoffset;
 	/* calc y coordinate of this point */
 	switch (type) {
-	case HAL_BIT:
-	    if (dptr->d_u8) {
+	case HAL_BOOL:
+	    if (dptr->b) {
 		fy = 1.0;
 	    } else {
 		fy = 0.0;
 	    };
 	    break;
-	case HAL_FLOAT:
-	    fy = dptr->d_real;
+	case HAL_REAL:
+	    fy = dptr->r;
 	    break;
 	case HAL_S32:
-	    fy = dptr->d_s32;
+	    fy = dptr->s;
 	    break;
 	case HAL_U32:
-	    fy = dptr->d_u32;
+	    fy = dptr->u;
+	    break;
+	case HAL_SINT:
+	    fy = dptr->s;
+	    break;
+	case HAL_UINT:
+	    fy = dptr->u;
 	    break;
 	default:
 	    fy = 0.0;

--- a/src/hal/utils/scope_files.c
+++ b/src/hal/utils/scope_files.c
@@ -43,7 +43,6 @@
 
 #include <rtapi.h>		/* RTAPI realtime OS API */
 #include <hal.h>		/* HAL public API decls */
-#include "../hal_priv.h"	/* HAL private API decls */
 
 #include <gtk/gtk.h>
 #include "miscgtk.h"		/* generic GTK stuff */
@@ -254,7 +253,7 @@ void write_log_file(char *filename)
     scope_vert_t *vert;
     hal_type_t type[16];
 
-    char *label[16] = {};
+    const char *label[16] = {};
     char *old_locale, *saved_locale;
     int sample_len, chan_active, chan_num, sample_period_ns, samples, n;
     FILE *fp;
@@ -569,30 +568,35 @@ void read_log_file(char *filename)
         int matched = 0;
 
         /* Try to find matching HAL pin */
-        hal_pin_t *pin = halpr_find_pin_by_name(channel_names[i]);
-        if (pin != NULL) {
+        hal_query_t qp = {};
+        qp.name = channel_names[i];
+        qp.qtype = HAL_QTYPE_PIN;
+        if (0 == hal_getref_p(&qp)) {
             chan->data_source_type = 0;
-            chan->data_source = SHMOFF(pin);
-            chan->data_type = pin->type;
-            chan->name = pin->name;
+            chan->data_source = hal_reference_unmap(qp.pp.ref.u);
+            chan->data_type = qp.pp.type;
+            chan->name = qp.name;
             matched = 1;
         } else {
             /* Try to find matching HAL signal */
-            hal_sig_t *sig = halpr_find_sig_by_name(channel_names[i]);
-            if (sig != NULL) {
+            hal_query_t qs = {};
+            qs.name = channel_names[i];
+            if (0 == hal_getref_s(&qs)) {
                 chan->data_source_type = 1;
-                chan->data_source = SHMOFF(sig);
-                chan->data_type = sig->type;
-                chan->name = sig->name;
+                chan->data_source = hal_reference_unmap(qs.sig.ref.u);
+                chan->data_type = qs.sig.type;
+                chan->name = qs.name;
                 matched = 1;
             } else {
                 /* Try to find matching HAL parameter */
-                hal_param_t *param = halpr_find_param_by_name(channel_names[i]);
-                if (param != NULL) {
-                    chan->data_source_type = 2;
-                    chan->data_source = SHMOFF(param);
-                    chan->data_type = param->type;
-                    chan->name = param->name;
+                hal_query_t qa = {};
+                qa.name = channel_names[i];
+                qa.qtype = HAL_QTYPE_PARAM;
+                if (0 == hal_getref_p(&qa)) {
+                    chan->data_source_type = 0;
+                    chan->data_source = hal_reference_unmap(qa.pp.ref.u);
+                    chan->data_type = qa.pp.type;
+                    chan->name = qa.name;
                     matched = 1;
                 }
             }
@@ -606,8 +610,8 @@ void read_log_file(char *filename)
                          "[CSV] %s", channel_names[i]);
 
                 chan->data_source_type = -1;  /* No source */
-                chan->data_source = 0;
-                chan->data_type = HAL_FLOAT;  /* Default to float for CSV data */
+                memset(&chan->data_source, 0, sizeof(chan->data_source));
+                chan->data_type = HAL_REAL;  /* Default to float for CSV data */
                 chan->name = phantom_name;
                 chan->is_phantom = 1;
             }
@@ -615,23 +619,25 @@ void read_log_file(char *filename)
 
         /* Set up channel data length and scale limits based on type */
         switch (chan->data_type) {
-        case HAL_BIT:
-            chan->data_len = sizeof(hal_bit_t);
+        case HAL_BOOL:
+            chan->data_len = sizeof(scope_data_t);
             chan->min_index = -2;
             chan->max_index = 2;
             break;
-        case HAL_FLOAT:
-            chan->data_len = sizeof(hal_float_t);
+        case HAL_REAL:
+            chan->data_len = sizeof(scope_data_t);
             chan->min_index = -36;
             chan->max_index = 36;
             break;
         case HAL_S32:
-            chan->data_len = sizeof(hal_s32_t);
+        case HAL_SINT:
+            chan->data_len = sizeof(scope_data_t);
             chan->min_index = -2;
             chan->max_index = 30;
             break;
         case HAL_U32:
-            chan->data_len = sizeof(hal_u32_t);
+        case HAL_UINT:
+            chan->data_len = sizeof(scope_data_t);
             chan->min_index = -2;
             chan->max_index = 30;
             break;
@@ -742,17 +748,23 @@ void read_log_file(char *filename)
 
             /* Convert to appropriate type */
             switch (channel_types[i]) {
-            case HAL_BIT:
-                dptr->d_u8 = (value != 0.0) ? 1 : 0;
+            case HAL_BOOL:
+                dptr->b = (value != 0.0) ? 1 : 0;
                 break;
-            case HAL_FLOAT:
-                dptr->d_real = (real_t)value;
+            case HAL_REAL:
+                dptr->r = (rtapi_real)value;
                 break;
             case HAL_S32:
-                dptr->d_s32 = (rtapi_s32)value;
+                dptr->s = (rtapi_s32)value;
                 break;
             case HAL_U32:
-                dptr->d_u32 = (rtapi_u32)value;
+                dptr->u = (rtapi_u32)value;
+                break;
+            case HAL_SINT:
+                dptr->s = (rtapi_sint)value;
+                break;
+            case HAL_UINT:
+                dptr->u = (rtapi_uint)value;
                 break;
             default:
                 break;
@@ -829,21 +841,23 @@ static void write_sample(FILE *fp, scope_data_t *dptr, hal_type_t type)
 {
 	double data_value;
 	switch (type) {
-		case HAL_BIT:
-			if (dptr->d_u8) {
-			data_value = 1.0;
-			} else {
-			data_value = 0.0;
-			};
+		case HAL_BOOL:
+			data_value = dptr->b ? 1.0 : 0.0;
 			break;
-		case HAL_FLOAT:
-			data_value = dptr->d_real;
+		case HAL_REAL:
+			data_value = dptr->r;
 			break;
 		case HAL_S32:
-			data_value = dptr->d_s32;
+			data_value = dptr->s;
 			break;
 		case HAL_U32:
-			data_value = dptr->d_u32;
+			data_value = dptr->u;
+			break;
+		case HAL_SINT:
+			data_value = dptr->s;
+			break;
+		case HAL_UINT:
+			data_value = dptr->u;
 			break;
 		default:
 			data_value = 0.0;

--- a/src/hal/utils/scope_horiz.c
+++ b/src/hal/utils/scope_horiz.c
@@ -47,7 +47,6 @@
 #include <rtapi.h>		/* RTAPI realtime OS API */
 #include <rtapi_mutex.h>
 #include <hal.h>		/* HAL public API decls */
-#include "../hal_priv.h"	/* private HAL decls */
 
 #include <gtk/gtk.h>
 #include "miscgtk.h"		/* generic GTK stuff */
@@ -215,71 +214,68 @@ static void init_horiz_window(void)
     gtk_label_size_to_fit(GTK_LABEL(horiz->state_label), " TRIGGERED ");
 }
 
+static int find_funct_cb(hal_query_t *q, void *arg)
+{
+    if(!strcmp((const char *)arg, q->name)) {
+        // The name will stick to q->name when we return from hal_list_funct()
+        return 1;  // Positive, break the loop without error
+    }
+    return 0;
+}
+
+static int find_threadfunct_cb(hal_query_t *q, void *arg)
+{
+    if(q->qtype == HAL_QTYPE_THREAD_FUNCT && !strcmp((const char *)arg, q->thread.funct)) {
+        // The thread name will stick to q->name when we return from hal_list_thread()
+        return 1;  // Positive, break the loop without error
+    }
+    return 0;
+}
+
 static void init_acquire_function(void)
 {
-    hal_funct_t *funct;
-    int next_thread;
-    hal_thread_t *thread;
-    hal_list_t *list_root, *list_entry;
-    hal_funct_entry_t *fentry;
     scope_horiz_t *horiz;
 
     horiz = &(ctrl_usr->horiz);
     /* set watchdog to trip immediately once heartbeat funct is called */
     ctrl_shm->watchdog = 10;
     /* is the realtime function present? */
-    funct = halpr_find_funct_by_name("scope.sample");
-    if (funct == NULL) {
+    hal_query_t q = {};
+    int rv = hal_list_funct(&q, find_funct_cb, (void *)"scope.sample");
+    if (rv <= 0) {
 	/* realtime function not present - watchdog timeout will open a
 	   dialog asking the user to insmod the module */
 	return;
     }
-    if (funct->users == 0) {
+    if (q.funct.users == 0) {
 	/* function not in use - watchdog timeout will open a dialog asking
 	   the user to select a thread */
 	return;
     }
     /* function is in use, find out which thread it is linked to */
-    halpr_mutex_acquire();
-    next_thread = hal_data->thread_list_ptr;
-    while (next_thread != 0) {
-	thread = SHMPTR(next_thread);
-	list_root = &(thread->funct_list);
-	list_entry = list_next(list_root);
-	while (list_entry != list_root) {
-	    fentry = (hal_funct_entry_t *) list_entry;
-	    if (funct == SHMPTR(fentry->funct_ptr)) {
-		/* found a match, update structure members */
-		horiz->thread_name = thread->name;
-		horiz->thread_period_ns = thread->period;
-		/* done with hal data */
-		halpr_mutex_release();
-		/* reset watchdog to give RT code some time */
-		ctrl_shm->watchdog = 1;
-		return;
-	    }
-	    list_entry = list_next(list_entry);
-	}
-	next_thread = thread->next_ptr;
+    hal_query_t qt = {};
+    qt.qtype = HAL_QTYPE_THREAD_FUNCT;
+    if(hal_list_thread(&qt, find_threadfunct_cb, (void *)q.name) > 0) {
+        /* found a match, update structure members */
+        horiz->thread_name = qt.name;
+        horiz->thread_period_ns = qt.thread.period;
+        /* reset watchdog to give RT code some time */
+        ctrl_shm->watchdog = 1;
     }
-    /* didn't find a linked thread - should never get here, but... */
-    halpr_mutex_release();
-    return;
 }
 
 void handle_watchdog_timeout(void)
 {
-    hal_funct_t *funct;
-
     /* stop sampling */
     ctrl_shm->state = IDLE;
     ctrl_shm->samples = 0;
     /* does realtime function exist? */
-    funct = halpr_find_funct_by_name("scope.sample");
-    if (funct == NULL) {
+    hal_query_t q = {};
+    int rv = hal_list_funct(&q, find_funct_cb, (void *)"scope.sample");
+    if (rv <= 0) {
 	/* function is not loaded */
 	dialog_realtime_not_loaded();
-    } else if (funct->users == 0) {
+    } else if (q.funct.users == 0) {
 	/* function is loaded, but not in a thread */
 	dialog_realtime_not_linked();
     } else if (ctrl_shm->watchdog != 0) {
@@ -485,15 +481,43 @@ static void dialog_realtime_not_loaded(void)
     }
 }
 
+typedef struct {
+    scope_horiz_t *horiz;
+    int n;
+    int sel_row;
+} listthreadcb_t;
+
+static int list_thread_cb(hal_query_t *q, void *arg)
+{
+    listthreadcb_t *ltc = (listthreadcb_t *)arg;
+
+    if (q->thread.period <= 1000000000) {
+        const char *strs[2];
+        char buf[BUFLEN + 1];
+        /* period is less than 1 sec, add to list */
+        double period = q->thread.period / 1000000000.0;
+        /* create a string for display */
+        format_time_value(buf, BUFLEN, period);
+        strs[1] = buf;
+        /* get thread name */
+        strs[0] = q->name;
+        /* add to list */
+        add_to_list(ltc->horiz->thread_list, strs, NUM_COLS);
+        if ((ltc->horiz->thread_name != NULL) && (strcmp(ltc->horiz->thread_name, q->name) == 0)) {
+            /* found the current thread, remember it's row number */
+            ltc->sel_row = ltc->n;
+            /* and make sure thread_period is correct */
+            ltc->horiz->thread_period_ns = q->thread.period;
+        }
+    }
+    ltc->n++;
+    return 0;
+}
 static void dialog_realtime_not_linked(void)
 {
     scope_horiz_t *horiz;
 
-    int next, sel_row, n;
     int retval;
-    double period;
-    hal_thread_t *thread;
-    char *strs[2];
     char buf[BUFLEN + 1];
     GtkWidget *hbox, *label;
     GtkWidget *content_area;
@@ -501,7 +525,7 @@ static void dialog_realtime_not_linked(void)
     GtkWidget *scrolled_window;
     GtkTreeSelection *selection;
 
-    char *titles[NUM_COLS];
+    const char *titles[NUM_COLS];
     const char *title, *msg;
 
     horiz = &(ctrl_usr->horiz);
@@ -589,37 +613,11 @@ static void dialog_realtime_not_linked(void)
     g_signal_connect(selection, "changed",
             G_CALLBACK(acquire_selection_made), horiz);
 
-    /* get mutex before traversing list */
-    halpr_mutex_acquire();
-    n = 0;
-    sel_row = -1;
-    next = hal_data->thread_list_ptr;
-    while (next != 0) {
-	thread = SHMPTR(next);
-	/* check thread period */
-	if (thread->period <= 1000000000) {
-	    /* period is less than 1 sec, add to list */
-	    period = thread->period / 1000000000.0;
-	    /* create a string for display */
-	    format_time_value(buf, BUFLEN, period);
-	    strs[1] = buf;
-	    /* get thread name */
-	    strs[0] = thread->name;
-	    /* add to list */
-	    add_to_list(horiz->thread_list, strs, NUM_COLS);
-	    if ((horiz->thread_name != NULL)
-		&& (strcmp(horiz->thread_name, thread->name) == 0)) {
-		/* found the current thread, remember it's row number */
-		sel_row = n;
-		/* and make sure thread_period is correct */
-		horiz->thread_period_ns = thread->period;
-	    }
-	}
-	n++;
-	next = thread->next_ptr;
-    }
-
-    halpr_mutex_release();
+    /* traverse the thread list */
+    listthreadcb_t ltc = { .horiz = horiz, .n = 0, .sel_row = -1 };
+    hal_query_t q = {};
+    q.qtype = HAL_QTYPE_THREAD;
+    hal_list_thread(&q, list_thread_cb, (void *)&ltc);
 
     /* set up the the layout for the multiplier spinbutton */
     hbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 5);
@@ -670,9 +668,9 @@ static void dialog_realtime_not_linked(void)
     ctrl_shm->rec_len = ctrl_shm->buf_len / 16;
 
     /* was a thread previously used? */
-    if (sel_row > -1) {
+    if (ltc.sel_row > -1) {
 	/* yes, preselect appropriate line */
-        mark_selected_row(horiz->thread_list, sel_row);
+        mark_selected_row(horiz->thread_list, ltc.sel_row);
     }
     gtk_widget_show_all(dialog);
 
@@ -845,24 +843,33 @@ static void acquire_selection_made(GtkWidget *widget, gpointer data)
     }
 }
 
+static int find_thread_cb(hal_query_t *q, void *arg)
+{
+    if(!strcmp((const char *)arg, q->name)) {
+        // q->name will retain the name
+        return 1;  // Break the loop but no error
+    }
+    return 0;
+}
+
 static int set_sample_thread_name(char *name)
 {
     scope_horiz_t *horiz;
-    hal_thread_t *thread;
     long max_mult;
 
     /* get a pointer to the horiz data structure */
     horiz = &(ctrl_usr->horiz);
     /* look for a new thread that matches name*/
-    thread = halpr_find_thread_by_name(name);
-    if (thread == NULL) {
+    hal_query_t q = {};
+    q.qtype = HAL_QTYPE_THREAD;
+    if(hal_list_thread(&q, find_thread_cb, (void *)name) <= 0) {
 	return -1;
     }
     /* shut down any prior thread */
     deactivate_sample_thread();
     /* save info about the thread */
-    horiz->thread_name = thread->name;
-    horiz->thread_period_ns = thread->period;
+    horiz->thread_name = q.name;
+    horiz->thread_period_ns = q.thread.period;
     /* calc max possible mult (to keep sample period <= 1 sec */
     max_mult = (1000000000 / horiz->thread_period_ns);
     if (max_mult > 1000) {
@@ -1011,7 +1018,7 @@ static void calc_horiz_scaling(void)
 static void refresh_horiz_info(void)
 {
     scope_horiz_t *horiz;
-    gchar *name;
+    const gchar *name;
     static gchar tmp[BUFLEN + 1], rate[BUFLEN + 1], period[BUFLEN + 1];
     static gchar scale[BUFLEN + 1], rec_len[BUFLEN + 1], msg[BUFLEN + 1];
     double freqval;

--- a/src/hal/utils/scope_rt.c
+++ b/src/hal/utils/scope_rt.c
@@ -35,7 +35,6 @@
 #include <rtapi.h>		/* RTAPI realtime OS API */
 #include <rtapi_app.h>		/* RTAPI realtime module decls */
 #include <hal.h>		/* HAL public API decls */
-#include "../hal_priv.h"	/* HAL private API decls */
 #include "scope_rt.h"		/* scope related declarations */
 #include <rtapi_string.h>
 
@@ -103,7 +102,7 @@ int rtapi_app_main(void)
 	num_samples = SCOPE_NUM_SAMPLES_MAX;
     }
     /* connect to scope shared memory block */
-    skip = (sizeof(scope_shm_control_t) + 3) & ~3;
+    skip = (sizeof(scope_shm_control_t) + 7) & ~7;
     shm_size = skip + num_samples * sizeof(scope_data_t);
     shm_id = rtapi_shmem_new(SCOPE_SHM_KEY, comp_id, shm_size);
     if (shm_id < 0) {
@@ -193,7 +192,7 @@ static void sample(void *arg, long period)
 	ctrl_rt->auto_timer = 0;
 	/* get info about channels */
 	for (n = 0; n < 16; n++) {
-	    ctrl_rt->data_addr[n] = SHMPTR(ctrl_shm->data_offset[n]);
+	    ctrl_rt->data_addr[n] = (hal_refs_u)(hal_uint_t)hal_reference_map(ctrl_shm->data_offset[n]);
 	    ctrl_rt->data_type[n] = ctrl_shm->data_type[n];
 	    ctrl_rt->data_len[n] = ctrl_shm->data_len[n];
 	}
@@ -263,30 +262,17 @@ static void capture_sample(void)
     dest = &(ctrl_rt->buffer[ctrl_shm->curr]);
     /* loop through all channels to acquire data */
     for (n = 0; n < 16; n++) {
-	/* capture 1, 2, or 4 bytes, based on data size */
-	switch (ctrl_rt->data_len[n]) {
-	case 1:
-	    dest->d_u8 = *((unsigned char *) (ctrl_rt->data_addr[n]));
-	    dest++;
-	    break;
-	case 4:
-	    dest->d_u32 = *((unsigned long *) (ctrl_rt->data_addr[n]));
-	    dest++;
-	    break;
-	case 8:
-            {
-                ireal_t sample_a, sample_b;
-                do {
-                    sample_a = *((volatile ireal_t *) (ctrl_rt->data_addr[n]));
-                    sample_b = *((volatile ireal_t *) (ctrl_rt->data_addr[n]));
-                } while( sample_a != sample_b );
-                dest->d_ireal = sample_a;
-                dest++;
-            }
-	    break;
-	default:
-	    break;
-	}
+        if(0 == ctrl_rt->data_len[n]) // Unused channel
+            continue;
+        switch(ctrl_rt->data_type[n]) {
+        case HAL_BOOL: dest->b = hal_get_bool(ctrl_rt->data_addr[n].b); dest++; break;
+        case HAL_S32:  dest->s = hal_get_si32(ctrl_rt->data_addr[n].s); dest++; break;
+        case HAL_U32:  dest->u = hal_get_ui32(ctrl_rt->data_addr[n].u); dest++; break;
+        case HAL_SINT: dest->s = hal_get_sint(ctrl_rt->data_addr[n].s); dest++; break;
+        case HAL_UINT: dest->u = hal_get_uint(ctrl_rt->data_addr[n].u); dest++; break;
+        case HAL_REAL: dest->r = hal_get_real(ctrl_rt->data_addr[n].r); dest++; break;
+        default: break;
+        }
     }
     /* increment sample pointer */
     ctrl_shm->curr += ctrl_shm->sample_len;
@@ -297,13 +283,11 @@ static void capture_sample(void)
     }
 }
 
-// TODO: type-independent way to get high bit
-// #define SIGN_BIT (~(((ireal_t)~(ireal_t)0)>>1))
 static int check_trigger(void)
 {
     static int compare_result = 0;
     int prev_compare_result;
-    scope_data_t *value, *level;
+    scope_data_t *level;
 
     /* has user forced trigger? */
     if (ctrl_shm->force_trig != 0) {
@@ -323,66 +307,33 @@ static int check_trigger(void)
     if (ctrl_shm->trig_chan == 0) {
 	return 0;
     }
-    /* point a scope_data_t union at the signal value */
-    value = ctrl_rt->data_addr[ctrl_shm->trig_chan - 1];
     /* and at the trigger level */
     level = &(ctrl_shm->trig_level);
     /* save previous compare result */
     prev_compare_result = compare_result;
     /* compare actual value to trigger level */
     switch (ctrl_rt->data_type[ctrl_shm->trig_chan - 1]) {
-    case HAL_BIT:
-	/* for bits, we don't even look at the trigger level */
-	compare_result = value->d_u8;
-	break;
-    case HAL_FLOAT:
-	{
-	ireal_t tmp1, tmp2;
-	/* don't want to use the FPU in this function, so we use */
-	/* a hack - see http://en.wikipedia.org/wiki/IEEE_754 */
-	/* this _only_ works with IEEE-754 floating point numbers */
-	/* and will probably fail for infinities, NANs, etc. */
-	/* OK, here we go! */
-	/* get the value as an integer */
-	tmp1 = value->d_ireal;
-	/* get the trigger as an integer */
-	tmp2 = level->d_ireal;
-	/* is the value negative? (highest bit) */
-	if (tmp1 & 0x8000000000000000ull) {
-	    /* yes, is the trigger level negative? */
-	    if (tmp2 & 0x8000000000000000ull) {
-		/* yes, make both positive */
-		tmp1 ^= 0x8000000000000000ull;
-		tmp2 ^= 0x8000000000000000ull;
-		/* and compare them as unsigned ints */
-		/* because of negation, we reverse the compare */
-		compare_result = (tmp1 < tmp2);
-	    } else {
-		/* trigger level positive, value negative */
-		compare_result = 0;
-	    }
-	} else {
-	    /* value is positive, is trigger level negative? */
-	    if (tmp2 & 0x8000000000000000ull) {
-		/* trigger level negative, value positive */
-		compare_result = 1;
-	    } else {
-		/* both are positive */
-		/* compare them as unsigned ints */
-		compare_result = (tmp1 > tmp2);
-	    }
-	}
-	}
-	break;
+    case HAL_BOOL:
+        compare_result = hal_get_bool(ctrl_rt->data_addr[ctrl_shm->trig_chan - 1].b);
+        break;
     case HAL_S32:
-	compare_result = (value->d_s32 > level->d_s32);
-	break;
+        compare_result = hal_get_si32(ctrl_rt->data_addr[ctrl_shm->trig_chan - 1].s) > level->s;
+        break;
+    case HAL_SINT:
+        compare_result = hal_get_sint(ctrl_rt->data_addr[ctrl_shm->trig_chan - 1].s) > level->s;
+        break;
     case HAL_U32:
-	compare_result = (value->d_u32 > level->d_u32);
-	break;
+        compare_result = hal_get_ui32(ctrl_rt->data_addr[ctrl_shm->trig_chan - 1].u) > level->u;
+        break;
+    case HAL_UINT:
+        compare_result = hal_get_uint(ctrl_rt->data_addr[ctrl_shm->trig_chan - 1].u) > level->u;
+        break;
+    case HAL_REAL:
+        compare_result = hal_get_real(ctrl_rt->data_addr[ctrl_shm->trig_chan - 1].r) > level->r;
+        break;
     default:
-	compare_result = 0;
-	break;
+        compare_result = 0;
+        break;
     }
     /* test for rising edge */
     if (ctrl_shm->trig_edge && compare_result && !prev_compare_result) {
@@ -411,8 +362,8 @@ static void init_rt_control_struct(void *shmem)
     }
     /* save pointer to shared control structure */
     ctrl_shm = shmem;
-    /* round size of shared struct up to a multiple of 4 for alignment */
-    skip = (sizeof(scope_shm_control_t) + 3) & ~3;
+    /* round size of shared struct up to a multiple of 8 for alignment */
+    skip = (sizeof(scope_shm_control_t) + 7) & ~7;
     /* the rest of the shared memory area is the data buffer */
     ctrl_rt->buffer = (scope_data_t *) (((char *) (shmem)) + skip);
     init_shm_control_struct();
@@ -431,9 +382,9 @@ static void init_shm_control_struct(void)
     for (n = 0; n < (int)sizeof(scope_shm_control_t); n++) {
 	cp[n] = 0;
     }
-    /* round size of shared struct up to a multiple of 4 for alignment */
+    /* round size of shared struct up to a multiple of 8 for alignment */
     ctrl_shm->shm_size = shm_size;
-    skip = (sizeof(scope_shm_control_t) + 3) & ~3;
+    skip = (sizeof(scope_shm_control_t) + 7) & ~7;
     /* remainder of shmem area is buffer */
     ctrl_shm->buf_len = (shm_size - skip) / sizeof(scope_data_t);
     /* init any non-zero fields */

--- a/src/hal/utils/scope_rt.h
+++ b/src/hal/utils/scope_rt.h
@@ -50,7 +50,7 @@ typedef struct {
     int mult_cntr;		/* used to divide by 'mult' */
     int auto_timer;		/* delay timer for auto triggering */
     char data_len[16];		/* data size for each channel */
-    void *data_addr[16];	/* pointers to data for each channel */
+    hal_refs_u data_addr[16];	/* pointers to data for each channel */
     hal_type_t data_type[16];	/* data type for each channel */
 } scope_rt_control_t;
 

--- a/src/hal/utils/scope_shm.h
+++ b/src/hal/utils/scope_shm.h
@@ -59,11 +59,10 @@ typedef enum {
 /* this struct holds a single value - one sample of one channel */
 
 typedef union {
-    unsigned char d_u8;		/* variable for bit */
-    rtapi_u32 d_u32;		/* variable for u32 */
-    rtapi_s32 d_s32;		/* variable for s32 */
-    real_t d_real;		/* variable for float */
-    ireal_t d_ireal;		/* intlike variable for float */
+    rtapi_bool b;
+    rtapi_uint u;
+    rtapi_sint s;
+    rtapi_real r;
 } scope_data_t;
 
 /** This struct holds control data needed by both realtime and GUI code.
@@ -90,7 +89,7 @@ typedef struct {
     int curr;			/* R next sample to be acquired */
     int samples;		/* R number of valid samples */
     scope_state_t state;	/* RU current state */
-    int data_offset[16];	/* U data addr in shmem for each channel */
+    rtapi_intptr_t data_offset[16];	/* U data addr in shmem for each channel */
     hal_type_t data_type[16];	/* U data type for each channel */
     char data_len[16];		/* U data size, 0 if not to be acquired */
 } scope_shm_control_t;

--- a/src/hal/utils/scope_trig.c
+++ b/src/hal/utils/scope_trig.c
@@ -45,7 +45,6 @@
 
 #include <rtapi.h>		/* RTAPI realtime OS API */
 #include <hal.h>		/* HAL public API decls */
-#include "../hal_priv.h"	/* private HAL decls */
 
 #include <gtk/gtk.h>
 #include "miscgtk.h"		/* generic GTK stuff */
@@ -136,31 +135,49 @@ void refresh_trigger(void)
 	chan->vert_offset;
     /* apply type specific tweaks to trigger level */
     switch (chan->data_type) {
-    case HAL_FLOAT:
-	ctrl_shm->trig_level.d_real = fp_level;
+    case HAL_REAL:
+	ctrl_shm->trig_level.r = fp_level;
 	break;
     case HAL_S32:
-	if (fp_level > 2147483647.0) {
-	    fp_level = 2147483647.0;
+	if (fp_level > (rtapi_real)RTAPI_INT32_MAX) {
+	    fp_level = (rtapi_real)RTAPI_INT32_MAX;
 	}
-	if (fp_level < -2147483648.0) {
-	    fp_level = -2147483648.0;
+	if (fp_level < (rtapi_real)RTAPI_INT32_MIN) {
+	    fp_level = (rtapi_real)RTAPI_INT32_MIN;
 	}
-	ctrl_shm->trig_level.d_s32 = fp_level;
+	ctrl_shm->trig_level.s = fp_level;
 	break;
     case HAL_U32:
-	if (fp_level > 4294967295.0) {
-	    fp_level = 4294967295.0;
+	if (fp_level > (rtapi_real)RTAPI_UINT32_MAX) {
+	    fp_level = (rtapi_real)RTAPI_UINT32_MAX;
 	}
 	if (fp_level < 0.0) {
 	    fp_level = 0.0;
 	}
-	ctrl_shm->trig_level.d_u32 = fp_level;
+	ctrl_shm->trig_level.u = fp_level;
+	break;
+    case HAL_SINT:
+	if (fp_level > (rtapi_real)RTAPI_SINT_MAX) {
+	    fp_level = (rtapi_real)RTAPI_SINT_MAX;
+	}
+	if (fp_level < (rtapi_real)RTAPI_SINT_MIN) {
+	    fp_level = (rtapi_real)RTAPI_SINT_MIN;
+	}
+	ctrl_shm->trig_level.s = fp_level;
+	break;
+    case HAL_UINT:
+	if (fp_level > (rtapi_real)RTAPI_UINT_MAX) {
+	    fp_level = (rtapi_real)RTAPI_UINT_MAX;
+	}
+	if (fp_level < 0.0) {
+	    fp_level = 0.0;
+	}
+	ctrl_shm->trig_level.u = fp_level;
 	break;
     default:
 	break;
     }
-    if (chan->data_type == HAL_BIT) {
+    if (chan->data_type == HAL_BOOL) {
 	snprintf(buf, BUFLEN, "  ----  ");
         gtk_widget_set_sensitive(GTK_WIDGET(trig->level_slider), 0);
     } else {
@@ -299,7 +316,7 @@ static void dialog_select_trigger_source(void)
 {
     char *msg;
     int n;
-    char *strs[2], *titles[NUM_COLS];
+    const char *strs[2], *titles[NUM_COLS];
     char buf[BUFLEN + 1];
     GtkWidget *label, *scrolled_window, *trig_list;
     GtkWidget *content_area;

--- a/src/hal/utils/scope_usr.h
+++ b/src/hal/utils/scope_usr.h
@@ -48,7 +48,7 @@
 
 typedef struct {
     /* general data */
-    gchar *thread_name;		/* name of thread that does sampling */
+    const gchar *thread_name;	/* name of thread that does sampling */
     long thread_period_ns;	/* period of thread in nano-secs */
     long sample_period_ns;	/* sample period in nano-secs */
     double sample_period;	/* sample period as a double */
@@ -88,10 +88,10 @@ typedef struct {
 typedef struct {
     int data_source_type;	/* 0 = pin, 1 = signal, 2 = param,
 				   -1 = no source assigned */
-    int data_source;		/* points to pin/param/signal struct */
-    char *name;			/* name of pin/sig/parameter */
+    rtapi_intptr_t data_source;	/* points to pin/param/signal data source */
+    const char *name;		/* name of pin/sig/parameter */
     hal_type_t data_type;	/* data type */
-    int data_len;		/* data length */
+    int data_len;		/* data length (== 0 when chan not used; != 0 if used) */
     double vert_offset;		/* offset to be applied */
     double saved_vert_offset;	/* saved offset when AC coupling is enabled */
     int ac_offset;              /* TRUE if the signal should be AC-coupled */

--- a/src/hal/utils/scope_vert.c
+++ b/src/hal/utils/scope_vert.c
@@ -48,7 +48,6 @@
 #include <rtapi_mutex.h>
 #include <rtapi_string.h>	// rtapi_strlcpy()
 #include <hal.h>		// HAL public API decls
-#include "../hal_priv.h"	// private HAL decls
 
 #include <gtk/gtk.h>
 
@@ -204,65 +203,69 @@ int set_channel_source(int chan_num, int type, char *name)
 {
     scope_vert_t *vert;
     scope_chan_t *chan;
-    hal_pin_t *pin;
-    hal_sig_t *sig;
-    hal_param_t *param;
 
     vert = &(ctrl_usr->vert);
     chan = &(ctrl_usr->chan[chan_num - 1]);
     /* locate the selected item in the HAL */
     if (type == 0) {
 	/* search the pin list */
-	pin = halpr_find_pin_by_name(name);
-	if (pin == NULL) {
+        hal_query_t q = {};
+        q.name = name;
+        q.qtype = HAL_QTYPE_PIN;
+        if(0 != hal_getref_p(&q)) {
 	    /* pin not found */
 	    return -1;
 	}
 	chan->data_source_type = 0;
-	chan->data_source = SHMOFF(pin);
-	chan->data_type = pin->type;
-	chan->name = pin->name;
+	chan->data_source = hal_reference_unmap(q.pp.ref.u);
+	chan->data_type = q.pp.type;
+	chan->name = q.name;
     } else if (type == 1) {
 	/* search the signal list */
-	sig = halpr_find_sig_by_name(name);
-	if (sig == NULL) {
+        hal_query_t q = {};
+        q.name = name;
+        if(0 != hal_getref_s(&q)) {
 	    /* signal not found */
 	    return -1;
 	}
 	chan->data_source_type = 1;
-	chan->data_source = SHMOFF(sig);
-	chan->data_type = sig->type;
-	chan->name = sig->name;
+	chan->data_source = hal_reference_unmap(q.sig.ref.u);
+	chan->data_type = q.sig.type;
+	chan->name = q.name;
     } else if (type == 2) {
 	/* search the parameter list */
-	param = halpr_find_param_by_name(name);
-	if (param == NULL) {
+        hal_query_t q = {};
+        q.name = name;
+        q.qtype = HAL_QTYPE_PARAM;
+        if(0 != hal_getref_p(&q)) {
 	    /* parameter not found */
 	    return -1;
 	}
 	chan->data_source_type = 2;
-	chan->data_source = SHMOFF(param);
-	chan->data_type = param->type;
-	chan->name = param->name;
+	chan->data_source = hal_reference_unmap(q.pp.ref.u);
+	chan->data_type = q.pp.type;
+	chan->name = q.name;
     }
     switch (chan->data_type) {
-    case HAL_BIT:
-	chan->data_len = sizeof(hal_bit_t);
+    case HAL_BOOL:
+	chan->data_len = sizeof(scope_data_t);
 	chan->min_index = -2;
 	chan->max_index = 2;
 	break;
-    case HAL_FLOAT:
-	chan->data_len = sizeof(hal_float_t);
+    case HAL_REAL:
+	chan->data_len = sizeof(scope_data_t);
 	chan->min_index = -36;
 	chan->max_index = 36;
 	break;
     case HAL_S32:
-	chan->data_len = sizeof(hal_s32_t);
+    case HAL_SINT:
+	chan->data_len = sizeof(scope_data_t);
 	chan->min_index = -2;
 	chan->max_index = 30;
 	break;
     case HAL_U32:
-	chan->data_len = sizeof(hal_u32_t);
+    case HAL_UINT:
+	chan->data_len = sizeof(scope_data_t);
 	chan->min_index = -2;
 	chan->max_index = 30;
 	break;
@@ -394,7 +397,7 @@ int set_vert_offset(double setting, int ac_coupled)
     /* copy the offset to restore when toggling AC coupling */
     chan->saved_vert_offset = chan->vert_offset;
     /* update the offset display */
-    if (chan->data_type == HAL_BIT) {
+    if (chan->data_type == HAL_BOOL) {
 	snprintf(buf1, BUFLEN, "----");
     } else {
         if(chan->ac_offset) {
@@ -660,7 +663,7 @@ static void offset_button(GtkWidget * widget, gpointer gdata)
 	return;
     }
     chan = &(ctrl_usr->chan[chan_num - 1]);
-    if (chan->data_type == HAL_BIT) {
+    if (chan->data_type == HAL_BOOL) {
 	/* no offset for bits */
 	return;
     }
@@ -876,6 +879,31 @@ static void change_page(GtkNotebook *notebook, GtkWidget *page,
     gtk_widget_grab_focus(GTK_WIDGET(vert->lists[page_num]));
 }
 
+// for the callback data
+typedef struct {
+    scope_vert_t *vert;
+    scope_chan_t *chan;
+    int row;
+    int tab;
+    int match_row;
+    int match_tab;
+} rowcolref_t;
+
+static int rowcol_cb(hal_query_t *q, void *arg)
+{
+    rowcolref_t *rcr = (rowcolref_t *)arg;
+    const char *name[2] = {};
+    name[0] = q->name;
+
+    add_to_list(rcr->vert->lists[rcr->tab], name, NUM_COLS);
+    if (NULL != rcr->chan->name && !strcmp(rcr->chan->name, q->name)) {
+        rcr->match_tab = rcr->tab;
+        rcr->match_row = rcr->row;
+    }
+    rcr->row++;
+    return 0;
+}
+
 static gboolean dialog_select_source(int chan_num)
 {
     scope_vert_t *vert;
@@ -886,16 +914,10 @@ static gboolean dialog_select_source(int chan_num)
     GtkWidget *label;
     GtkWidget *scrolled_window;
 
-    hal_pin_t *pin;
-    hal_sig_t *sig;
-    hal_param_t *param;
-
-    char *tab_label_text[3];
-    char *name[HAL_NAME_LEN + 1];
+    const char *tab_label_text[3];
     char signal_name[HAL_NAME_LEN + 1];
     char title[BUFLEN];
-    int next, n, tab, retval;
-    int row, match_tab, match_row;
+    int n, retval;
 
     vert = &(ctrl_usr->vert);
     chan = &(ctrl_usr->chan[chan_num - 1]);
@@ -959,66 +981,35 @@ static gboolean dialog_select_source(int chan_num)
             G_CALLBACK(change_page), vert);
 
     /* populate the pin, signal, and parameter lists */
-    halpr_mutex_acquire();
-    next = hal_data->pin_list_ptr;
-    match_tab = -1;
-    match_row = 0;
-    row = 0;
-    tab = 0;
-    while (next != 0) {
-        pin = SHMPTR(next);
-        *name = pin->name;
+    rowcolref_t rcr = {};
+    rcr.vert = vert;
+    rcr.chan = chan;
+    rcr.match_tab = -1;
 
-        add_to_list(vert->lists[tab], name, NUM_COLS);
-        if (chan->name == *name) {
-            match_tab = tab;
-            match_row = row;
-        }
-        next = pin->next_ptr;
-        row++;
-    }
+    hal_query_t q = {};
 
-    next = hal_data->sig_list_ptr;
-    row = 0;
-    tab = 1;
-    while (next != 0) {
-        sig = SHMPTR(next);
-        *name = sig->name;
+    q.qtype = HAL_QTYPE_PIN;
+    hal_list_p(&q, rowcol_cb, &rcr);
 
-        add_to_list(vert->lists[tab], name, NUM_COLS);
-        if (chan->name == *name) {
-            match_tab = tab;
-            match_row = row;
-        }
-        next = sig->next_ptr;
-        row++;
-    }
+    memset(&q, 0, sizeof(q));
+    q.qtype = HAL_QTYPE_SIGNAL;
+    rcr.tab = 1;
+    rcr.row = 0;
+    hal_list_s(&q, rowcol_cb, &rcr);
 
-    next = hal_data->param_list_ptr;
-    row = 0;
-    tab = 2;
-    while (next != 0) {
-        param = SHMPTR(next);
-        *name = param->name;
-
-        add_to_list(vert->lists[tab], name, NUM_COLS);
-        if (chan->name == *name) {
-            match_tab = tab;
-            match_row = row;
-        }
-        next = param->next_ptr;
-        row++;
-    }
-
-    halpr_mutex_release();
+    memset(&q, 0, sizeof(q));
+    q.qtype = HAL_QTYPE_PARAM;
+    rcr.tab = 2;
+    rcr.row = 0;
+    hal_list_p(&q, rowcol_cb, &rcr);
 
     gtk_widget_show_all(dialog);
 
     /* highlight the currently selected name */
     /* set scrolling window to show the highlighted name */
-    if (match_tab != -1) {
-        gtk_notebook_set_current_page(GTK_NOTEBOOK(vert->notebook), match_tab);
-        mark_selected_row(vert->lists[match_tab], match_row);
+    if (rcr.match_tab != -1) {
+        gtk_notebook_set_current_page(GTK_NOTEBOOK(vert->notebook), rcr.match_tab);
+        mark_selected_row(vert->lists[rcr.match_tab], rcr.match_row);
     }
 
     retval = gtk_dialog_run(GTK_DIALOG(dialog));
@@ -1060,7 +1051,7 @@ void channel_changed(void)
     scope_vert_t *vert;
     scope_chan_t *chan;
     GtkAdjustment *adj;
-    gchar *name;
+    const gchar *name;
     gchar buf1[BUFLEN + 1], buf2[BUFLEN + 1];
     static int last_channel = 0;
     vert = &(ctrl_usr->vert);
@@ -1101,7 +1092,7 @@ void channel_changed(void)
     gtk_label_set_text_if(vert->chan_num_label, buf1);
     gtk_label_set_text_if(vert->source_name_label, name);
     /* update the offset display */
-    if (chan->data_type == HAL_BIT) {
+    if (chan->data_type == HAL_BOOL) {
 	    snprintf(buf1, BUFLEN, "----");
     } else {
         if(chan->ac_offset) {


### PR DESCRIPTION
This PR removes direct HAL access from halmeter and halscope. It now uses the query API and getter/setter infrastructure to operate. There are no functional changes.

Both halmeter and halscope are now prepared to handle 64-bit integers for when we remove the public 32-bit versions. Also, some functions had their strings arguments const'ified where appropriate.