### PR TITLE
hal: Update first batch of uspace drivers to getter/setter

### DIFF
--- a/src/hal/drivers/hal_gpio.c
+++ b/src/hal/drivers/hal_gpio.c
@@ -81,8 +81,8 @@ RTAPI_MP_ARRAY_STRING(pullup, MAX_CHAN, "set BIAS_PULL_UP flag");
 */
 
 typedef struct{
-    hal_bit_t *value;
-    hal_bit_t *value_not;
+    hal_bool_t value;
+    hal_bool_t value_not;
 } hal_gpio_hal_t;
 
 /* flags are defined such:
@@ -115,7 +115,7 @@ typedef struct {
 typedef struct {
     // Bulk line access has to all be to the same "chip" so we have an
     // array of chips with their bulk line collections.
-    hal_u32_t *reset_ns;
+    hal_uint_t *reset_ns;
     int num_in_chips;
     int num_out_chips;
     hal_gpio_bulk_t *in_chips;
@@ -400,8 +400,8 @@ rtapi_print_msg(RTAPI_MSG_INFO, "Libgpiod is %i\n", LIBGPIOD_VER);
 	gpio->in_chips[c].hal = hal_malloc(gpio->in_chips[c].num_lines * sizeof(hal_gpio_hal_t));
 	for (i = 0; i < gpio->in_chips[c].num_lines; i++){
 	    line_name = get_line_name(&gpio->in_chips[c], i);
-	    retval += hal_pin_bit_newf(HAL_OUT, &(gpio->in_chips[c].hal[i].value), comp_id, "hal_gpio.%s-in", line_name);
-	    retval += hal_pin_bit_newf(HAL_OUT, &(gpio->in_chips[c].hal[i].value_not), comp_id, "hal_gpio.%s-in-not", line_name);
+	    retval += hal_pin_new_bool(comp_id, HAL_OUT, &(gpio->in_chips[c].hal[i].value), 0, "hal_gpio.%s-in", line_name);
+	    retval += hal_pin_new_bool(comp_id, HAL_OUT, &(gpio->in_chips[c].hal[i].value_not), 1, "hal_gpio.%s-in-not", line_name);
 	}
 	if (retval < 0){
 	    rtapi_print_msg(RTAPI_MSG_ERR, "hal_gpio: Failed to allocate GPIO input HAL pins\n");
@@ -437,7 +437,7 @@ rtapi_print_msg(RTAPI_MSG_INFO, "Libgpiod is %i\n", LIBGPIOD_VER);
 	gpio->out_chips[c].hal = hal_malloc(gpio->out_chips[c].num_lines * sizeof(hal_gpio_hal_t));
 	for (i = 0; i < gpio->out_chips[c].num_lines; i++){
 	    line_name = get_line_name(&gpio->out_chips[c], i);
-	    retval += hal_pin_bit_newf(HAL_IN, &(gpio->out_chips[c].hal[i].value), comp_id, "hal_gpio.%s-out", line_name);
+	    retval += hal_pin_new_bool(comp_id, HAL_IN, &(gpio->out_chips[c].hal[i].value), 0, "hal_gpio.%s-out", line_name);
 	}
 	if (retval < 0){
 	    rtapi_print_msg(RTAPI_MSG_ERR, "hal_gpio: Failed to allocate GPIO output HAL pins\n");
@@ -451,9 +451,9 @@ rtapi_print_msg(RTAPI_MSG_INFO, "Libgpiod is %i\n", LIBGPIOD_VER);
     retval += hal_export_funct(hal_name, hal_gpio_write, gpio, 0, 0, comp_id);
 
     if (reset_active){
-	gpio->reset_ns = hal_malloc(sizeof(hal_u32_t));
+	gpio->reset_ns = hal_malloc(sizeof(*gpio->reset_ns));
 	rtapi_snprintf(hal_name, HAL_NAME_LEN, "hal_gpio.reset");
-	retval += hal_param_u32_newf(HAL_RW, gpio->reset_ns, comp_id, "hal_gpio.reset_ns");
+	retval += hal_param_new_ui32(comp_id, HAL_RW, gpio->reset_ns, 0, "hal_gpio.reset_ns");
 	retval += hal_export_funct(hal_name, hal_gpio_reset, gpio, 0, 0, comp_id);
     }
     if (retval < 0){
@@ -484,8 +484,8 @@ static void hal_gpio_read(void *arg, __attribute__((unused)) long period)
 	gpiod_line_get_value_bulk(gpio->in_chips[c].lines, gpio->in_chips[c].vals);
 #endif
 	for (i = 0; i < gpio->in_chips[c].num_lines; i++){
-	   *(gpio->in_chips[c].hal[i].value) = gpio->in_chips[c].vals[i];
-	   *(gpio->in_chips[c].hal[i].value_not) = ! gpio->in_chips[c].vals[i];
+	   hal_set_bool(gpio->in_chips[c].hal[i].value, gpio->in_chips[c].vals[i]);
+	   hal_set_bool(gpio->in_chips[c].hal[i].value_not, ! gpio->in_chips[c].vals[i]);
 	}
     }
 }
@@ -497,9 +497,9 @@ static void hal_gpio_write(void *arg, __attribute__((unused)) long period)
     for (c = 0; c < gpio->num_out_chips; c++){
 	for (i = 0; i < gpio->out_chips[c].num_lines; i++){
 	    if (gpio->out_chips[c].flags[i] & 0x20){
-		gpio->out_chips[c].vals[i] = ! *(gpio->out_chips[c].hal[i].value);
+		gpio->out_chips[c].vals[i] = ! hal_get_bool(gpio->out_chips[c].hal[i].value);
 	    } else {
-		gpio->out_chips[c].vals[i] = *(gpio->out_chips[c].hal[i].value);
+		gpio->out_chips[c].vals[i] = hal_get_bool(gpio->out_chips[c].hal[i].value);
 	    }
 	}
 #if LIBGPIOD_VER >200
@@ -525,8 +525,8 @@ static void hal_gpio_reset(void *arg, long period)
 		gpio->out_chips[c].vals[i] = 0;
 	    }
 	}
-	if (*gpio->reset_ns > period/4) *gpio->reset_ns = period/4;
-	deadline = last_reset + *gpio->reset_ns;
+	if (hal_get_ui32(*gpio->reset_ns) > period/4) hal_set_ui32(*gpio->reset_ns, period/4);
+	deadline = last_reset + hal_get_ui32(*gpio->reset_ns);
         while(rtapi_get_time() < deadline) {} // busy-wait!
 #if LIBGPIOD_VER > 200
 	gpiod_line_request_set_values(gpio->out_chips[c].lines, gpio->out_chips[c].vals);

--- a/src/hal/drivers/hal_pi_gpio.c
+++ b/src/hal/drivers/hal_pi_gpio.c
@@ -78,7 +78,7 @@ static unsigned exclude_map;
 
 static int comp_id;		/* component ID */
 static unsigned char *pins, *gpios;
-hal_bit_t **port_data;
+hal_bool_t *port_data;
 
 static void write_port(void *arg, long period);
 static void read_port(void *arg, long period);
@@ -262,8 +262,8 @@ int rtapi_app_main(void)
       }
       break;
     }
-    port_data = hal_malloc(npins * sizeof(void *));
-    if (port_data == 0) {
+    port_data = hal_malloc(npins * sizeof(*port_data));
+    if (NULL == port_data) {
 	rtapi_print_msg(RTAPI_MSG_ERR,
 	    "HAL_PI_GPIO: ERROR: hal_malloc() failed\n");
 	hal_exit(comp_id);
@@ -312,13 +312,13 @@ int rtapi_app_main(void)
       pinno = pins[n];
       if (dir_map & RTAPI_BIT(n)) {
 	bcm2835_gpio_fsel(gpios[n], BCM2835_GPIO_FSEL_OUTP);
-	if ((retval = hal_pin_bit_newf(HAL_IN, &port_data[n],
-				       comp_id, "hal_pi_gpio.pin-%02d-out", pinno)) < 0)
+	if ((retval = hal_pin_new_bool(comp_id, HAL_IN, &port_data[n],
+				       0, "hal_pi_gpio.pin-%02d-out", pinno)) < 0)
 	  break;
       } else {
 	bcm2835_gpio_fsel(gpios[n], BCM2835_GPIO_FSEL_INPT);
-	if ((retval = hal_pin_bit_newf(HAL_OUT, &port_data[n],
-				       comp_id, "hal_pi_gpio.pin-%02d-in", pinno)) < 0)
+	if ((retval = hal_pin_new_bool(comp_id, HAL_OUT, &port_data[n],
+				       0, "hal_pi_gpio.pin-%02d-in", pinno)) < 0)
 	  break;
       }
     }
@@ -372,7 +372,7 @@ static void write_port(void *arg, long period)
     if (exclude_map & RTAPI_BIT(n))
       continue;
     if (dir_map & RTAPI_BIT(n)) {
-      if (*(port_data[n])) {
+      if (hal_get_bool(port_data[n])) {
 	bcm2835_gpio_set(gpios[n]);
       } else {
 	bcm2835_gpio_clr(gpios[n]);
@@ -389,6 +389,6 @@ static void read_port(void *arg, long period)
 
   for (n = 0; n < npins; n++) {
     if ((~dir_map & RTAPI_BIT(n)) && (~exclude_map & RTAPI_BIT(n)))
-      *port_data[n] = bcm2835_gpio_lev(gpios[n]);
+      hal_set_bool(port_data[n], bcm2835_gpio_lev(gpios[n]));
   }
 }

--- a/src/hal/drivers/hal_skeleton.c
+++ b/src/hal/drivers/hal_skeleton.c
@@ -109,7 +109,7 @@ RTAPI_MP_STRING(cfg, "config string"); */
 */
 
 typedef struct {
-    hal_u32_t *data_out;		/* ptrs for output */
+    hal_uint_t data_out;		/* ptrs for output */
 } skeleton_t;
 
 /* pointer to array of skeleton_t structs in shared memory, 1 per port */
@@ -161,8 +161,8 @@ int rtapi_app_main(void)
     }
 
     /* STEP 3: export the pin(s) */
-    retval = hal_pin_u32_newf(HAL_IN, &(port_data_array->data_out),
-			     comp_id, "skeleton.%d.pin-%02d-out", n, 1);
+    retval = hal_pin_new_ui32(comp_id, HAL_IN, &(port_data_array->data_out),
+			     0, "skeleton.%d.pin-%02d-out", n, 1);
     if (retval < 0) {
 	rtapi_print_msg(RTAPI_MSG_ERR,
 	    "SKELETON: ERROR: port %d var export failed with err=%i\n", n,
@@ -202,7 +202,7 @@ static void write_port(void *arg, long period)
     unsigned char outdata;
     port = arg;
 
-    outdata = *(port->data_out) & 0xFF;
+    outdata = hal_get_ui32(port->data_out) & 0xFF;
     /* write it to the hardware */
     rtapi_outb(outdata, 0x378);
 }

--- a/src/hal/drivers/hal_speaker.c
+++ b/src/hal/drivers/hal_speaker.c
@@ -98,7 +98,7 @@ RTAPI_MP_STRING(cfg, "config string"); */
 */
 
 typedef struct {
-    hal_bit_t *signals[8];
+    hal_bool_t signals[8];
     uint8_t last;
 } speaker_t;
 
@@ -125,7 +125,7 @@ static void write_port(void *arg, long period)
     port = arg;
     
     for(i=0; i<8; i++) {
-        if(*(port->signals[i])) v = v | (1<<i);
+        if(hal_get_bool(port->signals[i])) v = v | (1<<i);
     }
 
     /* write it to the hardware */
@@ -171,7 +171,7 @@ int rtapi_app_main(void)
 #endif /* RTAPI_RTAI */
 
     /* STEP 2: allocate shared memory for skeleton data */
-    port_data_array = hal_malloc(num_ports * sizeof(speaker_t));
+    port_data_array = hal_malloc(num_ports * sizeof(*port_data_array));
     if (port_data_array == 0) {
 	rtapi_print_msg(RTAPI_MSG_ERR,
 	    "SPEAKER: ERROR: hal_malloc() failed\n");
@@ -181,8 +181,8 @@ int rtapi_app_main(void)
 
     /* STEP 3: export the pin(s) */
     for(i = 0; i < 8; i++) {
-        retval = hal_pin_bit_newf(HAL_IN, &(port_data_array->signals[i]),
-				  comp_id, "speaker.%d.pin-%02d-out", n, i);
+        retval = hal_pin_new_bool(comp_id, HAL_IN, &(port_data_array->signals[i]),
+				  0, "speaker.%d.pin-%02d-out", n, i);
         if (retval < 0) {
             rtapi_print_msg(RTAPI_MSG_ERR,
                 "SPEAKER: ERROR: port %d var export failed with err=%i\n", n,

--- a/src/hal/drivers/mesa_7i65.comp
+++ b/src/hal/drivers/mesa_7i65.comp
@@ -13,16 +13,16 @@ sequence, one for each bspi instance included in the bitfile loaded to each
 installed card during the Hostmot2 setup sequence. Type "dmesg" at the terminal
 prompt to view the output.""";
 
-pin in float analogue.#.out [8] """Analogue output values. The value will be
+pin in real analogue.#.out [8] """Analogue output values. The value will be
 limited to a  -1.0 to +1.0 range""";
-pin out float analogue.#.in [8] "Analogue outputs read by the 7i65 (in Volts)";
-pin out bit digital.#.in [4] "Miscellaneous Digital Inputs";
-pin in bit enable.#.out [8] "Amplifier-enable control pins";
-pin out bit watchdog.has-bit """Indicates the status of the 7i65 Watchdog (which
+pin out real analogue.#.in [8] "Analogue outputs read by the 7i65 (in Volts)";
+pin out bool digital.#.in [4] "Miscellaneous Digital Inputs";
+pin in bool enable.#.out [8] "Amplifier-enable control pins";
+pin out bool watchdog.has-bit """Indicates the status of the 7i65 Watchdog (which
 is separate from the FPGA card watchdog""";
-param rw float scale-# [8] = 10 """Analogue output scale factor. For example if
+param rw real scale-# [8] = 10 """Analogue output scale factor. For example if
 the scale is 7 then an input of 1.0 will give 7V on the output terminals""";
-param rw bit is-bipolar-# [8] = 1 """Set this value to TRUE for a plus/minus
+param rw bool is-bipolar-# [8] = 1 """Set this value to TRUE for a plus/minus
 "scale" output. Set to 0 for a 0-"scale" output""";
 
 option extra_setup yes;
@@ -50,7 +50,7 @@ include <hostmot2-serial.h>;
 ;;
 
 // to parse the modparam
-char *bspi_chans[16] = {0,};
+char *bspi_chans[16] = {};
 RTAPI_MP_ARRAY_STRING(bspi_chans, 16, "BSPI Channel names");
 
 static int read(void *subdata) {
@@ -78,9 +78,9 @@ static int read(void *subdata) {
     // Limit DAC Outputs
     for (i = 0 ; i < 8 ; i++) {
         if (scale(i) > 10)
-            scale(i) = 10;
+            scale_set(i, 10);
         if (scale(i) < -10)
-            scale(i) = -10;
+            scale_set(i, -10);
 
         aout[i] = analogue_out(i);
         if (aout[i] > 1)
@@ -147,15 +147,15 @@ static int read(void *subdata) {
     }
 
     // Read Misc IO and Watchdog from CPLD
-    digital_in(0) = (*CPLD_read & 0x1) ? 1:0;
-    digital_in(1) = (*CPLD_read & 0x2) ? 1:0;
-    digital_in(2) = (*CPLD_read & 0x4) ? 1:0;
-    digital_in(3) = (*CPLD_read & 0x8) ? 1:0;
-    watchdog_has_bit = (*CPLD_read & 0x100) ? 1:0;
+    digital_in_set(0, (*CPLD_read & 0x1) ? 1:0);
+    digital_in_set(1, (*CPLD_read & 0x2) ? 1:0);
+    digital_in_set(2, (*CPLD_read & 0x4) ? 1:0);
+    digital_in_set(3, (*CPLD_read & 0x8) ? 1:0);
+    watchdog_has_bit_set((*CPLD_read & 0x100) ? 1:0);
 
     // Read ADC's into Pins
     for(i=0; i < 8; i++) {
-        analogue_in(i) = (double)((int16_t)((*AD7329_read[i] & 0x1FFF) << 3)) / 3276.8;
+        analogue_in_set(i, (double)((int16_t)((*AD7329_read[i] & 0x1FFF) << 3)) / 3276.8);
     }
     return 0;
 }
@@ -231,14 +231,14 @@ EXTRA_SETUP(){
     }
 
     // analog outputs
-    r += hm2_tram_add_bspi_frame(name, 1, &AD5754_1A,0);
-    r += hm2_tram_add_bspi_frame(name, 1, &AD5754_1B,0);
-    r += hm2_tram_add_bspi_frame(name, 1, &AD5754_1C,0);
-    r += hm2_tram_add_bspi_frame(name, 1, &AD5754_1D,0);
-    r += hm2_tram_add_bspi_frame(name, 2, &AD5754_2A,0);
-    r += hm2_tram_add_bspi_frame(name, 2, &AD5754_2B,0);
-    r += hm2_tram_add_bspi_frame(name, 2, &AD5754_2C,0);
-    r += hm2_tram_add_bspi_frame(name, 2, &AD5754_2D,0);
+    r += hm2_tram_add_bspi_frame(name, 1, &AD5754_1A, NULL);
+    r += hm2_tram_add_bspi_frame(name, 1, &AD5754_1B, NULL);
+    r += hm2_tram_add_bspi_frame(name, 1, &AD5754_1C, NULL);
+    r += hm2_tram_add_bspi_frame(name, 1, &AD5754_1D, NULL);
+    r += hm2_tram_add_bspi_frame(name, 2, &AD5754_2A, NULL);
+    r += hm2_tram_add_bspi_frame(name, 2, &AD5754_2B, NULL);
+    r += hm2_tram_add_bspi_frame(name, 2, &AD5754_2C, NULL);
+    r += hm2_tram_add_bspi_frame(name, 2, &AD5754_2D, NULL);
 
     // This is required, or nothing happens.
     r += hm2_allocate_bspi_tram(name);

--- a/src/hal/drivers/mesa_uart.comp
+++ b/src/hal/drivers/mesa_uart.comp
@@ -41,10 +41,10 @@ license "GPL";
 
 include <hostmot2-serial.h>;
 
-pin in u32 tx-data-##[16] "Data to be transmitted";
-pin out u32 rx-data-##[16] "Data received";
-pin in s32 tx-bytes "Number of bytes to transmit";
-pin out s32 rx-bytes "Number of Bytes received";
+pin in  ui32 tx-data-##[16] "Data to be transmitted";
+pin out ui32 rx-data-##[16] "Data received";
+pin in  si32 tx-bytes "Number of bytes to transmit";
+pin out si32 rx-bytes "Number of Bytes received";
 
 variable char *name; // UART name
 
@@ -59,7 +59,7 @@ function receive;
 /* This uses the RTAPI_MP_ARRAY_STRING macro to load the list of UART channels
 into an array. This is copied into the *name string of each */
 
-char *uart_chans[18] = {0,};
+char *uart_chans[18] = {};
 RTAPI_MP_ARRAY_STRING(uart_chans, 16, "UART Channel names");
 
 FUNCTION(send){
@@ -82,9 +82,9 @@ FUNCTION(receive){
     
     int i;
     unsigned char data[16];
-    rx_bytes = hm2_uart_read(name, data);
+    rx_bytes_set(hm2_uart_read(name, data));
     for (i = 0 ; i < rx_bytes ; i++){
-         rx_data(i) = data[i];
+         rx_data_set(i, data[i]);
     }
 }
     

--- a/src/hal/drivers/serport.comp
+++ b/src/hal/drivers/serport.comp
@@ -19,27 +19,28 @@ the Linux kernel by setting a kernel commandline parameter or not loading
 the serial kernel module if it is a modularized driver.
 """;
 
-pin out bit pin_1_in "Also called DCD (data carrier detect); pin 8 on the 25-pin serial pinout";
-pin out bit pin_6_in "Also called DSR (data set ready); pin 6 on the 25-pin serial pinout";
-pin out bit pin_8_in "Also called CTS (clear to send); pin 5 on the 25-pin serial pinout";
-pin out bit pin_9_in "Also called RI (ring indicator); pin 22 on the 25-pin serial pinout";
+pin out bool pin_1_in "Also called DCD (data carrier detect); pin 8 on the 25-pin serial pinout";
+pin out bool pin_6_in "Also called DSR (data set ready); pin 6 on the 25-pin serial pinout";
+pin out bool pin_8_in "Also called CTS (clear to send); pin 5 on the 25-pin serial pinout";
+pin out bool pin_9_in "Also called RI (ring indicator); pin 22 on the 25-pin serial pinout";
 
-pin out bit pin_1_in_not "Inverted version of pin-1-in";
-pin out bit pin_6_in_not "Inverted version of pin-6-in";
-pin out bit pin_8_in_not "Inverted version of pin-8-in";
-pin out bit pin_9_in_not "Inverted version of pin-9-in";
+pin out bool pin_1_in_not "Inverted version of pin-1-in";
+pin out bool pin_6_in_not "Inverted version of pin-6-in";
+pin out bool pin_8_in_not "Inverted version of pin-8-in";
+pin out bool pin_9_in_not "Inverted version of pin-9-in";
 
-pin in bit pin_3_out  "Also called TX (transmit data); pin 2 on the 25-pin serial pinout";
-pin in bit pin_4_out "Also called DTR (data terminal ready); pin 20 on the 25-pin serial pinout";
-pin in bit pin_7_out "Also called RTS (request to send); pin 4 on the 25-pin serial pinout";
+pin in  bool pin_3_out "Also called TX (transmit data); pin 2 on the 25-pin serial pinout";
+pin in  bool pin_4_out "Also called DTR (data terminal ready); pin 20 on the 25-pin serial pinout";
+pin in  bool pin_7_out "Also called RTS (request to send); pin 4 on the 25-pin serial pinout";
 
-param rw bit pin_3_out_invert;
-param rw bit pin_4_out_invert;
-param rw bit pin_7_out_invert;
-param r u32 ioaddr;
+param rw bool pin_3_out_invert;
+param rw bool pin_4_out_invert;
+param rw bool pin_7_out_invert;
+param r ui32 ioaddr;
 
 option count_function;
 option extra_setup;
+option post_export;
 option extra_cleanup;
 option constructable no;
 option period no;
@@ -65,6 +66,7 @@ int get_count(void) {
 
 EXTRA_SETUP() {
     (void)prefix;
+    (void)__comp_inst;
     rtapi_print_msg(RTAPI_MSG_INFO, "requesting I/O region 0x%x\n",
 			io[extra_arg]);
     if(!rtapi_request_region(io[extra_arg], 7, "serport")) {
@@ -77,7 +79,13 @@ EXTRA_SETUP() {
         io[extra_arg] = 0; 
         return -EBUSY;
     }
-    ioaddr = io[extra_arg];
+    return 0;
+}
+
+POST_EXPORT() {
+    (void)prefix;
+    // Parameter can only be set after parameter is created.
+    ioaddr_set(io[extra_arg]);
     return 0;
 }
 
@@ -106,17 +114,17 @@ EXTRA_CLEANUP() {
 FUNCTION(read) { 
     int i = rtapi_inb(MSR);
 
-    pin_9_in = (i & RI) == 0;
-    pin_9_in_not = (i & RI) == RI;
+    pin_9_in_set((i & RI) == 0);
+    pin_9_in_not_set((i & RI) == RI);
 
-    pin_1_in = (i & DCD) == 0;
-    pin_1_in_not = (i & DCD) == DCD;
+    pin_1_in_set((i & DCD) == 0);
+    pin_1_in_not_set((i & DCD) == DCD);
 
-    pin_6_in = (i & DSR) == 0;
-    pin_6_in_not = (i & DSR) == DSR;
+    pin_6_in_set((i & DSR) == 0);
+    pin_6_in_not_set((i & DSR) == DSR);
 
-    pin_8_in = (i & CTS) == 0;
-    pin_8_in_not = (i & CTS) == CTS;
+    pin_8_in_set((i & CTS) == 0);
+    pin_8_in_not_set((i & CTS) == CTS);
 }
 
 FUNCTION(write) {


### PR DESCRIPTION
This updates the first few small drivers that are compiled in uspace. These are of the more simple kind and quite easily verified by inspection.

Some of these are really old and probably outdated, considering most current (non-IO-mapped IO) hardware. Trimming the code-base for obsolete drivers will require some hard choices in the near future.