### PR TITLE
motion: defer mode transitions instead of dropping them when not in position

### DIFF
--- a/src/emc/motion/control.c
+++ b/src/emc/motion/control.c
@@ -956,8 +956,8 @@ static void set_operating_mode(void)
             // entering teleop (INPOS), remove ext offsets
             axis_sync_teleop_tp_to_carte_pos(-1, pcmd_p);
 	} else {
-	    /* not in position-- don't honor mode change */
-	    emcmotInternal->teleoperating = 0;
+	    /* not in position-- defer the mode change; the request stays
+	       pending and is honored when motion comes to rest */
 	}
     } else {
 	if (GET_MOTION_INPOS_FLAG()) {
@@ -996,8 +996,8 @@ static void set_operating_mode(void)
 		SET_MOTION_TELEOP_FLAG(0);
 		SET_MOTION_ERROR_FLAG(0);
 	    } else {
-		/* not in position-- don't honor mode change */
-		emcmotInternal->coordinating = 0;
+		/* not in position-- defer the mode change; the request stays
+		   pending and is honored when motion comes to rest */
 	    }
 	}
 
@@ -1016,8 +1016,8 @@ static void set_operating_mode(void)
 		SET_MOTION_TELEOP_FLAG(0);
 		SET_MOTION_ERROR_FLAG(0);
 	    } else {
-		/* not in position-- don't honor mode change */
-		emcmotInternal->coordinating = 1;
+		/* not in position-- defer the mode change; the request stays
+		   pending and is honored when motion comes to rest */
 	    }
 	}
     }


### PR DESCRIPTION
Motion's set_operating_mode() honored a requested mode change (teleop, coord, free) only if motion was in position in the single servo cycle that processed the request; otherwise the request was silently erased. Task acknowledges EMC_TASK_SET_MODE as soon as it is read and flips mdiOrAuto immediately, so a dropped transition left task mode and traj mode permanently diverged: determineMode() reports MANUAL whenever traj is FREE/TELEOP, nothing re-issues the request, and no error is reported anywhere. The mode machine stays wedged until some unrelated mode command happens by.

This is the likely cause of the intermittent halui/mdi CI failures tracked in #4283 ("timeout waiting for task mode" / "halui to report mode"). Those are wedges, not slowness, so no timeout bump can fix them.

Fix: keep the request pending when not in position; the transition completes as soon as motion comes to rest, matching the documented EMCMOT_COORD contract ("can be done at any time") and the existing deferred-enable behavior.

Verification:
- deterministic repro: requesting MANUAL mid-MDI-move wedges task mode at AUTO on master; with this change the mode converges to MANUAL when the move ends
- halui (jogging, mdi), linuxcncrsh, mdi-queue and abort runtests pass
- 60/60 halui/mdi iterations under CPU and IO load