### PR TITLE
hal: Update the smaller components to getter/setter

### DIFF
--- a/src/hal/components/abs.comp
+++ b/src/hal/components/abs.comp
@@ -15,11 +15,11 @@
 //   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 component abs "Compute the absolute value and sign of a float input signal";
 
-pin in float in "Analog input value" ;
-pin out float out "Analog output value, always positive";
-pin out bit sign "Sign of input, false for positive, true for negative" ;
-pin out bit is_positive "TRUE if input is positive, FALSE if input is 0 or negative";
-pin out bit is_negative "TRUE if input is negative, FALSE if input is 0 or positive";
+pin in real in "Analog input value" ;
+pin out real out "Analog output value, always positive";
+pin out bool sign "Sign of input, false for positive, true for negative" ;
+pin out bool is_positive_ "TRUE if input is positive, FALSE if input is 0 or negative";
+pin out bool is_negative_ "TRUE if input is negative, FALSE if input is 0 or positive";
 
 option period no;
 function _;
@@ -27,18 +27,15 @@ license "GPL";
 author "John Kasunich";
 ;;
 FUNCTION(_) {
-    double tmp = in;
+    rtapi_real tmp = in;
     if ( tmp >= 0.0 ) {
-	sign = 0;
-	out = tmp;
+        sign_set(0);
+        out_set(tmp);
     } else {
-	sign = 1;
-	out = -tmp;
+        sign_set(1);
+        out_set(-tmp);
     }
 
-    if (tmp > 0.000001) is_positive = 1;
-    else is_positive = 0;
-
-    if (tmp < -0.000001) is_negative = 1;
-    else is_negative = 0;
+    is_positive__set(tmp > 0.000001);
+    is_negative__set(tmp < -0.000001);
 }

--- a/src/hal/components/abs_s32.comp
+++ b/src/hal/components/abs_s32.comp
@@ -15,11 +15,11 @@
 //   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 component abs_s32 "Compute the absolute value and sign of a integer input signal";
 
-pin in s32 in "input value" ;
-pin out s32 out "output value, always non-negative";
-pin out bit sign "Sign of input, false for positive, true for negative" ;
-pin out bit is_positive "TRUE if input is positive, FALSE if input is 0 or negative";
-pin out bit is_negative "TRUE if input is negative, FALSE if input is 0 or positive";
+pin in si32 in "input value" ;
+pin out si32 out "output value, always non-negative";
+pin out bool sign "Sign of input, false for positive, true for negative" ;
+pin out bool is_positive_ "TRUE if input is positive, FALSE if input is 0 or negative";
+pin out bool is_negative_ "TRUE if input is negative, FALSE if input is 0 or positive";
 
 option period no;
 function _;
@@ -27,21 +27,15 @@ license "GPL";
 author "Sebastian Kuzminsky";
 ;;
 FUNCTION(_) {
-    if ( in >= 0 ) {
-	sign = false;
-	out = in;
+    rtapi_s32 i = in;
+    if ( i >= 0 ) {
+        sign_set(false);
+        out_set(i);
     } else {
-	sign = true;
-	out = -in;
+        sign_set(true);
+        out_set(-i);
     }
 
-    if (in > 0)
-        is_positive = true;
-    else
-        is_positive = false;
-
-    if (in < 0)
-        is_negative = true;
-    else
-        is_negative = false;
+    is_positive__set(i > 0);
+    is_negative__set(i < 0);
 }

--- a/src/hal/components/abs_s64.comp
+++ b/src/hal/components/abs_s64.comp
@@ -17,11 +17,11 @@
 //   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 component abs_s64 "Computes the absolute value and sign of a 64 bit integer input signal";
 
-pin in s64 in "input value" ;
-pin out s64 out "output value, always non-negative";
-pin out bit sign "Sign of input, false for positive, true for negative" ;
-pin out bit is_positive "true if input is positive, false if input is 0 or negative";
-pin out bit is_negative "true if input is negative, false if input is 0 or positive";
+pin in sint in "input value" ;
+pin out sint out "output value, always non-negative";
+pin out bool sign "Sign of input, false for positive, true for negative" ;
+pin out bool is_positive_ "true if input is positive, false if input is 0 or negative";
+pin out bool is_negative_ "true if input is negative, false if input is 0 or positive";
 
 option period no;
 function _;
@@ -30,21 +30,15 @@ author "ArcEye based on code from Sebastian Kuzminsky";
 ;;
 FUNCTION(_)
 {
-    if ( in >= 0 ) {
-        sign = false;
-        out = in;
+    rtapi_sint i = in;
+    if ( i >= 0 ) {
+        sign_set(false);
+        out_set(i);
     } else {
-        sign = true;
-        out = -in;
+        sign_set(true);
+        out_set(-i);
     }
 
-    if (in > 0)
-        is_positive = true;
-    else
-        is_positive = false;
-
-    if (in < 0)
-        is_negative = true;
-    else
-        is_negative = false;
+    is_positive__set(i > 0);
+    is_negative__set(i < 0);
 }

--- a/src/hal/components/and2.comp
+++ b/src/hal/components/and2.comp
@@ -1,7 +1,7 @@
 component and2 "Two-input AND gate";
-pin in bit in0 "First input";
-pin in bit in1 "Second input";
-pin out bit out "Output";
+pin in bool in0 "First input";
+pin in bool in1 "Second input";
+pin out bool out "Output";
 
 description """
 The *out* pin is computed from the value of the *in0* and *in1* pins according
@@ -33,4 +33,4 @@ see_also """
 license "GPL";
 author "Jeff Epler";
 ;;
-FUNCTION(_) { out = in0 && in1; }
+FUNCTION(_) { out_set(in0 && in1); }

--- a/src/hal/components/bin2gray.comp
+++ b/src/hal/components/bin2gray.comp
@@ -1,10 +1,11 @@
 component bin2gray "convert a number to the gray-code representation";
 description """Converts a number into gray-code""";
-pin in unsigned in "binary code in";
-pin out unsigned out "gray code out";
+pin in ui32 in "binary code in";
+pin out ui32 out "gray code out";
 license "GPL";
 author "Andy Pugh";
 option period no;
 function _;
 ;;
-out = (in >> 1) ^ in;
+rtapi_u32 i = in;
+out_set((i >> 1) ^ i);

--- a/src/hal/components/bitmerge.comp
+++ b/src/hal/components/bitmerge.comp
@@ -3,8 +3,8 @@ description """This component creates a compound unsigned-32 from individual
 bit-inputs for each bit of an unsigned-32 output. The number of bits can be
 limited by the "personality" modparam.
 The inverse process can be performed by the bitslice HAL component.""";
-pin out u32 out "The output value";
-pin in  bit in-##[32:personality];
+pin out ui32 out "The output value";
+pin in  bool in-##[32:personality];
 author "Andy Pugh";
 license "GPL2+";
 function _;
@@ -17,4 +17,4 @@ for (int i = personality; i > 0;) {
 	if (in(--i))
 		v |= 1;
 }
-out = v;
+out_set(v);

--- a/src/hal/components/bitslice.comp
+++ b/src/hal/components/bitslice.comp
@@ -3,8 +3,8 @@ description """This component creates individual bit-outputs for each bit of an
 unsigned-32 input. The number of bits can be limited by the "personality"
 modparam.
 The inverse process can be performed by the bitmerge HAL component.""";
-pin in u32 in "The input value";
-pin out bit out-##[32:personality];
+pin in ui32 in "The input value";
+pin out bool out-##[32:personality];
 author "Andy Pugh";
 license "GPL2+";
 function _;
@@ -13,6 +13,6 @@ option period no;
 ;;
 rtapi_u32 v = in;
 for (int i = 0; i < personality; i++) {
-	out(i) = v & 1;
+	out_set(i, v & 1);
 	v >>= 1;
 }

--- a/src/hal/components/bitwise.comp
+++ b/src/hal/components/bitwise.comp
@@ -1,12 +1,12 @@
 component bitwise "Computes various bitwise operations on the two input values";
-pin in u32 in0 "First input value";
-pin in u32 in1 "Second input value";
-pin out u32 out-and "The bitwise AND of the two inputs";
-pin out u32 out-or "The bitwise OR of the two inputs";
-pin out u32 out-xor "The bitwise XOR of the two inputs";
-pin out u32 out-nand "The inverse of the bitwise AND";
-pin out u32 out-nor "The inverse of the bitwise OR";
-pin out u32 out-xnor "The inverse of the bitwise XOR";
+pin in ui32 in0 "First input value";
+pin in ui32 in1 "Second input value";
+pin out ui32 out-and "The bitwise AND of the two inputs";
+pin out ui32 out-or "The bitwise OR of the two inputs";
+pin out ui32 out-xor "The bitwise XOR of the two inputs";
+pin out ui32 out-nand "The inverse of the bitwise AND";
+pin out ui32 out-nor "The inverse of the bitwise OR";
+pin out ui32 out-xnor "The inverse of the bitwise XOR";
 
 author "Andy Pugh";
 license "GPL 2+";
@@ -14,9 +14,8 @@ function _;
 option period no;
 ;;
 
-out_and = (in0 & in1);
-out_nand = ~out_and;
-out_or = (in0 | in1);
-out_nor = ~out_or;
-out_xor = (in0 ^ in1);
-out_xnor = ~out_xor;
+rtapi_u32 i0 = in0;
+rtapi_u32 i1 = in1;
+out_nand_set(~out_and_set(i0 & i1));
+out_nor_set( ~out_or_set( i0 | i1));
+out_xnor_set(~out_xor_set(i0 ^ i1));

--- a/src/hal/components/blend.comp
+++ b/src/hal/components/blend.comp
@@ -17,12 +17,12 @@
 
 component blend "Perform linear interpolation between two values";
 
-pin in float in1 "First input.  If select is equal to 1.0, the output is equal to in1";
-pin in float in2 "Second input.  If select is equal to 0.0, the output is equal to in2";
-pin in float select "Select input.  For values between 0.0 and 1.0, the output changes linearly from in2 to in1";
-pin out float out "Output value.";
+pin in real in1 "First input.  If select is equal to 1.0, the output is equal to in1";
+pin in real in2 "Second input.  If select is equal to 0.0, the output is equal to in2";
+pin in real select "Select input.  For values between 0.0 and 1.0, the output changes linearly from in2 to in1";
+pin out real out "Output value.";
 
-param rw bit open "If true, select values outside the range 0.0 to 1.0 give values outside the range in2 to in1.  If false, outputs are clamped to the the range in2 to in1";
+param rw bool open "If true, select values outside the range 0.0 to 1.0 give values outside the range in2 to in1.  If false, outputs are clamped to the the range in2 to in1";
 
 option period no;
 function _;
@@ -32,7 +32,7 @@ author "Jeff Epler";
 ;;
 
 FUNCTION(_) {
-    double select_ = select;
+    rtapi_real select_ = select;
     if(!open) { if(select_ < 0) select_ = 0; if(select_ > 1) select_ = 1; }
-    out = in1 * select_ + in2 * (1 - select_);
+    out_set(in1 * select_ + in2 * (1 - select_));
 }

--- a/src/hal/components/charge_pump.comp
+++ b/src/hal/components/charge_pump.comp
@@ -17,10 +17,10 @@
 
 component charge_pump "Create a square-wave for the 'charge pump' input of some controller boards";
 option singleton yes;
-pin out bit out "Square wave if 'enable' is TRUE or unconnected, low if 'enable' is FALSE";
-pin out bit out-2 "Square wave at half the frequency of 'out'";
-pin out bit out-4 "Square wave at a quarter of the frequency of 'out'";
-pin in bit enable = TRUE "If FALSE, forces all 'out' pins to be low";
+pin out bool out "Square wave if 'enable' is TRUE or unconnected, low if 'enable' is FALSE";
+pin out bool out-2 "Square wave at half the frequency of 'out'";
+pin out bool out-4 "Square wave at a quarter of the frequency of 'out'";
+pin in bool enable = TRUE "If FALSE, forces all 'out' pins to be low";
 function _ "Toggle the output bit (if enabled)";
 description """
 The 'Charge Pump' should be added to the base thread function.
@@ -37,12 +37,12 @@ FUNCTION(_) {
     static int acc;
     if ( enable ) {
         acc++;
-        out = (acc & 0x1);
-        out_2 = (acc & 0x2);
-        out_4 = (acc & 0x4);
+        out_set((acc & 0x1));
+        out_2_set((acc & 0x2));
+        out_4_set((acc & 0x4));
     } else {
-	out = 0;
-	out_2 = 0;
-	out_4 = 0;
+        out_set(0);
+        out_2_set(0);
+        out_4_set(0);
     }
 }

--- a/src/hal/components/clarke2.comp
+++ b/src/hal/components/clarke2.comp
@@ -12,10 +12,10 @@ B of the input.  Since the H (homopolar) output will always be zero in
 this case, it is not generated.""";
 see_also """*clarke3*(9) for the general case, *clarkeinv*(9) for
 the inverse transform.""";
-pin in float a;
-pin in float b "first two phases of three phase input";
-pin out float x;
-pin out float y "cartesian components of output";
+pin in real a;
+pin in real b "first two phases of three phase input";
+pin out real x;
+pin out real y "cartesian components of output";
 option period no;
 function _;
 license "GPL";
@@ -31,6 +31,6 @@ author "John Kasunich";
 #define K2 (1.154700538379250)  /* 2/sqrt(3) */
 
 FUNCTION(_) {
-    x = a;
-    y = K1*a + K2*b;
+    rtapi_real a_ = x_set(a);
+    y_set(K1*a_ + K2*b);
 }

--- a/src/hal/components/clarke3.comp
+++ b/src/hal/components/clarke3.comp
@@ -9,12 +9,12 @@ three phases are known to sum to zero, see *clarke2* for a
 simpler version.""";
 see_also """*clarke2*(9) for the 'a+b+c=0' case, *clarkeinv*(9) for
 the inverse transform.""";
-pin in float a;
-pin in float b;
-pin in float c "three phase input vector";
-pin out float x;
-pin out float y "cartesian components of output";
-pin out float h "homopolar component of output";
+pin in real a;
+pin in real b;
+pin in real c "three phase input vector";
+pin out real x;
+pin out real y "cartesian components of output";
+pin out real h "homopolar component of output";
 option period no;
 function _;
 license "GPL";
@@ -32,9 +32,12 @@ author "John Kasunich";
 #define K4 (0.471404520791032)  /* sqrt(2)/3 */
 
 FUNCTION(_) {
-    x = K1*a - K2*(b+c);
-    y = K3*(b-c);
-    h = K4*(a+b+c);
+    rtapi_real a_ = a;
+    rtapi_real b_ = b;
+    rtapi_real c_ = c;
+    x_set(K1*a_ - K2*(b_+c_));
+    y_set(K3*(b_-c_));
+    h_set(K4*(a_+b_+c_));
 }
 
 

--- a/src/hal/components/clarkeinv.comp
+++ b/src/hal/components/clarkeinv.comp
@@ -3,13 +3,13 @@ description """The inverse Clarke transform can be used rotate a
 vector quantity and then translate it from Cartesian coordinate
 system to a three phase system (three components 120 degrees apart).""";
 see_also """*clarke2*(9) and *clarke3*(9) for the forward transform.""";
-pin in float x;
-pin in float y "cartesian components of input";
-pin in float h "homopolar component of input (usually zero)";
-pin in float theta "rotation angle: 0.00 to 1.00 = 0 to 360 degrees";
-pin out float a;
-pin out float b;
-pin out float c "three phase output vector";
+pin in real x;
+pin in real y "cartesian components of input";
+pin in real h "homopolar component of input (usually zero)";
+pin in real theta "rotation angle: 0.00 to 1.00 = 0 to 360 degrees";
+pin out real a;
+pin out real b;
+pin out real c "three phase output vector";
 option period no;
 function _;
 license "GPL";
@@ -28,7 +28,7 @@ author "John Kasunich";
 #define rev2rad (6.283185308)   /* 2 * pi */
 
 FUNCTION(_) {
-    double xr, yr, rads, costheta, sintheta;
+    rtapi_real xr, yr, rads, costheta, sintheta;
 
     // rotate it
     rads = theta * rev2rad;
@@ -38,7 +38,8 @@ FUNCTION(_) {
     yr = x * sintheta + y * costheta;
 
     /* transform to three phase */
-    a =  xr +  K3*h;
-    b = -K1*xr + K2*yr + K3*h;
-    c = -K1*xr - K2*yr + K3*h;
+    rtapi_real h_ = h;
+    a_set(xr +  K3*h_);
+    b_set(-K1*xr + K2*yr + K3*h_);
+    c_set(-K1*xr - K2*yr + K3*h_);
 }

--- a/src/hal/components/comp.comp
+++ b/src/hal/components/comp.comp
@@ -1,10 +1,10 @@
 component comp "Two input comparator with hysteresis";
-pin in float in0 "Inverting input to the comparator";
-pin in float in1 "Non-inverting input to the comparator";
-pin out bit out "Normal output. True when *in1* > *in0* (see parameter *hyst* for details)";
-pin out bit equal "Match output.  True when difference between *in1* and *in0* is less than *hyst*/2";
+pin in real in0 "Inverting input to the comparator";
+pin in real in1 "Non-inverting input to the comparator";
+pin out bool out "Normal output. True when *in1* > *in0* (see parameter *hyst* for details)";
+pin out bool equal "Match output.  True when difference between *in1* and *in0* is less than *hyst*/2";
 
-param rw float hyst=0.0 """Hysteresis of the comparator (default 0.0)
+param rw real hyst=0.0 """Hysteresis of the comparator (default 0.0)
 
 With zero hysteresis, the output is true when *in1* > *in0*.  With nonzero
 hysteresis, the output switches on and off at two different values,
@@ -18,16 +18,16 @@ license "GPL";
 author "Jeff Epler";
 ;;
 FUNCTION(_) {
-    double tmp = in1 - in0;
-    double halfhyst = 0.5 * hyst;
+    rtapi_real tmp = in1 - in0;
+    rtapi_real halfhyst = 0.5 * hyst;
 
     if(tmp < -halfhyst) {
-	out = 0;
-	equal = 0;
+        out_set(0);
+        equal_set(0);
     } else if(tmp > halfhyst){
-	out = 1;
-	equal = 0;
+        out_set(1);
+        equal_set(0);
     } else {
-	equal = 1;
+        equal_set(1);
     }
 }

--- a/src/hal/components/dbounce.comp
+++ b/src/hal/components/dbounce.comp
@@ -5,9 +5,9 @@ delay pins for each instance and supports *count*= or *names*= parameters
 (groups are not used)
 """;
 
-pin in  bit in;
-pin out bit out;
-pin in  u32 delay = 5;
+pin in  bool in;
+pin out bool out;
+pin in  ui32 delay = 5;
 
 variable unsigned state;
 option period no;
@@ -24,7 +24,7 @@ FUNCTION(_) {
             state++;
         } else {
             /* yes, set output */
-            out = 1;
+            out_set(1);
         }
     } else {
         /* input false, is state at zero? */
@@ -33,7 +33,7 @@ FUNCTION(_) {
             state--;
         } else {
             /* yes, clear output */
-            out = 0;
+            out_set(0);
         }
     }
 }

--- a/src/hal/components/ddt.comp
+++ b/src/hal/components/ddt.comp
@@ -33,14 +33,14 @@ every time the real time function is called.
 """;
 
 
-pin in float in;
-pin out float out;
+pin in real in;
+pin out real out;
 
-variable double old;
+variable rtapi_real old;
 
 function _;
 license "GPL";
 ;;
-double tmp = in;
-out = (tmp - old) / (period * 1e-9);
+rtapi_real tmp = in;
+out_set((tmp - old) / (period * 1e-9));
 old = tmp;

--- a/src/hal/components/deadzone.comp
+++ b/src/hal/components/deadzone.comp
@@ -1,8 +1,8 @@
 component deadzone "Return the center if within the threshold";
-param rw float center = 0.0 "The center of the dead zone";
-param rw float threshold = 1.0 "The dead zone is *center* ±(*threshold*/2)";
-pin in float in;
-pin out float out;
+param rw real center = 0.0 "The center of the dead zone";
+param rw real threshold = 1.0 "The dead zone is *center* ±(*threshold*/2)";
+pin in real in;
+pin out real out;
 
 option period no;
 function _ "Update *out* based on *in* and the parameters.";
@@ -11,12 +11,12 @@ license "GPL";
 author "Jeff Epler";
 ;;
 FUNCTION(_) {
-    double th2 = threshold / 2;
-    double lo = center - th2;
-    double hi = center + th2;
-    double in_ = in;
+    rtapi_real th2 = threshold / 2;
+    rtapi_real lo = center - th2;
+    rtapi_real hi = center + th2;
+    rtapi_real in_ = in;
     
-    if(in_ < lo) out = in_ + th2;
-    else if(in_ > hi) out = in_ - th2;
-    else out = center;
+    if(in_ < lo) out_set(in_ + th2);
+    else if(in_ > hi) out_set(in_ - th2);
+    else out_set(center);
 }

--- a/src/hal/components/demux.comp
+++ b/src/hal/components/demux.comp
@@ -10,12 +10,12 @@ An optional operating mode is enabled by setting the "bargraph"
 parameter to true, in this case all bits up to the selected bit will be
 set, as might be required for an LED bargraph display.""";
 
-pin in bit sel-bit-## [5] "Binary-number bit selectors";
-pin in unsigned sel-u32 "Integer selection input";
-pin out bit out-## [32:personality] "The set of output bits";
+pin in bool sel-bit-## [5] "Binary-number bit selectors";
+pin in ui32 sel-u32 "Integer selection input";
+pin out bool out-## [32:personality] "The set of output bits";
 
 option default_personality 32;
-param rw bit bargraph = 0;
+param rw bool bargraph = 0;
 
 see_also "*select8*(9)";
 license "GPL 2+";
@@ -32,7 +32,8 @@ FUNCTION(_){
     bit = sel_u32 + sel_bit(0) + (sel_bit(1) << 1) + (sel_bit(2) << 2)
           + (sel_bit(3) << 3) + (sel_bit(4) << 4);
     if (bit >= personality) bit = personality - 1;
+    rtapi_bool bg = bargraph;
     for (i = 0; i < personality ; i++) {
-        out(i) = (bargraph) ? (bit > i) : (bit == i);
+        out_set(i, bg ? (bit > i) : (bit == i));
     }
 }

--- a/src/hal/components/div2.comp
+++ b/src/hal/components/div2.comp
@@ -20,10 +20,10 @@
 //
 
 component div2 "Quotient of two floating point inputs";
-pin in  float in0 "the Dividend";
-pin in  float in1 "the Divisor";
-pin out float out "the Quotient   out = in0 / in1";
-param rw float deadband "The *out* will be zero if *in* is between -*deadband* and +*deadband*" ;
+pin in  real in0 "the Dividend";
+pin in  real in1 "the Divisor";
+pin out real out "the Quotient   out = in0 / in1";
+param rw real deadband "The *out* will be zero if *in* is between -*deadband* and +*deadband*" ;
 
 description """
 A very simple comp to divide a floating point number
@@ -45,23 +45,26 @@ function _;
 static bool error_msg = 0;
 
 FUNCTION(_) {
-    double dividend = in0;
-    double divisor = in1;
-    if ( deadband < 1e-12 ) deadband = 1e-12;
-    if ( divisor > -deadband && divisor < 0 ) {
-        out = ( dividend / -deadband );
+    rtapi_real dividend = in0;
+    rtapi_real divisor = in1;
+    rtapi_real ddbd = deadband;
+    if ( ddbd < 1e-12 ) {
+        ddbd = deadband_set(1e-12);
+    }
+    if ( divisor > -ddbd && divisor < 0 ) {
+        out_set(dividend / -ddbd);
         if (!error_msg)
             rtapi_print_msg(RTAPI_MSG_ERR,
                             "\n \n DIV2 DIVISOR IS TOO CLOSE TO -ZERO,\n THEREFORE -DEADBAND IS USED.\n INCREASE THE DIVISOR, in1.\n \n \n");
         error_msg = 1;
-    } else if (divisor >= 0 && divisor < deadband) {
-        out = ( dividend / deadband );
+    } else if (divisor >= 0 && divisor < ddbd) {
+        out_set(dividend / ddbd);
         if (!error_msg)
             rtapi_print_msg(RTAPI_MSG_ERR,
                             "\n \n DIV2 DIVISOR IS TOO CLOSE TO +ZERO,\n THEREFORE +DEADBAND IS USED.\n INCREASE THE DIVISOR, in1.\n \n \n");
         error_msg = 1;
     } else {
-        out = ( dividend / divisor );
+        out_set(dividend / divisor);
         error_msg = 0;
     }
 }

--- a/src/hal/components/estop_latch.comp
+++ b/src/hal/components/estop_latch.comp
@@ -36,12 +36,12 @@ In more complex systems, it may be more appropriate to use classicladder to
 manage the software portion of the estop chain.
 """;
 
-pin in bit ok_in = true;
-pin in bit fault_in = false;
-pin in bit reset;
-pin out bit ok_out = false;
-pin out bit fault_out = true;
-pin out bit watchdog;
+pin in bool ok_in = true;
+pin in bool fault_in = false;
+pin in bool reset;
+pin out bool ok_out = false;
+pin out bool fault_out = true;
+pin out bool watchdog;
 option period no;
 function _;
 option data estop_data;
@@ -54,20 +54,20 @@ typedef struct { int old_reset; } estop_data;
 FUNCTION(_) {
     /* check inputs */
     if ( ok_in && !fault_in) {
-	/* no fault conditions, check for reset edge */
-	if ( reset && !data.old_reset ) {
-	    /* got a rising edge, indicate "OK" on outputs */
-	    ok_out = 1;
-	    fault_out = 0;
-	}
-	if( ok_out ) {
-	    /* toggle watchdog */
-	    watchdog = !watchdog;
-	}
+        /* no fault conditions, check for reset edge */
+        if ( reset && !data.old_reset ) {
+            /* got a rising edge, indicate "OK" on outputs */
+            ok_out_set(1);
+            fault_out_set(0);
+        }
+        if( ok_out ) {
+            /* toggle watchdog */
+            watchdog_set(!watchdog);
+        }
     } else {
-	/* fault condition exists, trip */
-	ok_out = 0;
-	fault_out = 1;
+        /* fault condition exists, trip */
+        ok_out_set(0);
+        fault_out_set(1);
     }
     /* store state of reset input for next pass (for edge detect) */
     data.old_reset = reset;

--- a/src/hal/components/feedcomp.comp
+++ b/src/hal/components/feedcomp.comp
@@ -15,11 +15,11 @@
 //   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 component feedcomp "Multiply the input by the ratio of current velocity to the feed rate.";
-pin out float out "Proportionate output value";
-pin in float in "Reference value";
-pin in bit enable "Turn compensation on or off.";
-pin in float vel "Current velocity";
-param rw float feed "Feed rate reference value";
+pin out real out "Proportionate output value";
+pin in real in "Reference value";
+pin in bool enable "Turn compensation on or off.";
+pin in real vel "Current velocity";
+param rw real feed "Feed rate reference value";
 notes "Note that if enable is false, out = in.";
 
 option period no;
@@ -28,6 +28,6 @@ license "GPL";
 author "Eric H. Johnson";
 ;;
 FUNCTION(_) {
-  if (enable) out = in * (vel / feed);
-  else out = in;
+    if (enable) out_set(in * (vel / feed));
+    else out_set(in);
 }

--- a/src/hal/components/filter_kalman.comp
+++ b/src/hal/components/filter_kalman.comp
@@ -44,23 +44,23 @@ Common practice is also to conservatively set *Rk* and *Qk* slightly larger then
 ones to get robustness.
 """;
 
-pin    in   bit  debug = FALSE             "When asserted, prints out measured and estimated values.";
-pin    in   bit  passthrough = FALSE       "When asserted, copies measured value into estimated value.";
-pin    in   bit  reset = FALSE
+pin    in bool  debug = FALSE             "When asserted, prints out measured and estimated values.";
+pin    in bool  passthrough = FALSE       "When asserted, copies measured value into estimated value.";
+pin    in bool  reset = FALSE
 """When asserted, resets filter to its initial state and returns 0 as an estimated value (*reset* pin
 has higher priority than *passthrough* pin).""";
-pin    in float     zk                     "Measured value.";
-pin   out float xk_out                     "Estimated value.";
-param  rw float     Rk = 1.17549e-38       "Estimation of the noise covariances (process).";
-param  rw float     Qk = 1.17549e-38       "Estimation of the noise covariances (observation).";
+pin    in real     zk                     "Measured value.";
+pin   out real xk_out                     "Estimated value.";
+param  rw real     Rk = 1.17549e-38       "Estimation of the noise covariances (process).";
+param  rw real     Qk = 1.17549e-38       "Estimation of the noise covariances (observation).";
 
 option extra_setup yes;
 option period no;
 
 function _ "Update *xk-out* based on *zk* input.";
 
-variable float xk_last;
-variable float Pk_last;
+variable rtapi_real xk_last;
+variable rtapi_real Pk_last;
 
 variable bool initialized = FALSE;
 variable int cidx = 0;
@@ -68,7 +68,7 @@ variable int cidx = 0;
 ;;
 #include <rtapi_math.h>
 
-typedef hal_float_t D; // to Keep code synchronized with C++ based TrivialKalmanFilter implementation.
+typedef rtapi_real D; // to Keep code synchronized with C++ based TrivialKalmanFilter implementation.
 
 // Based on: https://github.com/dwrobel/TrivialKalmanFilter/blob/master/src/TrivialKalmanFilter.h
 // Assumes simplified model
@@ -101,7 +101,7 @@ FUNCTION(_) {
         initialized = TRUE;
 
         if (reset) {
-            xk_out = 0;
+            xk_out_set(0);
 
             if (debug) {
                 print_info(cidx, zk, xk_out);
@@ -112,7 +112,7 @@ FUNCTION(_) {
     }
 
     if (passthrough) {
-        xk_out = zk;
+        xk_out_set(zk);
 
         if (debug) {
             print_info(cidx, zk, xk_out);
@@ -136,7 +136,7 @@ FUNCTION(_) {
 
         xk_last    = xk;
         Pk_last    = Pk;
-        xk_out     = xk;
+        xk_out_set(xk);
 
         if (debug) {
             print_info(cidx, zk, xk_out);

--- a/src/hal/components/flipflop.comp
+++ b/src/hal/components/flipflop.comp
@@ -1,10 +1,10 @@
 component flipflop "D type flip-flop";
-pin in bit data_ "data input";
-pin in bit clk "clock, rising edge writes data to out";
-pin in bit set "when true, force out true";
-pin in bit reset "when true, force out false; overrides set";
-pin io bit out "output";
-pin io bit out-not "inverted output";
+pin in bool data_ "data input";
+pin in bool clk "clock, rising edge writes data to out";
+pin in bool set "when true, force out true";
+pin in bool reset "when true, force out false; overrides set";
+pin io bool out "output";
+pin io bool out-not "inverted output";
 option data flipflop_data;
 
 option period no;
@@ -20,12 +20,13 @@ FUNCTION(_) {
 
     c = clk;
     if ( reset ) {
-	out = 0;
+        out_set(0);
+        out_not_set(1);
     } else if ( set ) {
-	out = 1;
+        out_set(1);
+        out_not_set(0);
     } else if ( c && ! data.oldclk ) {
-	out = data_;
+        out_not_set(!out_set(data_));
     }
-    out_not = !out;
     data.oldclk = c;
 }

--- a/src/hal/components/gray2bin.comp
+++ b/src/hal/components/gray2bin.comp
@@ -1,14 +1,15 @@
 component gray2bin "convert a gray-code input to binary";
 description """Converts a gray-coded number into the corresponding binary value""";
-pin in unsigned in "gray code in";
-pin out unsigned out "binary code out";
+pin in ui32 in "gray code in";
+pin out ui32 out "binary code out";
 license "GPL";
 author "Andy Pugh";
 function _;
 option period no;
 ;;
-unsigned int mask;
-out = in;
-for(mask = in >> 1 ; mask != 0 ; mask = mask >> 1){
-    out ^= mask;
+rtapi_u32 mask;
+rtapi_u32 val = in;
+for(mask = val >> 1 ; mask != 0 ; mask = mask >> 1){
+    val ^= mask;
 }
+out_set(val);

--- a/src/hal/components/hypot.comp
+++ b/src/hal/components/hypot.comp
@@ -1,8 +1,8 @@
 component hypot "Three-input hypotenuse (Euclidean distance) calculator";
-pin in float in0;
-pin in float in1;
-pin in float in2;
-pin out float out "out = sqrt(*in0*^2^ + *in1*^2^ + *in2*^2^)";
+pin in real in0;
+pin in real in1;
+pin in real in2;
+pin out real out "out = sqrt(*in0*^2^ + *in1*^2^ + *in2*^2^)";
 option period no;
 function _;
 license "GPL";
@@ -10,6 +10,6 @@ author "Jeff Epler";
 ;;
 #include <rtapi_math.h>
 FUNCTION(_) {
-    double a = in0, b = in1, c = in2;
-    out = sqrt(a*a + b*b + c*c);
+    rtapi_real a = in0, b = in1, c = in2;
+    out_set(sqrt(a*a + b*b + c*c));
 }

--- a/src/hal/components/ilowpass.comp
+++ b/src/hal/components/ilowpass.comp
@@ -13,21 +13,21 @@ on the MPG.  Choose *gain* according to the smoothing level
 desired.  Divide the **axis**.__N__.**jog-scale** values by
 *scale*.""";
 
-pin in s32 in;
+pin in si32 in;
 
-pin out s32 out """*out* tracks *in* * *scale* through a low-pass
+pin out si32 out """*out* tracks *in* * *scale* through a low-pass
 filter of *gain* per period.""";
 
-param rw float scale = 1024 """A scale factor applied to the output
+param rw real scale = 1024 """A scale factor applied to the output
 value of the low-pass filter.""";
 
-param rw float gain = .5 """Together with the period, sets the rate at
+param rw real gain = .5 """Together with the period, sets the rate at
 which the output changes.  Useful range is between 0 and 1, with higher
 values causing the input value to be tracked more quickly.  For
 instance, a setting of 0.9 causes the output value to go 90% of the way
 towards the input value in each period.""";
 
-variable double value;
+variable rtapi_real value;
 
 option period no;
 function _ "Update the output based on the input and parameters.";
@@ -39,5 +39,5 @@ author "Jeff Epler";
 
 FUNCTION(_) {
     value += (in - value) * gain;
-    out = (int)(rtapi_s64)floor((value * scale) + 0.5);
+    out_set((rtapi_s64)floor((value * scale) + 0.5));
 }

--- a/src/hal/components/integ.comp
+++ b/src/hal/components/integ.comp
@@ -1,18 +1,20 @@
 component integ "Integrator with gain pin and windup limits";
-pin in float in;
-pin in float gain = 1.0;
-pin out float out "The discrete integral of 'gain * in' since 'reset' was deasserted";
-pin in bit reset "When asserted, set out to 0";
-pin in float max_ =  1e20;
+pin in real in;
+pin in real gain = 1.0;
+pin out real out "The discrete integral of 'gain * in' since 'reset' was deasserted";
+pin in bool reset "When asserted, set out to 0";
+pin in real max_ =  1e20;
+pin in real min_ = -1e20;
 
-pin in float min_ = -1e20;
 function _;
 license "GPL";
 author "Jeff Epler";
 ;;
 FUNCTION(_) {
-    if(reset) out = 0;
-    else out = out + gain * in * fperiod;
-    if (out > max_) out = max_;
-    if (out < min_) out = min_;
+    rtapi_real val = out;
+    if(reset) val = 0.0;
+    else out_set(val += gain * in * fperiod);
+    rtapi_real tmp;
+    if(val > (tmp = max_)) out_set(tmp);
+    if(val < (tmp = min_)) out_set(tmp);
 }

--- a/src/hal/components/invert.comp
+++ b/src/hal/components/invert.comp
@@ -18,9 +18,9 @@ The output will be the mathematical inverse of the input, ie *out* = 1 / *in*.
 The parameter *deadband* can be used to control how close to 0 the denominator can be
 before the output is clamped to 0. *deadband* must be at least 1e-8, and must be positive.""";
 
-pin in float in "Analog input value";
-pin out float out "Analog output value";
-param rw float deadband "The *out* will be zero if *in* is between -*deadband* and +*deadband*.";
+pin in real in "Analog input value";
+pin out real out "Analog output value";
+param rw real deadband "The *out* will be zero if *in* is between -*deadband* and +*deadband*.";
 
 option period no;
 function _;
@@ -32,12 +32,13 @@ see_also " invert(9), div2(9) ";
 #include <rtapi_math.h>
 
 FUNCTION(_) {
-    double tmp = in;
-    if (deadband < 1e-12) deadband = 1e-12;
-    if ( tmp > -deadband && tmp <0)
-	out = -1/deadband;
-    else if (tmp >= 0 && tmp <deadband)
-	out = 1/deadband;
+    rtapi_real tmp = in;
+    rtapi_real ddbd = deadband;
+    if (ddbd < 1e-12) deadband_set(ddbd = 1e-12);
+    if ( tmp > -ddbd && tmp < 0)
+        out_set(-1.0/ddbd);
+    else if (tmp >= 0 && tmp < ddbd)
+        out_set(1.0/ddbd);
     else
-	out = 1/tmp;
+        out_set(1.0/tmp);
 }

--- a/src/hal/components/limit1.comp
+++ b/src/hal/components/limit1.comp
@@ -1,16 +1,16 @@
 component limit1 "Limit the output signal to fall between min and max";
-pin in float in;
-pin out float out;
-pin in float min_=-1e20;
-pin in float max_=1e20;
+pin in real in;
+pin out real out;
+pin in real min_=-1e20;
+pin in real max_=1e20;
 option period no;
 function _;
 license "GPL";
 author "Jeff Epler";
 ;;
 FUNCTION(_) {
-    double tmp = in;
+    rtapi_real tmp = in;
     if(tmp < min_) tmp = min_;
     if(tmp > max_) tmp = max_;
-    out = tmp;
+    out_set(tmp);
 }

--- a/src/hal/components/limit2.comp
+++ b/src/hal/components/limit2.comp
@@ -1,20 +1,20 @@
 component limit2 "Limit the output signal to fall between min and max and limit its slew rate to less than maxv per second.  When the signal is a position, this means that position and velocity are limited.";
-pin in float in;
-pin out float out;
-pin in bit load "When TRUE, immediately set *out* to *in*, ignoring maxv";
-pin in float min_=-1e20;
-pin in float max_=1e20;
-pin in float maxv=1e20;
+pin in real in;
+pin out real out;
+pin in bool load "When TRUE, immediately set *out* to *in*, ignoring maxv";
+pin in real min_=-1e20;
+pin in real max_=1e20;
+pin in real maxv=1e20;
 option data limit2_data;
 function _;
 license "GPL";
 author "Jeff Epler";
 ;;
 
-typedef struct { double old_out; } limit2_data;
+typedef struct { rtapi_real old_out; } limit2_data;
 
 #ifndef clamp
-static inline double clamp(double v, double sub, double sup) {
+static inline rtapi_real clamp(rtapi_real v, rtapi_real sub, rtapi_real sup) {
     if(v < sub) return sub;
     if(v > sup) return sup;
     return v;
@@ -22,11 +22,11 @@ static inline double clamp(double v, double sub, double sup) {
 #endif
 
 FUNCTION(_) {
-    double tmp = in;
-    double maxdelta = maxv * fperiod;
+    rtapi_real tmp = in;
+    rtapi_real maxdelta = maxv * fperiod;
     tmp = clamp(tmp, min_, max_);
-    if(load) { out = data.old_out = tmp; return; }
+    if(load) { out_set(data.old_out = tmp); return; }
     tmp = clamp(tmp, data.old_out - maxdelta, data.old_out + maxdelta);
     data.old_out = tmp;
-    out = tmp;
+    out_set(tmp);
 }

--- a/src/hal/components/limit3.comp
+++ b/src/hal/components/limit3.comp
@@ -3,23 +3,23 @@ Limit the output signal to fall between min and max, limit its slew
 rate to less than maxv per second, and limit its second derivative to
 less than maxa per second squared.  When the signal is a position,
 this means that the position, velocity, and acceleration are limited.""";
-pin in float in;
-pin in bit enable = 1 "1: out follows in, 0: out returns to 0 (always per constraints)";
-pin out float out;
-pin in bit load=0
+pin in real in;
+pin in bool enable = 1 "1: out follows in, 0: out returns to 0 (always per constraints)";
+pin out real out;
+pin in bool load=0
     """When TRUE, immediately set *out* to *in*, ignoring maxv
 and maxa""";
-pin in float min_=-1e20;
-pin in float max_=1e20;
-pin in float maxv=1e20;
-pin in float maxa=1e7 """Max Acceleration. Note that the component becomes
+pin in real min_=-1e20;
+pin in real max_=1e20;
+pin in real maxv=1e20;
+pin in real maxa=1e7 """Max Acceleration. Note that the component becomes
 unstable with maxa greater than about 1e7 in a 1kHz thread""";
-pin in u32 smooth_steps=2
+pin in ui32 smooth_steps=2
     """Smooth out acceleration this many periods before reaching input or
 max/min limit.  Higher values avoid oscillation, but will accelerate
 slightly more slowly.""";
-variable double in_pos_old;
-variable double out_old;
+variable rtapi_real in_pos_old;
+variable rtapi_real out_old;
 function _;
 license "GPL";
 author "John Kasunich";
@@ -30,7 +30,7 @@ author "John Kasunich";
 #define SET_NEXT_STATE(_out, _in)			\
     do {						\
 	out_old = out;					\
-	out = _out;					\
+	out_set(_out);					\
 	in_pos_old = _in;				\
 	return;						\
     } while (0)
@@ -47,19 +47,19 @@ author "John Kasunich";
 #define EPSILON 1e-9
 
 FUNCTION(_) {
-    double invalue;
-    double in_pos_lim, in_vel;
-    double min_vel, max_vel, min_pos, max_pos;
-    double stop_pos_max, stop_pos_min;
-    double stop_time_max, stop_time_min;
-    double in_vel_time_max, in_vel_time_min;
-    double out_pos_max, out_pos_min, in_pos_max, in_pos_min;
-    double ach_pos_min, ach_pos_max;
+    rtapi_real invalue;
+    rtapi_real in_pos_lim, in_vel;
+    rtapi_real min_vel, max_vel, min_pos, max_pos;
+    rtapi_real stop_pos_max, stop_pos_min;
+    rtapi_real stop_time_max, stop_time_min;
+    rtapi_real in_vel_time_max, in_vel_time_min;
+    rtapi_real out_pos_max, out_pos_min, in_pos_max, in_pos_min;
+    rtapi_real ach_pos_min, ach_pos_max;
 
-    double out_vel = (out-out_old)/fperiod;
-    double goal_pos_min, goal_pos_max, goal_pos_cur;
-    double pos_diff, vel_diff, goal_pos_prev;
-    double t, ti, a, v, s;
+    rtapi_real out_vel = (out-out_old)/fperiod;
+    rtapi_real goal_pos_min, goal_pos_max, goal_pos_cur;
+    rtapi_real pos_diff, vel_diff, goal_pos_prev;
+    rtapi_real t, ti, a, v, s;
 
     if (enable) {
         invalue = in; // out pin follows in pin per limits

--- a/src/hal/components/logic.comp
+++ b/src/hal/components/logic.comp
@@ -13,12 +13,12 @@ Each number defines the behaviour of the individual logic gate.  The
 list must have the same number of personalities as the N count.
 
 """;
-pin in bit in-##[16 : personality & 0xff];
-pin out bit and if personality & 0x100;
-pin out bit or if personality & 0x200;
-pin out bit xor if personality & 0x400;
-pin out bit nand if personality & 0x800;
-pin out bit nor if personality & 0x1000;
+pin in bool in-##[16 : personality & 0xff];
+pin out bool and if personality & 0x100;
+pin out bool or if personality & 0x200;
+pin out bool xor if personality & 0x400;
+pin out bool nand if personality & 0x800;
+pin out bool nor if personality & 0x1000;
 function _ "Read the inputs and toggle the output bit.";
 description """
 General `logic function' component.  Can perform `and', `or',
@@ -82,9 +82,9 @@ FUNCTION(_) {
         if(in(i)) { o = 1; x = !x; }
         else { a = 0; }
     }
-    if(personality & 0x100) and = a;
-    if(personality & 0x200) or = o;
-    if(personality & 0x400) xor = x;
-    if(personality & 0x800) nand = !a;
-    if(personality & 0x1000) nor = !o;
+    if(personality & 0x100) and_set(a);
+    if(personality & 0x200) or_set(o);
+    if(personality & 0x400) xor_set(x);
+    if(personality & 0x800) nand_set(!a);
+    if(personality & 0x1000) nor_set(!o);
 }

--- a/src/hal/components/lowpass.comp
+++ b/src/hal/components/lowpass.comp
@@ -30,10 +30,10 @@ Examples:
      a = (2 * pi * 1)      ( *1Hz* bandwidth single pole)
   gain = *0.0063*
 """;
-pin in float in;
-pin out float out " out += (in - out) * gain ";
-pin in bit load "When TRUE, copy *in* to *out* instead of applying the filter equation.";
-param rw float gain;
+pin in real in;
+pin out real out " out += (in - out) * gain ";
+pin in bool load "When TRUE, copy *in* to *out* instead of applying the filter equation.";
+param rw real gain;
 option period no;
 function _;
 license "GPL";
@@ -42,7 +42,9 @@ notes "The effect of a specific *gain* value is dependent on the period of the f
 ;;
 FUNCTION(_) {
     if(load)
-	out = in;
-    else
-	out += (in - out) * gain;
+        out_set(in);
+    else {
+        rtapi_real val = out;
+        out_set(val + (in - val) * gain);
+    }
 }

--- a/src/hal/components/lut5.comp
+++ b/src/hal/components/lut5.comp
@@ -1,11 +1,11 @@
 component lut5 """Arbitrary 5-input logic function based on a look-up table""";
-pin in bit in_0;
-pin in bit in_1;
-pin in bit in_2;
-pin in bit in_3;
-pin in bit in_4;
-pin out bit out;
-param rw u32 function;
+pin in bool in_0;
+pin in bool in_1;
+pin in bool in_2;
+pin in bool in_3;
+pin in bool in_4;
+pin out bool out;
+param rw ui32 function;
 function _;
 description """
 *lut5*
@@ -103,5 +103,5 @@ FUNCTION(_) {
     if(in_3) shift += 8;
     if(in_4) shift += 16;
 
-    out = (function & (1<<shift)) != 0;
+    out_set((function & (1<<shift)) != 0);
 }

--- a/src/hal/components/maj3.comp
+++ b/src/hal/components/maj3.comp
@@ -17,12 +17,12 @@
 
 component maj3 "Compute the majority of 3 inputs";
 
-pin in bit in1;
-pin in bit in2;
-pin in bit in3;
-pin out bit out;
+pin in bool in1;
+pin in bool in2;
+pin in bool in3;
+pin out bool out;
 
-param rw bit invert;
+param rw bool invert;
 
 option period no;
 function _;
@@ -40,7 +40,7 @@ FUNCTION(_) {
     if (in2) sum++;
     if (in3) sum++;
     if(invert)
-        out = sum < 2;
+        out_set(sum < 2);
     else
-        out = sum >= 2;
+        out_set(sum >= 2);
 }

--- a/src/hal/components/minmax.comp
+++ b/src/hal/components/minmax.comp
@@ -1,17 +1,17 @@
 component minmax "Track the minimum and maximum values of the input to the outputs";
-pin in float in;
-pin in bit reset "When reset is asserted, 'in' is copied to the outputs";
-pin out float max_;
-pin out float min_;
+pin in real in;
+pin in bool reset "When reset is asserted, 'in' is copied to the outputs";
+pin out real max_;
+pin out real min_;
 option period no;
 function _;
 license "GPL";
 author "Jeff Epler";
 ;;
 FUNCTION(_) {
-    if(reset) { max_ = min_ = in; }
+    if(reset) { max__set(min__set(in)); }
     else {
-        if(in > max_) max_ = in;
-        if(in < min_) min_ = in;
+        if(in > max_) max__set(in);
+        if(in < min_) min__set(in);
     }
 }

--- a/src/hal/components/mult2.comp
+++ b/src/hal/components/mult2.comp
@@ -1,7 +1,7 @@
 component mult2 "Product of two inputs";
-pin in float in0;
-pin in float in1;
-pin out float out "out = in0 * in1";
+pin in real in0;
+pin in real in1;
+pin out real out "out = in0 * in1";
 option period no;
 function _;
 license "GPL";
@@ -10,5 +10,5 @@ see_also " invert(9), div2(9) ";
 
 ;;
 FUNCTION(_) {
-    out = in0 * in1;
+    out_set(in0 * in1);
 }

--- a/src/hal/components/mux2.comp
+++ b/src/hal/components/mux2.comp
@@ -1,8 +1,8 @@
 component mux2 "Select from one of two input values";
-pin in bit sel;
-pin out float out "Follows the value of *in0* if *sel* is FALSE, or *in1* if *sel* is TRUE";
-pin in float in1;
-pin in float in0;
+pin in bool sel;
+pin out real out "Follows the value of *in0* if *sel* is FALSE, or *in1* if *sel* is TRUE";
+pin in real in1;
+pin in real in0;
 option period no;
 function _;
 license "GPL";
@@ -10,6 +10,6 @@ author "Jeff Epler";
 see_also "mux4(9), mux8(9), mux16(9), mux_generic(9).";
 ;;
 FUNCTION(_) {
-    if(sel) out = in1;
-    else out = in0;
+    if(sel) out_set(in1);
+    else out_set(in0);
 }

--- a/src/hal/components/mux4.comp
+++ b/src/hal/components/mux4.comp
@@ -1,9 +1,9 @@
 component mux4 "Select from one of four input values";
-pin in bit sel0;
-pin in bit sel1 """\
+pin in bool sel0;
+pin in bool sel1 """\
 Together, these determine which **in**__N__ value is copied to *out*.
 """;
-pin out float out """\
+pin out real out """\
 Follows the value of one of the **in**__N__ values according to the two *sel* values
 
 [cols="^1,^1,1"]
@@ -19,10 +19,10 @@ Follows the value of one of the **in**__N__ values according to the two *sel* va
 |===
 
 """;
-pin in float in0;
-pin in float in1;
-pin in float in2;
-pin in float in3;
+pin in real in0;
+pin in real in1;
+pin in real in2;
+pin in real in3;
 option period no;
 function _;
 license "GPL";
@@ -31,10 +31,10 @@ see_also "mux2(9), mux8(9), mux16(9), mux_generic(9).";
 ;;
 FUNCTION(_) {
     if(sel1) {
-        if(sel0) out = in3;
-        else out = in2;
+        if(sel0) out_set(in3);
+        else out_set(in2);
     } else {
-        if(sel0) out = in1;
-        else out = in0;
+        if(sel0) out_set(in1);
+        else out_set(in0);
     }
 }

--- a/src/hal/components/mux8.comp
+++ b/src/hal/components/mux8.comp
@@ -1,10 +1,10 @@
 component mux8 "Select from one of eight input values";
-pin in bit sel0;
-pin in bit sel1;
-pin in bit sel2 """\
+pin in bool sel0;
+pin in bool sel1;
+pin in bool sel2 """\
 Together, these determine which **in**__N__ value is copied to *out*.
 """;
-pin out float out """\
+pin out real out """\
 Follows the value of one of the **in**__N__ values according to the three *sel* values
 
 [cols="^1,^1,^1,1"]
@@ -25,14 +25,14 @@ Follows the value of one of the **in**__N__ values according to the three *sel* 
 |===
 
 """;
-pin in float in0;
-pin in float in1;
-pin in float in2;
-pin in float in3;
-pin in float in4;
-pin in float in5;
-pin in float in6;
-pin in float in7;
+pin in real in0;
+pin in real in1;
+pin in real in2;
+pin in real in3;
+pin in real in4;
+pin in real in5;
+pin in real in6;
+pin in real in7;
 option period no;
 function _;
 license "GPL";
@@ -42,22 +42,22 @@ see_also "mux2(9), mux4(9), mux16(9), mux_generic(9).";
 FUNCTION(_) {
     if(sel0) {
         if(sel1) {
-            if(sel2) out = in7;
-            else     out = in3;
+            if(sel2) out_set(in7);
+            else     out_set(in3);
         }
         else {
-            if(sel2) out = in5;
-            else     out = in1;
+            if(sel2) out_set(in5);
+            else     out_set(in1);
         }
     }
     else {
        if(sel1) {
-            if(sel2) out = in6;
-            else     out = in2;
+            if(sel2) out_set(in6);
+            else     out_set(in2);
         }
         else {
-            if(sel2) out = in4;
-            else     out = in0;
+            if(sel2) out_set(in4);
+            else     out_set(in0);
         }
     }
 }

--- a/src/hal/components/near.comp
+++ b/src/hal/components/near.comp
@@ -1,9 +1,9 @@
 component near "Determine whether two values are roughly equal.";
-pin in float in1_;
-pin in float in2_;
-param rw float scale=1;
-param rw float difference=0;
-pin out bit out """
+pin in real in1_;
+pin in real in2_;
+param rw real scale=1;
+param rw real difference=0;
+pin out bool out """
 *out* is true if *in1* and *in2* are within a factor of
 *scale* (i.e., for in1 positive, in1/scale ≤ in2 ≤ in1*scale), OR
 if their absolute difference is no greater than *difference* (i.e.,
@@ -15,15 +15,15 @@ author "Chris Radek";
 ;;
 #include <rtapi_math.h>
 FUNCTION(_) {
-	double in1 = in1_, in2 = in2_;
+	rtapi_real in1 = in1_, in2 = in2_;
 	if(in1 < 0) {
 		in1 = -in1;
 		in2 = -in2;
 	}
 	if((scale > 1 && in1/scale <= in2 && in2 <= in1*scale) || fabs(in1-in2) <= difference) {
-		out = 1;
+		out_set(1);
 	}
 	else {
-		out = 0;
+		out_set(0);
 	}
 }

--- a/src/hal/components/not.comp
+++ b/src/hal/components/not.comp
@@ -1,6 +1,6 @@
 component not "Inverter";
-pin in bit in;
-pin out bit out;
+pin in bool in;
+pin out bool out;
 description """
 The *out* output pin is set to the inverted logic level of the *in* input pin.
 """;
@@ -16,4 +16,4 @@ license "GPL";
 author "Jeff Epler";
 option period no;
 ;;
-FUNCTION(_) { out = ! in; }
+FUNCTION(_) { out_set(! in); }

--- a/src/hal/components/offset.comp
+++ b/src/hal/components/offset.comp
@@ -19,18 +19,18 @@ component offset "Adds an offset to an input, and subtracts it from the feedback
 function update_output "Updated the output value by adding the offset to the input.";
 function update_feedback "Update the feedback value by subtracting the offset from the feedback.";
 
-pin in float offset "The offset value";
+pin in real offset "The offset value";
 
-pin in float in "The input value";
-pin out float out "The output value";
+pin in real in "The input value";
+pin out real out "The output value";
 
-pin in float fb_in "The feedback input value";
-pin out float fb_out "The feedback output value";
+pin in real fb_in "The feedback input value";
+pin out real fb_out "The feedback output value";
 
 license "GPL";
 author "Jeff Epler";
 option period no;
 ;;
 
-FUNCTION(update_feedback) { fb_out = fb_in - offset; }
-FUNCTION(update_output)   { out = in + offset; }
+FUNCTION(update_feedback) { fb_out_set(fb_in - offset); }
+FUNCTION(update_output)   { out_set(in + offset); }

--- a/src/hal/components/or2.comp
+++ b/src/hal/components/or2.comp
@@ -1,7 +1,7 @@
 component or2 "Two-input OR gate";
-pin in bit in0 "First input";
-pin in bit in1 "Second input";
-pin out bit out "Output";
+pin in bool in0 "First input";
+pin in bool in1 "Second input";
+pin out bool out "Output";
 
 description """
 The *out* pin is computed from the value of the *in0* and *in1* pins according
@@ -29,4 +29,4 @@ license "GPL";
 author "Jeff Epler";
 option period no;
 ;;
-FUNCTION(_) { out = in0 || in1; }
+FUNCTION(_) { out_set(in0 || in1); }

--- a/src/hal/components/output_buffer.comp
+++ b/src/hal/components/output_buffer.comp
@@ -1,8 +1,8 @@
 component output_buffer "Feed through multiple bits when enable pin is set";
-pin in bit enable "Enable input";
-pin in bit off-level = 0 "Signal level when output is off (enable=0)";
-pin in bit in-#[32 : personality] "Inputs";
-pin out bit out-#[32 : personality] "Outputs (Follow inputs when enable=1)";
+pin in bool enable "Enable input";
+pin in bool off-level = 0 "Signal level when output is off (enable=0)";
+pin in bool in-#[32 : personality] "Inputs";
+pin out bool out-#[32 : personality] "Outputs (Follow inputs when enable=1)";
 
 function _;
 description """
@@ -37,12 +37,12 @@ option period no;
 FUNCTION(_) {
     if(enable) {
         for(int i = 0; i < personality; i++) {
-            out(i) = in(i);
+            out_set(i, in(i));
         }
     } else {
         bool lvl = off_level;
         for(int i = 0; i < personality; i++) {
-            out(i) = lvl;
+            out_set(i, lvl);
         }
     }
 }

--- a/src/hal/components/sample_hold.comp
+++ b/src/hal/components/sample_hold.comp
@@ -1,7 +1,7 @@
 component sample_hold "Sample and Hold";
-pin in s32 in;
-pin in bit hold;
-pin out s32 out;
+pin in si32 in;
+pin in bool hold;
+pin out si32 out;
 option period no;
 function _;
 see_also "*tristate*(9)";
@@ -10,6 +10,6 @@ author "Stephen Wille Padnos";
 ;;
 FUNCTION(_) { 
 	if (!hold) {
-		out = in;
+		out_set(in);
 	}
 }

--- a/src/hal/components/scale.comp
+++ b/src/hal/components/scale.comp
@@ -1,13 +1,13 @@
 component scale "LinuxCNC HAL component that applies a scale and offset to its input";
-pin in float in;
-pin in float gain;
-pin in float offset;
-pin out float out "out = in * gain + offset";
+pin in real in;
+pin in real gain;
+pin in real offset;
+pin out real out "out = in * gain + offset";
 option period no;
 function _;
 license "GPL";
 author "Jeff Epler";
 ;;
 FUNCTION(_) {
-    out = in * gain + offset;
+    out_set(in * gain + offset);
 }

--- a/src/hal/components/scaled_s32_sums.comp
+++ b/src/hal/components/scaled_s32_sums.comp
@@ -1,20 +1,20 @@
 component scaled_s32_sums "Sum of four inputs (each with a scale)";
 see_also "sum2(9), weighted_sum(9)";
-pin in s32 in0;
-pin in s32 in1;
-pin in s32 in2;
-pin in s32 in3;
-pin in float scale0 = 1.0;
-pin in float scale1 = 1.0;
-pin in float scale2 = 1.0;
-pin in float scale3 = 1.0;
-pin out s32 out_s;
-pin out float out_f "out-s = out-f = (in0 * scale0) + (in1 * scale1) + (in2 * scale2) + (in3 * scale3)";
+pin in si32 in0;
+pin in si32 in1;
+pin in si32 in2;
+pin in si32 in3;
+pin in real scale0 = 1.0;
+pin in real scale1 = 1.0;
+pin in real scale2 = 1.0;
+pin in real scale3 = 1.0;
+pin out si32 out_s;
+pin out real out_f "out-s = out-f = (in0 * scale0) + (in1 * scale1) + (in2 * scale2) + (in3 * scale3)";
 option period no;
 function _;
 license "GPL";
 author "Chris S Morley";
 ;;
 FUNCTION(_) {
-    out_s = out_f = in0 * scale0 + in1 * scale1 + in2 * scale2 + in3 * scale3;
+    out_s_set(out_f_set(in0 * scale0 + in1 * scale1 + in2 * scale2 + in3 * scale3));
 }

--- a/src/hal/components/select8.comp
+++ b/src/hal/components/select8.comp
@@ -1,7 +1,7 @@
 component select8 "8-bit binary match detector";
-pin in bit enable = TRUE "Set enable to FALSE to cause all outputs to be set FALSE.";
-pin in s32 sel "The number of the output to set TRUE.  All other outputs well be set FALSE.";
-pin out bit out#[8] "Output bits.  If enable is set and the sel input is between 0 and 7, then the corresponding output bit will be set true.";
+pin in bool enable = TRUE "Set enable to FALSE to cause all outputs to be set FALSE.";
+pin in si32 sel "The number of the output to set TRUE.  All other outputs well be set FALSE.";
+pin out bool out#[8] "Output bits.  If enable is set and the sel input is between 0 and 7, then the corresponding output bit will be set true.";
 option period no;
 function _;
 see_also "*demux*(9)";
@@ -9,14 +9,12 @@ license "GPL";
 author "Stephen Wille Padnos";
 ;;
 FUNCTION(_) {
-	hal_s32_t temp_sel;
-	int i, temp_enable;
-	temp_sel = sel;
-	temp_enable = enable;
-	for (i=0;i<8;i++) {
+	rtapi_s32 temp_sel = sel;
+	rtapi_bool temp_enable = enable;
+	for (int i=0;i<8;i++) {
 		if (!temp_enable || temp_sel!=i)
-			out(i)=0;
+			out_set(i, 0);
 		else
-			out(i)=1;
+			out_set(i, 1);
 	}
 }

--- a/src/hal/components/sum2.comp
+++ b/src/hal/components/sum2.comp
@@ -1,16 +1,16 @@
 component sum2 "Sum of two inputs (each with a gain) and an offset";
 see_also "scaled_s32_sums(9), weighted_sum(9)";
-pin in float in0;
-pin in float in1;
-param rw float gain0 = 1.0;
-param rw float gain1 = 1.0;
-param rw float offset;
-pin out float out "out = in0 * gain0 + in1 * gain1 + offset";
+pin in real in0;
+pin in real in1;
+param rw real gain0 = 1.0;
+param rw real gain1 = 1.0;
+param rw real offset;
+pin out real out "out = in0 * gain0 + in1 * gain1 + offset";
 option period no;
 function _;
 license "GPL";
 author "Jeff Epler";
 ;;
 FUNCTION(_) {
-    out = in0 * gain0 + in1 * gain1 + offset;
+    out_set(in0 * gain0 + in1 * gain1 + offset);
 }

--- a/src/hal/components/threadtest.comp
+++ b/src/hal/components/threadtest.comp
@@ -1,5 +1,5 @@
 component threadtest "LinuxCNC HAL component for testing thread behavior";
-pin out unsigned count;
+pin out ui32 count;
 option period no;
 function increment;
 function reset;
@@ -8,5 +8,5 @@ author "Jeff Epler";
 
 ;;
 
-FUNCTION(increment) { count++; }
-FUNCTION(reset) { count=0; }
+FUNCTION(increment) { count_set(count + 1); }
+FUNCTION(reset) { count_set(0); }

--- a/src/hal/components/tpcomp.comp
+++ b/src/hal/components/tpcomp.comp
@@ -37,7 +37,7 @@ https://github.com/LinuxCNC/linuxcnc/blob/BRANCHNAME/src/hal/components/tpcomp.c
 
 """;
 
-pin out bit is_module=1; //one pin is required to use halcompile)
+pin out bool is_module=1; //one pin is required to use halcompile)
 
 license "GPL";
 author "Dewey Garrett";

--- a/src/hal/components/tristate_bit.comp
+++ b/src/hal/components/tristate_bit.comp
@@ -1,12 +1,12 @@
 component tristate_bit "Place a signal on an I/O pin only when enabled, similar to a tristate buffer in electronics";
 
-pin in bit in_ "Input value";
-pin io bit out "Output value";
-pin in bit enable "When TRUE, copy in to out";
+pin in bool in_ "Input value";
+pin io bool out "Output value";
+pin in bool enable "When TRUE, copy in to out";
 
 option period no;
 function _ "If *enable* is TRUE, copy *in* to *out*.";
 license "GPL";
 author "Jeff Epler";
 ;;
-if(enable) out = in_;
+if(enable) out_set(in_);

--- a/src/hal/components/tristate_float.comp
+++ b/src/hal/components/tristate_float.comp
@@ -1,8 +1,8 @@
 component tristate_float "Place a signal on an I/O pin only when enabled, similar to a tristate buffer in electronics";
 
-pin in float in_ "Input value";
-pin io float out "Output value";
-pin in bit enable "When TRUE, copy in to out";
+pin in real in_ "Input value";
+pin io real out "Output value";
+pin in bool enable "When TRUE, copy in to out";
 
 option period no;
 function _  "If *enable* is TRUE, copy *in* to *out*.";
@@ -10,4 +10,4 @@ license "GPL";
 author "Jeff Epler";
 ;;
 
-FUNCTION(_) { if(enable) out = in_; }
+FUNCTION(_) { if(enable) out_set(in_); }

--- a/src/hal/components/wcomp.comp
+++ b/src/hal/components/wcomp.comp
@@ -1,10 +1,10 @@
 component wcomp "Window comparator";
-pin in float in "Value being compared";
-pin in float min_ "Low boundary for comparison";
-pin in float max_ "High boundary for comparison";
-pin out bit out "True if *in* is strictly between *min* and *max*";
-pin out bit under "True if *in* is less than or equal to *min*";
-pin out bit over "True if *in* is greater than or equal to *max*";
+pin in real in "Value being compared";
+pin in real min_ "Low boundary for comparison";
+pin in real max_ "High boundary for comparison";
+pin out bool out "True if *in* is strictly between *min* and *max*";
+pin out bool under "True if *in* is less than or equal to *min*";
+pin out bool over "True if *in* is greater than or equal to *max*";
 notes "If *max* <= *min* then the behavior is undefined.";
 
 option period no;
@@ -13,8 +13,10 @@ license "GPL";
 author "Jeff Epler";
 ;;
 FUNCTION(_) { 
-  double tmp = in;
-  under = (tmp <= min_);
-  over = (tmp >= max_);
-  out = !(over || under);
+    rtapi_real tmp = in;
+    rtapi_bool u = tmp <= min_;
+    rtapi_bool o = tmp >= max_;
+    under_set(u);
+    over_set(o);
+    out_set(!(o || u));
 }

--- a/src/hal/components/xor2.comp
+++ b/src/hal/components/xor2.comp
@@ -1,7 +1,7 @@
 component xor2 "Two-input XOR (exclusive OR) gate";
-pin in bit in0 "First input";
-pin in bit in1 "Second input";
-pin out bit out "Output";
+pin in bool in0 "First input";
+pin in bool in1 "Second input";
+pin out bool out "Output";
 
 description """
 The *out* pin is computed from the value of the *in0* and *in1* pins according
@@ -33,10 +33,6 @@ author "John Kasunich";
 option period no;
 ;;
 FUNCTION(_) {
-    if (( in0 && !in1 ) || ( in1 && !in0 )) {
-	out = 1;
-    } else {
-	out = 0;
-    }
+    out_set((int)in0 ^ (int)in1);
 }
 


### PR DESCRIPTION
This is the first set of component updates that converts them from old-style pins/params to the new getter/setter style.

The conversion is quite straight forward. The types are changed so halcompile automatically uses the getter/setter infrastructure (float->real, bit->bool, {s32,signed}->si32, {u32,unsigned}->ui32, s64->sint, u64->uint). All reading from pins and parameters stays the same. Writing requires the _set suffix and the value as argument.

Some pin/param names were changed by appending an '_' for min, max, clamp, is_positive and is_negative. These would otherwise collide with kernel used identifiers. The user visible pin/param name does not change by appending the underscore (hal names have all underscores replaced with dash and are right-stripped of dashes and periods, in that order, by halcompile).

A few components have been slightly altered to remove multiple reads or writes of the same pin/param. Multiple reads/writes are very expensive. The changes were only made if it was a rather trivial change.The functionality was not altered, even if there could have been some extra thought put in (see f.ex. integ.comp where the min/max/assign sequence could have been better if there was a guarantee that min ≤ max; in that case, the ifs could have been separated with an else).

Bad use of old hal types have been replaced by the correct rtapi types that match the underlying type that was meant. Most components will need another pass when we do the 64-bit clean test and upgrade. But that is for later after the user visible types become 64-bit only.