### PR TITLE
hal: Fix constructor signature and remove rtapi_app's access to private HAL API

### DIFF
--- a/src/hal/hal.h
+++ b/src/hal/hal.h
@@ -1110,7 +1110,7 @@ extern int hal_stop_threads(void);
     instance of its component.  Return value is >=0 for success,
     <0 for error.
 */
-typedef int(*constructor)(char *prefix, char *arg);
+typedef int(*constructor)(const char *prefix, const char *arg);
 
 /** hal_set_constructor() sets the constructor function for this component
 */

--- a/src/hal/hal_lib.c
+++ b/src/hal/hal_lib.c
@@ -617,6 +617,45 @@ int hal_set_constructor(int comp_id, constructor make) {
     halpr_mutex_release();
     return 0;
 }
+
+// Invoke the constructor for a new instance
+int hal_comp_invoke_make(const char *compname, const char *newname, const char *arg)
+{
+    if(NULL == hal_data) {
+        rtapi_print_msg(RTAPI_MSG_DBG, "hal_invoke_make: HAL shared memory not mapped\n");
+        return -EFAULT;
+    }
+    if(!compname || !newname || !arg) {
+        rtapi_print_msg(RTAPI_MSG_DBG, "hal_invoke_make: Invalid arguments\n");
+        return -EINVAL;
+    }
+
+    halpr_mutex_acquire();
+    hal_comp_t *comp = halpr_find_comp_by_name(compname);
+    if(!comp) {
+        halpr_mutex_release();
+        rtapi_print_msg(RTAPI_MSG_DBG, "hal_invoke_make: Component '%s' not found\n", compname);
+        return -ENOENT;
+    }
+
+    if(!comp->make) {
+        halpr_mutex_release();
+        rtapi_print_msg(RTAPI_MSG_DBG, "hal_invoke_make: Component '%s' has no contructor\n", compname);
+        return -ENOEXEC;
+    }
+    halpr_mutex_release();
+    // This is a race, but only if the module gets unloaded before we call its
+    // constructor. Luckily, this is rather unlikely. However, the original in
+    // uspace_rtapi_main.cc:so_newinst_cmd() also had this race. It is unclear
+    // how it can be prevented. Unless we want to hold the mutex while the
+    // module calls hal_init() and creates pins and the like, which is not
+    // necessarily a good idea. But with the recursive mutex, it could be made
+    // working.
+    // The code assumes that the constructor is called from the rtapi_app
+    // context (which houses all uspace RT modules). If not, then the function
+    // pointer will point into the wrong context and a crash is expected.
+    return comp->make(newname, arg);
+}
 #endif
 
 int hal_set_unready(int comp_id) {
@@ -5178,6 +5217,7 @@ EXPORT_SYMBOL(hal_param_s64_set);
 EXPORT_SYMBOL(hal_param_set);
 
 EXPORT_SYMBOL(hal_set_constructor);
+EXPORT_SYMBOL(hal_comp_invoke_make);
 
 EXPORT_SYMBOL(hal_export_funct);
 EXPORT_SYMBOL(hal_export_functf);

--- a/src/hal/hal_lib_extra.c
+++ b/src/hal/hal_lib_extra.c
@@ -83,46 +83,6 @@ int hal_enforce_exact_base_period(void)
     return 0;
 }
 
-// Invoke the constructor for a new instance
-int hal_comp_invoke_make(const char *compname, const char *newname, const char *arg)
-{
-    if(NULL == hal_data) {
-        rtapi_print_msg(RTAPI_MSG_DBG, "hal_invoke_make: HAL shared memory not mapped\n");
-        return -EFAULT;
-    }
-    if(!compname || !newname || !arg) {
-        rtapi_print_msg(RTAPI_MSG_DBG, "hal_invoke_make: Invalid arguments\n");
-        return -EINVAL;
-    }
-
-    halpr_mutex_acquire();
-    hal_comp_t *comp = halpr_find_comp_by_name(compname);
-    if(!comp) {
-        halpr_mutex_release();
-        rtapi_print_msg(RTAPI_MSG_DBG, "hal_invoke_make: Component '%s' not found\n", compname);
-        return -ENOENT;
-    }
-
-    if(!comp->make) {
-        halpr_mutex_release();
-        rtapi_print_msg(RTAPI_MSG_DBG, "hal_invoke_make: Component '%s' has no contructor\n", compname);
-        return -ENOEXEC;
-    }
-    halpr_mutex_release();
-    // This is a race, but only if the module gets unloaded before we call its
-    // constructor. Luckily, this is rather unlikely. However, the original in
-    // uspace_rtapi_main.cc:so_newinst_cmd() also had this race. It is unclear
-    // how it can be prevented. Unless we want to hold the mutex while the
-    // module calls hal_init() and creates pins and the like, which is not
-    // necessarily a good idea. But with the recursive mutex, it could be made
-    // working.
-    // The code assumes that the constructor is called from the rtapi_app
-    // context (which houses all uspace RT modules). If not, then the function
-    // pointer will point into the wrong context and a crash is expected.
-    // FIXME: Remove the cast when we fix the prototype.
-    return comp->make((char *)newname, (char *)arg);
-}
-
 //
 // Set the insmod arguments in a named component
 // This call is used when loading is (nearly) done

--- a/src/hal/utils/halcompile.g
+++ b/src/hal/utils/halcompile.g
@@ -551,7 +551,7 @@ static int comp_id;
 
     if options.get("rtapi_app", 1):
         if options.get("constructable") and not options.get("singleton"):
-            print("static int export_1(char *prefix, char *argstr) {", file=f)
+            print("static int export_1(const char *prefix, const char *argstr) {", file=f)
             print("    int arg = simple_strtol(argstr, NULL, 0);", file=f)
             print("    return export(prefix, arg);", file=f)
             print("}"   , file=f)

--- a/src/rtapi/uspace_rtapi_main.cc
+++ b/src/rtapi/uspace_rtapi_main.cc
@@ -58,7 +58,6 @@
 
 #include "rtapi.h"
 #include <hal.h>
-#include "hal/hal_priv.h"
 #include "uspace_common.h"
 
 static RtapiApp &App();
@@ -444,19 +443,27 @@ static int do_newinst_cmd(const std::string &type, const std::string &name, cons
         return -1;
     }
 
-    hal_comp_t *(*find_comp_by_name)(char *) = DLSYM<hal_comp_t *(*)(char *)>(module, "halpr_find_comp_by_name");
-    if (!find_comp_by_name) {
-        rtapi_print_msg(RTAPI_MSG_ERR, "newinst: halpr_find_comp_by_name not found\n");
+    // In HAL rtlib:
+    // int hal_comp_invoke_make(const char *compname, const char *newname, const char *arg);
+    typedef int (*invoke_make_t)(const char *, const char *, const char *);
+    invoke_make_t invoke_make = DLSYM<invoke_make_t>(module, "hal_comp_invoke_make");
+    if(!invoke_make) {
+        rtapi_print_msg(RTAPI_MSG_ERR, "newinst: hal_comp_invoke_make not found\n");
         return -1;
     }
 
-    hal_comp_t *comp = find_comp_by_name((char *)type.c_str());
-    if (!comp) {
-        rtapi_print_msg(RTAPI_MSG_ERR, "newinst: component %s not found\n", type.c_str());
+    int rv = invoke_make(type.c_str(), name.c_str(), arg.c_str());
+    if(rv) {
+        if(-ENOENT == rv)
+            rtapi_print_msg(RTAPI_MSG_ERR, "newinst: component %s not found\n", type.c_str());
+        else if(-ENOEXEC == rv)
+            rtapi_print_msg(RTAPI_MSG_ERR, "newinst: component %s does not support instantiation\n", type.c_str());
+        else
+            rtapi_print_msg(RTAPI_MSG_ERR, "newinst: component %s returned error %d\n", type.c_str(), rv);
         return -1;
     }
 
-    return comp->make((char *)name.c_str(), (char *)arg.c_str());
+    return 0;
 }
 
 static int do_one_item(


### PR DESCRIPTION
This PR updates the constructor signature for `constructable` modules (rtapi_app's `newinst` command). Note that constructable modules are highly experimental, completely untested and not readily accessible by normal users.
There are no in-tree components that use the construct and the mailing list has been silent. It is assumed to be a dormant feature never fully developed. It can therefore be assumed that the `newinst` construct has no users. It is inaccessible from halcmd and needs direct rtapi_app interaction to be activated.

Regardless, the old code was problematic because the constructor signature was lacking const in its arguments and rtapi_app used private HAL APIs to achieve its goal. This is no longer allowed and the construction needs to be inside the HAL library with a proper call from rtapi_app. Both problems are fixed.

Changing the constructor signature should not be a problem considering it is only accessible by being a very experimentation  happy user. We already require recompilation on many of the committed changes. This is no different.

The PR moves the already exposed function from hal_lib_extra.c into hal_lib.c so that it (easily) can become part of the RT HAL library, which is a requirement for the call from rtapi_app because of the dynamic load.