### PR TITLE
hal: Update type converters to use getter/setter

### DIFF
--- a/src/hal/components/conv.comp.in
+++ b/src/hal/components/conv.comp.in
@@ -1,8 +1,8 @@
-component conv_@IN@_@OUT@ "Convert a value from @IN@ to @OUT@";
+component conv_@XIN@_@XOUT@ "Convert a value from @IN@ to @OUT@";
 pin in @IN@ in;
 pin out @OUT@ out;
-@CC@pin out bit out_of_range "TRUE when 'in' is not in the range of @OUT@";
-@CC@param rw bit clamp """If TRUE, then clamp to the range of @OUT@.  If FALSE, then allow the value to "wrap around".""";
+@CC@pin out bool out_of_range "TRUE when 'in' is not in the range of @OUT@";
+@CC@param rw bool clamp_ """If TRUE, then clamp to the range of @OUT@.  If FALSE, then allow the value to "wrap around".""";
 option period no;
 function _ "Update 'out' based on 'in'";
 license "GPL";
@@ -12,17 +12,17 @@ author "Jeff Epler";
 #include <rtapi_stdint.h>
 FUNCTION(_) {
 	@TYPI@ val = in;
-@CC@	if(clamp) {
+@CC@	if(clamp_) {
 #if @MAXEN@ == 0
-@CC@		if(val > (@TYPI@)@MAX@) { out = @MAX@; out_of_range = 1; return; }
+@CC@		if(val > (@TYPI@)@MAX@) { out_set(@MAX@); out_of_range_set(1); return; }
 #endif
 #if @MINEN@ == 0
-@CC@		if(val < (@TYPI@)@MIN@) { out = @MIN@; out_of_range = 1; return; }
+@CC@		if(val < (@TYPI@)@MIN@) { out_set(@MIN@); out_of_range_set(1); return; }
 #endif
-@CC@		out = (@TYPO@)val;
-@CC@		out_of_range = 0;
+@CC@		out_set((@TYPO@)val);
+@CC@		out_of_range_set(0);
 @CC@	} else {
-		out = (@TYPO@)val;
-@CC@		if((@TYPI@)out != val) out_of_range = 1;
+		out_set((@TYPO@)val);
+@CC@		if((@TYPI@)out != val) out_of_range_set(1);
 @CC@	}
 }

--- a/src/hal/components/mkconv.sh
+++ b/src/hal/components/mkconv.sh
@@ -9,12 +9,12 @@ fi
 # Convert the hal type into the underlying type
 utype() {
 	case "$1" in
-	"bit")	echo "bool" ;;
+	"bit")	echo "rtapi_bool" ;;
 	"s32")	echo "rtapi_s32" ;;
 	"u32")	echo "rtapi_u32" ;;
-	"s64")	echo "rtapi_s64" ;;
-	"u64")	echo "rtapi_u64" ;;
-	"float") echo "real_t" ;;
+	"s64")	echo "rtapi_sint" ;;
+	"u64")	echo "rtapi_uint" ;;
+	"float") echo "rtapi_real" ;;
 	*)	echo "This_Will_Generate_An_Error" ;;
 	esac
 }
@@ -45,6 +45,18 @@ minval() {
 	esac
 }
 
+# New HAL types
+_newtype() {
+	case "$1" in
+	"bit")	echo "bool" ;;
+	"s32")	echo "si32" ;;
+	"u32")	echo "ui32" ;;
+	"s64")	echo "sint" ;;
+	"u64")	echo "uint" ;;
+	"float") echo "real" ;;
+	*)	echo "This_Will_Generate_An_Error" ;;
+	esac
+}
 #
 # Conversions
 # xxx = unsupported conversion
@@ -95,11 +107,13 @@ if test	"$2" = 'float' -o \
 	\( "$1" = 's32' -a "$2" = 's64' \)
 then CC="s,@CC@,//,g"; else CC="s,@CC@,,g"; fi
 
-IN="s,@IN@,$1,g"
-OUT="s,@OUT@,$2,g"
+XIN="s,@XIN@,${1},g"
+XOUT="s,@XOUT@,${2},g"
+IN="s,@IN@,$(_newtype "$1"),g"
+OUT="s,@OUT@,$(_newtype "$2"),g"
 MIN="s,@MIN@,$(minval "$2"),g"
 MAX="s,@MAX@,$(maxval "$2"),g"
 TYPI="s,@TYPI@,$(utype "$1"),g"
 TYPO="s,@TYPO@,$(utype "$2"),g"
 
-exec sed -e "$IN; $OUT; $CC; $MIN; $MAX; $TYPI; $TYPO; $MINEN; $MAXEN;"
+exec sed -e "$IN; $OUT; $CC; $MIN; $MAX; $TYPI; $TYPO; $MINEN; $MAXEN; $XIN; $XOUT;"


### PR DESCRIPTION
This PR converts the pin type converters to getter/setter.

The 'clamp' pin name was changed to 'clamp_' to prevent a identifier clash with the kernel.

The names of these converters is not changed because that would create a real problem for users and break hal-files. When we break the API and user-land, then these should be renamed too and all 32-bit versions must be eliminated in that process.