### PR TITLE
hal: Update more easy-to-convert components to getter/setter

### DIFF
--- a/src/hal/components/anglejog.comp
+++ b/src/hal/components/anglejog.comp
@@ -36,28 +36,28 @@ pin is current-scale-out as it depends on the iscale-factor setting.
 Simulation Config: `configs/sim/axis/anglejog/anglejog.in`
 """;
 
-pin in  bit   enable_in "enables motion (disables alteration of angle and scale)";
-pin in  s32   counts_in "MPG (wheel) counts";
-pin in  float angle_degrees_in "vector angle";
-pin in  s32   iscale_factor = 10000 "integer scaling factor (>1)";
-pin in  float scale_in "magnitude units/count (mag = counts * scale)";
-pin in  float max_vel "vector max velocity magnitude";
-pin in  float max_accel "vector max acceleration magnitude";
-pin in  float accel_fraction_in = 1 "acceleration fraction input";
+pin in  bool enable_in "enables motion (disables alteration of angle and scale)";
+pin in  si32 counts_in "MPG (wheel) counts";
+pin in  real angle_degrees_in "vector angle";
+pin in  si32 iscale_factor = 10000 "integer scaling factor (>1)";
+pin in  real scale_in "magnitude units/count (mag = counts * scale)";
+pin in  real max_vel "vector max velocity magnitude";
+pin in  real max_accel "vector max acceleration magnitude";
+pin in  real accel_fraction_in = 1 "acceleration fraction input";
 
-pin out bit   enable_out "to: axis.M.jog-enable AND axis.N.jog-enable";
-pin out float current_scale "effective scale (informational)";
-pin out float current_scale_out "to: axis.M.jog-scale AND axis.N.jog-scale";
-pin out s32   coscounts  "to: axis.M.jog-counts (cosine counts)";
-pin out s32   sincounts  "to: axis.N.jog-counts (sine   counts)";
-pin out float cos_accel_fraction "to: axis.M.jog-accel-fraction";
-pin out float sin_accel_fraction "to: axis.N.jog-accel-fraction";
+pin out bool enable_out "to: axis.M.jog-enable AND axis.N.jog-enable";
+pin out real current_scale "effective scale (informational)";
+pin out real current_scale_out "to: axis.M.jog-scale AND axis.N.jog-scale";
+pin out si32 coscounts  "to: axis.M.jog-counts (cosine counts)";
+pin out si32 sincounts  "to: axis.N.jog-counts (sine   counts)";
+pin out real cos_accel_fraction "to: axis.M.jog-accel-fraction";
+pin out real sin_accel_fraction "to: axis.N.jog-accel-fraction";
 
 // output monitor pins:
-pin out bit   active "angle jog move in progress";
-pin out float current_angle_degrees "current angle";
-pin out float current_mag "current vector magnitude";
-pin out float current_vel "current vector speed";
+pin out bool active "angle jog move in progress";
+pin out real current_angle_degrees "current angle";
+pin out real current_mag "current vector magnitude";
+pin out real current_vel "current vector speed";
 
 function _;
 license "GPL";
@@ -66,7 +66,7 @@ author  "Dewey Garrett";
 #include <rtapi_math.h>
 #define TO_RAD M_PI/180
 // replicate simple_tp.h define for tiny magnitude delta:
-#define TINY_DP(max_accel,period) (max_accel*period*period*0.001)
+#define TINY_DP(_max_accel,_period) ((_max_accel)*(_period)*(_period)*0.001)
 #define MIN_ISCALE_FACTOR     10
 #define MAX_ISCALE_FACTOR 100000
 
@@ -83,9 +83,9 @@ static int  ifactor = 0;
     int     newcounts;
 
     if (once) {
-        current_angle_degrees = angle_degrees_in;
-        current_scale     = scale_in;
-        current_scale_out = scale_in/iscale_factor;
+        current_angle_degrees_set(angle_degrees_in);
+        current_scale_set(scale_in);
+        current_scale_out_set(scale_in/iscale_factor);
         ifactor = iscale_factor;
         once = 0;
     }
@@ -100,13 +100,13 @@ static int  ifactor = 0;
     delta_counts  = newcounts - old_counts_in;
     old_enable_in = enable_in;
     old_counts_in = newcounts;
-    enable_out    = enable_in;
+    enable_out_set(enable_in);
 
     if (delta_counts!=0) {wait_for_count_change = 0;}
     if (enable_in) { tot_counts = tot_counts + delta_counts;}
     mag_cmd = tot_counts * current_scale_out;
 
-    active = 0;
+    active_set(0);
     /* compute max change in velocity per servo period */
     max_dv = max_accel * fperiod;
     /* compute a tiny magnitude range, to be treated as zero */
@@ -123,12 +123,12 @@ static int  ifactor = 0;
             vel_req = -max_dv +
                        sqrt(2.0 * max_accel * mag_err + max_dv * max_dv);
             /* mark planner as active */
-            active = 1;
+            active_set(1);
         } else if (mag_err < -tiny_dp) {
             vel_req =  max_dv -
                        sqrt(-2.0 * max_accel * mag_err + max_dv * max_dv);
             /* mark planner as active */
-            active = 1;
+            active_set(1);
         } else {
             /* within 'tiny_dp' of desired mag, no need to move */
             vel_req = 0.0;
@@ -158,11 +158,11 @@ static int  ifactor = 0;
                     }
                 }
             }
-            current_angle_degrees = angle_degrees_in;
+            current_angle_degrees_set(angle_degrees_in);
             if (   current_scale_out != scale_in
                 || new_ifactor) {
-                current_scale      = scale_in;
-                current_scale_out  = scale_in/ifactor;
+                current_scale_set(scale_in);
+                current_scale_out_set(scale_in/ifactor);
                 tot_counts = current_mag/current_scale_out;
             }
         }
@@ -176,24 +176,24 @@ static int  ifactor = 0;
     }
     /* ramp velocity toward request at accel limit */
     if (vel_req > current_vel + max_dv) {
-        current_vel += max_dv;
+        current_vel_set(current_vel + max_dv);
     } else if (vel_req < current_vel - max_dv) {
-        current_vel -= max_dv;
+        current_vel_set(current_vel - max_dv);
     } else {
-        current_vel = vel_req;
+        current_vel_set(vel_req);
     }
     /* check for still moving */
     if (current_vel != 0.0) {
         /* yes, mark planner active */
-        active = 1;
+        active_set(1);
     }
     /* integrate velocity to get new magnitude */
-    current_mag += current_vel * fperiod;
+    current_mag_set(current_mag + current_vel * fperiod);
     double cos_angle,sin_angle;
     cos_angle = cos(current_angle_degrees * TO_RAD);
     sin_angle = sin(current_angle_degrees * TO_RAD);
-    coscounts = current_mag * cos_angle/current_scale_out;
-    sincounts = current_mag * sin_angle/current_scale_out;
-    cos_accel_fraction = accel_fraction_in * cos_angle;
-    sin_accel_fraction = accel_fraction_in * sin_angle;
+    coscounts_set(current_mag * cos_angle/current_scale_out);
+    sincounts_set(current_mag * sin_angle/current_scale_out);
+    cos_accel_fraction_set(accel_fraction_in * cos_angle);
+    sin_accel_fraction_set(accel_fraction_in * sin_angle);
 }

--- a/src/hal/components/axistest.comp
+++ b/src/hal/components/axistest.comp
@@ -1,22 +1,22 @@
 component axistest """\
 Used to allow testing of an axis. Used IN PnCconf.""";
-pin in bit jog-minus "Drive TRUE to jog the axis in its negative ('minus') direction.";
-pin in bit jog-plus "Drive TRUE to jog the axis in its positive direction.";
-pin in bit run "Drive TRUE to run the axis near its current position_fb with a trapezoidal velocity profile.";
-pin in float maxvel "Maximum velocity";
-pin in float amplitude "Approximate amplitude of positions to command during 'run'";
-pin in s32 dir "Direction from central point to test: 0 = both, 1 = positive, 2 = negative";
-pin out float position-cmd;
-pin in float position-fb;
-pin out bit running;
-pin out float run-target;
-pin out float run-start;
-pin out float run-low;
-pin out float run-high;
-pin in s32 pause = 0 "Pause time for each end of run in seconds";
-param rw float epsilon = .001;
+pin in bool jog-minus "Drive TRUE to jog the axis in its negative ('minus') direction.";
+pin in bool jog-plus "Drive TRUE to jog the axis in its positive direction.";
+pin in bool run "Drive TRUE to run the axis near its current position_fb with a trapezoidal velocity profile.";
+pin in real maxvel "Maximum velocity";
+pin in real amplitude "Approximate amplitude of positions to command during 'run'";
+pin in si32 dir "Direction from central point to test: 0 = both, 1 = positive, 2 = negative";
+pin in real position-fb;
+pin out real position-cmd;
+pin out bool running;
+pin out real run-target;
+pin out real run-start;
+pin out real run-low;
+pin out real run-high;
+pin in si32 pause = 0 "Pause time for each end of run in seconds";
+param rw real epsilon = .001;
 variable double timer;
-param r float elapsed "Current value of the internal timer";
+param r real elapsed "Current value of the internal timer";
 variable int timer_on;
 function update;
 license "GPL";
@@ -27,19 +27,19 @@ extern double fabs(double);
 if (timer_on) {
     timer += fperiod;
 }
-elapsed = timer;
+elapsed_set(timer);
 if(run) {
     if(!running) {
-        running = 1;
-        run_start = position_fb;
+        running_set(1);
+        run_start_set(position_fb);
 
-        if(dir == 2) run_high = run_start;
-        else run_high = run_start + amplitude;
+        if(dir == 2) run_high_set(run_start);
+        else run_high_set(run_start + amplitude);
 
-        if(dir == 1) run_low = run_start;
-        else run_low = run_start - amplitude;
+        if(dir == 1) run_low_set(run_start);
+        else run_low_set(run_start - amplitude);
 
-        position_cmd = run_low;
+        position_cmd_set(run_low);
     }
 
     if(fabs(position_fb - position_cmd) < epsilon) {
@@ -50,26 +50,26 @@ if(run) {
             } else if (timer >= pause) {
                 timer_on = false; 
                 if(position_cmd == run_low) {
-                    position_cmd = run_high;
+                    position_cmd_set(run_high);
                 } else {
-                    position_cmd = run_low;
+                    position_cmd_set(run_low);
                 }
             }
         }
     }
 } else if(running) {
-    position_cmd = run_start;
+    position_cmd_set(run_start);
     if(fabs(position_fb - run_start) < epsilon) {
-        running = 0;
+        running_set(0);
         timer_on = false;
     }
 } else {
     if(jog_minus) {
-        position_cmd = position_fb - 10;
+        position_cmd_set(position_fb - 10);
     } else if(jog_plus) {
-        position_cmd = position_fb + 10;
+        position_cmd_set(position_fb + 10);
     } else {
-        position_cmd = position_fb;
+        position_cmd_set(position_fb);
     }
 }
 

--- a/src/hal/components/biquad.comp
+++ b/src/hal/components/biquad.comp
@@ -38,31 +38,31 @@ component biquad "Biquad IIR filter";
 description """Biquad IIR filter. Implements the following transfer function:
 H(z) = (n~0~ + n~1~z^-1^ + n~2~z^-2^) / (1 + d~1~z^-1^ + d~2~z^-2^)""";
 
-pin in float in "Filter input.";
-pin out float out "Filter output.";
-pin in bit enable = 0 "Filter enable. When false, the *in* pin \
+pin in real in "Filter input.";
+pin out real out "Filter output.";
+pin in bool enable = 0 "Filter enable. When false, the *in* pin \
 is passed to the *out* pin without any filtering.  \
 A *transition from false to true* causes filter \
 coefficients to be calculated according to the current \
 *type* and the describing pin and parameter settings";
-pin out bit valid = 0 "When false, indicates an error occurred when calculating \
+pin out bool valid = 0 "When false, indicates an error occurred when calculating \
 filter coefficients (require 2>**Q**>0.5 and *f0*>sampleRate/2)";
 
-pin   in u32 type_ = 0 "Filter type determines the type of filter \
+pin   in ui32 type_ = 0 "Filter type determines the type of filter \
 coefficients calculated.  When 0, coefficients must be loaded directly \
 from the *n0,n1,n2,d1* params.  When 1, \
 a low pass filter is created specified by the *f0,Q* pins.  \
 When 2, a notch filter is created specified by the *f0,Q* pins.";
-pin   in float f0 = 250.0 "The corner frequency of the filter.";
-pin   in float Q = 0.7071 "The Q of the filter.";
+pin   in real f0 = 250.0 "The corner frequency of the filter.";
+pin   in real Q = 0.7071 "The Q of the filter.";
 
-param rw float d1 = 0.0 "1st-delayed denominator coef";
-param rw float d2 = 0.0 "2nd-delayed denominator coef";
-param rw float n0 = 1.0 "non-delayed numerator coef";
-param rw float n1 = 0.0 "1st-delayed numerator coef";
-param rw float n2 = 0.0 "2nd-delayed numerator coef";
-pin  out float s1 = 0.0 "1st-delayed internal state (for debug only)";
-pin  out float s2 = 0.0 "2nd-delayed internal state (for debug only)";
+param rw real d1 = 0.0 "1st-delayed denominator coef";
+param rw real d2 = 0.0 "2nd-delayed denominator coef";
+param rw real n0 = 1.0 "non-delayed numerator coef";
+param rw real n1 = 0.0 "1st-delayed numerator coef";
+param rw real n2 = 0.0 "2nd-delayed numerator coef";
+pin  out real s1 = 0.0 "1st-delayed internal state (for debug only)";
+pin  out real s2 = 0.0 "2nd-delayed internal state (for debug only)";
 
 option data Internal;
 option extra_setup;
@@ -92,7 +92,7 @@ typedef enum {
 
 
 typedef struct {
-    hal_bit_t                   lastEnable;
+    rtapi_bool lastEnable;
 } Internal;
 
 
@@ -117,7 +117,7 @@ FUNCTION(_)
 
                 // If not direct coefficient loading.
                 if(type_ != TYPE_DIRECT){
-                    valid = 0;
+                    valid_set(0);
 
                     sampleRate = 1.0 / (period * 1e-9);
 
@@ -145,25 +145,26 @@ FUNCTION(_)
                         break;
                     }
 
-                    n0 = b0 / a0;
-                    n1 = b1 / a0;
-                    n2 = b2 / a0;
-                    d1 = a1 / a0;
-                    d2 = a2 / a0;
-                    s1 = s2 = 0.0;
+                    n0_set(b0 / a0);
+                    n1_set(b1 / a0);
+                    n2_set(b2 / a0);
+                    d1_set(a1 / a0);
+                    d2_set(a2 / a0);
+                    s1_set(s2_set(0.0));
                 }
 
-                valid = 1;
+                valid_set(1);
             } while(0);
     }
 
     if(!enable || !valid){
-        out = in;
+        out_set(in);
     }else{
         // Transposed direct form II.
-        out = in * n0 + s1;
-        s1 = in * n1 - out * d1 + s2;
-        s2 = in * n2 - out * d2;
+        rtapi_real in_ = in;
+        out_set(in_ * n0 + s1);
+        s1_set( in_ * n1 - out * d1 + s2);
+        s2_set( in_ * n2 - out * d2);
     }
 }
 

--- a/src/hal/components/edge.comp
+++ b/src/hal/components/edge.comp
@@ -16,16 +16,16 @@
 //   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 component edge "Edge detector";
 
-pin in bit in;
-pin out bit out "Goes high when the desired edge is seen on 'in'";
-pin out bit out_invert "Goes low when the desired edge is seen on 'in'";
+pin in bool in;
+pin out bool out "Goes high when the desired edge is seen on 'in'";
+pin out bool out_invert "Goes low when the desired edge is seen on 'in'";
 
-param rw bit both=FALSE "If TRUE, selects both edges.  Otherwise, selects one edge according to in-edge";
-param rw bit in_edge=TRUE "If both is FALSE, selects the one desired edge: TRUE means falling, FALSE means rising";
-param rw signed out_width_ns=0 "Time in nanoseconds of the output pulse";
+param rw bool both=FALSE "If TRUE, selects both edges.  Otherwise, selects one edge according to in-edge";
+param rw bool in_edge=TRUE "If both is FALSE, selects the one desired edge: TRUE means falling, FALSE means rising";
+param rw si32 out_width_ns=0 "Time in nanoseconds of the output pulse";
 
-param r signed time_left_ns "Time left in this output pulse";
-param r bit last_in "Previous input value";
+param r si32 time_left_ns "Time left in this output pulse";
+param r bool last_in "Previous input value";
 variable int first = 1;
 
 function _ "Produce output pulses from input edges";
@@ -35,8 +35,9 @@ author "Jeff Epler";
 
 FUNCTION(_){ 
     int new_in = in;
-    if (time_left_ns > 0) {
-        time_left_ns -= period;
+    rtapi_s32 tlns = time_left_ns;
+    if (tlns > 0) {
+        time_left_ns_set(tlns -= period);
     }
     if ( !first ) {
         int rise = new_in && !last_in;
@@ -45,18 +46,18 @@ FUNCTION(_){
             both ? rise || fall
                     : in_edge ? fall : rise;
         if(desired_edge) {
-            time_left_ns = out_width_ns;
-            out = 1;
-        } else if(time_left_ns > 0) {
-            out = 1;
+            time_left_ns_set(out_width_ns);
+            out_set(1);
+        } else if(tlns > 0) {
+            out_set(1);
         } else {
-            time_left_ns = 0;
-            out = 0;
+            time_left_ns_set(0);
+            out_set(0);
         }
     } else {
         first = 0;
     }
-    last_in = new_in;
-    out_invert = !out;
+    last_in_set(new_in);
+    out_invert_set(!out);
 }
 

--- a/src/hal/components/eoffset_per_angle.comp
+++ b/src/hal/components/eoffset_per_angle.comp
@@ -61,27 +61,27 @@ transverse *X* coordinate according to the selected *fnum* function.
 
 //" quote char for vim highlighting
 
-pin  in   bit active      = 0     "From: motion.eoffset-active";
-pin  in   bit is_on       = 0     "From: halui.machine.is-on";
+pin  in bool active      = 0     "From: motion.eoffset-active";
+pin  in bool is_on       = 0     "From: halui.machine.is-on";
 
-pin  in   bit enable_in   = 0     "Enable Input";
-pin  in float radius_ref  = 1     "Radius reference (see notes)";
-pin  in float angle       = 0     "Input angle (in degrees)";
-pin  in float start_angle = 0     "Start angle (in degrees)";
-pin  in   s32 fnum        = 0     "Function selector (default 0)";
-pin  in float rfraction   = 0.1   "Offset amplitude (+/- fraction of radius_ref)";
-pin  in float fmult       = 6     "Offset frequency multiplier";
-pin  in   u32 k           = 10000 "Scaling Factor (if 0, use 10000)";
+pin  in bool enable_in   = 0     "Enable Input";
+pin  in real radius_ref  = 1     "Radius reference (see notes)";
+pin  in real angle       = 0     "Input angle (in degrees)";
+pin  in real start_angle = 0     "Start angle (in degrees)";
+pin  in si32 fnum        = 0     "Function selector (default 0)";
+pin  in real rfraction   = 0.1   "Offset amplitude (+/- fraction of radius_ref)";
+pin  in real fmult       = 6     "Offset frequency multiplier";
+pin  in ui32 k           = 10000 "Scaling Factor (if 0, use 10000)";
 
-pin out   bit is_off      "invert is_on (for convenience)";
+pin out bool is_off      "invert is_on (for convenience)";
 
-pin out   bit enable_out  "To: axis.L.eoffset-enable";
-pin out   bit clear       "To: axis.L.eoffset-clear";
-pin out   s32 kcounts     "To: axis.L.eoffset-counts";
-pin out float kreciprocal "To: axis.L.eoffset-scale (1/k)";
+pin out bool enable_out  "To: axis.L.eoffset-enable";
+pin out bool clear       "To: axis.L.eoffset-clear";
+pin out si32 kcounts     "To: axis.L.eoffset-counts";
+pin out real kreciprocal "To: axis.L.eoffset-scale (1/k)";
 
-pin out float eoffset_dbg "offset (debug pin--use kcounts & kreciprocal)";
-pin out   u32 state_dbg   "state  (debug pin)";
+pin out real eoffset_dbg "offset (debug pin--use kcounts & kreciprocal)";
+pin out ui32 state_dbg   "state  (debug pin)";
 
 //---------------------------------------------------------------------
 // per-instance items:
@@ -151,19 +151,20 @@ FUNCTION(_) {
     ofunc* thefunc;
 
     run_ct++;
-    state_dbg = STATE;
+    state_dbg_set(STATE);
     kfactor = k;
     if (k == 0) {kfactor = 10000;}
-    kreciprocal = 1/((float)kfactor);
+    kreciprocal_set(1/((rtapi_real)kfactor));
 
-    is_off = !is_on; // convenience pin
+    is_off_set(!is_on); // convenience pin
 
     if (is_off) {
         // note: the external_offsets implementation defines
         //       axis.L.eoffset as zero when machine is off
         err_stop   = 0;
-        enable_out = 0;
-        kcounts    = 0; eoffset_dbg = 0;
+        enable_out_set(0);
+        kcounts_set(0);
+        eoffset_dbg_set(0);
         messaged   = 0;
         STATE      = OFF;
         return;
@@ -182,15 +183,16 @@ FUNCTION(_) {
         }
         err_stop = 0;
         messaged = 1;
-        kcounts  = 0;
+        kcounts_set(0);
         STATE    = READY;
         dprint("OFF->READY",kcounts);
         return;
         break;
     case READY:
         if (!enable_in) {return;}
-        kcounts    = 0; eoffset_dbg = 0;
-        enable_out = 0;
+        kcounts_set(0);
+        eoffset_dbg_set(0);
+        enable_out_set(0);
         delay_ct   = 0;
         STATE      = RUNNING;
         dprint("READY->RUNNING",kcounts);
@@ -198,7 +200,7 @@ FUNCTION(_) {
         break;
     case RUNNING:
         if (enable_in) {
-            enable_out = 1;
+            enable_out_set(1);
             STATE      = RUNNING;
         } else {
             /*
@@ -210,8 +212,9 @@ FUNCTION(_) {
             ** to zero to remove any residual with no modifications to
             ** simple_tp.c
             */
-            clear    = 1;
-            kcounts  = 0; eoffset_dbg = 0;
+            clear_set(1);
+            kcounts_set(0);
+            eoffset_dbg_set(0);
             STATE    = STOPPING;
             delay_ct = run_ct;
             dprint("RUNNING->STOPPING",kcounts);
@@ -234,7 +237,7 @@ FUNCTION(_) {
         if (run_ct < (FINISH_DELAY + delay_ct) ) {
             STATE = FINISH;
         } else {
-            enable_out = 0;
+            enable_out_set(0);
             if (err_stop) {
                 STATE = OFF;
                 dprint("FINISH->OFF",kcounts);
@@ -243,7 +246,7 @@ FUNCTION(_) {
                 dprint("FINISH->READY",kcounts);
             }
         }
-        clear = 0;
+        clear_set(0);
         return;
         break;
     } //switch (STATE)
@@ -265,15 +268,16 @@ FUNCTION(_) {
         // thefunc returned nonzero (problem)
         err_stop     = 1;
         dptr->ovalue = 0;
-        kcounts      = 0; eoffset_dbg = 0;
+        kcounts_set(0);
+        eoffset_dbg_set(0);
         STATE        = STOPPING;
         rtapi_print_msg(RTAPI_MSG_ERR,
              "eoffset_per_angle stopping:func%d problem\n",fnum);
         return;
     }
 
-    kcounts     = kfactor * dptr->ovalue;
-    eoffset_dbg = kcounts * kreciprocal; // debug pin
+    kcounts_set(kfactor * dptr->ovalue);
+    eoffset_dbg_set(kcounts * kreciprocal); // debug pin
     return;
 }
 

--- a/src/hal/components/gearchange.comp
+++ b/src/hal/components/gearchange.comp
@@ -5,19 +5,19 @@ The scale of gear 1 is assumed to be 1, so the output device scale
 should be chosen accordingly.
 The scale of gear 2 is relative to gear 1, so if gear 2 runs the spindle
 2.5 times as fast as gear 1, scale2 should be set to 2.5.""";
-pin in bit sel "Gear selection input";
-pin in float speed_in "Speed command input";
-pin out float speed_out "Speed command to DAC/PWM";
-pin in bit dir_in "Direction command input";
-pin out bit dir_out "Direction output - possibly inverted for second gear";
-param rw float min1 = 0 "Minimum allowed speed in gear range 1";
-param rw float max1 = 100000 "Maximum allowed speed in gear range 1";
-param rw float min2 = 0 "Minimum allowed speed in gear range 2";
-param rw float max2 = 100000 "Maximum allowed speed in gear range 2";
-param rw float scale2 = 1.0 """Relative scale of gear 2 vs. gear 1.
+pin in   bool sel "Gear selection input";
+pin in   real speed_in "Speed command input";
+pin out  real speed_out "Speed command to DAC/PWM";
+pin in   bool dir_in "Direction command input";
+pin out  bool dir_out "Direction output - possibly inverted for second gear";
+param rw real min1 = 0 "Minimum allowed speed in gear range 1";
+param rw real max1 = 100000 "Maximum allowed speed in gear range 1";
+param rw real min2 = 0 "Minimum allowed speed in gear range 2";
+param rw real max2 = 100000 "Maximum allowed speed in gear range 2";
+param rw real scale2 = 1.0 """Relative scale of gear 2 vs. gear 1.
 Since it is assumed that gear 2 is "high gear", *scale2* must be
 greater than 1, and will be reset to 1 if set lower.""";
-param rw bit reverse = 0 "Set to 1 to reverse the spindle in second gear.";
+param rw bool reverse = 0 "Set to 1 to reverse the spindle in second gear.";
 
 option period no;
 function _;
@@ -25,11 +25,11 @@ license "GPL";
 author "Stephen Wille Padnos";
 ;;
 FUNCTION(_) {
-    hal_float_t temp_in = speed_in;
-    hal_float_t sign=1;
+    rtapi_real temp_in = speed_in;
+    rtapi_real sign=1;
     /* Assume that the output device is scaled so that gear 1 is "Pass-through" */
     /* the other gear(s) need to be scaled by the relative scale for that gear */
-    if (scale2 < 1) scale2 = 1;
+    if (scale2 < 1) scale2_set(1);
     if (temp_in < 0) {
 	sign = -1;
 	temp_in = -temp_in;
@@ -38,11 +38,11 @@ FUNCTION(_) {
     	if (temp_in < min2) temp_in = min2;
     	else if (temp_in > max2) temp_in = max2;
     	temp_in /= scale2;		/* scale up to second gear output range */
-	dir_out = dir_in ^ reverse;
+	dir_out_set(dir_in ^ reverse);
     } else {
     	if (temp_in < min1) temp_in = min1;
     	else if (temp_in > max1) temp_in = max1;
-	dir_out = dir_in;
+	dir_out_set(dir_in);
     }
-    speed_out = sign*temp_in;
+    speed_out_set(sign*temp_in);
 }

--- a/src/hal/components/knob2float.comp
+++ b/src/hal/components/knob2float.comp
@@ -17,13 +17,13 @@
 
 component knob2float "Convert counts (probably from an encoder) to a float value";
 
-pin in s32 counts "Counts";
-pin in bit enable "When TRUE, output is controlled by count, when FALSE, output is fixed";
-pin in float scale "Amount of output change per count";
-pin out float out "Output value";
+pin in si32 counts "Counts";
+pin in bool enable "When TRUE, output is controlled by count, when FALSE, output is fixed";
+pin in real scale "Amount of output change per count";
+pin out real out "Output value";
 
-param rw float max_out=1.0 "Maximum output value, further increases in count will be ignored";
-param rw float min_out=0.0 "Minimum output value, further decreases in count will be ignored";
+param rw real max_out=1.0 "Maximum output value, further increases in count will be ignored";
+param rw real min_out=0.0 "Minimum output value, further decreases in count will be ignored";
 
 option data knob2float_data;
 
@@ -35,27 +35,27 @@ author "John Kasunich";
 
 typedef struct {
     long old_counts;
-    double old_out;
+    rtapi_real old_out;
 } knob2float_data;
 
 FUNCTION(_) {
     long delta_counts;
-    double tmp_out;
+    rtapi_real tmp_out;
 
     if ( min_out > max_out ) {
-	min_out = max_out;
+        min_out_set(max_out);
     }
     delta_counts = counts - data.old_counts;
     if ( enable ) {
-	tmp_out = data.old_out + delta_counts * scale;
-	if ( tmp_out > max_out ) {
-	    data.old_out = max_out;
-	} else if ( tmp_out < min_out ) {
-	    data.old_out = min_out;
-	} else {
-	    data.old_out = tmp_out;
-	}
+        tmp_out = data.old_out + delta_counts * scale;
+        if ( tmp_out > max_out ) {
+            data.old_out = max_out;
+        } else if ( tmp_out < min_out ) {
+            data.old_out = min_out;
+        } else {
+            data.old_out = tmp_out;
+        }
     }
-    out = data.old_out;
+    out_set(data.old_out);
     data.old_counts += delta_counts;
 }

--- a/src/hal/components/led_dim.comp
+++ b/src/hal/components/led_dim.comp
@@ -36,8 +36,8 @@
  *
  ******************************************************************************/
 component led_dim "HAL component for dimming LEDs";
-pin in  float in "Brightness input value -> 0 to 1";
-pin out float out "Luminance output value -> 0 to 1";
+pin in  real in "Brightness input value -> 0 to 1";
+pin out real out "Luminance output value -> 0 to 1";
 function _ "Update the output value";
 description """
 Component for LED dimming according to human perception of brightness of light.
@@ -47,7 +47,7 @@ The output is calculated using the CIE 1931 formula.
 license "GPL";
 author "Alexander Rössler";
 option period no;
-variable hal_float_t last_in = 0.0;
+variable rtapi_real last_in = 0.0;
 ;;
 #include <rtapi_math.h>
 #define MIN(x,y) (x < y ? x : y)
@@ -56,17 +56,17 @@ variable hal_float_t last_in = 0.0;
 FUNCTION(_) {
     if (last_in != in)
     {
-        hal_float_t input = MIN(MAX(in, 0.0), 1.0); // clamp to 0.0, 1.0
+        rtapi_real input = MIN(MAX(in, 0.0), 1.0); // clamp to 0.0, 1.0
 
         // luminance calculation based on CIE 1931 formula
         // see http://forum.arduino.cc/index.php/topic,147810.0.html
         if (input < 0.079996)
         {
-            out = input / 9.033;
+            out_set(input / 9.033);
         }
         else
         {
-            out = pow((input + 0.16) / 1.16, 3.0);
+            out_set(pow((input + 0.16) / 1.16, 3.0));
         }
 
         last_in = in;

--- a/src/hal/components/limit_axis.comp
+++ b/src/hal/components/limit_axis.comp
@@ -42,19 +42,19 @@ option extra_setup 1;
 option period no;
 function _;
 
-pin out bit error-no-range "error pin indicating that no range matches the fb";
-pin out float min-output "Minimum limit output";
-pin out float max-output "Maximum limit output";
-pin in float fb "Feedback pin, the value of this pin determines which range is active";
-pin out unsigned current-range "Indicates which range is currently active";
-pin in float min-limit-## [10:personality] "The array of minimum limits to select from";
-pin in float max-limit-## [10:personality] "The array of macimum limits";
-pin in float min-range-## [10:personality] "Defines the range of values with which the fb is compared to set the range";
-pin in float max-range-## [10:personality] "Defines the range of values with which the fb is compared to set the range";
-pin in bit enable-## [10:personality] "Used to enable and disable a specific range";
-pin in bit sticky-## [10:personality] "Used to make specific range 'sticky' or not";
-pin out bit error-range-## [10:personality] = 1 "Error bit indicating that the fb pin falls outside all ranges";
-pin out bit error-limit-## [10:personality] = 1 "Error bit indicating that the max limit is not larger than the min limit";
+pin out bool error-no-range "error pin indicating that no range matches the fb";
+pin out real min-output "Minimum limit output";
+pin out real max-output "Maximum limit output";
+pin in real fb "Feedback pin, the value of this pin determines which range is active";
+pin out ui32 current-range "Indicates which range is currently active";
+pin in real min-limit-## [10:personality] "The array of minimum limits to select from";
+pin in real max-limit-## [10:personality] "The array of macimum limits";
+pin in real min-range-## [10:personality] "Defines the range of values with which the fb is compared to set the range";
+pin in real max-range-## [10:personality] "Defines the range of values with which the fb is compared to set the range";
+pin in bool enable-## [10:personality] "Used to enable and disable a specific range";
+pin in bool sticky-## [10:personality] "Used to make specific range 'sticky' or not";
+pin out bool error-range-## [10:personality] = 1 "Error bit indicating that the fb pin falls outside all ranges";
+pin out bool error-limit-## [10:personality] = 1 "Error bit indicating that the max limit is not larger than the min limit";
 
 ;;
 
@@ -66,8 +66,8 @@ FUNCTION(_){
         fb <= max_range(current_range) &&
         enable(current_range)) {
 
-      max_output = max_limit(current_range);
-      min_output = min_limit(current_range);
+      max_output_set(max_limit(current_range));
+      min_output_set(min_limit(current_range));
 
       return;
     }
@@ -87,12 +87,12 @@ FUNCTION(_){
                         i,
                         max_range(i),
                         min_range(i));
-        error_range(i) = 1;
+        error_range_set(i, 1);
       }
       continue;
     }
     // If we made it to here clear the error
-    error_range(i) = 0;
+    error_range_set(i, 0);
 
     if (max_limit(i) < min_limit(i)){
       // Throw Error and skip this range
@@ -102,22 +102,22 @@ FUNCTION(_){
                         i,
                         max_limit(i),
                         min_limit(i));
-        error_limit(i) = 1;
+        error_limit_set(i, 1);
       }
       continue;
     }
     // If we made it to here clear the error
-    error_limit(i) = 0;
+    error_limit_set(i, 0);
 
     // Check position, take first range that it fits in.
     if(min_range(i) <= fb && fb <= max_range(i)) {
-      max_output = max_limit(i);
-      min_output = min_limit(i);
+      max_output_set(max_limit(i));
+      min_output_set(min_limit(i));
       // Found our limits, stop looking
-      error_no_range = 0;
+      error_no_range_set(0);
       if (i != (int)current_range){
         rtapi_print_msg(RTAPI_MSG_INFO, "limit_axis: Switching to Range %d\n", i);
-        current_range = i;
+        current_range_set(i);
       }
       return;
     }
@@ -125,7 +125,7 @@ FUNCTION(_){
 
   // If we've looked through all our ranges, then it's not there
   if (!error_no_range){
-    error_no_range = 1;
+    error_no_range_set(1);
     rtapi_print_msg(RTAPI_MSG_ERR,
                     "limit_axis: No Range found corresponding to feedback");
 

--- a/src/hal/components/lincurve.comp
+++ b/src/hal/components/lincurve.comp
@@ -23,12 +23,12 @@ Sample usage: loadrt lincurve count=3 personality=4,4,4
 for a set of three 4-element graphs.
  """;
 
-param rw float x-val-##[16 : personality] "axis breakpoints";
-param rw float y-val-##[16 : personality] "output values to be interpolated";
+param rw real x-val-##[16 : personality] "axis breakpoints";
+param rw real y-val-##[16 : personality] "output values to be interpolated";
 
-pin in float in_ "The input value";
-pin out float out_ "The output value";
-pin io float out-io "The output value, compatible with PID gains";
+pin in real in_ "The input value";
+pin out real out_ "The output value";
+pin io real out-io "The output value, compatible with PID gains";
 
 variable unsigned i = 0;
 
@@ -43,24 +43,22 @@ function _;
 ;;
 
 FUNCTION(_){
-    double f, x;
+    rtapi_real f, x;
     x = in_;
     if (x >= x_val(personality-1)) {
-        out_ = y_val(personality-1);
-        out_io = out_;
+        out_io_set(out__set(y_val(personality-1)));
         return;
     }
     if (x <= x_val(0)) {
-        out_ = y_val(0);
-        out_io = out_;
+        out_io_set(out__set(y_val(0)));
         return;
     }
+    // FIXME: potential buffer overflow read
     while (x > x_val(i+1)) { i++;}
     while (x < (x_val(i))) { i--;}
     
     f = (x - x_val(i))/(x_val(i+1)-x_val(i));
-    out_ = y_val(i) + f * (y_val(i+1) - y_val(i));
-    out_io = out_;
+    out_io_set(out__set(y_val(i) + f * (y_val(i+1) - y_val(i))));
 }
 
 EXTRA_SETUP(){

--- a/src/hal/components/match8.comp
+++ b/src/hal/components/match8.comp
@@ -1,22 +1,22 @@
 component match8 "8-bit binary match detector";
-pin in bit in = TRUE "cascade input - if false, output is false regardless of other inputs";
-pin in bit a0;
-pin in bit a1;
-pin in bit a2;
-pin in bit a3;
-pin in bit a4;
-pin in bit a5;
-pin in bit a6;
-pin in bit a7;
-pin in bit b0;
-pin in bit b1;
-pin in bit b2;
-pin in bit b3;
-pin in bit b4;
-pin in bit b5;
-pin in bit b6;
-pin in bit b7;
-pin out bit out "true only if in is true and a[m] matches b[m] for m = 0 thru 7";
+pin in bool in = TRUE "cascade input - if false, output is false regardless of other inputs";
+pin in bool a0;
+pin in bool a1;
+pin in bool a2;
+pin in bool a3;
+pin in bool a4;
+pin in bool a5;
+pin in bool a6;
+pin in bool a7;
+pin in bool b0;
+pin in bool b1;
+pin in bool b2;
+pin in bool b3;
+pin in bool b4;
+pin in bool b5;
+pin in bool b6;
+pin in bool b7;
+pin out bool out "true only if in is true and a[m] matches b[m] for m = 0 thru 7";
 option period no;
 function _;
 license "GPL";
@@ -36,5 +36,5 @@ FUNCTION(_) {
     if (( a7 && !b7 ) || ( !a7 && b7 )) goto nomatch;
     tmp = 1;
 nomatch:
-    out = tmp;
+    out_set(tmp);
 }

--- a/src/hal/components/mesa_pktgyro_test.comp
+++ b/src/hal/components/mesa_pktgyro_test.comp
@@ -51,7 +51,7 @@ include <hostmot2-serial.h>;
 include "hal/drivers/mesa-hostmot2/hostmot2.h";
 
 
-pin out s32 rxbytes  "Number of Bytes received or negative Error code";
+pin out si32 rxbytes  "Number of Bytes received or negative Error code";
 
 variable char *name; // PktUART name
 
@@ -71,7 +71,7 @@ function receive;
 /* This uses the RTAPI_MP_ARRAY_STRING macro to load the list of PktUART channels
 into an array. This is copied into the *name string of each */
 
-char *pktuart_chans[4] = {0,};
+char *pktuart_chans[4] = {};
 RTAPI_MP_ARRAY_STRING(pktuart_chans, 2, "PktUART Channel names");
 
 static hostmot2_t* hm2=NULL;
@@ -88,8 +88,8 @@ FUNCTION(receive){
 #undef NUM_FRAMES
 
 	rtapi_u16 frame_sizes3[20];
-	rxbytes=hm2_pktuart_read(name, Replyd3, &num_frames, &max_frame_length, frame_sizes3);
-	rtapi_print_msg(RTAPI_MSG_INFO, "PktUART receive: got %d bytes, %d frames\n", rxbytes, num_frames);
+	rxbytes_set(hm2_pktuart_read(name, Replyd3, &num_frames, &max_frame_length, frame_sizes3));
+	rtapi_print_msg(RTAPI_MSG_INFO, "PktUART receive: got %d bytes, %d frames\n", (int)rxbytes, num_frames);
 
 	//Print out the actual frame sizes
 	int i;

--- a/src/hal/components/multiclick.comp
+++ b/src/hal/components/multiclick.comp
@@ -24,54 +24,54 @@ component multiclick "Single-, double-, triple-, and quadruple-click detector";
 license "GPL";
 author "Sebastian Kuzminsky";
 
-pin in  bit in "The input line, this is where we look for clicks.";
+pin in  bool in "The input line, this is where we look for clicks.";
 
-pin out bit single_click
+pin out bool single_click
 "Goes high briefly when a single-click is detected on the 'in' pin.";
 
-pin out bit single_click_only
+pin out bool single_click_only
 """Goes high briefly when a single-click is detected on the 'in' pin
 and no second click followed it.""";
 
-pin out bit double_click
+pin out bool double_click
 "Goes high briefly when a double-click is detected on the 'in' pin.";
 
-pin out bit double_click_only
+pin out bool double_click_only
 """Goes high briefly when a double-click is detected on the 'in' pin
 and no third click followed it.""";
 
-pin out bit triple_click
+pin out bool triple_click
 "Goes high briefly when a triple-click is detected on the 'in' pin.";
 
-pin out bit triple_click_only
+pin out bool triple_click_only
 """Goes high briefly when a triple-click is detected on the 'in' pin
 and no fourth click followed it.""";
 
-pin out bit quadruple_click
+pin out bool quadruple_click
 "Goes high briefly when a quadruple-click is detected on the 'in' pin.";
 
-pin out bit quadruple_click_only
+pin out bool quadruple_click_only
 """Goes high briefly when a quadruple-click is detected on the 'in'
 pin and no fifth click followed it.""";
 
 
 // for debugging
-pin out s32 state;
+pin out si32 state;
 
 
-param rw bit invert_input = FALSE
+param rw bool invert_input = FALSE
 """If FALSE (the default), clicks start with rising edges.  If TRUE,
 clicks start with falling edges.""";
 
-param rw u32 max_hold_ns  = 250000000
+param rw ui32 max_hold_ns  = 250000000
 """If the input is held down longer than this, it's not part of a
 multi-click.  (Default 250,000,000 ns, 250 ms.)""";
 
-param rw u32 max_space_ns = 250000000
+param rw ui32 max_space_ns = 250000000
 """If the input is released longer than this, it's not part of a
 multi-click.  (Default 250,000,000 ns, 250 ms.)""";
 
-param rw u32 output_hold_ns = 100000000
+param rw ui32 output_hold_ns = 100000000
 """Positive pulses on the output pins last this long.  (Default
 100,000,000 ns, 100 ms.)""";
 
@@ -176,7 +176,7 @@ FUNCTION(_) {
             single_click_hold_timer -= period;
         } else {
             single_click_hold_timer = 0;
-            single_click = 0;
+            single_click_set(0);
         }
     }
 
@@ -185,7 +185,7 @@ FUNCTION(_) {
             single_click_only_hold_timer -= period;
         } else {
             single_click_only_hold_timer = 0;
-            single_click_only = 0;
+            single_click_only_set(0);
         }
     }
 
@@ -194,7 +194,7 @@ FUNCTION(_) {
             double_click_hold_timer -= period;
         } else {
             double_click_hold_timer = 0;
-            double_click = 0;
+            double_click_set(0);
         }
     }
 
@@ -203,7 +203,7 @@ FUNCTION(_) {
             double_click_only_hold_timer -= period;
         } else {
             double_click_only_hold_timer = 0;
-            double_click_only = 0;
+            double_click_only_set(0);
         }
     }
 
@@ -212,7 +212,7 @@ FUNCTION(_) {
             triple_click_hold_timer -= period;
         } else {
             triple_click_hold_timer = 0;
-            triple_click = 0;
+            triple_click_set(0);
         }
     }
 
@@ -221,7 +221,7 @@ FUNCTION(_) {
             triple_click_only_hold_timer -= period;
         } else {
             triple_click_only_hold_timer = 0;
-            triple_click_only = 0;
+            triple_click_only_set(0);
         }
     }
 
@@ -230,7 +230,7 @@ FUNCTION(_) {
             quadruple_click_hold_timer -= period;
         } else {
             quadruple_click_hold_timer = 0;
-            quadruple_click = 0;
+            quadruple_click_set(0);
         }
     }
 
@@ -239,7 +239,7 @@ FUNCTION(_) {
             quadruple_click_only_hold_timer -= period;
         } else {
             quadruple_click_only_hold_timer = 0;
-            quadruple_click_only = 0;
+            quadruple_click_only_set(0);
         }
     }
 
@@ -263,7 +263,7 @@ FUNCTION(_) {
                 click_state = SAW_FIRST_CLICK;
                 timer = 0;
                 timeout = max_space_ns;
-                single_click = 1;
+                single_click_set(1);
                 single_click_hold_timer = output_hold_ns;
             }
             break;
@@ -283,7 +283,7 @@ FUNCTION(_) {
                 click_state = SAW_SECOND_CLICK;
                 timer = 0;
                 timeout = max_space_ns;
-                double_click = 1;
+                double_click_set(1);
                 double_click_hold_timer = output_hold_ns;
             }
             break;
@@ -303,7 +303,7 @@ FUNCTION(_) {
                 click_state = SAW_THIRD_CLICK;
                 timer = 0;
                 timeout = max_space_ns;
-                triple_click = 1;
+                triple_click_set(1);
                 triple_click_hold_timer = output_hold_ns;
             }
             break;
@@ -325,7 +325,7 @@ FUNCTION(_) {
                 click_state = SAW_FOURTH_CLICK;
                 timer = 0;
                 timeout = max_space_ns;
-                quadruple_click = 1;
+                quadruple_click_set(1);
                 quadruple_click_hold_timer = output_hold_ns;
             }
             break;
@@ -359,22 +359,22 @@ FUNCTION(_) {
             // of the "only" outputs if appropriate
             switch (click_state) {
                 case SAW_FIRST_CLICK: {
-                    single_click_only = 1;
+                    single_click_only_set(1);
                     single_click_only_hold_timer = output_hold_ns;
                     break;
                 }
                 case SAW_SECOND_CLICK: {
-                    double_click_only = 1;
+                    double_click_only_set(1);
                     double_click_only_hold_timer = output_hold_ns;
                     break;
                 }
                 case SAW_THIRD_CLICK: {
-                    triple_click_only = 1;
+                    triple_click_only_set(1);
                     triple_click_only_hold_timer = output_hold_ns;
                     break;
                 }
                 case SAW_FOURTH_CLICK: {
-                    quadruple_click_only = 1;
+                    quadruple_click_only_set(1);
                     quadruple_click_only_hold_timer = output_hold_ns;
                     break;
                 }
@@ -383,6 +383,6 @@ FUNCTION(_) {
         }
     }
 
-    state = click_state;
+    state_set(click_state);
 }
 

--- a/src/hal/components/mux16.comp
+++ b/src/hal/components/mux16.comp
@@ -1,24 +1,24 @@
 component mux16 "Select from one of sixteen input values";
-pin in bit use_graycode"""\
+pin in bool use_graycode"""\
 This signifies the input will use Gray code instead of binary.
 Gray code is a good choice when using physical switches because
 for each increment only one select input changes at a time.
 """;
-pin in bit suppress_no_input"""\
+pin in bool suppress_no_input"""\
 This suppresses changing the output if all select lines are false.
 This stops unwanted jumps in output between transitions of input.
 but make in00 unavailable.
 """;
-pin in float debounce_time"""\
+pin in real debounce_time"""\
 sets debounce time in seconds.  eg. .10 = a tenth of a second
 input must be stable this long before outputs changes. This
 helps to ignore 'noisy' switches.
 """;
-pin in bit sel#[4] """\
+pin in bool sel#[4] """\
 Together, these determine which **in**__N__ value is copied to *out*.
 """;
-pin out float out_f;
-pin out s32 out_s """\
+pin out real out_f;
+pin out si32 out_s """\
 Follows the value of one of the **in**__N__ values according to the four *sel* values
 and whether use-graycode is active.
 The s32 value will be trunuated and limited to the max and min values of signed values. 
@@ -50,10 +50,10 @@ The s32 value will be trunuated and limited to the max and min values of signed 
 |===
 
 """;
-param r float elapsed "Current value of the internal debounce timer for debugging.";
-param r s32 selected "Current value of the internal selection variable after conversion for debugging";
-pin in float in##[16] "array of selectable outputs";
-variable double delaytime;
+param r real elapsed "Current value of the internal debounce timer for debugging.";
+param r si32 selected "Current value of the internal selection variable after conversion for debugging";
+pin in real in##[16] "array of selectable outputs";
+variable rtapi_real delaytime;
 variable int lastnum;
 variable int running;
 function _;
@@ -78,9 +78,9 @@ FUNCTION(_) {
         for(i = 1; i < 4; i++){
             internal[i] = internal[i] ^ internal[i - 1];
         }
-        selected = num = internal[3]+(internal[2]*2) + (internal[1]*4) + (internal[0]*8);
+        selected_set(num = internal[3]+(internal[2]*2) + (internal[1]*4) + (internal[0]*8));
     }else{
-        selected = num = (sel(0))+(sel(1)*2) + (sel(2)*4) + (sel(3)*8);
+        selected_set(num = (sel(0))+(sel(1)*2) + (sel(2)*4) + (sel(3)*8));
     }
     if(debounce_time) {
         if (num != lastnum) {
@@ -90,17 +90,17 @@ FUNCTION(_) {
             }
             if (delaytime < debounce_time) {
                 delaytime += fperiod;
-                elapsed = delaytime;
+                elapsed_set(delaytime);
                 return;
             }else{
             running = 0;
             lastnum = num;
-            out_s = out_f = in(num);
+            out_s_set(out_f_set(in(num)));
             return;
             }
         }
     }
     /* select the output */
-    out_s = out_f = in(num);
+    out_s_set(out_f_set(in(num)));
 
 }

--- a/src/hal/components/ohmic.comp
+++ b/src/hal/components/ohmic.comp
@@ -49,17 +49,17 @@ net ohmic-true   ohmicsense.ohmic-on    => plasmac.ohmic-probe
 
 author "Rod Webster";
 
-pin in  bit   is_probing                 "True if probing";
-pin in  float ohmic_low = 21             "The threshold volts below which ohmic sensing is set to be false";
-pin in  float ohmic_threshold = 22       "The threshold volts above which ohmic sensing is set to be true";
-pin in  float thcad_0_volt_freq          "0 volt calibration data for THCAD card in Hz";
-pin in  float thcad_divide = 32          "THCAD divider set by links on THCAD board (1, 32, 64, or 128)";
-pin in  float thcad_fullscale = 5        "THCAD full scale in Volt (5, 10, or 300 Volt)";
-pin in  float thcad_max_volt_freq        "Full scale calibration data for THCAD Card in Hz";
-pin in  float velocity_in                "The velocity returned from the THCAD and read by the Mesa encoder input";
-pin in  float volt_divider = 4.9         "The divide ratio";
-pin out bit   ohmic_on                   "True if ohmic circuit is closed (material is sensed)";
-pin out float ohmic_volts                "Calculated ohmic voltage";
+pin in  bool is_probing                 "True if probing";
+pin in  real ohmic_low = 21             "The threshold volts below which ohmic sensing is set to be false";
+pin in  real ohmic_threshold = 22       "The threshold volts above which ohmic sensing is set to be true";
+pin in  real thcad_0_volt_freq          "0 volt calibration data for THCAD card in Hz";
+pin in  real thcad_divide = 32          "THCAD divider set by links on THCAD board (1, 32, 64, or 128)";
+pin in  real thcad_fullscale = 5        "THCAD full scale in Volt (5, 10, or 300 Volt)";
+pin in  real thcad_max_volt_freq        "Full scale calibration data for THCAD Card in Hz";
+pin in  real velocity_in                "The velocity returned from the THCAD and read by the Mesa encoder input";
+pin in  real volt_divider = 4.9         "The divide ratio";
+pin out bool ohmic_on                   "True if ohmic circuit is closed (material is sensed)";
+pin out real ohmic_volts                "Calculated ohmic voltage";
 
 option period no;
 function _;
@@ -68,13 +68,13 @@ license "GPL";
 #include <rtapi_math.h>
 
 FUNCTION(_) {
-    double thcad_vel_scale = 1/((thcad_max_volt_freq - thcad_0_volt_freq)/thcad_fullscale/thcad_divide);
-    double thcad_scale_offset = thcad_0_volt_freq/thcad_divide;
+    rtapi_real thcad_vel_scale = 1/((thcad_max_volt_freq - thcad_0_volt_freq)/thcad_fullscale/thcad_divide);
+    rtapi_real thcad_scale_offset = thcad_0_volt_freq/thcad_divide;
 
-    ohmic_volts = (velocity_in - thcad_scale_offset) * thcad_vel_scale * volt_divider;
+    ohmic_volts_set((velocity_in - thcad_scale_offset) * thcad_vel_scale * volt_divider);
     if(is_probing)
-        ohmic_on = (ohmic_volts >= ohmic_threshold ? 1 : 0);
+        ohmic_on_set(ohmic_volts >= ohmic_threshold);
     else
         if(ohmic_volts <= ohmic_low)
-            ohmic_on = 0;
+            ohmic_on_set(0);
 }

--- a/src/hal/components/oneshot.comp
+++ b/src/hal/components/oneshot.comp
@@ -24,16 +24,16 @@ multiple of that thread period, typically 1ms.
 For a similar function that can run in the base thread, and which offers higher
 resolution, see "edge".""";
 
-pin in bit in "Trigger input";
-pin in bit reset "Reset";
-pin out bit out "Active high pulse";
-pin out bit out_not "Active low pulse";
-pin in float width=0 "Pulse width in seconds";
-pin out float time_left "Time left in current output pulse";
+pin in bool in "Trigger input";
+pin in bool reset "Reset";
+pin out bool out "Active high pulse";
+pin out bool out_not "Active low pulse";
+pin in real width=0 "Pulse width in seconds";
+pin out real time_left "Time left in current output pulse";
 
-param rw bit retriggerable=TRUE "Allow additional edges to extend pulse";
-param rw bit rising=TRUE "Trigger on rising edge";
-param rw bit falling=FALSE "Trigger on falling edge";
+param rw bool retriggerable=TRUE "Allow additional edges to extend pulse";
+param rw bool rising=TRUE "Trigger on rising edge";
+param rw bool falling=FALSE "Trigger on falling edge";
 
 option data internal;
 option extra_setup yes;
@@ -44,7 +44,7 @@ author "John Kasunich";
 ;;
 
 typedef struct {
-    double timer;
+    rtapi_real timer;
     char old_in;
 } internal;
 
@@ -62,8 +62,8 @@ FUNCTION(_){
     if (reset) {
         data.timer = 0.0;
         data.old_in = 0;
-        out = 0;
-        out_not = 1;
+        out_set(0);
+        out_not_set(1);
         return;
     }
     new = in;
@@ -88,13 +88,13 @@ FUNCTION(_){
 	data.timer = width;
     }
     /* drive outputs */
-    time_left = data.timer;
+    time_left_set(data.timer);
     if ( data.timer > 0.0 ) {
-	out = 1;
-	out_not = 0;
+	out_set(1);
+	out_not_set(0);
     } else {
-	out = 0;
-	out_not = 1;
+	out_set(0);
+	out_not_set(1);
     }
 }
 

--- a/src/hal/components/orient.comp
+++ b/src/hal/components/orient.comp
@@ -1,18 +1,17 @@
 component orient "Provide a PID command input for orientation mode based on current spindle position, target angle and orient mode";
 
-pin in  bit   enable      "enable angular output for orientation mode";
-pin in  s32   mode        "0: rotate - shortest move; 1: always rotate clockwise; 2: always rotate counterclockwise";
-pin in  float position    "spindle position input, unit 1 rev";
-pin in  float angle       "orient target position in degrees, 0 ≤ angle < 360";
-pin out float command     "target spindle position, input to PID command";
-pin out float poserr      "in degrees - aid for PID tuning";
-pin out bit is-oriented   "This pin goes high when poserr < tolerance. Use to drive spindle.N.is-oriented";
-pin in float tolerance = 0.5  "The tolerance in degrees for considering the align completed";
+pin in  bool enable      "enable angular output for orientation mode";
+pin in  si32 mode        "0: rotate - shortest move; 1: always rotate clockwise; 2: always rotate counterclockwise";
+pin in  real position    "spindle position input, unit 1 rev";
+pin in  real angle       "orient target position in degrees, 0 ≤ angle < 360";
+pin out real command     "target spindle position, input to PID command";
+pin out real poserr      "in degrees - aid for PID tuning";
+pin out bool is-oriented   "This pin goes high when poserr < tolerance. Use to drive spindle.N.is-oriented";
+pin in  real tolerance = 0.5  "The tolerance in degrees for considering the align completed";
 
 variable int   last_enable = 0;
 variable int    debounce = 0; // to prevent the in-position triggering with the spindle moving
 
-option fp yes;
 option period no;
 
 function _ "Update *command* based on *enable*, *position*, *mode* and *angle*.";
@@ -63,30 +62,30 @@ license "GPL";
 
 FUNCTION(_) {
 
-    double target_angle;
-    double latched_position;
-    is_oriented = 0; // spindle.is-oriented inhibits spindle.orient
+    rtapi_real target_angle;
+    rtapi_real latched_position;
+    is_oriented_set(0); // spindle.is-oriented inhibits spindle.orient
     if (enable) {
        if (enable ^ last_enable) {     // positive edge on enable
-           is_oriented = 0;
+           is_oriented_set(0);
             debounce = 0;
             latched_position = position; // sample now
             target_angle =  angle/360.0;
             switch (mode) {
             case 0: // shortest move
-                command = floor(latched_position+0.5-target_angle) + target_angle;
+                command_set(floor(latched_position+0.5-target_angle) + target_angle);
                 break;
             case 1: // always cw
-                command = ceil(latched_position-target_angle)  + target_angle;
+                command_set(ceil(latched_position-target_angle)  + target_angle);
                 break;
             case 2: // always ccw
-                command = floor(latched_position-target_angle) + target_angle ;
+                command_set(floor(latched_position-target_angle) + target_angle );
                 break;
             }
        }
-       poserr = (position - command) * 360.0;
+       poserr_set((position - command) * 360.0);
        debounce += (fabs(poserr) < tolerance && debounce <=100);
-       is_oriented = (debounce > 100);
+       is_oriented_set((debounce > 100));
     }
     last_enable = enable;
 }

--- a/src/hal/components/radiobutton.comp
+++ b/src/hal/components/radiobutton.comp
@@ -9,11 +9,11 @@ The \\fBselected\\fR pin will indicate which set of outputs is currently
 active.
 Note that channel-0 should be used to provide the default values.""";
 
-pin in bit sel-##[32:personality] "Inputs to select a channel";
-pin out bit out-##[32:personality] "output selected";
-pin out signed selected = 0 "indicates which output is currently active";
-pin in float input-##[32:personality] "Possible output values";
-pin out float value "currently-selected output value";
+pin in  bool sel-##[32:personality] "Inputs to select a channel";
+pin out bool out-##[32:personality] "output selected";
+pin out si32 selected = 0 "indicates which output is currently active";
+pin in  real input-##[32:personality] "Possible output values";
+pin out real value "currently-selected output value";
 
 function _;
 option period no;
@@ -23,18 +23,18 @@ author "Andy Pugh";
 ;;
 
 FUNCTION(_){
-	int i;
-	for(i = 0; i < personality; i++){
+	rtapi_s32 s = selected;
+	for(int i = 0; i < personality; i++){
 		if(sel(i) !=0){
-			selected = i;
+			s = selected_set(i);
 		}
 	}
-	for(i = 0; i < personality; i++){
-		if(i == selected){
-			out(i) = 1;
-			value = input(i);
+	for(int i = 0; i < personality; i++){
+		if(i == s){
+			out_set(i, 1);
+			value_set(input(i));
 		} else {
-			out(i) = 0;
+			out_set(i, 0);
 		}
 	}
 }

--- a/src/hal/components/reset.comp
+++ b/src/hal/components/reset.comp
@@ -37,18 +37,18 @@
  ******************************************************************************/
 
 component reset "Resets an IO signal";
-pin in  bit     trigger             "Trigger input";
-pin io  u32     out_u32      = 0    "Unsigned 32 bit integer output value";
-pin in  u32     reset_u32    = 0    "Unsigned 32 bit integer reset value";
-pin io  s32     out_s32      = 0    "Signed 32 bit integer output value";
-pin in  s32     reset_s32    = 0    "Signed 32 bit integer reset value";
-pin io  float   out_float    = 0.0  "Float output value";
-pin in  float   reset_float  = 0.0  "Float reset value";
-pin io  bit     out_bit      = false  "Bit integer output value";
-pin in  bit     reset_bit    = false  "Bit reset value";
-pin in  bit     retriggerable = true  "Allow additional edges to reset";
-pin in  bit     rising        = true  "Trigger on rising edge";
-pin in  bit     falling       = false "Trigger on falling edge";
+pin in  bool trigger             "Trigger input";
+pin io  ui32 out_u32      = 0    "Unsigned 32 bit integer output value";
+pin in  ui32 reset_u32    = 0    "Unsigned 32 bit integer reset value";
+pin io  si32 out_s32      = 0    "Signed 32 bit integer output value";
+pin in  si32 reset_s32    = 0    "Signed 32 bit integer reset value";
+pin io  real out_float    = 0.0  "Float output value";
+pin in  real reset_float  = 0.0  "Float reset value";
+pin io  bool out_bit      = false  "Bit integer output value";
+pin in  bool reset_bit    = false  "Bit reset value";
+pin in  bool retriggerable = true  "Allow additional edges to reset";
+pin in  bool rising        = true  "Trigger on rising edge";
+pin in  bool falling       = false "Trigger on falling edge";
 option period no;
 function _ "Update the output value";
 description """
@@ -61,16 +61,16 @@ passed via the input pins reset_float/s32/u32/bit.
 """;
 license "GPL";
 author "Alexander Rössler";
-variable hal_bit_t last_trigger = false;
+variable rtapi_bool last_trigger = false;
 ;;
 FUNCTION(_) {
-    if (((rising && (trigger)) || (falling && (!trigger)))
-       && (trigger != last_trigger))
+    rtapi_bool new_trigger = trigger;
+    if ((new_trigger != last_trigger) && ((rising && (new_trigger)) || (falling && (!new_trigger))))
     {
-        out_u32 = reset_u32;
-        out_s32 = reset_s32;
-        out_float = reset_float;
-        out_bit = reset_bit;
+        out_u32_set(reset_u32);
+        out_s32_set(reset_s32);
+        out_float_set(reset_float);
+        out_bit_set(reset_bit);
     }
-    last_trigger = trigger;
+    last_trigger = new_trigger;
 }

--- a/src/hal/components/safety_latch.comp
+++ b/src/hal/components/safety_latch.comp
@@ -52,20 +52,20 @@ return to false when reset is set to true.
 The inputs pin min and max clamp the error count value to a
 specified range.
 """;
-pin in bit error_in = false "Error Input";
-pin in s32 heal = 1 "Heal when ok per tick";
-pin in s32 harm = 1 "Harm when error per tick";
-pin in bit latching = true "If a reset is necessary to heal an error";
-pin in bit reset = false "Reset input";
-pin in s32 threshold = 100 "Error output threshold";
-pin in s32 min = 0 "Minimum count";
-pin in s32 max = 1000 "Maximum count";
-pin in bit enable = true "If not enabled the error count is passed to the output";
-pin out s32 count = 0 "Current count";
-pin out bit error_out = false "Error output";
-pin out bit ok_out = true "Ok output";
+pin in bool error_in = false "Error Input";
+pin in si32 heal = 1 "Heal when ok per tick";
+pin in si32 harm = 1 "Harm when error per tick";
+pin in bool latching = true "If a reset is necessary to heal an error";
+pin in bool reset = false "Reset input";
+pin in si32 threshold = 100 "Error output threshold";
+pin in si32 min_ = 0 "Minimum count";
+pin in si32 max_ = 1000 "Maximum count";
+pin in bool enable = true "If not enabled the error count is passed to the output";
+pin out si32 count = 0 "Current count";
+pin out bool error_out = false "Error output";
+pin out bool ok_out = true "Ok output";
 
-variable hal_bit_t last_reset = false;
+variable bool last_reset = false;
 
 option period no;
 function _;
@@ -79,38 +79,38 @@ FUNCTION(_)
 {
     if (!enable)
     {
-        error_out = error_in;
-        ok_out = !error_in;
-        count = 0;
+        error_out_set(error_in);
+        ok_out_set(!error_in);
+        count_set(0);
     }
     else
     {
         if ((reset ^ last_reset) && reset)
         {
-            count = 0;
-            error_out = false;
-            ok_out = true;
+            count_set(0);
+            error_out_set(false);
+            ok_out_set(true);
         }
 
         if (error_in)
         {
-            count += harm;
+            count_set(count + harm);
         }
         else
         {
-            count -= heal;
+            count_set(count - heal);
         }
-        count = MIN(MAX(count, min), max);
+        count_set(MIN(MAX(count, min_), max_));
 
         if (count >= threshold)
         {
-            error_out = true;
-            ok_out = false;
+            error_out_set(true);
+            ok_out_set(false);
         }
         else if (!latching)
         {
-            error_out = false;
-            ok_out = true;
+            error_out_set(false);
+            ok_out_set(true);
         }
     }
 

--- a/src/hal/components/sim_home_switch.comp
+++ b/src/hal/components/sim_home_switch.comp
@@ -8,16 +8,16 @@ A pin (index-enable) is provided for use when
 *[JOINT_n]HOME_USE_INDEX* is specified to reset
 the I/O pin *joint.N.index-enable*.
 """;
-pin in float cur_pos "Current position (typically: joint.n.motor-pos-fb)";
-pin in float home_pos = 1 "Home switch position";
-pin in float hysteresis = 0.1"Travel required to backoff (hysteresis)";
-pin out bit  home_sw"Home switch activated";
+pin in  real cur_pos "Current position (typically: joint.n.motor-pos-fb)";
+pin in  real home_pos = 1 "Home switch position";
+pin in  real hysteresis = 0.1"Travel required to backoff (hysteresis)";
+pin out bool home_sw"Home switch activated";
 
-pin io  bit  index_enable "typ: connect to joint.N.index-enable";
-pin in float index_delay_ms = 10 "delay in msec to reset index-enable";
+pin io  bool index_enable "typ: connect to joint.N.index-enable";
+pin in  real index_delay_ms = 10 "delay in msec to reset index-enable";
 
 variable int    old_index_enable;
-variable double index_timer_ms;
+variable rtapi_real index_timer_ms;
 
 function _;
 license "GPL";
@@ -29,30 +29,30 @@ FUNCTION(_) {
     if (home_pos >= 0) {
         // home switch is on positive side
         if (cur_pos >= home_pos) {
-            home_sw = 1;
+            home_sw_set(1);
         } else {
             if (cur_pos <= (home_pos - hysteresis) ) {
-                home_sw = 0;
+                home_sw_set(0);
             } else {
                 if (home_sw) {
-                    home_sw = 1;
+                    home_sw_set(1);
                 } else {
-                    home_sw = 0;
+                    home_sw_set(0);
                 }
             }
         }
     } else {
         // negative home switch location
         if (cur_pos <= home_pos) {
-            home_sw = 1;
+            home_sw_set(1);
         } else {
             if (cur_pos >= (home_pos + hysteresis) ) {
-                home_sw = 0;
+                home_sw_set(0);
             } else {
                 if (home_sw) {
-                    home_sw = 1;
+                    home_sw_set(1);
                 } else {
-                    home_sw = 0;
+                    home_sw_set(0);
                 }
             }
         }
@@ -63,7 +63,7 @@ FUNCTION(_) {
        index_timer_ms -= period * 1e-6; // period is in nS
        if (index_timer_ms <= 0) {
            index_timer_ms = 0;
-           index_enable = 0;
+           index_enable_set(0);
            return;
        }
     }

--- a/src/hal/components/sim_matrix_kb.comp
+++ b/src/hal/components/sim_matrix_kb.comp
@@ -1,15 +1,15 @@
 component sim_matrix_kb "convert HAL pin inputs to keycodes";
 
-pin out u32 out "pin that outputs the Keycode";
+pin out ui32 out "pin that outputs the Keycode";
 
-pin in bit button.c00.r##[8] "array of  inputs";
-pin in bit button.c01.r##[8] "array of  inputs";
-pin in bit button.c02.r##[8] "array of  inputs";
-pin in bit button.c03.r##[8] "array of  inputs";
-pin in bit button.c04.r##[8] "array of  inputs";
-pin in bit button.c05.r##[8] "array of  inputs";
-pin in bit button.c06.r##[8] "array of  inputs";
-pin in bit button.c07.r##[8] "array of  inputs";
+pin in bool button.c00.r##[8] "array of  inputs";
+pin in bool button.c01.r##[8] "array of  inputs";
+pin in bool button.c02.r##[8] "array of  inputs";
+pin in bool button.c03.r##[8] "array of  inputs";
+pin in bool button.c04.r##[8] "array of  inputs";
+pin in bool button.c05.r##[8] "array of  inputs";
+pin in bool button.c06.r##[8] "array of  inputs";
+pin in bool button.c07.r##[8] "array of  inputs";
 
 variable int keydown = 0xC0;
 variable int keyup = 0x80;
@@ -44,19 +44,19 @@ FUNCTION(_) {
                 rtapi_print("row: %d column: %d code: %d\n",r,c,num);
                 last[num] = cur_button;
                 if (cur_button == 1){
-                    out = num | keydown;
+                    out_set(num | keydown);
                     return;
                 }else{
-                    out = num | keyup;
+                    out_set(num | keyup);
                     return;
                 }
             }
         }
     }
     if (allup_flag){
-        out = 0;
+        out_set(0);
     }else{
-        out = nokeychange;
+        out_set(nokeychange);
     }
 
 }

--- a/src/hal/components/sim_spindle.comp
+++ b/src/hal/components/sim_spindle.comp
@@ -1,9 +1,9 @@
 component sim_spindle "Simulated spindle with index pulse";
 
-pin in float velocity-cmd "Commanded speed";
-pin out float position-fb "Feedback position, in revolutions";
-pin io bit index-enable "Reset *position-fb* to 0 at the next full rotation";
-param rw float scale = 1.0 
+pin in real velocity-cmd "Commanded speed";
+pin out real position-fb "Feedback position, in revolutions";
+pin io bool index-enable "Reset *position-fb* to 0 at the next full rotation";
+param rw real scale = 1.0
 """factor applied to *velocity-cmd*.
 
 The result of '*velocity-cmd* * *scale*' be in revolutions per second.
@@ -20,16 +20,16 @@ function _;
 
 
 FUNCTION(_) {
-   double old_position = position_fb;
-   double new_position = position_fb + velocity_cmd * fperiod * scale;
+   rtapi_real old_position = position_fb;
+   rtapi_real new_position = position_fb + velocity_cmd * fperiod * scale;
 
    if(index_enable && (floor(old_position) != floor(new_position))) {
-       index_enable = false;
+       index_enable_set(false);
        if(velocity_cmd < 0)
            new_position = new_position - ceil(new_position);
        else
            new_position = new_position - floor(new_position);
    }
-   position_fb = new_position;
+   position_fb_set(new_position);
 }
 

--- a/src/hal/components/simple_tp.comp
+++ b/src/hal/components/simple_tp.comp
@@ -21,23 +21,23 @@ component simple_tp """\
 This component is a single axis simple trajectory planner, same as used for jogging in LinuxCNC.
 Used by PNCconf to allow testing of acceleration and velocity values for an axis.""";
 
-pin in float target-pos "target position to plan for.";
-pin in float maxvel "Maximum velocity";
-pin in float maxaccel "Acceleration rate";
-pin in bit enable "If disabled, planner sets velocity to zero immediately.";
+pin in real target-pos "target position to plan for.";
+pin in real maxvel "Maximum velocity";
+pin in real maxaccel "Acceleration rate";
+pin in bool enable "If disabled, planner sets velocity to zero immediately.";
 
-pin out float current-pos "position commanded at this point in time.";
-pin out float current-vel "velocity commanded at this moment in time.";
-pin out bit active "if active is true, the planner is requesting movement.";
+pin out real current-pos "position commanded at this point in time.";
+pin out real current-vel "velocity commanded at this moment in time.";
+pin out bool active "if active is true, the planner is requesting movement.";
 function update;
 license "GPL";
 author "Chris S Morley";
 ;;
 #include <rtapi_math.h>
 FUNCTION(update) {
-    double max_dv, tiny_dp, pos_err, vel_req;
+    rtapi_real max_dv, tiny_dp, pos_err, vel_req;
 
-    active = 0;
+    active_set(0);
     /* compute max change in velocity per servo period */
     max_dv = maxaccel * fperiod;
     /* compute a tiny position range, to be treated as zero */
@@ -54,12 +54,12 @@ FUNCTION(update) {
 	    vel_req = -max_dv +
 		       sqrt(2.0 * maxaccel * pos_err + max_dv * max_dv);
 	    /* mark planner as active */
-	    active = 1;
+	    active_set(1);
 	} else if (pos_err < -tiny_dp) {
 	    vel_req =  max_dv -
 		       sqrt(-2.0 * maxaccel * pos_err + max_dv * max_dv);
 	    /* mark planner as active */
-	    active = 1;
+	    active_set(1);
 	} else {
 	    /* within 'tiny_dp' of desired pos, no need to move */
 	    vel_req = 0.0;
@@ -76,18 +76,18 @@ FUNCTION(update) {
     }
     /* ramp velocity toward request at accel limit */
     if (vel_req > current_vel + max_dv) {
-	current_vel += max_dv;
+	current_vel_set(current_vel + max_dv);
     } else if (vel_req < current_vel - max_dv) {
-	current_vel -= max_dv;
+	current_vel_set(current_vel - max_dv);
     } else {
-	current_vel = vel_req;
+	current_vel_set(vel_req);
     }
     /* check for still moving */
     if (current_vel != 0.0) {
 	/* yes, mark planner active */
-	active = 1;
+	active_set(1);
     }
     /* integrate velocity to get new position */
-    current_pos += current_vel * fperiod;
+    current_pos_set(current_pos + current_vel * fperiod);
 }
 

--- a/src/hal/components/sphereprobe.comp
+++ b/src/hal/components/sphereprobe.comp
@@ -2,16 +2,16 @@ component sphereprobe "Probe a pretend hemisphere";
 author "Jeff Epler";
 license "GPL";
 
-pin in signed px;
-pin in signed py;
-pin in signed pz "*rawcounts* position from software encoder";
+pin in si32 px;
+pin in si32 py;
+pin in si32 pz "*rawcounts* position from software encoder";
 
-pin in signed cx;
-pin in signed cy;
-pin in signed cz "Center of sphere in counts";
-pin in signed r "Radius of hemisphere in counts";
+pin in si32 cx;
+pin in si32 cy;
+pin in si32 cz "Center of sphere in counts";
+pin in si32 r "Radius of hemisphere in counts";
 
-pin out bit probe-out;
+pin out bool probe-out;
 
 option period no;
 function _ "update probe-out based on inputs";
@@ -24,9 +24,9 @@ FUNCTION(_) {
     rtapi_u64 d2 = dx*dx + dy*dy;
     rtapi_u64 r2 = (rtapi_s64)r*(rtapi_s64)r;
     if(d2 > r2) {
-        probe_out = pz < cz;
+        probe_out_set(pz < cz);
     } else {
         d2 += dz*dz;
-        probe_out = d2 <= r2;
+        probe_out_set(d2 <= r2);
     }
 }

--- a/src/hal/components/spindle_monitor.comp
+++ b/src/hal/components/spindle_monitor.comp
@@ -1,13 +1,13 @@
 component spindle_monitor "spindle at-speed and underspeed detection";
-pin in bit spindle-is-on;
-pin in float spindle-command;
-pin in float spindle-feedback;
+pin in bool spindle-is-on;
+pin in real spindle-command;
+pin in real spindle-feedback;
 
-pin out bit spindle-at-speed;
-pin out bit spindle-underspeed;
+pin out bool spindle-at-speed;
+pin out bool spindle-underspeed;
 
-param rw unsigned level "state machine state";
-param rw float threshold;
+param rw ui32 level "state machine state";
+param rw real threshold;
 
 option period no;
 function _;
@@ -22,28 +22,28 @@ FUNCTION(_) {
 
 switch (level){
     case 0:  // idle
-        spindle_at_speed = 0;
-        spindle_underspeed = 0;
-        if (spindle_is_on) level = 1;
+        spindle_at_speed_set(0);
+        spindle_underspeed_set(0);
+        if (spindle_is_on) level_set(1);
         break;
     case 1: // waiting for spindle-at-speed
         if ( ! spindle_is_on ) {
-            level = 0;
+            level_set(0);
             return; }
         if (fabs(spindle_command - spindle_feedback) < threshold) {
-            level = 2;
-            spindle_at_speed = 1;
+            level_set(2);
+            spindle_at_speed_set(1);
             return; }
         break;
     case 2: // monitoring speed
         if ( ! spindle_is_on ) {
-            level = 0;
+            level_set(0);
             return; }
         if  ((spindle_command - spindle_feedback) > threshold) {
-            spindle_underspeed = 1; }
+            spindle_underspeed_set(1); }
         break;
     default:
         // not sure how we got here, but fix the situation
-        level = 0;
+        level_set(0);
     }
 }

--- a/src/hal/components/steptest.comp
+++ b/src/hal/components/steptest.comp
@@ -1,46 +1,46 @@
 component steptest """\
 Used by Stepconf to allow testing of acceleration and velocity values for an axis.""";
-pin in bit jog-minus "Drive TRUE to jog the axis in its minus direction";
-pin in bit jog-plus "Drive TRUE to jog the axis in its positive direction";
-pin in bit run "Drive TRUE to run the axis near its current position_fb with a trapezoidal velocity profile";
-pin in float maxvel "Maximum velocity";
-pin in float maxaccel "Permitted Acceleration";
-pin in float amplitude "Approximate amplitude of positions to command during 'run'";
-pin in s32 dir "Direction from central point to test: 0 = both, 1 = positive, 2 = negative";
-pin out float position-cmd;
-pin in float position-fb;
-pin out bit running;
-pin out float run-target;
-pin out float run-start;
-pin out float run-low;
-pin out float run-high;
-pin in s32 pause = 0 "pause time for each end of run in seconds";
-param rw float epsilon = .001;
-variable double timer;
-param r float elapsed "Current value of the internal timer";
+pin in bool jog-minus "Drive TRUE to jog the axis in its minus direction";
+pin in bool jog-plus "Drive TRUE to jog the axis in its positive direction";
+pin in bool run "Drive TRUE to run the axis near its current position_fb with a trapezoidal velocity profile";
+pin in real maxvel "Maximum velocity";
+pin in real maxaccel "Permitted Acceleration";
+pin in real amplitude "Approximate amplitude of positions to command during 'run'";
+pin in si32 dir "Direction from central point to test: 0 = both, 1 = positive, 2 = negative";
+pin out real position-cmd;
+pin in real position-fb;
+pin out bool running;
+pin out real run-target;
+pin out real run-start;
+pin out real run-low;
+pin out real run-high;
+pin in si32 pause = 0 "pause time for each end of run in seconds";
+param rw real epsilon = .001;
+variable rtapi_real timer;
+param r real elapsed "Current value of the internal timer";
 variable int timer_on;
 function _;
 license "GPL";
 author "Jeff Epler";
+include <rtapi_math.h>;
 ;;
-extern double fabs(double);
 
 if (timer_on) {
     timer += fperiod;
 }
-elapsed = timer;
+elapsed_set(timer);
 if(run) {
     if(!running) {
-        running = 1;
-        run_start = position_fb;
+        running_set(1);
+        run_start_set(position_fb);
 
-        if(dir == 2) run_high = run_start;
-        else run_high = run_start + amplitude;
+        if(dir == 2) run_high_set(run_start);
+        else run_high_set(run_start + amplitude);
 
-        if(dir == 1) run_low = run_start;
-        else run_low = run_start - amplitude;
+        if(dir == 1) run_low_set(run_start);
+        else run_low_set(run_start - amplitude);
 
-        position_cmd = run_low;
+        position_cmd_set(run_low);
     }
 
     if(fabs(position_fb - position_cmd) < epsilon) {
@@ -51,29 +51,29 @@ if(run) {
             } else if (timer >= pause) {
                 timer_on = false; 
                 if(position_cmd == run_low) {
-                    position_cmd = run_high;
+                    position_cmd_set(run_high);
                 } else {
-                    position_cmd = run_low;
+                    position_cmd_set(run_low);
                 }
             }
         }
     }
 } else if(running) {
-    position_cmd = run_start;
+    position_cmd_set(run_start);
     if(fabs(position_fb - run_start) < epsilon) {
-        running = 0;
+        running_set(0);
         timer_on = false;
     }
 } else {
     if(jog_minus) {
-        position_cmd = position_fb - 2 * maxvel * fperiod;
+        position_cmd_set(position_fb - 2 * maxvel * fperiod);
     } else if(jog_plus) {
-        position_cmd = position_fb + 2 * maxvel * fperiod;
+        position_cmd_set(position_fb + 2 * maxvel * fperiod);
     } else {
         // Let the command track the feedback while the stepgen decelerates
         // to a halt, then keep the command constant there.
         if (fabs(position_fb - position_cmd) > (0.001 * maxvel * fperiod)) {
-            position_cmd = position_fb;
+            position_cmd_set(position_fb);
         }
     }
 }

--- a/src/hal/components/thc.comp
+++ b/src/hal/components/thc.comp
@@ -59,33 +59,33 @@ license "GPLv2 or greater";
 option singleton yes;
 
 // Input Pins
-pin in float encoder_vel "Connect to hm2_5i20.0.encoder.00.velocity";
-pin in float current_vel "Connect to motion.current-vel";
-pin in float requested_vel "Connect to motion.requested-vel";
-pin in float volts_requested "Tip Volts current_vel >= min_velocity requested";
-pin in float vel_tol "Velocity Tolerance (Corner Lock)";
-pin in bit torch_on "Connect to spindle.N.on";
-pin in bit arc_ok "Arc OK from Plasma Torch";
-pin in bit enable "Enable the THC, if not enabled Z position is passed through";
-pin in float z_pos_in "Z Motor Position Command in from axis.n.motor-pos-cmd";
+pin in real encoder_vel "Connect to hm2_5i20.0.encoder.00.velocity";
+pin in real current_vel "Connect to motion.current-vel";
+pin in real requested_vel "Connect to motion.requested-vel";
+pin in real volts_requested "Tip Volts current_vel >= min_velocity requested";
+pin in real vel_tol "Velocity Tolerance (Corner Lock)";
+pin in bool torch_on "Connect to spindle.N.on";
+pin in bool arc_ok "Arc OK from Plasma Torch";
+pin in bool enable "Enable the THC, if not enabled Z position is passed through";
+pin in real z_pos_in "Z Motor Position Command in from axis.n.motor-pos-cmd";
 
 // Output Pins
-pin out float z_pos_out "Z Motor Position Command Out";
-pin out float z_fb_out "Z Position Feedback to Axis";
-pin out float volts "The Calculated Volts";
-pin out bit vel_status "When the THC thinks we are at requested speed";
-pin out float offset_value "The Current Offset";
+pin out real z_pos_out "Z Motor Position Command Out";
+pin out real z_fb_out "Z Position Feedback to Axis";
+pin out real volts "The Calculated Volts";
+pin out bool vel_status "When the THC thinks we are at requested speed";
+pin out real offset_value "The Current Offset";
 
 // Parameters
-param rw float vel_scale "The scale to convert the Velocity signal to Volts";
-param rw float scale_offset "The offset of the velocity input at 0 volts";
-param rw float velocity_tol "The deviation percent from planned velocity";
-param rw float voltage_tol "The deviation of Tip Voltage before correction takes place";
-param rw float correction_vel "The amount of change in user units per period to move Z to correct";
+param rw real vel_scale "The scale to convert the Velocity signal to Volts";
+param rw real scale_offset "The offset of the velocity input at 0 volts";
+param rw real velocity_tol "The deviation percent from planned velocity";
+param rw real voltage_tol "The deviation of Tip Voltage before correction takes place";
+param rw real correction_vel "The amount of change in user units per period to move Z to correct";
 
 // Global Variables
-variable float offset;
-variable float last_z_in;
+variable rtapi_real offset;
+variable rtapi_real last_z_in;
 
 option period no;
 function _;
@@ -96,14 +96,14 @@ function _;
 
 FUNCTION(_) {
     // convert encoder velocity to volts
-    volts = (encoder_vel - scale_offset) * vel_scale;
-    if(volts < 0){volts = 0;} // make sure volts is not negative
-    offset_value = offset;
+    volts_set((encoder_vel - scale_offset) * vel_scale);
+    if(volts < 0){volts_set(0);} // make sure volts is not negative
+    offset_value_set(offset);
 
     if(enable){
-        float min_velocity = requested_vel -(requested_vel*(velocity_tol*0.01));
-        if(current_vel > 0 && current_vel >= min_velocity){vel_status = 1;}
-        else {vel_status =0;}
+        rtapi_real min_velocity = requested_vel -(requested_vel*(velocity_tol*0.01));
+        if(current_vel > 0 && current_vel >= min_velocity){vel_status_set(1);}
+        else {vel_status_set(0);}
         
         if(torch_on && arc_ok && vel_status){ // allow correction
             if((volts + voltage_tol) > volts_requested){
@@ -115,7 +115,7 @@ FUNCTION(_) {
             last_z_in = 0;
         }
         if(!torch_on){ // remove any offset
-            float z_diff;
+            rtapi_real z_diff;
             z_diff = z_pos_in - last_z_in;
             if(z_diff > 0 && offset != 0){ // torch is moving up
                 if(offset > 0){ // positive offset
@@ -133,12 +133,12 @@ FUNCTION(_) {
             }
             last_z_in = z_pos_in;
         }
-        z_pos_out = z_pos_in + offset;
-        z_fb_out = z_pos_in; // keep axis motor position fb from being confused
+        z_pos_out_set(z_pos_in + offset);
+        z_fb_out_set(z_pos_in); // keep axis motor position fb from being confused
     }
     if(!enable){
-        z_pos_out = z_pos_in;
-        z_fb_out = z_pos_in; // keep axis motor position fb from being confused
+        z_pos_out_set(z_pos_in);
+        z_fb_out_set(z_pos_in); // keep axis motor position fb from being confused
     }
 }
 

--- a/src/hal/components/thcud.comp
+++ b/src/hal/components/thcud.comp
@@ -69,28 +69,28 @@ license "GPLv2 or greater";
 option singleton yes;
 
 // Input Pins
-pin in bit torch_up "Connect to an input pin";
-pin in bit torch_down "Connect to input pin";
-pin in float current_vel "Connect to motion.current-vel";
-pin in float requested_vel "Connect to motion.requested-vel";
-pin in bit torch_on "Connect to spindle.N.on";
-pin in bit arc_ok "Arc Ok from Plasma Torch";
-pin in bit enable "Enable the THC, if not enabled Z position is passed through";
-pin in float z_pos_in "Z Motor Position Command in from axis.n.motor-pos-cmd";
+pin in bool torch_up "Connect to an input pin";
+pin in bool torch_down "Connect to input pin";
+pin in real current_vel "Connect to motion.current-vel";
+pin in real requested_vel "Connect to motion.requested-vel";
+pin in bool torch_on "Connect to spindle.N.on";
+pin in bool arc_ok "Arc Ok from Plasma Torch";
+pin in bool enable "Enable the THC, if not enabled Z position is passed through";
+pin in real z_pos_in "Z Motor Position Command in from axis.n.motor-pos-cmd";
 
 // Output Pins
-pin out float z_pos_out "Z Motor Position Command Out";
-pin out float z_fb_out "Z Position Feedback to Axis";
-pin out float cur_offset "The Current Offset";
-pin out bit vel_status "When the THC thinks we are at requested speed";
-pin out bit removing_offset "Pin for testing";
-pin in float correction_vel "The Velocity to move Z to correct";
+pin out real z_pos_out "Z Motor Position Command Out";
+pin out real z_fb_out "Z Position Feedback to Axis";
+pin out real cur_offset "The Current Offset";
+pin out bool vel_status "When the THC thinks we are at requested speed";
+pin out bool removing_offset "Pin for testing";
+pin in  real correction_vel "The Velocity to move Z to correct";
 
 // Parameters
-param rw float velocity_tol "The deviation percent from planned velocity";
+param rw real velocity_tol "The deviation percent from planned velocity";
 
 // Global Variables
-variable float last_z_in;
+variable rtapi_real last_z_in;
 
 option period no;
 function _;
@@ -101,46 +101,46 @@ function _;
 
 FUNCTION(_) {
     if(enable){
-        float min_velocity = requested_vel -(requested_vel*(velocity_tol*0.01));
-        if(current_vel > 0 && current_vel >= min_velocity){vel_status = 1;}
-        else {vel_status =0;}
+        rtapi_real min_velocity = requested_vel -(requested_vel*(velocity_tol*0.01));
+        if(current_vel > 0 && current_vel >= min_velocity){vel_status_set(1);}
+        else {vel_status_set(0);}
         
         if(torch_on && arc_ok && vel_status){ // allow correction
             if(torch_down){
-                cur_offset -= correction_vel;
+                cur_offset_set(cur_offset - correction_vel);
             }
             if(torch_up){
-                cur_offset += correction_vel;
+                cur_offset_set(cur_offset + correction_vel);
             }    
             last_z_in = 0;
         }
         if(!torch_on){ // remove any offset
-            float z_diff;
+            rtapi_real z_diff;
             z_diff = z_pos_in - last_z_in;
             if(z_diff > 0 && cur_offset != 0){ // torch is moving up
-                removing_offset = 1;
+                removing_offset_set(1);
                 if(cur_offset > 0){ // positive offset
                     if(cur_offset > z_diff){ // remove some
-                        cur_offset -= z_diff;
+                        cur_offset_set(cur_offset - z_diff);
                     }
-                    else {cur_offset = 0;}
+                    else {cur_offset_set(0);}
                 }
                 if(cur_offset < 0){ // negative offset
                     if(cur_offset < z_diff){ // remove some
-                        cur_offset += z_diff;
+                        cur_offset_set(cur_offset + z_diff);
                     }
-                    else {cur_offset = 0;}
+                    else {cur_offset_set(0);}
                 }
             }
-            else {removing_offset = 0;}
+            else {removing_offset_set(0);}
             last_z_in = z_pos_in;
         }
-        z_pos_out = z_pos_in + cur_offset;
-        z_fb_out = z_pos_in; // keep axis motor position fb from being confused
+        z_pos_out_set(z_pos_in + cur_offset);
+        z_fb_out_set(z_pos_in); // keep axis motor position fb from being confused
     }
     if(!enable){
-        z_pos_out = z_pos_in + cur_offset;
-        z_fb_out = z_pos_in; // keep axis motor position fb from being confused
+        z_pos_out_set(z_pos_in + cur_offset);
+        z_fb_out_set(z_pos_in); // keep axis motor position fb from being confused
     }
 }
 

--- a/src/hal/components/time.comp
+++ b/src/hal/components/time.comp
@@ -100,16 +100,16 @@ author "John Thornton, itaib, Moses McKnight";
 license "GPL";
 
 // Input Pins
-pin in bit start "Timer On";
-pin in bit pause = 0 "Pause";
+pin in bool start "Timer On";
+pin in bool pause = 0 "Pause";
 
 // Output Pins
-pin out u32 seconds "Seconds";
-pin out u32 minutes "Minutes";
-pin out u32 hours "Hours";
+pin out ui32 seconds "Seconds";
+pin out ui32 minutes "Minutes";
+pin out ui32 hours "Hours";
 
 // Global Variables
-variable double totalnsec;
+variable rtapi_real totalnsec;
 variable int old_start;
 
 function _;
@@ -120,16 +120,16 @@ function _;
 
 FUNCTION(_) {
     rtapi_u32 totalseconds;
-    int running = start | pause;
+    int running = start || pause;
     if(running && !old_start) totalnsec = 0;
 
     if(start && !pause){
-    totalnsec = totalnsec + period;
-    totalseconds = totalnsec * 0.000000001;
-    seconds = totalseconds % 60;
-	minutes = (totalseconds / 60) % 60;
-	hours = (totalseconds / 3600);
-	}
-	old_start = running;
+        totalnsec = totalnsec + period;
+        totalseconds = totalnsec * 0.000000001;
+        seconds_set(totalseconds % 60);
+        minutes_set((totalseconds / 60) % 60);
+        hours_set((totalseconds / 3600));
+    }
+    old_start = running;
 }
 

--- a/src/hal/components/timedelay.comp
+++ b/src/hal/components/timedelay.comp
@@ -1,34 +1,34 @@
 component timedelay "The equivalent of a time-delay relay";
 
-pin in bit in;
-pin out bit out """Follows the value of *in* after applying the delays
+pin in bool in;
+pin out bool out """Follows the value of *in* after applying the delays
 *on-delay* and *off-delay*.""";
 
-pin in float on-delay = 0.5 """The time, in seconds, for which *in* must be
+pin in real on-delay = 0.5 """The time, in seconds, for which *in* must be
 *true* before *out* becomes *true*""";
-pin in float off-delay = 0.5 """The time, in seconds, for which *in* must be
+pin in real off-delay = 0.5 """The time, in seconds, for which *in* must be
 *false* before *out* becomes *false*""";
 
-pin out float elapsed "Current value of the internal timer";
-variable double timer;
+pin out real elapsed "Current value of the internal timer";
+variable rtapi_real timer;
 
 function _;
 
 license "GPL";
 author "Jeff Epler, based on works by Stephen Wille Padnos and John Kasunich";
 ;;
-hal_bit_t in_ = in;
+rtapi_bool in_ = in;
 if(in_ != out) {
     timer += fperiod;
-    elapsed = timer;
+    elapsed_set(timer);
     if(in_) {
         if(timer >= on_delay) {
-            out = 1;
+            out_set(1);
             timer = 0.0;
         }
     } else {
         if(timer >= off_delay) {
-            out = 0;
+            out_set(0);
             timer = 0.0;
         }
     }

--- a/src/hal/components/timedelta.comp
+++ b/src/hal/components/timedelta.comp
@@ -1,22 +1,22 @@
 component timedelta "LinuxCNC HAL component that measures thread scheduling timing behavior";
 
-pin out s32 jitter=0 "Worst-case scheduling error (in ns).  This is the largest discrepancy between ideal thread period, and actual time between sequential runs of this component.  This uses the absolute value of the error, so 'got run too early' and 'got run too late' both show up as positive jitter.";
+pin out si32 jitter=0 "Worst-case scheduling error (in ns).  This is the largest discrepancy between ideal thread period, and actual time between sequential runs of this component.  This uses the absolute value of the error, so 'got run too early' and 'got run too late' both show up as positive jitter.";
 
-pin out s32 current_jitter=0 "Scheduling error (in ns) of the current invocation.  This is the discrepancy between ideal thread period, and actual time since the previous run of this component.  This uses the absolute value of the error, so 'got run too early' and 'got run too late' both show up as positive jitter.";
+pin out si32 current_jitter=0 "Scheduling error (in ns) of the current invocation.  This is the discrepancy between ideal thread period, and actual time since the previous run of this component.  This uses the absolute value of the error, so 'got run too early' and 'got run too late' both show up as positive jitter.";
 
-pin out s32 current_error=0 "Scheduling error (in ns) of the current invocation.  This is the discrepancy between ideal thread period, and actual time since the previous run of this component.  This does not use the absolute value of the error, so 'got run too early' shows up as negative error and 'got run too late' shows up as positive error.";
+pin out si32 current_error=0 "Scheduling error (in ns) of the current invocation.  This is the discrepancy between ideal thread period, and actual time since the previous run of this component.  This does not use the absolute value of the error, so 'got run too early' shows up as negative error and 'got run too late' shows up as positive error.";
 
-pin out s32 min_=0 "Minimum time (in ns) between sequential runs of this component.";
+pin out si32 min_=0 "Minimum time (in ns) between sequential runs of this component.";
 
-pin out s32 max_=0 "Maximum time (in ns) between sequential runs of this component.";
+pin out si32 max_=0 "Maximum time (in ns) between sequential runs of this component.";
 
-pin in bit reset "Set this pin to True, then back to False, to reset some of the statistics.";
+pin in bool reset "Set this pin to True, then back to False, to reset some of the statistics.";
 
-pin out s32 out "Time (in ns) since the previous run of this component.  This should ideally be equal to the thread period.";
+pin out si32 out "Time (in ns) since the previous run of this component.  This should ideally be equal to the thread period.";
 
-pin out s32 err=0 "Cumulative time error (in ns).  Probably not useful.";
+pin out si32 err=0 "Cumulative time error (in ns).  Probably not useful.";
 
-pin out float avg_err=0 "The average scheduling error (in ns).";
+pin out real avg_err=0 "The average scheduling error (in ns).";
 
 
 function _;
@@ -32,23 +32,31 @@ rtapi_s64 now = rtapi_get_time();
 
 if(last != 0) {
         rtapi_s64 del = (now - last);
-        out = del;
+        out_set(del);
 
-	err = err + del - period;
+	err_set(err + del - period);
 	if(first) {
 		first = 0;
-		min_ = max_ = del;
-		jitter = 0;
+		min__set(del);
+		max__set(del);
+		jitter_set(0);
 	} else {
-		if(del < min_) min_ = del;
-		if(del > max_) max_ = del;
-		jitter = max(max_ - period, period - min_);
-		current_jitter = max(del - period, period - del);
-		current_error = del - period;
+		if(del < min_) min__set(del);
+		if(del > max_) max__set(del);
+		jitter_set(max(max_ - period, period - min_));
+		current_jitter_set(max(del - period, period - del));
+		current_error_set(del - period);
 	}
 	count++;
-	avg_err = err / (double)count;
+	avg_err_set(err / (double)count);
 }
 
-if(reset) { first = 1; last = 0; out = 0; jitter = 0; max_ = 0; }
-else last = now;
+if(reset) {
+	first = 1;
+	last = 0;
+	out_set(0);
+	jitter_set(0);
+	max__set(0);
+} else {
+	last = now;
+}

--- a/src/hal/components/tof.comp
+++ b/src/hal/components/tof.comp
@@ -18,11 +18,11 @@
 *
 ********************************************************************/
 component tof "IEC TOF timer - delay falling edge on a signal";
-pin in bit in "Input signal";
-pin out bit q "Output signal";
-pin out float et "Elapsed time since falling edge in seconds";
+pin in bool in "Input signal";
+pin out bool q "Output signal";
+pin out real et "Elapsed time since falling edge in seconds";
 
-param rw float pt "Delay time in seconds";
+param rw real pt "Delay time in seconds";
 
 function _ "Update the timer";
 license "GPL";
@@ -30,12 +30,12 @@ author "Chad Woitas";
 ;;
 FUNCTION(_) {
         if(pt < 0) {
-            pt = 0;
+            pt_set(0);
             rtapi_print_msg(RTAPI_MSG_WARN,
                             "tof: Delay time must be positive, resetting to 0");
         }
         if(et < 0) {
-            et = 0;
+            et_set(0);
             rtapi_print_msg(RTAPI_MSG_WARN,
                             "tof: Elapsed time rolled over, resetting to 0");
         }
@@ -43,16 +43,16 @@ FUNCTION(_) {
         // Check timers
         if(in){
             // Reset Variables
-            q = 1;
-            et = 0;
+            q_set(1);
+            et_set(0);
         }
         else{
             // Update outputs
             if(et >= pt){
-                q = 0;
+                q_set(0);
             }
             else{
-                et += fperiod;
+                et_set(et + fperiod);
             }
         }
 }

--- a/src/hal/components/toggle.comp
+++ b/src/hal/components/toggle.comp
@@ -12,9 +12,9 @@ out: └─────┘           └─────
 
 """;
 
-pin in bit in "button input";
-pin io bit out "on/off output";
-param rw u32 debounce = 2 "debounce delay in periods";
+pin in bool in "button input";
+pin io bool out "on/off output";
+param rw ui32 debounce = 2 "debounce delay in periods";
 option data toggle_data;
 option period no;
 
@@ -29,19 +29,19 @@ typedef struct {
 } toggle_data;
 
 FUNCTION(_) {
-
-    if (( debounce < 1 ) || ( debounce > 10000 )) {
+    rtapi_u32 deb = debounce;
+    if (( deb < 1 ) || ( deb > 10000 )) {
 	/* set a sane value, we don't want 2 million second delays */
-	debounce = 2;
+	debounce_set(deb = 2);
     }
     if ( in ) {
 	/* pressed */
 	data.debounce_cntr++;
-	if ( data.debounce_cntr >= (int)debounce ) {
-	    data.debounce_cntr = debounce;
+	if ( data.debounce_cntr >= (int)deb ) {
+	    data.debounce_cntr = deb;
 	    if ( data.debounced == 0 ) {
 		/* toggle output */
-		out = !out;
+		out_set(!out);
 	    }
 	    data.debounced = 1;
 	}

--- a/src/hal/components/toggle2nist.comp
+++ b/src/hal/components/toggle2nist.comp
@@ -26,13 +26,13 @@ is-on: └─────────────────┘       �
 
 """;
 
-pin in bit in  "momentary button in";
-pin in bit is_on "current state of device";
-pin in unsigned debounce = 2 "debounce delay for 'in'-pin in cycles";
-pin out bit on "turn device on";
-pin out bit off "turn device off";
+pin in bool in  "momentary button in";
+pin in bool is_on "current state of device";
+pin in ui32 debounce = 2 "debounce delay for 'in'-pin in cycles";
+pin out bool on "turn device on";
+pin out bool off "turn device off";
 variable int debounce_cntr;
-variable unsigned debounce_set;
+variable unsigned debounce_val;
 variable int state;
 
 option period no;
@@ -43,33 +43,33 @@ author "Anders Wallin, David Mueller";
 FUNCTION(_)  {
 
     if (( debounce < 1 ) || ( debounce > 10000 )) {
-        debounce_set = 2; /* set a sane value */
+        debounce_val = 2; /* set a sane value */
     } else {
-        debounce_set = debounce;
+        debounce_val = debounce;
     }
 
     if (in && state == 0 )  { /* input has changed from debounced 0 -> 1 */
         debounce_cntr++;
-        if ( debounce_cntr >= (int)debounce_set ) {
+        if ( debounce_cntr >= (int)debounce_val ) {
             if (!is_on) { /* turn ON if it's off */
-                on=1;
-                off=0;
+                on_set(1);
+                off_set(0);
             } else { /* turn OFF if it's on */
-                on=0;
-                off=1;
+                on_set(0);
+                off_set(1);
             }
             state = 1;
             debounce_cntr = 0;
         }
     } else if (!in && state == 1) { /* input has changed from debounced 1 -> 0 */
         debounce_cntr++;
-        if ( debounce_cntr >= (int)debounce_set ) {
+        if ( debounce_cntr >= (int)debounce_val ) {
             state = 0;
             debounce_cntr = 0;
         }
     } else if ((!is_on && off) || (is_on && on)) { /* reset outputs once device has switched*/
-        on = 0;
-        off = 0;
+        on_set(0);
+        off_set(0);
         debounce_cntr = 0;
     } else {
     	debounce_cntr = 0;

--- a/src/hal/components/ton.comp
+++ b/src/hal/components/ton.comp
@@ -18,11 +18,11 @@
 *
 ********************************************************************/
 component ton "IEC TON timer - delay rising edge on a signal";
-pin in bit in "Input signal";
-pin out bit q "Output signal";
-pin out float et "Elapsed time since rising edge in seconds";
+pin in bool in "Input signal";
+pin out bool q "Output signal";
+pin out real et "Elapsed time since rising edge in seconds";
 
-param rw float pt "Delay time in seconds";
+param rw real pt "Delay time in seconds";
 
 function _ "Update the timer";
 license "GPL";
@@ -30,12 +30,12 @@ author "Chad Woitas";
 ;;
 FUNCTION(_) {
         if(pt < 0) {
-            pt = 0;
+            pt_set(0);
             rtapi_print_msg(RTAPI_MSG_WARN,
                             "ton: Delay time must be positive, resetting to 0");
         }
         if(et < 0) {
-            et = 0;
+            et_set(0);
             rtapi_print_msg(RTAPI_MSG_WARN,
                             "ton: Elapsed time rolled over, resetting to 0");
         }
@@ -44,15 +44,15 @@ FUNCTION(_) {
         if(in){
             // Update outputs
             if(et >= pt){
-                q = 1;
+                q_set(1);
             }
             else{
-                et += fperiod;
+                et_set(et + fperiod);
             }
         }
         else{
             // Reset Variables
-            et = 0;
-            q = 0;
+            et_set(0);
+            q_set(0);
         }
 }

--- a/src/hal/components/tp.comp
+++ b/src/hal/components/tp.comp
@@ -18,11 +18,11 @@
 *
 ********************************************************************/
 component tp "IEC TP timer - generate a high pulse of defined duration on rising edge";
-pin in bit in "Input signal";
-pin out bit q "Output signal";
-pin out float et "Elapsed time since start of pulse in seconds";
+pin in bool in "Input signal";
+pin out bool q "Output signal";
+pin out real et "Elapsed time since start of pulse in seconds";
 
-param rw float pt "Pulse time in seconds";
+param rw real pt "Pulse time in seconds";
 
 variable int in_old; // Value of in on last cycle, for rising edge detection
 
@@ -32,12 +32,12 @@ author "Chad Woitas";
 ;;
 FUNCTION(_) {
         if(pt < 0) {
-            pt = 0;
+            pt_set(0);
             rtapi_print_msg(RTAPI_MSG_WARN,
                             "tp: Pulse time must be positive, resetting to 0");
         }
         if(et < 0) {
-            et = 0;
+            et_set(0);
             rtapi_print_msg(RTAPI_MSG_WARN,
                             "tp: Elapsed time rolled over, resetting to 0");
         }
@@ -46,17 +46,17 @@ FUNCTION(_) {
         if((in && !in_old) || q){
             // Update outputs
             if(et < pt){
-                q = 1;
-                et += fperiod;
+                q_set(1);
+                et_set(et + fperiod);
             }
             else{
-                q = 0;
+                q_set(0);
             }
         }
         else{
             // Reset Variables
-            et = 0;
-            q = 0;
+            et_set(0);
+            q_set(0);
         }
         in_old = in;
 }

--- a/src/hal/components/updown.comp
+++ b/src/hal/components/updown.comp
@@ -1,12 +1,12 @@
 component updown "Counts up or down, with optional limits and wraparound behavior";
-pin in bit countup "Increment count when this pin goes from 0 to 1";
-pin in bit countdown "Decrement count when this pin goes from 0 to 1";
-pin in bit reset "Reset count when this pin goes from 0 to 1";
-pin out s32 count "The current count";
-param rw bit clamp "If TRUE, then clamp the output to the min and max parameters.";
-param rw bit wrap "If TRUE, then wrap around when the count goes above or below the min and max parameters.  Note that wrap implies (and overrides) clamp.";
-param rw s32 max = 0x7FFFFFFF "If clamp or wrap is set, count will never exceed this number";
-param rw s32 min "If clamp or wrap is set, count will never be less than this number";
+pin in bool countup "Increment count when this pin goes from 0 to 1";
+pin in bool countdown "Decrement count when this pin goes from 0 to 1";
+pin in bool reset "Reset count when this pin goes from 0 to 1";
+pin out si32 count "The current count";
+param rw bool clamp_ "If TRUE, then clamp the output to the min and max parameters.";
+param rw bool wrap "If TRUE, then wrap around when the count goes above or below the min and max parameters.  Note that wrap implies (and overrides) clamp.";
+param rw si32 max_ = 0x7FFFFFFF "If clamp or wrap is set, count will never exceed this number";
+param rw si32 min_ "If clamp or wrap is set, count will never be less than this number";
 variable int oldup;
 variable int olddown;
 variable int first = 1;
@@ -18,7 +18,7 @@ author "Stephen Wille Padnos";
 ;;
 
 FUNCTION(_) {
-	hal_s32_t temp_count = count;
+	rtapi_s32 temp_count = count;
 	if (first) {
 		oldup=countup;
 		olddown=countdown;
@@ -34,17 +34,17 @@ FUNCTION(_) {
 		temp_count=0;
 	}
 	if (wrap) {
-		if (temp_count > max)
-			temp_count = min;
-		else if (temp_count < min)
-			temp_count = max;
-	} else if (clamp) {
-		if (temp_count > max)
-			temp_count = max;
-		else if (temp_count < min)
-			temp_count = min;
+		if (temp_count > max_)
+			temp_count = min_;
+		else if (temp_count < min_)
+			temp_count = max_;
+	} else if (clamp_) {
+		if (temp_count > max_)
+			temp_count = max_;
+		else if (temp_count < min_)
+			temp_count = min_;
 	}
-	count = temp_count;
+	count_set(temp_count);
 	oldup = countup;
 	olddown = countdown;
 }

--- a/src/hal/components/xhc_hb04_util.comp
+++ b/src/hal/components/xhc_hb04_util.comp
@@ -8,43 +8,43 @@ calculating the filter time constant ($ man lowpass).
 
 """;
 
-pin in bit start_or_pause;
-pin in bit is_paused;
-pin in bit is_idle;
-pin in bit is_running;
-pin out bit pause;
-pin out bit resume;
-pin out bit run;
+pin in bool start_or_pause;
+pin in bool is_paused;
+pin in bool is_idle;
+pin in bool is_running;
+pin out bool pause;
+pin out bool resume;
+pin out bool run;
 
 // integer low pass filters (see ilowpass.comp)
-pin in s32 in0;
-pin in s32 in1;
-pin in s32 in2;
-pin in s32 in3;
-pin out s32 out0;
-pin out s32 out1;
-pin out s32 out2;
-pin out s32 out3;
-pin in float scale0 = 1.0;
-pin in float scale1 = 1.0;
-pin in float scale2 = 1.0;
-pin in float scale3 = 1.0;
-pin in float coef0 = 1.0;
-pin in float coef1 = 1.0;
-pin in float coef2 = 1.0;
-pin in float coef3 = 1.0;
+pin in si32 in0;
+pin in si32 in1;
+pin in si32 in2;
+pin in si32 in3;
+pin out si32 out0;
+pin out si32 out1;
+pin out si32 out2;
+pin out si32 out3;
+pin in real scale0 = 1.0;
+pin in real scale1 = 1.0;
+pin in real scale2 = 1.0;
+pin in real scale3 = 1.0;
+pin in real coef0 = 1.0;
+pin in real coef1 = 1.0;
+pin in real coef2 = 1.0;
+pin in real coef3 = 1.0;
 
-pin in  float divide_by_k_in;
-pin out float divide_by_k_out;
-pin in  float k = 1.0;
+pin in  real divide_by_k_in;
+pin out real divide_by_k_out;
+pin in  real k = 1.0;
 
 option data xhc_data;
 option period no;
 
-variable double value0;
-variable double value1;
-variable double value2;
-variable double value3;
+variable rtapi_real value0;
+variable rtapi_real value1;
+variable rtapi_real value2;
+variable rtapi_real value3;
 
 function _;
 license "GPL";
@@ -57,9 +57,9 @@ typedef struct { int old_start_or_pause; } xhc_data;
 FUNCTION(_) {
 
     if (k == 0) {
-      divide_by_k_out = 1e99;
+      divide_by_k_out_set(1e99);
     } else {
-      divide_by_k_out = divide_by_k_in / k;
+      divide_by_k_out_set(divide_by_k_in / k);
     }
 
     // protect so that 0 <= coef <= 1
@@ -68,18 +68,18 @@ FUNCTION(_) {
     value2 += (in2 - value2) * (fabs(coef2) < 1 ? fabs(coef2) : 1);
     value3 += (in3 - value3) * (fabs(coef3) < 1 ? fabs(coef3) : 1);
 
-    out0 =  ceil(value0 * scale0 - .5);
-    out1 =  ceil(value1 * scale1 - .5);
-    out2 =  ceil(value2 * scale2 - .5);
-    out3 =  ceil(value3 * scale3 - .5);
+    out0_set(ceil(value0 * scale0 - .5));
+    out1_set(ceil(value1 * scale1 - .5));
+    out2_set(ceil(value2 * scale2 - .5));
+    out3_set(ceil(value3 * scale3 - .5));
 
     if (data.old_start_or_pause == start_or_pause) return;
     data.old_start_or_pause = start_or_pause;
     if (!start_or_pause) {
-        pause = run = resume = 0;
+        pause_set(0); run_set(0); resume_set(0);
         return;
     }
-    if (is_paused)  {pause = 0; run = 0; resume = 1; }
-    if (is_running) {pause = 1; run = 0; resume = 0; }
-    if (is_idle)    {pause = 0; run = 1; resume = 0; }
+    if (is_paused)  {pause_set(0); run_set(0); resume_set(1); }
+    if (is_running) {pause_set(1); run_set(0); resume_set(0); }
+    if (is_idle)    {pause_set(0); run_set(1); resume_set(0); }
 }


### PR DESCRIPTION
This PR updates the next set of components to getter/setter. These components should also be rather easy as most changes are to the type names and using pinname_set(...) for the write action. The changes are not big, but there are just many components.

A few places a local variable was introduced to prevent multiple reads if the change was trivial. Pin/param names max/min/clamp were suffixed with an underscore to prevent kernel identifier clashes. Any inappropriate use of the old hal types has been cleaned up.