### PR TITLE
hal: Update inihal, halui and motion-logger to getter/setter

### DIFF
--- a/src/emc/ini/inihal.cc
+++ b/src/emc/ini/inihal.cc
@@ -24,6 +24,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #include <stdio.h>
 #include <hal.h>
 #include <rtapi.h>
+#include <rtapi_math.h>
 #include "inihal.hh"
 #include "iniaxis.hh"
 #include "inispindle.hh"
@@ -36,19 +37,11 @@ static ptr_inihal_data *the_inihal_data;
 
 #define PREFIX "ini."
 #define EPSILON .00001
-#define CLOSE(a,b,eps) ((a)-(b) < +(eps) && (a)-(b) > -(eps))
 
 #define NEW(NAME) new_inihal_data.NAME
 
-#define CHANGED(NAME) \
-    ((old_inihal_data.NAME) - (new_inihal_data.NAME) > +(EPSILON)) \
-    || \
-    ((old_inihal_data.NAME) - (new_inihal_data.NAME) < -(EPSILON))
-
-#define CHANGED_IDX(NAME,IDX) \
-    ((old_inihal_data.NAME[IDX]) - (new_inihal_data.NAME[IDX]) > +(EPSILON)) \
-    || \
-    ((old_inihal_data.NAME[IDX]) - (new_inihal_data.NAME[IDX]) < -(EPSILON))
+#define CHANGED(NAME) (fabs((old_inihal_data.NAME) - (new_inihal_data.NAME)) > (EPSILON))
+#define CHANGED_IDX(NAME,IDX) (fabs((old_inihal_data.NAME[IDX]) - (new_inihal_data.NAME[IDX])) > (EPSILON))
 
 #define UPDATE(NAME) old_inihal_data.NAME = new_inihal_data.NAME
 
@@ -86,44 +79,46 @@ static ptr_inihal_data *the_inihal_data;
                                                         new_inihal_data.NAME[IDX]);
 #define MAKE_BIT_PIN(NAME,DIR) \
 do { \
-     retval = hal_pin_bit_newf(DIR,&(the_inihal_data->NAME),comp_id,PREFIX#NAME); \
+     int retval = hal_pin_new_bool(comp_id, DIR, &(the_inihal_data->NAME), 0, PREFIX#NAME); \
      if (retval < 0) return retval; \
    } while (0)
 
 #define MAKE_S32_PIN(NAME,DIR) \
 do { \
-     retval = hal_pin_s32_newf(DIR,&(the_inihal_data->NAME),comp_id,PREFIX#NAME); \
+     int retval = hal_pin_new_si32(comp_id, DIR, &(the_inihal_data->NAME), 0, PREFIX#NAME); \
      if (retval < 0) return retval; \
    } while (0)
 
 #define MAKE_S32_PIN_IDX(NAME,HALPIN_NAME,DIR,IDX) \
 do { \
-     retval = hal_pin_s32_newf(DIR,&(the_inihal_data->NAME[IDX]),\
-                               comp_id,PREFIX"%d."#HALPIN_NAME,IDX); \
+     int retval = hal_pin_new_si32(comp_id, DIR, &(the_inihal_data->NAME[IDX]),\
+                               0, PREFIX"%d."#HALPIN_NAME, IDX); \
      if (retval < 0) return retval; \
    } while (0)
 
 #define MAKE_FLOAT_PIN(NAME,DIR) \
 do { \
-     retval = hal_pin_float_newf(DIR,&(the_inihal_data->NAME),comp_id,PREFIX#NAME); \
+     int retval = hal_pin_new_real(comp_id, DIR, &(the_inihal_data->NAME), 0,PREFIX#NAME); \
      if (retval < 0) return retval; \
    } while (0)
 
 #define MAKE_FLOAT_PIN_IDX(NAME,HALPIN_NAME,DIR,IDX) \
 do {                        \
-     retval = hal_pin_float_newf(DIR,&(the_inihal_data->NAME[IDX]),\
-                                 comp_id,PREFIX"%d."#HALPIN_NAME,IDX); \
+     int retval = hal_pin_new_real(comp_id, DIR, &(the_inihal_data->NAME[IDX]),\
+                                 0.0, PREFIX"%d."#HALPIN_NAME, IDX); \
      if (retval < 0) return retval; \
    } while (0)
 
 #define MAKE_FLOAT_PIN_LETTER(NAME,HALPIN_NAME,DIR,IDX,LETTER) \
 do {                        \
-     retval = hal_pin_float_newf(DIR,&(the_inihal_data->NAME[IDX]),\
-                                 comp_id,PREFIX"%c."#HALPIN_NAME,LETTER); \
+     int retval = hal_pin_new_real(comp_id, DIR, &(the_inihal_data->NAME[IDX]),\
+                               0.0, PREFIX"%c."#HALPIN_NAME, LETTER); \
      if (retval < 0) return retval; \
    } while (0)
 
-#define INIT_PIN(NAME) *(the_inihal_data->NAME) = old_inihal_data.NAME;
+#define INIT_PIN_R(NAME) hal_set_real(the_inihal_data->NAME, old_inihal_data.NAME);
+#define INIT_PIN_S(NAME) hal_set_si32(the_inihal_data->NAME, old_inihal_data.NAME);
+#define INIT_PIN_B(NAME) hal_set_bool(the_inihal_data->NAME, old_inihal_data.NAME);
 
 int ini_hal_exit(void)
 {
@@ -134,8 +129,6 @@ int ini_hal_exit(void)
 
 int ini_hal_init(int numjoints)
 {
-    int retval;
-
     comp_id = hal_init("inihal");
     if (comp_id < 0) {
     rtapi_print_msg(RTAPI_MSG_ERR,
@@ -193,39 +186,39 @@ int ini_hal_init(int numjoints)
 
 int ini_hal_init_pins(int numjoints)
 {
-    INIT_PIN(traj_default_velocity);
-    INIT_PIN(traj_max_velocity);
-    INIT_PIN(traj_default_acceleration);
-    INIT_PIN(traj_max_acceleration);
-    INIT_PIN(traj_max_jerk);
-    INIT_PIN(traj_planner_type);
+    INIT_PIN_R(traj_default_velocity);
+    INIT_PIN_R(traj_max_velocity);
+    INIT_PIN_R(traj_default_acceleration);
+    INIT_PIN_R(traj_max_acceleration);
+    INIT_PIN_R(traj_max_jerk);
+    INIT_PIN_S(traj_planner_type);
 
-    INIT_PIN(traj_arc_blend_enable);
-    INIT_PIN(traj_arc_blend_fallback_enable);
-    INIT_PIN(traj_arc_blend_optimization_depth);
-    INIT_PIN(traj_arc_blend_gap_cycles);
-    INIT_PIN(traj_arc_blend_ramp_freq);
-    INIT_PIN(traj_arc_blend_tangent_kink_ratio);
+    INIT_PIN_B(traj_arc_blend_enable);
+    INIT_PIN_B(traj_arc_blend_fallback_enable);
+    INIT_PIN_S(traj_arc_blend_optimization_depth);
+    INIT_PIN_R(traj_arc_blend_gap_cycles);
+    INIT_PIN_R(traj_arc_blend_ramp_freq);
+    INIT_PIN_R(traj_arc_blend_tangent_kink_ratio);
 
     for (int idx = 0; idx < numjoints; idx++) {
-        INIT_PIN(joint_backlash[idx]);
-        INIT_PIN(joint_ferror[idx]);
-        INIT_PIN(joint_min_ferror[idx]);
-        INIT_PIN(joint_min_limit[idx]);
-        INIT_PIN(joint_max_limit[idx]);
-        INIT_PIN(joint_max_velocity[idx]);
-        INIT_PIN(joint_max_acceleration[idx]);
-        INIT_PIN(joint_jerk[idx]);
-        INIT_PIN(joint_home[idx]);
-        INIT_PIN(joint_home_offset[idx]);
-        INIT_PIN(joint_home_sequence[idx]);
+        INIT_PIN_R(joint_backlash[idx]);
+        INIT_PIN_R(joint_ferror[idx]);
+        INIT_PIN_R(joint_min_ferror[idx]);
+        INIT_PIN_R(joint_min_limit[idx]);
+        INIT_PIN_R(joint_max_limit[idx]);
+        INIT_PIN_R(joint_max_velocity[idx]);
+        INIT_PIN_R(joint_max_acceleration[idx]);
+        INIT_PIN_R(joint_jerk[idx]);
+        INIT_PIN_R(joint_home[idx]);
+        INIT_PIN_R(joint_home_offset[idx]);
+        INIT_PIN_S(joint_home_sequence[idx]);
     }
     for (int idx = 0; idx < EMCMOT_MAX_AXIS; idx++) {
-        INIT_PIN(axis_min_limit[idx]);
-        INIT_PIN(axis_max_limit[idx]);
-        INIT_PIN(axis_max_velocity[idx]);
-        INIT_PIN(axis_max_acceleration[idx]);
-        INIT_PIN(axis_jerk[idx]);
+        INIT_PIN_R(axis_min_limit[idx]);
+        INIT_PIN_R(axis_max_limit[idx]);
+        INIT_PIN_R(axis_max_velocity[idx]);
+        INIT_PIN_R(axis_max_acceleration[idx]);
+        INIT_PIN_R(axis_jerk[idx]);
     }
 
     return 0;
@@ -233,9 +226,18 @@ int ini_hal_init_pins(int numjoints)
 
 static void copy_hal_data(const ptr_inihal_data &i, value_inihal_data &j)
 {
-    int x;
-#define FIELD(t,f) j.f = (i.f)?*i.f:0;
-#define ARRAY(t,f,n) do { for (x = 0; x < n; x++) j.f[x] = (i.f[x])?*i.f[x]:0; } while (0);
+#define FIELD(t,f) do { \
+        if(i.f) { \
+            j.f = hal_get_##t(i.f); \
+        } \
+    } while(0);
+#define ARRAY(t,f,n) do { \
+        for (int x = 0; x < n; x++) { \
+            if(i.f[x]) { \
+                j.f[x] = hal_get_##t(i.f[x]); \
+            } \
+        } \
+    } while (0);
     HAL_FIELDS
 #undef FIELD
 #undef ARRAY
@@ -243,7 +245,7 @@ static void copy_hal_data(const ptr_inihal_data &i, value_inihal_data &j)
 
 int check_ini_hal_items(int numjoints)
 {
-    value_inihal_data new_inihal_data_mutable;
+    value_inihal_data new_inihal_data_mutable = {};
     copy_hal_data(*the_inihal_data, new_inihal_data_mutable);
     const value_inihal_data &new_inihal_data = new_inihal_data_mutable;
 

--- a/src/emc/ini/inihal.hh
+++ b/src/emc/ini/inihal.hh
@@ -47,42 +47,50 @@ int ini_hal_init_pins(int numjoints);
 [JOINT_n]COMP_FILE_TYPE
 [JOINT_n]COMP
 */
+// FIXME: This will have to go again when we do proper 64-bit
+// The typedefs are necessary to map to hal_[gs]et_[su]i32() in the expansion
+// of below macros because they are selected based on text-concatenation in the
+// preprocessor. Even the 32-bit version use sint/uint, but the expansion would
+// then select the 64-bit versions.
+typedef hal_sint_t hal_si32_t;
+typedef hal_uint_t hal_ui32_t;
+
 #define HAL_FIELDS \
-    FIELD(hal_float_t,traj_default_velocity) \
-    FIELD(hal_float_t,traj_max_velocity) \
-    FIELD(hal_float_t,traj_default_acceleration) \
-    FIELD(hal_float_t,traj_max_acceleration) \
-    FIELD(hal_float_t,traj_max_jerk) \
-    FIELD(hal_s32_t,traj_planner_type) \
+    FIELD(real,traj_default_velocity) \
+    FIELD(real,traj_max_velocity) \
+    FIELD(real,traj_default_acceleration) \
+    FIELD(real,traj_max_acceleration) \
+    FIELD(real,traj_max_jerk) \
+    FIELD(si32,traj_planner_type) \
 \
-    FIELD(hal_bit_t,traj_arc_blend_enable) \
-    FIELD(hal_bit_t,traj_arc_blend_fallback_enable) \
-    FIELD(hal_s32_t,traj_arc_blend_optimization_depth) \
-    FIELD(hal_float_t,traj_arc_blend_gap_cycles) \
-    FIELD(hal_float_t,traj_arc_blend_ramp_freq) \
-    FIELD(hal_float_t,traj_arc_blend_tangent_kink_ratio) \
+    FIELD(bool,traj_arc_blend_enable) \
+    FIELD(bool,traj_arc_blend_fallback_enable) \
+    FIELD(si32,traj_arc_blend_optimization_depth) \
+    FIELD(real,traj_arc_blend_gap_cycles) \
+    FIELD(real,traj_arc_blend_ramp_freq) \
+    FIELD(real,traj_arc_blend_tangent_kink_ratio) \
 \
-    ARRAY(hal_float_t,joint_backlash,EMCMOT_MAX_JOINTS) \
-    ARRAY(hal_float_t,joint_ferror,EMCMOT_MAX_JOINTS) \
-    ARRAY(hal_float_t,joint_min_ferror,EMCMOT_MAX_JOINTS) \
-    ARRAY(hal_float_t,joint_min_limit,EMCMOT_MAX_JOINTS) \
-    ARRAY(hal_float_t,joint_max_limit,EMCMOT_MAX_JOINTS) \
-    ARRAY(hal_float_t,joint_max_velocity,EMCMOT_MAX_JOINTS) \
-    ARRAY(hal_float_t,joint_max_acceleration,EMCMOT_MAX_JOINTS) \
-    ARRAY(hal_float_t,joint_jerk,EMCMOT_MAX_JOINTS) \
-    ARRAY(hal_float_t,joint_home,EMCMOT_MAX_JOINTS) \
-    ARRAY(hal_float_t,joint_home_offset,EMCMOT_MAX_JOINTS) \
-    ARRAY(hal_s32_t,  joint_home_sequence,EMCMOT_MAX_JOINTS) \
+    ARRAY(real,joint_backlash,EMCMOT_MAX_JOINTS) \
+    ARRAY(real,joint_ferror,EMCMOT_MAX_JOINTS) \
+    ARRAY(real,joint_min_ferror,EMCMOT_MAX_JOINTS) \
+    ARRAY(real,joint_min_limit,EMCMOT_MAX_JOINTS) \
+    ARRAY(real,joint_max_limit,EMCMOT_MAX_JOINTS) \
+    ARRAY(real,joint_max_velocity,EMCMOT_MAX_JOINTS) \
+    ARRAY(real,joint_max_acceleration,EMCMOT_MAX_JOINTS) \
+    ARRAY(real,joint_jerk,EMCMOT_MAX_JOINTS) \
+    ARRAY(real,joint_home,EMCMOT_MAX_JOINTS) \
+    ARRAY(real,joint_home_offset,EMCMOT_MAX_JOINTS) \
+    ARRAY(si32,joint_home_sequence,EMCMOT_MAX_JOINTS) \
 \
-    ARRAY(hal_float_t,axis_min_limit,EMCMOT_MAX_AXIS) \
-    ARRAY(hal_float_t,axis_max_limit,EMCMOT_MAX_AXIS) \
-    ARRAY(hal_float_t,axis_max_velocity,EMCMOT_MAX_AXIS) \
-    ARRAY(hal_float_t,axis_max_acceleration,EMCMOT_MAX_AXIS) \
-    ARRAY(hal_float_t,axis_jerk,EMCMOT_MAX_AXIS) \
+    ARRAY(real,axis_min_limit,EMCMOT_MAX_AXIS) \
+    ARRAY(real,axis_max_limit,EMCMOT_MAX_AXIS) \
+    ARRAY(real,axis_max_velocity,EMCMOT_MAX_AXIS) \
+    ARRAY(real,axis_max_acceleration,EMCMOT_MAX_AXIS) \
+    ARRAY(real,axis_jerk,EMCMOT_MAX_AXIS) \
 
 struct PTR {
     template<class T>
-    struct field { typedef T *type; };
+    struct field { typedef T type; };
 };
 
 #pragma GCC diagnostic push
@@ -90,10 +98,14 @@ struct PTR {
 #pragma GCC diagnostic ignored "-Wignored-attributes"
 #endif
 template<class T> struct NATIVE {};
-template<> struct NATIVE<hal_bit_t> { typedef bool type; };
-template<> struct NATIVE<hal_s32_t> { typedef rtapi_s32 type; };
-template<> struct NATIVE<hal_u32_t> { typedef rtapi_u32 type; };
-template<> struct NATIVE<hal_float_t> { typedef double type; };
+template<> struct NATIVE<hal_bool_t> { typedef rtapi_bool type; };
+template<> struct NATIVE<hal_si32_t> { typedef rtapi_s32 type; };
+template<> struct NATIVE<hal_ui32_t> { typedef rtapi_u32 type; };
+// FIXME: These need to be 64-bit. Can't set them now because the compiler sees
+// the typedef mapped overlap.
+//template<> struct NATIVE<hal_sint_t> { typedef rtapi_sint type; };
+//template<> struct NATIVE<hal_uint_t> { typedef rtapi_uint type; };
+template<> struct NATIVE<hal_real_t> { typedef rtapi_real type; };
 struct VALUE {
     template<class T> struct field { typedef typename NATIVE<T>::type type; };
 };
@@ -101,8 +113,8 @@ struct VALUE {
 template<class T>
 struct inihal_base
 {
-#define FIELD(t,f) typename T::template field<t>::type f;
-#define ARRAY(t,f,n) typename T::template field<t>::type f[n];
+#define FIELD(t,f) typename T::template field<hal_##t##_t>::type f;
+#define ARRAY(t,f,n) typename T::template field<hal_##t##_t>::type f[n];
 HAL_FIELDS
 #undef FIELD
 #undef ARRAY

--- a/src/emc/motion-logger/motion-logger.c
+++ b/src/emc/motion-logger/motion-logger.c
@@ -38,7 +38,7 @@
 #include "motion/axis.h"
 
 static struct motion_logger_data_t {
-    hal_bit_t *reopen;
+    hal_bool_t reopen;
 } *motion_logger_data;
 
 FILE *logfile = NULL;
@@ -234,12 +234,12 @@ static void mark_joint_homed(int joint_num) {
 }
 
 void maybe_reopen_logfile() {
-    if(*motion_logger_data->reopen) {
+    if(hal_get_bool(motion_logger_data->reopen)) {
         if(logfile != stdout) {
             fclose(logfile);
             logfile = NULL;
         }
-        *motion_logger_data->reopen = 0;
+        hal_set_bool(motion_logger_data->reopen, 0);
     }
 }
 
@@ -296,13 +296,12 @@ int main(int argc, char* argv[]) {
         exit(EXIT_FAILURE);
     }
     int r;
-    if((r = hal_pin_bit_new("motion-logger.reopen-log", HAL_IO, &motion_logger_data->reopen, mot_comp_id)) < 0) {
+    if((r = hal_pin_new_bool(mot_comp_id, HAL_IO, &motion_logger_data->reopen, 0, "motion-logger.reopen-log")) < 0) {
         hal_exit(mot_comp_id);
         errno = -r;
-        perror("hal_pin_bit_new");
+        perror("hal_pin_new_bool");
         exit(EXIT_FAILURE);
     }
-    *motion_logger_data->reopen = 0;
     if((r = hal_ready(mot_comp_id)) < 0) {
         hal_exit(mot_comp_id);
         errno = -r;

--- a/src/emc/usr_intf/halui.cc
+++ b/src/emc/usr_intf/halui.cc
@@ -51,171 +51,178 @@ static int axis_mask = 0;
 
 #define MDI_MAX 64
 
-#pragma GCC diagnostic push
-#if defined(__GNUC__) && (__GNUC__ > 4)
-#pragma GCC diagnostic ignored "-Wignored-attributes"
-#endif
+// FIXME: This will have to go again when we do proper 64-bit
+// The typedefs are necessary to map to hal_[gs]et_[su]i32() in the expansion
+// of below macros because they are selected based on text-concatenation in the
+// preprocessor. Even the 32-bit version use sint/uint, but the expansion would
+// then select the 64-bit versions.
+typedef hal_sint_t hal_si32_t;
+typedef hal_uint_t hal_ui32_t;
 
 #define HAL_FIELDS \
-    FIELD(hal_bit_t,machine_on) /* pin for setting machine On */ \
-    FIELD(hal_bit_t,machine_off) /* pin for setting machine Off */ \
-    FIELD(hal_bit_t,machine_is_on) /* pin for machine is On/Off */ \
-    FIELD(hal_bit_t,estop_activate) /* pin for activating EMC ESTOP  */ \
-    FIELD(hal_bit_t,estop_reset) /* pin for resetting ESTOP */ \
-    FIELD(hal_bit_t,estop_is_activated) /* pin for status ESTOP is activated */ \
+    FIELD(bool,machine_on) /* pin for setting machine On */ \
+    FIELD(bool,machine_off) /* pin for setting machine Off */ \
+    FIELD(bool,machine_is_on) /* pin for machine is On/Off */ \
+    FIELD(bool,estop_activate) /* pin for activating EMC ESTOP  */ \
+    FIELD(bool,estop_reset) /* pin for resetting ESTOP */ \
+    FIELD(bool,estop_is_activated) /* pin for status ESTOP is activated */ \
 \
-    FIELD(hal_bit_t,mode_manual) /* pin for requesting manual mode */ \
-    FIELD(hal_bit_t,mode_is_manual) /* pin for manual mode is on */ \
-    FIELD(hal_bit_t,mode_auto) /* pin for requesting auto mode */ \
-    FIELD(hal_bit_t,mode_is_auto) /* pin for auto mode is on */ \
-    FIELD(hal_bit_t,mode_mdi) /* pin for requesting mdi mode */ \
-    FIELD(hal_bit_t,mode_is_mdi) /* pin for mdi mode is on */ \
-    FIELD(hal_bit_t,mode_teleop) /* pin for requesting teleop mode */ \
-    FIELD(hal_bit_t,mode_is_teleop) /* pin for teleop mode is on */ \
-    FIELD(hal_bit_t,mode_joint) /* pin for requesting joint mode */ \
-    FIELD(hal_bit_t,mode_is_joint) /* pin for joint mode is on */ \
+    FIELD(bool,mode_manual) /* pin for requesting manual mode */ \
+    FIELD(bool,mode_is_manual) /* pin for manual mode is on */ \
+    FIELD(bool,mode_auto) /* pin for requesting auto mode */ \
+    FIELD(bool,mode_is_auto) /* pin for auto mode is on */ \
+    FIELD(bool,mode_mdi) /* pin for requesting mdi mode */ \
+    FIELD(bool,mode_is_mdi) /* pin for mdi mode is on */ \
+    FIELD(bool,mode_teleop) /* pin for requesting teleop mode */ \
+    FIELD(bool,mode_is_teleop) /* pin for teleop mode is on */ \
+    FIELD(bool,mode_joint) /* pin for requesting joint mode */ \
+    FIELD(bool,mode_is_joint) /* pin for joint mode is on */ \
 \
-    FIELD(hal_bit_t,mist_on) /* pin for starting mist */ \
-    FIELD(hal_bit_t,mist_off) /* pin for stopping mist */ \
-    FIELD(hal_bit_t,mist_is_on) /* pin for mist is on */ \
-    FIELD(hal_bit_t,flood_on) /* pin for starting flood */ \
-    FIELD(hal_bit_t,flood_off) /* pin for stopping flood */ \
-    FIELD(hal_bit_t,flood_is_on) /* pin for flood is on */ \
+    FIELD(bool,mist_on) /* pin for starting mist */ \
+    FIELD(bool,mist_off) /* pin for stopping mist */ \
+    FIELD(bool,mist_is_on) /* pin for mist is on */ \
+    FIELD(bool,flood_on) /* pin for starting flood */ \
+    FIELD(bool,flood_off) /* pin for stopping flood */ \
+    FIELD(bool,flood_is_on) /* pin for flood is on */ \
 \
-    FIELD(hal_bit_t,program_is_idle) /* pin for notifying user that program is idle */ \
-    FIELD(hal_bit_t,program_is_running) /* pin for notifying user that program is running */ \
-    FIELD(hal_bit_t,halui_mdi_is_running) /* pin for notifying user that halui MDI commands is running */ \
-    FIELD(hal_bit_t,program_is_paused) /* pin for notifying user that program is paused */ \
-    FIELD(hal_bit_t,program_run) /* pin for running program */ \
-    FIELD(hal_bit_t,program_pause) /* pin for pausing program */ \
-    FIELD(hal_bit_t,program_resume) /* pin for resuming program */ \
-    FIELD(hal_bit_t,program_step) /* pin for running one line of the program */ \
-    FIELD(hal_bit_t,program_stop) /* pin for stopping the program */ \
-    FIELD(hal_bit_t,program_os_on) /* pin for setting optional stop on */ \
-    FIELD(hal_bit_t,program_os_off) /* pin for setting optional stop off */ \
-    FIELD(hal_bit_t,program_os_is_on) /* status pin that optional stop is on */ \
-    FIELD(hal_bit_t,program_bd_on) /* pin for setting block delete on */ \
-    FIELD(hal_bit_t,program_bd_off) /* pin for setting block delete off */ \
-    FIELD(hal_bit_t,program_bd_is_on) /* status pin that block delete is on */ \
+    FIELD(bool,program_is_idle) /* pin for notifying user that program is idle */ \
+    FIELD(bool,program_is_running) /* pin for notifying user that program is running */ \
+    FIELD(bool,halui_mdi_is_running) /* pin for notifying user that halui MDI commands is running */ \
+    FIELD(bool,program_is_paused) /* pin for notifying user that program is paused */ \
+    FIELD(bool,program_run) /* pin for running program */ \
+    FIELD(bool,program_pause) /* pin for pausing program */ \
+    FIELD(bool,program_resume) /* pin for resuming program */ \
+    FIELD(bool,program_step) /* pin for running one line of the program */ \
+    FIELD(bool,program_stop) /* pin for stopping the program */ \
+    FIELD(bool,program_os_on) /* pin for setting optional stop on */ \
+    FIELD(bool,program_os_off) /* pin for setting optional stop off */ \
+    FIELD(bool,program_os_is_on) /* status pin that optional stop is on */ \
+    FIELD(bool,program_bd_on) /* pin for setting block delete on */ \
+    FIELD(bool,program_bd_off) /* pin for setting block delete off */ \
+    FIELD(bool,program_bd_is_on) /* status pin that block delete is on */ \
 \
-    FIELD(hal_u32_t,tool_number) /* pin for current selected tool */ \
-    FIELD(hal_float_t,tool_length_offset_x) /* current applied x tool-length-offset */ \
-    FIELD(hal_float_t,tool_length_offset_y) /* current applied y tool-length-offset */ \
-    FIELD(hal_float_t,tool_length_offset_z) /* current applied z tool-length-offset */ \
-    FIELD(hal_float_t,tool_length_offset_a) /* current applied a tool-length-offset */ \
-    FIELD(hal_float_t,tool_length_offset_b) /* current applied b tool-length-offset */ \
-    FIELD(hal_float_t,tool_length_offset_c) /* current applied c tool-length-offset */ \
-    FIELD(hal_float_t,tool_length_offset_u) /* current applied u tool-length-offset */ \
-    FIELD(hal_float_t,tool_length_offset_v) /* current applied v tool-length-offset */ \
-    FIELD(hal_float_t,tool_length_offset_w) /* current applied w tool-length-offset */ \
-    FIELD(hal_float_t,tool_diameter) /* current tool diameter (0 if no tool) */ \
+    FIELD(uint,tool_number) /* pin for current selected tool */ \
+    FIELD(real,tool_length_offset_x) /* current applied x tool-length-offset */ \
+    FIELD(real,tool_length_offset_y) /* current applied y tool-length-offset */ \
+    FIELD(real,tool_length_offset_z) /* current applied z tool-length-offset */ \
+    FIELD(real,tool_length_offset_a) /* current applied a tool-length-offset */ \
+    FIELD(real,tool_length_offset_b) /* current applied b tool-length-offset */ \
+    FIELD(real,tool_length_offset_c) /* current applied c tool-length-offset */ \
+    FIELD(real,tool_length_offset_u) /* current applied u tool-length-offset */ \
+    FIELD(real,tool_length_offset_v) /* current applied v tool-length-offset */ \
+    FIELD(real,tool_length_offset_w) /* current applied w tool-length-offset */ \
+    FIELD(real,tool_diameter) /* current tool diameter (0 if no tool) */ \
 \
-    ARRAY(hal_bit_t,spindle_start,EMCMOT_MAX_SPINDLES+1) /* pin for starting the spindle */ \
-    ARRAY(hal_bit_t,spindle_stop,EMCMOT_MAX_SPINDLES+1) /* pin for stopping the spindle */ \
-    ARRAY(hal_bit_t,spindle_is_on,EMCMOT_MAX_SPINDLES+1) /* status pin for spindle is on */ \
-    ARRAY(hal_bit_t,spindle_forward,EMCMOT_MAX_SPINDLES+1) /* pin for making the spindle go forward */ \
-    ARRAY(hal_bit_t,spindle_runs_forward,EMCMOT_MAX_SPINDLES+1) /* status pin for spindle running forward */ \
-    ARRAY(hal_bit_t,spindle_reverse,EMCMOT_MAX_SPINDLES+1) /* pin for making the spindle go reverse */ \
-    ARRAY(hal_bit_t,spindle_runs_backward,EMCMOT_MAX_SPINDLES+1) /* status pin for spindle running backward */ \
-    ARRAY(hal_bit_t,spindle_increase,EMCMOT_MAX_SPINDLES+1) /* pin for making the spindle go faster */ \
-    ARRAY(hal_bit_t,spindle_decrease,EMCMOT_MAX_SPINDLES+1) /* pin for making the spindle go slower */ \
+    ARRAY(bool,spindle_start,EMCMOT_MAX_SPINDLES+1) /* pin for starting the spindle */ \
+    ARRAY(bool,spindle_stop,EMCMOT_MAX_SPINDLES+1) /* pin for stopping the spindle */ \
+    ARRAY(bool,spindle_is_on,EMCMOT_MAX_SPINDLES+1) /* status pin for spindle is on */ \
+    ARRAY(bool,spindle_forward,EMCMOT_MAX_SPINDLES+1) /* pin for making the spindle go forward */ \
+    ARRAY(bool,spindle_runs_forward,EMCMOT_MAX_SPINDLES+1) /* status pin for spindle running forward */ \
+    ARRAY(bool,spindle_reverse,EMCMOT_MAX_SPINDLES+1) /* pin for making the spindle go reverse */ \
+    ARRAY(bool,spindle_runs_backward,EMCMOT_MAX_SPINDLES+1) /* status pin for spindle running backward */ \
+    ARRAY(bool,spindle_increase,EMCMOT_MAX_SPINDLES+1) /* pin for making the spindle go faster */ \
+    ARRAY(bool,spindle_decrease,EMCMOT_MAX_SPINDLES+1) /* pin for making the spindle go slower */ \
 \
-    ARRAY(hal_bit_t,spindle_brake_on,EMCMOT_MAX_SPINDLES) /* pin for activating spindle-brake */ \
-    ARRAY(hal_bit_t,spindle_brake_off, EMCMOT_MAX_SPINDLES) /* pin for deactivating spindle/brake */ \
-    ARRAY(hal_bit_t,spindle_brake_is_on, EMCMOT_MAX_SPINDLES) /* status pin that tells us if brake is on */ \
+    ARRAY(bool,spindle_brake_on,EMCMOT_MAX_SPINDLES) /* pin for activating spindle-brake */ \
+    ARRAY(bool,spindle_brake_off, EMCMOT_MAX_SPINDLES) /* pin for deactivating spindle/brake */ \
+    ARRAY(bool,spindle_brake_is_on, EMCMOT_MAX_SPINDLES) /* status pin that tells us if brake is on */ \
 \
-    ARRAY(hal_bit_t,joint_home,EMCMOT_MAX_JOINTS+1) /* pin for homing one joint */ \
-    ARRAY(hal_bit_t,joint_unhome,EMCMOT_MAX_JOINTS+1) /* pin for unhoming one joint */ \
-    ARRAY(hal_bit_t,joint_is_homed,EMCMOT_MAX_JOINTS+1) /* status pin that the joint is homed */ \
-    ARRAY(hal_bit_t,joint_on_soft_min_limit,EMCMOT_MAX_JOINTS+1) /* status pin that the joint is on the software min limit */ \
-    ARRAY(hal_bit_t,joint_on_soft_max_limit,EMCMOT_MAX_JOINTS+1) /* status pin that the joint is on the software max limit */ \
-    ARRAY(hal_bit_t,joint_on_hard_min_limit,EMCMOT_MAX_JOINTS+1) /* status pin that the joint is on the hardware min limit */ \
-    ARRAY(hal_bit_t,joint_on_hard_max_limit,EMCMOT_MAX_JOINTS+1) /* status pin that the joint is on the hardware max limit */ \
-    ARRAY(hal_bit_t,joint_override_limits,EMCMOT_MAX_JOINTS+1) /* status pin that the joint is on the hardware max limit */ \
-    ARRAY(hal_bit_t,joint_has_fault,EMCMOT_MAX_JOINTS+1) /* status pin that the joint has a fault */ \
-    FIELD(hal_u32_t,joint_selected) /* status pin for the joint selected */ \
-    FIELD(hal_u32_t,axis_selected) /* status pin for the axis selected */ \
+    ARRAY(bool,joint_home,EMCMOT_MAX_JOINTS+1) /* pin for homing one joint */ \
+    ARRAY(bool,joint_unhome,EMCMOT_MAX_JOINTS+1) /* pin for unhoming one joint */ \
+    ARRAY(bool,joint_is_homed,EMCMOT_MAX_JOINTS+1) /* status pin that the joint is homed */ \
+    ARRAY(bool,joint_on_soft_min_limit,EMCMOT_MAX_JOINTS+1) /* status pin that the joint is on the software min limit */ \
+    ARRAY(bool,joint_on_soft_max_limit,EMCMOT_MAX_JOINTS+1) /* status pin that the joint is on the software max limit */ \
+    ARRAY(bool,joint_on_hard_min_limit,EMCMOT_MAX_JOINTS+1) /* status pin that the joint is on the hardware min limit */ \
+    ARRAY(bool,joint_on_hard_max_limit,EMCMOT_MAX_JOINTS+1) /* status pin that the joint is on the hardware max limit */ \
+    ARRAY(bool,joint_override_limits,EMCMOT_MAX_JOINTS+1) /* status pin that the joint is on the hardware max limit */ \
+    ARRAY(bool,joint_has_fault,EMCMOT_MAX_JOINTS+1) /* status pin that the joint has a fault */ \
+    FIELD(uint,joint_selected) /* status pin for the joint selected */ \
+    FIELD(uint,axis_selected) /* status pin for the axis selected */ \
 \
-    ARRAY(hal_bit_t,joint_nr_select,EMCMOT_MAX_JOINTS) /* nr. of pins to select a joint */ \
-    ARRAY(hal_bit_t,axis_nr_select,EMCMOT_MAX_AXIS) /* nr. of pins to select a axis */ \
+    ARRAY(bool,joint_nr_select,EMCMOT_MAX_JOINTS) /* nr. of pins to select a joint */ \
+    ARRAY(bool,axis_nr_select,EMCMOT_MAX_AXIS) /* nr. of pins to select a axis */ \
 \
-    ARRAY(hal_bit_t,joint_is_selected,EMCMOT_MAX_JOINTS) /* nr. of status pins for joint selected */ \
-    ARRAY(hal_bit_t,axis_is_selected,EMCMOT_MAX_AXIS) /* nr. of status pins for axis selected */ \
+    ARRAY(bool,joint_is_selected,EMCMOT_MAX_JOINTS) /* nr. of status pins for joint selected */ \
+    ARRAY(bool,axis_is_selected,EMCMOT_MAX_AXIS) /* nr. of status pins for axis selected */ \
 \
-    ARRAY(hal_float_t,axis_pos_commanded,EMCMOT_MAX_AXIS+1) /* status pin for commanded cartesian position */ \
-    ARRAY(hal_float_t,axis_pos_feedback,EMCMOT_MAX_AXIS+1) /* status pin for actual cartesian position */ \
-    ARRAY(hal_float_t,axis_pos_relative,EMCMOT_MAX_AXIS+1) /* status pin for relative cartesian position */ \
+    ARRAY(real,axis_pos_commanded,EMCMOT_MAX_AXIS+1) /* status pin for commanded cartesian position */ \
+    ARRAY(real,axis_pos_feedback,EMCMOT_MAX_AXIS+1) /* status pin for actual cartesian position */ \
+    ARRAY(real,axis_pos_relative,EMCMOT_MAX_AXIS+1) /* status pin for relative cartesian position */ \
 \
-    FIELD(hal_float_t,jjog_speed) /* pin for setting the jog speed (halui internal) */ \
-    ARRAY(hal_bit_t,jjog_minus,EMCMOT_MAX_JOINTS+1) /* pin to jog in positive direction */ \
-    ARRAY(hal_bit_t,jjog_plus,EMCMOT_MAX_JOINTS+1) /* pin to jog in negative direction */ \
-    ARRAY(hal_float_t,jjog_analog,EMCMOT_MAX_JOINTS+1) /* pin for analog jogging (-1..0..1) */ \
-    ARRAY(hal_float_t,jjog_increment,EMCMOT_MAX_JOINTS+1) /* Incremental jogging */ \
-    ARRAY(hal_bit_t,jjog_increment_plus,EMCMOT_MAX_JOINTS+1) /* Incremental jogging, positive direction */ \
-    ARRAY(hal_bit_t,jjog_increment_minus,EMCMOT_MAX_JOINTS+1) /* Incremental jogging, negative direction */ \
+    FIELD(real,jjog_speed) /* pin for setting the jog speed (halui internal) */ \
+    ARRAY(bool,jjog_minus,EMCMOT_MAX_JOINTS+1) /* pin to jog in positive direction */ \
+    ARRAY(bool,jjog_plus,EMCMOT_MAX_JOINTS+1) /* pin to jog in negative direction */ \
+    ARRAY(real,jjog_analog,EMCMOT_MAX_JOINTS+1) /* pin for analog jogging (-1..0..1) */ \
+    ARRAY(real,jjog_increment,EMCMOT_MAX_JOINTS+1) /* Incremental jogging */ \
+    ARRAY(bool,jjog_increment_plus,EMCMOT_MAX_JOINTS+1) /* Incremental jogging, positive direction */ \
+    ARRAY(bool,jjog_increment_minus,EMCMOT_MAX_JOINTS+1) /* Incremental jogging, negative direction */ \
 \
-    FIELD(hal_float_t,ajog_speed) /* pin for setting the jog speed (halui internal) */ \
-    ARRAY(hal_bit_t,ajog_minus,EMCMOT_MAX_AXIS+1) /* pin to jog in positive direction */ \
-    ARRAY(hal_bit_t,ajog_plus,EMCMOT_MAX_AXIS+1) /* pin to jog in negative direction */ \
-    ARRAY(hal_float_t,ajog_analog,EMCMOT_MAX_AXIS+1) /* pin for analog jogging (-1..0..1) */ \
-    ARRAY(hal_float_t,ajog_increment,EMCMOT_MAX_AXIS+1) /* Incremental jogging */ \
-    ARRAY(hal_bit_t,ajog_increment_plus,EMCMOT_MAX_AXIS+1) /* Incremental jogging, positive direction */ \
-    ARRAY(hal_bit_t,ajog_increment_minus,EMCMOT_MAX_AXIS+1) /* Incremental jogging, negative direction */ \
+    FIELD(real,ajog_speed) /* pin for setting the jog speed (halui internal) */ \
+    ARRAY(bool,ajog_minus,EMCMOT_MAX_AXIS+1) /* pin to jog in positive direction */ \
+    ARRAY(bool,ajog_plus,EMCMOT_MAX_AXIS+1) /* pin to jog in negative direction */ \
+    ARRAY(real,ajog_analog,EMCMOT_MAX_AXIS+1) /* pin for analog jogging (-1..0..1) */ \
+    ARRAY(real,ajog_increment,EMCMOT_MAX_AXIS+1) /* Incremental jogging */ \
+    ARRAY(bool,ajog_increment_plus,EMCMOT_MAX_AXIS+1) /* Incremental jogging, positive direction */ \
+    ARRAY(bool,ajog_increment_minus,EMCMOT_MAX_AXIS+1) /* Incremental jogging, negative direction */ \
 \
-    FIELD(hal_float_t,jjog_deadband) /* pin for setting the jog analog deadband (where not to move) */ \
-    FIELD(hal_float_t,ajog_deadband) /* pin for setting the jog analog deadband (where not to move) */ \
+    FIELD(real,jjog_deadband) /* pin for setting the jog analog deadband (where not to move) */ \
+    FIELD(real,ajog_deadband) /* pin for setting the jog analog deadband (where not to move) */ \
 \
-    FIELD(hal_s32_t,mv_counts) /* pin for the Max Velocity counting */ \
-    FIELD(hal_bit_t,mv_count_enable) /* pin for the Max Velocity counting enable */ \
-    FIELD(hal_bit_t,mv_direct_value) /* pin for enabling direct value option instead of counts */ \
-    FIELD(hal_float_t,mv_scale) /* scale for the Max Velocity counting */ \
-    FIELD(hal_float_t,mv_value) /* current Max Velocity value */ \
-    FIELD(hal_bit_t,mv_increase) /* pin for increasing the MV (+=scale) */ \
-    FIELD(hal_bit_t,mv_decrease) /* pin for decreasing the MV (-=scale) */ \
+    FIELD(sint,mv_counts) /* pin for the Max Velocity counting */ \
+    FIELD(bool,mv_count_enable) /* pin for the Max Velocity counting enable */ \
+    FIELD(bool,mv_direct_value) /* pin for enabling direct value option instead of counts */ \
+    FIELD(real,mv_scale) /* scale for the Max Velocity counting */ \
+    FIELD(real,mv_value) /* current Max Velocity value */ \
+    FIELD(bool,mv_increase) /* pin for increasing the MV (+=scale) */ \
+    FIELD(bool,mv_decrease) /* pin for decreasing the MV (-=scale) */ \
 \
-    FIELD(hal_s32_t,fo_counts) /* pin for the Feed Override counting */ \
-    FIELD(hal_bit_t,fo_count_enable) /* pin for the Feed Override counting enable */ \
-    FIELD(hal_bit_t,fo_direct_value) /* pin for enabling direct value option instead of counts  */ \
-    FIELD(hal_float_t,fo_scale) /* scale for the Feed Override counting */ \
-    FIELD(hal_float_t,fo_value) /* current Feed Override value */ \
-    FIELD(hal_bit_t,fo_increase) /* pin for increasing the FO (+=scale) */ \
-    FIELD(hal_bit_t,fo_decrease) /* pin for decreasing the FO (-=scale) */ \
-    FIELD(hal_bit_t,fo_reset) /* pin for resetting Feed Override */ \
+    FIELD(sint,fo_counts) /* pin for the Feed Override counting */ \
+    FIELD(bool,fo_count_enable) /* pin for the Feed Override counting enable */ \
+    FIELD(bool,fo_direct_value) /* pin for enabling direct value option instead of counts  */ \
+    FIELD(real,fo_scale) /* scale for the Feed Override counting */ \
+    FIELD(real,fo_value) /* current Feed Override value */ \
+    FIELD(bool,fo_increase) /* pin for increasing the FO (+=scale) */ \
+    FIELD(bool,fo_decrease) /* pin for decreasing the FO (-=scale) */ \
+    FIELD(bool,fo_reset) /* pin for resetting Feed Override */ \
 \
-    FIELD(hal_s32_t,ro_counts) /* pin for the Feed Override counting */ \
-    FIELD(hal_bit_t,ro_count_enable) /* pin for the Feed Override counting enable */ \
-    FIELD(hal_bit_t,ro_direct_value) /* pin for enabling direct value option instead of counts  */ \
-    FIELD(hal_float_t,ro_scale) /* scale for the Feed Override counting */ \
-    FIELD(hal_float_t,ro_value) /* current Feed Override value */ \
-    FIELD(hal_bit_t,ro_increase) /* pin ror increasing the FO (+=scale) */ \
-    FIELD(hal_bit_t,ro_decrease) /* pin for decreasing the FO (-=scale) */ \
-    FIELD(hal_bit_t,ro_reset) /* pin for resetting Feed Override */ \
+    FIELD(sint,ro_counts) /* pin for the Feed Override counting */ \
+    FIELD(bool,ro_count_enable) /* pin for the Feed Override counting enable */ \
+    FIELD(bool,ro_direct_value) /* pin for enabling direct value option instead of counts  */ \
+    FIELD(real,ro_scale) /* scale for the Feed Override counting */ \
+    FIELD(real,ro_value) /* current Feed Override value */ \
+    FIELD(bool,ro_increase) /* pin ror increasing the FO (+=scale) */ \
+    FIELD(bool,ro_decrease) /* pin for decreasing the FO (-=scale) */ \
+    FIELD(bool,ro_reset) /* pin for resetting Feed Override */ \
 \
-    ARRAY(hal_s32_t,so_counts,EMCMOT_MAX_SPINDLES+1) /* pin for the Spindle Speed Override counting */ \
-    ARRAY(hal_bit_t,so_count_enable,EMCMOT_MAX_SPINDLES+1) /* pin for the Spindle Speed Override counting enable */ \
-    ARRAY(hal_bit_t,so_direct_value,EMCMOT_MAX_SPINDLES+1) /* pin for enabling direct value option instead of counts */ \
-    ARRAY(hal_float_t,so_scale,EMCMOT_MAX_SPINDLES+1) /* scale for the Spindle Speed Override counting */ \
-    ARRAY(hal_float_t,so_value,EMCMOT_MAX_SPINDLES+1) /* current Spindle speed Override value */ \
-    ARRAY(hal_bit_t,so_increase,EMCMOT_MAX_SPINDLES+1) /* pin for increasing the SO (+=scale) */ \
-    ARRAY(hal_bit_t,so_decrease,EMCMOT_MAX_SPINDLES+1) /* pin for decreasing the SO (-=scale) */ \
-    ARRAY(hal_bit_t,so_reset,EMCMOT_MAX_SPINDLES+1) /* pin for resetting Spindle Speed Override */ \
+    ARRAY(sint,so_counts,EMCMOT_MAX_SPINDLES+1) /* pin for the Spindle Speed Override counting */ \
+    ARRAY(bool,so_count_enable,EMCMOT_MAX_SPINDLES+1) /* pin for the Spindle Speed Override counting enable */ \
+    ARRAY(bool,so_direct_value,EMCMOT_MAX_SPINDLES+1) /* pin for enabling direct value option instead of counts */ \
+    ARRAY(real,so_scale,EMCMOT_MAX_SPINDLES+1) /* scale for the Spindle Speed Override counting */ \
+    ARRAY(real,so_value,EMCMOT_MAX_SPINDLES+1) /* current Spindle speed Override value */ \
+    ARRAY(bool,so_increase,EMCMOT_MAX_SPINDLES+1) /* pin for increasing the SO (+=scale) */ \
+    ARRAY(bool,so_decrease,EMCMOT_MAX_SPINDLES+1) /* pin for decreasing the SO (-=scale) */ \
+    ARRAY(bool,so_reset,EMCMOT_MAX_SPINDLES+1) /* pin for resetting Spindle Speed Override */ \
 \
-    FIELD(hal_bit_t,home_all) /* pin for homing all joints in sequence */ \
-    FIELD(hal_bit_t,abort) /* pin for aborting */ \
-    ARRAY(hal_bit_t,mdi_commands,MDI_MAX) \
+    FIELD(bool,home_all) /* pin for homing all joints in sequence */ \
+    FIELD(bool,abort) /* pin for aborting */ \
+    ARRAY(bool,mdi_commands,MDI_MAX) \
 \
-    FIELD(hal_float_t,units_per_mm) \
+    FIELD(real,units_per_mm) \
 
 struct PTR {
     template<class T>
-    struct field { typedef T *type; };
+    struct field { typedef T type; };
 };
 
 template<class T> struct NATIVE {};
-template<> struct NATIVE<hal_bit_t> { typedef bool type; };
-template<> struct NATIVE<hal_s32_t> { typedef rtapi_s32 type; };
-template<> struct NATIVE<hal_u32_t> { typedef rtapi_u32 type; };
-template<> struct NATIVE<hal_float_t> { typedef double type; };
+template<> struct NATIVE<hal_bool_t> { typedef rtapi_bool type; };
+template<> struct NATIVE<hal_si32_t> { typedef rtapi_s32 type; };
+template<> struct NATIVE<hal_ui32_t> { typedef rtapi_u32 type; };
+// FIXME: These need to be 64-bit. Can't set them now because the compiler sees
+// the typedef mapped overlap.
+//template<> struct NATIVE<hal_sint_t> { typedef rtapi_sint type; };
+//template<> struct NATIVE<hal_uint_t> { typedef rtapi_uint type; };
+template<> struct NATIVE<hal_real_t> { typedef rtapi_real type; };
 struct VALUE {
     template<class T> struct field { typedef typename NATIVE<T>::type type; };
 };
@@ -223,8 +230,8 @@ struct VALUE {
 template<class T>
 struct halui_str_base
 {
-#define FIELD(t,f) typename T::template field<t>::type f;
-#define ARRAY(t,f,n) typename T::template field<t>::type f[n];
+#define FIELD(t,f) typename T::template field<hal_##t##_t>::type f;
+#define ARRAY(t,f,n) typename T::template field<hal_##t##_t>::type f[n];
 HAL_FIELDS
 #undef FIELD
 #undef ARRAY
@@ -232,7 +239,6 @@ HAL_FIELDS
 
 typedef halui_str_base<PTR> halui_str;
 typedef halui_str_base<VALUE> local_halui_str;
-#pragma GCC diagnostic pop
 
 static halui_str *halui_data;
 static local_halui_str old_halui_data;
@@ -482,10 +488,10 @@ static ANGULAR_UNIT_CONVERSION angularUnitConversion = ANGULAR_UNITS_AUTO;
 #define GRAD_PER_DEG (100.0/90.0)
 #define RAD_PER_DEG TO_RAD	// from posemath.h
 
-int halui_export_pin_IN_bit(hal_bit_t **pin, const char *name)
+int halui_export_pin_IN_bit(hal_bool_t *pin, const char *name)
 {
     int retval;
-    retval = hal_pin_bit_new(name, HAL_IN, pin, comp_id);
+    retval = hal_pin_new_bool(comp_id, HAL_IN, pin, 0, "%s", name);
     if (retval < 0) {
 	rtapi_print_msg(RTAPI_MSG_ERR,"HALUI: ERROR: halui pin %s export failed with err=%i\n", name, retval);
 	hal_exit(comp_id);
@@ -494,10 +500,10 @@ int halui_export_pin_IN_bit(hal_bit_t **pin, const char *name)
     return 0;
 }
 
-int halui_export_pin_IN_s32(hal_s32_t **pin, const char *name)
+int halui_export_pin_IN_s32(hal_sint_t *pin, const char *name)
 {
     int retval;
-    retval = hal_pin_s32_new(name, HAL_IN, pin, comp_id);
+    retval = hal_pin_new_si32(comp_id, HAL_IN, pin, 0, "%s", name);
     if (retval < 0) {
 	rtapi_print_msg(RTAPI_MSG_ERR,"HALUI: ERROR: halui pin %s export failed with err=%i\n", name, retval);
 	hal_exit(comp_id);
@@ -506,10 +512,10 @@ int halui_export_pin_IN_s32(hal_s32_t **pin, const char *name)
     return 0;
 }
 
-int halui_export_pin_IN_float(hal_float_t **pin, const char *name)
+int halui_export_pin_IN_float(hal_real_t *pin, const char *name)
 {
     int retval;
-    retval = hal_pin_float_new(name, HAL_IN, pin, comp_id);
+    retval = hal_pin_new_real(comp_id, HAL_IN, pin, 0.0, "%s", name);
     if (retval < 0) {
 	rtapi_print_msg(RTAPI_MSG_ERR,"HALUI: ERROR: halui pin %s export failed with err=%i\n", name, retval);
 	hal_exit(comp_id);
@@ -519,10 +525,10 @@ int halui_export_pin_IN_float(hal_float_t **pin, const char *name)
 }
 
 
-int halui_export_pin_OUT_bit(hal_bit_t **pin, const char *name)
+int halui_export_pin_OUT_bit(hal_bool_t *pin, const char *name)
 {
     int retval;
-    retval = hal_pin_bit_new(name, HAL_OUT, pin, comp_id);
+    retval = hal_pin_new_bool(comp_id, HAL_OUT, pin, 0, "%s", name);
     if (retval < 0) {
 	rtapi_print_msg(RTAPI_MSG_ERR,"HALUI: ERROR: halui pin %s export failed with err=%i\n", name, retval);
 	hal_exit(comp_id);
@@ -540,13 +546,14 @@ int halui_export_pin_OUT_bit(hal_bit_t **pin, const char *name)
 *
 * Called By: main
 ********************************************************************/
+#define CHK(x) do { \
+        int rv = (x); \
+        if(rv < 0) \
+            return rv; \
+    } while(0)
+
 int halui_hal_init(void)
 {
-    int retval;
-    int joint;
-    int spindle;
-    int axis_num;
-
     /* STEP 1: initialise the hal component */
     comp_id = hal_init("halui");
     if (comp_id < 0) {
@@ -566,359 +573,203 @@ int halui_hal_init(void)
 
     /* STEP 3a: export the out-pin(s) */
 
-    retval =  hal_pin_float_newf(HAL_OUT, &(halui_data->units_per_mm), comp_id, "halui.machine.units-per-mm");
-    if (retval < 0) return retval;
-    retval = halui_export_pin_OUT_bit(&(halui_data->machine_is_on), "halui.machine.is-on");
-    if (retval < 0) return retval;
-    retval = halui_export_pin_OUT_bit(&(halui_data->estop_is_activated), "halui.estop.is-activated");
-    if (retval < 0) return retval;
-    retval = halui_export_pin_OUT_bit(&(halui_data->mode_is_manual), "halui.mode.is-manual");
-    if (retval < 0) return retval;
-    retval = halui_export_pin_OUT_bit(&(halui_data->mode_is_auto), "halui.mode.is-auto");
-    if (retval < 0) return retval;
-    retval = halui_export_pin_OUT_bit(&(halui_data->mode_is_mdi), "halui.mode.is-mdi");
-    if (retval < 0) return retval;
-    retval = halui_export_pin_OUT_bit(&(halui_data->mode_is_teleop), "halui.mode.is-teleop");
-    if (retval < 0) return retval;
-    retval = halui_export_pin_OUT_bit(&(halui_data->mode_is_joint), "halui.mode.is-joint");
-    if (retval < 0) return retval;
-    retval = halui_export_pin_OUT_bit(&(halui_data->mist_is_on), "halui.mist.is-on");
-    if (retval < 0) return retval;
-    retval = halui_export_pin_OUT_bit(&(halui_data->flood_is_on), "halui.flood.is-on");
-    if (retval < 0) return retval;
-    retval = halui_export_pin_OUT_bit(&(halui_data->program_is_idle), "halui.program.is-idle");
-    if (retval < 0) return retval;
-    retval = halui_export_pin_OUT_bit(&(halui_data->program_is_running), "halui.program.is-running");
-    if (retval < 0) return retval;
+    CHK(hal_pin_new_real(comp_id, HAL_OUT, &(halui_data->units_per_mm), 0.0, "halui.machine.units-per-mm"));
+    CHK(halui_export_pin_OUT_bit(&(halui_data->machine_is_on), "halui.machine.is-on"));
+    CHK(halui_export_pin_OUT_bit(&(halui_data->estop_is_activated), "halui.estop.is-activated"));
+    CHK(halui_export_pin_OUT_bit(&(halui_data->mode_is_manual), "halui.mode.is-manual"));
+    CHK(halui_export_pin_OUT_bit(&(halui_data->mode_is_auto), "halui.mode.is-auto"));
+    CHK(halui_export_pin_OUT_bit(&(halui_data->mode_is_mdi), "halui.mode.is-mdi"));
+    CHK(halui_export_pin_OUT_bit(&(halui_data->mode_is_teleop), "halui.mode.is-teleop"));
+    CHK(halui_export_pin_OUT_bit(&(halui_data->mode_is_joint), "halui.mode.is-joint"));
+    CHK(halui_export_pin_OUT_bit(&(halui_data->mist_is_on), "halui.mist.is-on"));
+    CHK(halui_export_pin_OUT_bit(&(halui_data->flood_is_on), "halui.flood.is-on"));
+    CHK(halui_export_pin_OUT_bit(&(halui_data->program_is_idle), "halui.program.is-idle"));
+    CHK(halui_export_pin_OUT_bit(&(halui_data->program_is_running), "halui.program.is-running"));
     
-    if (num_mdi_commands>0){
-    retval = halui_export_pin_OUT_bit(&(halui_data->halui_mdi_is_running), "halui.halui-mdi-is-running");
-    if (retval < 0) return retval;
-	}
+    if (num_mdi_commands > 0) {
+        CHK(halui_export_pin_OUT_bit(&(halui_data->halui_mdi_is_running), "halui.halui-mdi-is-running"));
+    }
     
-    retval = halui_export_pin_OUT_bit(&(halui_data->program_is_paused), "halui.program.is-paused");
-    if (retval < 0) return retval;
-    retval = halui_export_pin_OUT_bit(&(halui_data->program_os_is_on), "halui.program.optional-stop.is-on");
-    if (retval < 0) return retval;
-    retval = halui_export_pin_OUT_bit(&(halui_data->program_bd_is_on), "halui.program.block-delete.is-on");
+    CHK(halui_export_pin_OUT_bit(&(halui_data->program_is_paused), "halui.program.is-paused"));
+    CHK(halui_export_pin_OUT_bit(&(halui_data->program_os_is_on), "halui.program.optional-stop.is-on"));
+    CHK(halui_export_pin_OUT_bit(&(halui_data->program_bd_is_on), "halui.program.block-delete.is-on"));
 
-    for (spindle = 0; spindle < num_spindles; spindle++){
-		if (retval < 0) return retval;
-		retval = hal_pin_bit_newf(HAL_OUT, &(halui_data->spindle_is_on[spindle]), comp_id,  "halui.spindle.%i.is-on", spindle);
-		if (retval < 0) return retval;
-		retval = hal_pin_bit_newf(HAL_OUT, &(halui_data->spindle_runs_forward[spindle]),comp_id,  "halui.spindle.%i.runs-forward", spindle);
-		if (retval < 0) return retval;
-		retval = hal_pin_bit_newf(HAL_OUT, &(halui_data->spindle_runs_backward[spindle]), comp_id, "halui.spindle.%i.runs-backward", spindle);
-		if (retval < 0) return retval;
-		retval = hal_pin_bit_newf(HAL_OUT, &(halui_data->spindle_brake_is_on[spindle]), comp_id, "halui.spindle.%i.brake-is-on", spindle);
-		if (retval < 0) return retval;
-		retval = hal_pin_bit_newf(HAL_IN,  &(halui_data->spindle_start[spindle]), comp_id, "halui.spindle.%i.start", spindle);
-		if (retval < 0) return retval;
-		retval = hal_pin_bit_newf(HAL_IN,  &(halui_data->spindle_stop[spindle]), comp_id, "halui.spindle.%i.stop", spindle);
-		if (retval < 0) return retval;
-		retval = hal_pin_bit_newf(HAL_IN,  &(halui_data->spindle_forward[spindle]), comp_id, "halui.spindle.%i.forward", spindle);
-		if (retval < 0) return retval;
-		retval = hal_pin_bit_newf(HAL_IN,  &(halui_data->spindle_reverse[spindle]), comp_id, "halui.spindle.%i.reverse", spindle);
-		if (retval < 0) return retval;
-		retval = hal_pin_bit_newf(HAL_IN,  &(halui_data->spindle_increase[spindle]), comp_id, "halui.spindle.%i.increase", spindle);
-		if (retval < 0) return retval;
-		retval = hal_pin_bit_newf(HAL_IN,  &(halui_data->spindle_decrease[spindle]), comp_id, "halui.spindle.%i.decrease", spindle);
-		if (retval < 0) return retval;
-		retval = hal_pin_bit_newf(HAL_IN,  &(halui_data->spindle_brake_on[spindle]), comp_id, "halui.spindle.%i.brake-on", spindle);
-		if (retval < 0) return retval;
-		retval = hal_pin_bit_newf(HAL_IN,  &(halui_data->spindle_brake_off[spindle]), comp_id, "halui.spindle.%i.brake-off", spindle);
-		if (retval < 0) return retval;
-	    retval =  hal_pin_float_newf(HAL_OUT, &(halui_data->so_value[spindle]), comp_id, "halui.spindle.%i.override.value", spindle);
-	    if (retval < 0) return retval;
-	    retval = hal_pin_s32_newf(HAL_IN,  &(halui_data->so_counts[spindle]), comp_id, "halui.spindle.%i.override.counts", spindle);
-	    if (retval < 0) return retval;
-	    *halui_data->so_counts[spindle] = 0;
-	    retval = hal_pin_bit_newf(HAL_IN,  &(halui_data->so_count_enable[spindle]), comp_id, "halui.spindle.%i.override.count-enable", spindle);
-	    if (retval < 0) return retval;
-	    *halui_data->so_count_enable[spindle] = 1;
-	    retval = hal_pin_bit_newf(HAL_IN,  &(halui_data->so_direct_value[spindle]), comp_id, "halui.spindle.%i.override.direct-value", spindle);
-	    if (retval < 0) return retval;
-	    *halui_data->so_direct_value[spindle] = 0;
-	    retval = hal_pin_float_newf(HAL_IN,  &(halui_data->so_scale[spindle]), comp_id, "halui.spindle.%i.override.scale", spindle);
-	    if (retval < 0) return retval;
-	    retval = hal_pin_bit_newf(HAL_IN,  &(halui_data->so_increase[spindle]), comp_id, "halui.spindle.%i.override.increase", spindle);
-	    if (retval < 0) return retval;
-	    retval = hal_pin_bit_newf(HAL_IN,  &(halui_data->so_decrease[spindle]), comp_id, "halui.spindle.%i.override.decrease", spindle);
-            if (retval < 0) return retval;
-            retval = hal_pin_bit_newf(HAL_IN,  &(halui_data->so_reset[spindle]), comp_id, "halui.spindle.%i.override.reset", spindle);
+    for (int spindle = 0; spindle < num_spindles; spindle++){
+        CHK(hal_pin_new_bool(comp_id, HAL_OUT, &(halui_data->spindle_is_on[spindle]), 0, "halui.spindle.%i.is-on", spindle));
+        CHK(hal_pin_new_bool(comp_id, HAL_OUT, &(halui_data->spindle_runs_forward[spindle]), 0, "halui.spindle.%i.runs-forward", spindle));
+        CHK(hal_pin_new_bool(comp_id, HAL_OUT, &(halui_data->spindle_runs_backward[spindle]), 0, "halui.spindle.%i.runs-backward", spindle));
+        CHK(hal_pin_new_bool(comp_id, HAL_OUT, &(halui_data->spindle_brake_is_on[spindle]), 0, "halui.spindle.%i.brake-is-on", spindle));
+        CHK(hal_pin_new_bool(comp_id, HAL_IN, &(halui_data->spindle_start[spindle]), 0, "halui.spindle.%i.start", spindle));
+        CHK(hal_pin_new_bool(comp_id, HAL_IN, &(halui_data->spindle_stop[spindle]), 0, "halui.spindle.%i.stop", spindle));
+        CHK(hal_pin_new_bool(comp_id, HAL_IN, &(halui_data->spindle_forward[spindle]), 0, "halui.spindle.%i.forward", spindle));
+        CHK(hal_pin_new_bool(comp_id, HAL_IN, &(halui_data->spindle_reverse[spindle]), 0, "halui.spindle.%i.reverse", spindle));
+        CHK(hal_pin_new_bool(comp_id, HAL_IN, &(halui_data->spindle_increase[spindle]), 0, "halui.spindle.%i.increase", spindle));
+        CHK(hal_pin_new_bool(comp_id, HAL_IN, &(halui_data->spindle_decrease[spindle]), 0, "halui.spindle.%i.decrease", spindle));
+        CHK(hal_pin_new_bool(comp_id, HAL_IN, &(halui_data->spindle_brake_on[spindle]), 0, "halui.spindle.%i.brake-on", spindle));
+        CHK(hal_pin_new_bool(comp_id, HAL_IN, &(halui_data->spindle_brake_off[spindle]), 0, "halui.spindle.%i.brake-off", spindle));
+        CHK(hal_pin_new_real(comp_id, HAL_OUT, &(halui_data->so_value[spindle]), 0.0, "halui.spindle.%i.override.value", spindle));
+        CHK(hal_pin_new_si32(comp_id, HAL_IN, &(halui_data->so_counts[spindle]), 0, "halui.spindle.%i.override.counts", spindle));
+        CHK(hal_pin_new_bool(comp_id, HAL_IN, &(halui_data->so_count_enable[spindle]), 1, "halui.spindle.%i.override.count-enable", spindle));
+        CHK(hal_pin_new_bool(comp_id, HAL_IN, &(halui_data->so_direct_value[spindle]), 0, "halui.spindle.%i.override.direct-value", spindle));
+        CHK(hal_pin_new_real(comp_id, HAL_IN, &(halui_data->so_scale[spindle]), 0.0, "halui.spindle.%i.override.scale", spindle));
+        CHK(hal_pin_new_bool(comp_id, HAL_IN, &(halui_data->so_increase[spindle]), 0, "halui.spindle.%i.override.increase", spindle));
+        CHK(hal_pin_new_bool(comp_id, HAL_IN, &(halui_data->so_decrease[spindle]), 0, "halui.spindle.%i.override.decrease", spindle));
+        CHK(hal_pin_new_bool(comp_id, HAL_IN, &(halui_data->so_reset[spindle]), 0, "halui.spindle.%i.override.reset", spindle));
     }
 
-    for (joint=0; joint < num_joints ; joint++) {
-	retval =  hal_pin_bit_newf(HAL_OUT, &(halui_data->joint_is_homed[joint]), comp_id, "halui.joint.%d.is-homed", joint);
-	if (retval < 0) return retval;
-	retval =  hal_pin_bit_newf(HAL_OUT, &(halui_data->joint_is_selected[joint]), comp_id, "halui.joint.%d.is-selected", joint);
-	if (retval < 0) return retval;
-	retval =  hal_pin_bit_newf(HAL_OUT, &(halui_data->joint_on_soft_min_limit[joint]), comp_id, "halui.joint.%d.on-soft-min-limit", joint);
-	if (retval < 0) return retval;
-	retval =  hal_pin_bit_newf(HAL_OUT, &(halui_data->joint_on_soft_max_limit[joint]), comp_id, "halui.joint.%d.on-soft-max-limit", joint);
-	if (retval < 0) return retval;
-	retval =  hal_pin_bit_newf(HAL_OUT, &(halui_data->joint_on_hard_min_limit[joint]), comp_id, "halui.joint.%d.on-hard-min-limit", joint);
-	if (retval < 0) return retval;
-	retval =  hal_pin_bit_newf(HAL_OUT, &(halui_data->joint_on_hard_max_limit[joint]), comp_id, "halui.joint.%d.on-hard-max-limit", joint);
-	if (retval < 0) return retval;
-	retval =  hal_pin_bit_newf(HAL_OUT, &(halui_data->joint_override_limits[joint]), comp_id, "halui.joint.%d.override-limits", joint);
-	if (retval < 0) return retval;
-	retval =  hal_pin_bit_newf(HAL_OUT, &(halui_data->joint_has_fault[joint]), comp_id, "halui.joint.%d.has-fault", joint);
-	if (retval < 0) return retval;
+    for (int joint = 0; joint < num_joints ; joint++) {
+        CHK(hal_pin_new_bool(comp_id, HAL_OUT, &(halui_data->joint_is_homed[joint]), 0, "halui.joint.%d.is-homed", joint));
+        CHK(hal_pin_new_bool(comp_id, HAL_OUT, &(halui_data->joint_is_selected[joint]), 0, "halui.joint.%d.is-selected", joint));
+        CHK(hal_pin_new_bool(comp_id, HAL_OUT, &(halui_data->joint_on_soft_min_limit[joint]), 0, "halui.joint.%d.on-soft-min-limit", joint));
+        CHK(hal_pin_new_bool(comp_id, HAL_OUT, &(halui_data->joint_on_soft_max_limit[joint]), 0, "halui.joint.%d.on-soft-max-limit", joint));
+        CHK(hal_pin_new_bool(comp_id, HAL_OUT, &(halui_data->joint_on_hard_min_limit[joint]), 0, "halui.joint.%d.on-hard-min-limit", joint));
+        CHK(hal_pin_new_bool(comp_id, HAL_OUT, &(halui_data->joint_on_hard_max_limit[joint]), 0, "halui.joint.%d.on-hard-max-limit", joint));
+        CHK(hal_pin_new_bool(comp_id, HAL_OUT, &(halui_data->joint_override_limits[joint]), 0, "halui.joint.%d.override-limits", joint));
+        CHK(hal_pin_new_bool(comp_id, HAL_OUT, &(halui_data->joint_has_fault[joint]), 0, "halui.joint.%d.has-fault", joint));
     }
 
-    retval =  hal_pin_bit_newf(HAL_OUT, &(halui_data->joint_on_soft_min_limit[num_joints]), comp_id, "halui.joint.selected.on-soft-min-limit");
-    if (retval < 0) return retval;
-    retval =  hal_pin_bit_newf(HAL_OUT, &(halui_data->joint_on_soft_max_limit[num_joints]), comp_id, "halui.joint.selected.on-soft-max-limit");
-    if (retval < 0) return retval;
-    retval =  hal_pin_bit_newf(HAL_OUT, &(halui_data->joint_on_hard_min_limit[num_joints]), comp_id, "halui.joint.selected.on-hard-min-limit");
-    if (retval < 0) return retval;
-    retval =  hal_pin_bit_newf(HAL_OUT, &(halui_data->joint_on_hard_max_limit[num_joints]), comp_id, "halui.joint.selected.on-hard-max-limit");
-    if (retval < 0) return retval;
-    retval =  hal_pin_bit_newf(HAL_OUT, &(halui_data->joint_override_limits[num_joints]), comp_id, "halui.joint.selected.override-limits");
-    if (retval < 0) return retval;
-    retval =  hal_pin_bit_newf(HAL_OUT, &(halui_data->joint_has_fault[num_joints]), comp_id, "halui.joint.selected.has-fault");
-    if (retval < 0) return retval;
-    retval =  hal_pin_bit_newf(HAL_OUT, &(halui_data->joint_is_homed[num_joints]), comp_id, "halui.joint.selected.is-homed");
-    if (retval < 0) return retval;
+    CHK(hal_pin_new_bool(comp_id, HAL_OUT, &(halui_data->joint_on_soft_min_limit[num_joints]), 0, "halui.joint.selected.on-soft-min-limit"));
+    CHK(hal_pin_new_bool(comp_id, HAL_OUT, &(halui_data->joint_on_soft_max_limit[num_joints]), 0, "halui.joint.selected.on-soft-max-limit"));
+    CHK(hal_pin_new_bool(comp_id, HAL_OUT, &(halui_data->joint_on_hard_min_limit[num_joints]), 0, "halui.joint.selected.on-hard-min-limit"));
+    CHK(hal_pin_new_bool(comp_id, HAL_OUT, &(halui_data->joint_on_hard_max_limit[num_joints]), 0, "halui.joint.selected.on-hard-max-limit"));
+    CHK(hal_pin_new_bool(comp_id, HAL_OUT, &(halui_data->joint_override_limits[num_joints]), 0, "halui.joint.selected.override-limits"));
+    CHK(hal_pin_new_bool(comp_id, HAL_OUT, &(halui_data->joint_has_fault[num_joints]), 0, "halui.joint.selected.has-fault"));
+    CHK(hal_pin_new_bool(comp_id, HAL_OUT, &(halui_data->joint_is_homed[num_joints]), 0, "halui.joint.selected.is-homed"));
 
     bool first_axis = true;
-    for (axis_num=0; axis_num < EMCMOT_MAX_AXIS ; axis_num++) {
+    for (int axis_num = 0; axis_num < EMCMOT_MAX_AXIS; axis_num++) {
         if ( !(axis_mask & (1 << axis_num)) ) { continue; }
         char c = "xyzabcuvw"[axis_num];
-        retval =  hal_pin_bit_newf(HAL_OUT, &(halui_data->axis_is_selected[axis_num]), comp_id, "halui.axis.%c.is-selected", c);
-        if (retval < 0) return retval;
-	    retval =  hal_pin_float_newf(HAL_OUT, &(halui_data->axis_pos_commanded[axis_num]), comp_id, "halui.axis.%c.pos-commanded", c);
-        if (retval < 0) return retval;
-	    retval =  hal_pin_float_newf(HAL_OUT, &(halui_data->axis_pos_feedback[axis_num]), comp_id, "halui.axis.%c.pos-feedback", c);
-        if (retval < 0) return retval;
-	    retval =  hal_pin_float_newf(HAL_OUT, &(halui_data->axis_pos_relative[axis_num]), comp_id, "halui.axis.%c.pos-relative", c);
-        if (retval < 0) return retval;
+        CHK(hal_pin_new_bool(comp_id, HAL_OUT, &(halui_data->axis_is_selected[axis_num]), 0, "halui.axis.%c.is-selected", c));
+        CHK(hal_pin_new_real(comp_id, HAL_OUT, &(halui_data->axis_pos_commanded[axis_num]), 0.0, "halui.axis.%c.pos-commanded", c));
+        CHK(hal_pin_new_real(comp_id, HAL_OUT, &(halui_data->axis_pos_feedback[axis_num]), 0.0, "halui.axis.%c.pos-feedback", c));
+        CHK(hal_pin_new_real(comp_id, HAL_OUT, &(halui_data->axis_pos_relative[axis_num]), 0.0, "halui.axis.%c.pos-relative", c));
         if (first_axis) {
             // at startup, indicate first item is selected:
-            *halui_data->joint_is_selected[0] = 1;
-            *halui_data->axis_is_selected[axis_num] = 1;
+            hal_set_bool(halui_data->joint_is_selected[0], 1);
+            hal_set_bool(halui_data->axis_is_selected[axis_num], 1);
         }
         first_axis = false;
     }
 
-    retval =  hal_pin_float_newf(HAL_OUT, &(halui_data->mv_value), comp_id, "halui.max-velocity.value");
-    if (retval < 0) return retval;
-    retval =  hal_pin_float_newf(HAL_OUT, &(halui_data->fo_value), comp_id, "halui.feed-override.value");
-    if (retval < 0) return retval;
-    retval =  hal_pin_float_newf(HAL_OUT, &(halui_data->ro_value), comp_id, "halui.rapid-override.value");
-    if (retval < 0) return retval;
-    retval = hal_pin_u32_newf(HAL_OUT, &(halui_data->joint_selected), comp_id, "halui.joint.selected");
-    if (retval < 0) return retval;
-    retval = hal_pin_u32_newf(HAL_OUT, &(halui_data->axis_selected), comp_id, "halui.axis.selected");
-    if (retval < 0) return retval;
-    retval = hal_pin_u32_newf(HAL_OUT, &(halui_data->tool_number), comp_id, "halui.tool.number");
-    if (retval < 0) return retval;
-    retval =  hal_pin_float_newf(HAL_OUT, &(halui_data->tool_length_offset_x), comp_id, "halui.tool.length_offset.x");
-    if (retval < 0) return retval;
-    retval =  hal_pin_float_newf(HAL_OUT, &(halui_data->tool_length_offset_y), comp_id, "halui.tool.length_offset.y");
-    if (retval < 0) return retval;
-    retval =  hal_pin_float_newf(HAL_OUT, &(halui_data->tool_length_offset_z), comp_id, "halui.tool.length_offset.z");
-    if (retval < 0) return retval;
-    retval =  hal_pin_float_newf(HAL_OUT, &(halui_data->tool_length_offset_a), comp_id, "halui.tool.length_offset.a");
-    if (retval < 0) return retval;
-    retval =  hal_pin_float_newf(HAL_OUT, &(halui_data->tool_length_offset_b), comp_id, "halui.tool.length_offset.b");
-    if (retval < 0) return retval;
-    retval =  hal_pin_float_newf(HAL_OUT, &(halui_data->tool_length_offset_c), comp_id, "halui.tool.length_offset.c");
-    if (retval < 0) return retval;
-    retval =  hal_pin_float_newf(HAL_OUT, &(halui_data->tool_length_offset_u), comp_id, "halui.tool.length_offset.u");
-    if (retval < 0) return retval;
-    retval =  hal_pin_float_newf(HAL_OUT, &(halui_data->tool_length_offset_v), comp_id, "halui.tool.length_offset.v");
-    if (retval < 0) return retval;
-    retval =  hal_pin_float_newf(HAL_OUT, &(halui_data->tool_length_offset_w), comp_id, "halui.tool.length_offset.w");
-    if (retval < 0) return retval;
-    retval =  hal_pin_float_newf(HAL_OUT, &(halui_data->tool_diameter), comp_id, "halui.tool.diameter");
-    if (retval < 0) return retval;
+    CHK(hal_pin_new_real(comp_id, HAL_OUT, &(halui_data->mv_value), 0.0, "halui.max-velocity.value"));
+    CHK(hal_pin_new_real(comp_id, HAL_OUT, &(halui_data->fo_value), 0.0, "halui.feed-override.value"));
+    CHK(hal_pin_new_real(comp_id, HAL_OUT, &(halui_data->ro_value), 0.0, "halui.rapid-override.value"));
+    CHK(hal_pin_new_ui32(comp_id, HAL_OUT, &(halui_data->joint_selected), 0, "halui.joint.selected"));
+    CHK(hal_pin_new_ui32(comp_id, HAL_OUT, &(halui_data->axis_selected), 0, "halui.axis.selected"));
+    CHK(hal_pin_new_ui32(comp_id, HAL_OUT, &(halui_data->tool_number), 0, "halui.tool.number"));
+    CHK(hal_pin_new_real(comp_id, HAL_OUT, &(halui_data->tool_length_offset_x), 0.0, "halui.tool.length_offset.x"));
+    CHK(hal_pin_new_real(comp_id, HAL_OUT, &(halui_data->tool_length_offset_y), 0.0, "halui.tool.length_offset.y"));
+    CHK(hal_pin_new_real(comp_id, HAL_OUT, &(halui_data->tool_length_offset_z), 0.0, "halui.tool.length_offset.z"));
+    CHK(hal_pin_new_real(comp_id, HAL_OUT, &(halui_data->tool_length_offset_a), 0.0, "halui.tool.length_offset.a"));
+    CHK(hal_pin_new_real(comp_id, HAL_OUT, &(halui_data->tool_length_offset_b), 0.0, "halui.tool.length_offset.b"));
+    CHK(hal_pin_new_real(comp_id, HAL_OUT, &(halui_data->tool_length_offset_c), 0.0, "halui.tool.length_offset.c"));
+    CHK(hal_pin_new_real(comp_id, HAL_OUT, &(halui_data->tool_length_offset_u), 0.0, "halui.tool.length_offset.u"));
+    CHK(hal_pin_new_real(comp_id, HAL_OUT, &(halui_data->tool_length_offset_v), 0.0, "halui.tool.length_offset.v"));
+    CHK(hal_pin_new_real(comp_id, HAL_OUT, &(halui_data->tool_length_offset_w), 0.0, "halui.tool.length_offset.w"));
+    CHK(hal_pin_new_real(comp_id, HAL_OUT, &(halui_data->tool_diameter), 0.0, "halui.tool.diameter"));
 
     /* STEP 3b: export the in-pin(s) */
 
-    retval = halui_export_pin_IN_bit(&(halui_data->machine_on), "halui.machine.on");
-    if (retval < 0) return retval;
-    retval = halui_export_pin_IN_bit(&(halui_data->machine_off), "halui.machine.off");
-    if (retval < 0) return retval;
-    retval = halui_export_pin_IN_bit(&(halui_data->estop_activate), "halui.estop.activate");
-    if (retval < 0) return retval;
-    retval = halui_export_pin_IN_bit(&(halui_data->estop_reset), "halui.estop.reset");
-    if (retval < 0) return retval;
-    retval = halui_export_pin_IN_bit(&(halui_data->mode_manual), "halui.mode.manual");
-    if (retval < 0) return retval;
-    retval = halui_export_pin_IN_bit(&(halui_data->mode_auto), "halui.mode.auto");
-    if (retval < 0) return retval;
-    retval = halui_export_pin_IN_bit(&(halui_data->mode_mdi), "halui.mode.mdi");
-    if (retval < 0) return retval;
-    retval = halui_export_pin_IN_bit(&(halui_data->mode_teleop), "halui.mode.teleop");
-    if (retval < 0) return retval;
-    retval = halui_export_pin_IN_bit(&(halui_data->mode_joint), "halui.mode.joint");
-    if (retval < 0) return retval;
-    retval = halui_export_pin_IN_bit(&(halui_data->mist_on), "halui.mist.on");
-    if (retval < 0) return retval;
-    retval = halui_export_pin_IN_bit(&(halui_data->mist_off), "halui.mist.off");
-    if (retval < 0) return retval;
-    retval = halui_export_pin_IN_bit(&(halui_data->flood_on), "halui.flood.on");
-    if (retval < 0) return retval;
-    retval = halui_export_pin_IN_bit(&(halui_data->flood_off), "halui.flood.off");
-    if (retval < 0) return retval;
-    retval = halui_export_pin_IN_bit(&(halui_data->program_run), "halui.program.run");
-    if (retval < 0) return retval;
-    retval = halui_export_pin_IN_bit(&(halui_data->program_pause), "halui.program.pause");
-    if (retval < 0) return retval;
-    retval = halui_export_pin_IN_bit(&(halui_data->program_resume), "halui.program.resume");
-    if (retval < 0) return retval;
-    retval = halui_export_pin_IN_bit(&(halui_data->program_step), "halui.program.step");
-    if (retval < 0) return retval;
-    retval = halui_export_pin_IN_bit(&(halui_data->program_stop), "halui.program.stop");
-    if (retval < 0) return retval;
-    retval = halui_export_pin_IN_bit(&(halui_data->program_os_on), "halui.program.optional-stop.on");
-    if (retval < 0) return retval;
-    retval = halui_export_pin_IN_bit(&(halui_data->program_os_off), "halui.program.optional-stop.off");
-    if (retval < 0) return retval;
-    retval = halui_export_pin_IN_bit(&(halui_data->program_bd_on), "halui.program.block-delete.on");
-    if (retval < 0) return retval;
-    retval = halui_export_pin_IN_bit(&(halui_data->program_bd_off), "halui.program.block-delete.off");
-    if (retval < 0) return retval;
+    CHK(halui_export_pin_IN_bit(&(halui_data->machine_on), "halui.machine.on"));
+    CHK(halui_export_pin_IN_bit(&(halui_data->machine_off), "halui.machine.off"));
+    CHK(halui_export_pin_IN_bit(&(halui_data->estop_activate), "halui.estop.activate"));
+    CHK(halui_export_pin_IN_bit(&(halui_data->estop_reset), "halui.estop.reset"));
+    CHK(halui_export_pin_IN_bit(&(halui_data->mode_manual), "halui.mode.manual"));
+    CHK(halui_export_pin_IN_bit(&(halui_data->mode_auto), "halui.mode.auto"));
+    CHK(halui_export_pin_IN_bit(&(halui_data->mode_mdi), "halui.mode.mdi"));
+    CHK(halui_export_pin_IN_bit(&(halui_data->mode_teleop), "halui.mode.teleop"));
+    CHK(halui_export_pin_IN_bit(&(halui_data->mode_joint), "halui.mode.joint"));
+    CHK(halui_export_pin_IN_bit(&(halui_data->mist_on), "halui.mist.on"));
+    CHK(halui_export_pin_IN_bit(&(halui_data->mist_off), "halui.mist.off"));
+    CHK(halui_export_pin_IN_bit(&(halui_data->flood_on), "halui.flood.on"));
+    CHK(halui_export_pin_IN_bit(&(halui_data->flood_off), "halui.flood.off"));
+    CHK(halui_export_pin_IN_bit(&(halui_data->program_run), "halui.program.run"));
+    CHK(halui_export_pin_IN_bit(&(halui_data->program_pause), "halui.program.pause"));
+    CHK(halui_export_pin_IN_bit(&(halui_data->program_resume), "halui.program.resume"));
+    CHK(halui_export_pin_IN_bit(&(halui_data->program_step), "halui.program.step"));
+    CHK(halui_export_pin_IN_bit(&(halui_data->program_stop), "halui.program.stop"));
+    CHK(halui_export_pin_IN_bit(&(halui_data->program_os_on), "halui.program.optional-stop.on"));
+    CHK(halui_export_pin_IN_bit(&(halui_data->program_os_off), "halui.program.optional-stop.off"));
+    CHK(halui_export_pin_IN_bit(&(halui_data->program_bd_on), "halui.program.block-delete.on"));
+    CHK(halui_export_pin_IN_bit(&(halui_data->program_bd_off), "halui.program.block-delete.off"));
 
-    retval = halui_export_pin_IN_s32(&(halui_data->mv_counts), "halui.max-velocity.counts");
-    if (retval < 0) return retval;
-    *halui_data->mv_counts = 0;
-    retval = halui_export_pin_IN_bit(&(halui_data->mv_count_enable), "halui.max-velocity.count-enable");
-    if (retval < 0) return retval;
-    *halui_data->mv_count_enable = 1;
-    retval = halui_export_pin_IN_bit(&(halui_data->mv_direct_value), "halui.max-velocity.direct-value");
-    if (retval < 0) return retval;
-    *halui_data->mv_direct_value = 0;
-    retval = halui_export_pin_IN_float(&(halui_data->mv_scale), "halui.max-velocity.scale");
-    if (retval < 0) return retval;
-    retval = halui_export_pin_IN_bit(&(halui_data->mv_increase), "halui.max-velocity.increase");
-    if (retval < 0) return retval;
-    retval = halui_export_pin_IN_bit(&(halui_data->mv_decrease), "halui.max-velocity.decrease");
-    if (retval < 0) return retval;
+    CHK(halui_export_pin_IN_s32(&(halui_data->mv_counts), "halui.max-velocity.counts"));
+    CHK(halui_export_pin_IN_bit(&(halui_data->mv_count_enable), "halui.max-velocity.count-enable"));
+    hal_set_bool(halui_data->mv_count_enable, 1);
+    CHK(halui_export_pin_IN_bit(&(halui_data->mv_direct_value), "halui.max-velocity.direct-value"));
+    CHK(halui_export_pin_IN_float(&(halui_data->mv_scale), "halui.max-velocity.scale"));
+    CHK(halui_export_pin_IN_bit(&(halui_data->mv_increase), "halui.max-velocity.increase"));
+    CHK(halui_export_pin_IN_bit(&(halui_data->mv_decrease), "halui.max-velocity.decrease"));
 
-    retval = halui_export_pin_IN_s32(&(halui_data->fo_counts), "halui.feed-override.counts");
-    if (retval < 0) return retval;
-    *halui_data->fo_counts = 0;
-    retval = halui_export_pin_IN_bit(&(halui_data->fo_count_enable), "halui.feed-override.count-enable");
-    if (retval < 0) return retval;
-    *halui_data->fo_count_enable = 1;
-    retval = halui_export_pin_IN_bit(&(halui_data->fo_direct_value), "halui.feed-override.direct-value");
-    if (retval < 0) return retval;
-    *halui_data->fo_direct_value = 0;
-    retval = halui_export_pin_IN_float(&(halui_data->fo_scale), "halui.feed-override.scale");
-    if (retval < 0) return retval;
-    retval = halui_export_pin_IN_bit(&(halui_data->fo_increase), "halui.feed-override.increase");
-    if (retval < 0) return retval;
-    retval = halui_export_pin_IN_bit(&(halui_data->fo_decrease), "halui.feed-override.decrease");
-    if (retval < 0) return retval;
-    retval = halui_export_pin_IN_bit(&(halui_data->fo_reset), "halui.feed-override.reset");
-    if (retval < 0) return retval;
+    CHK(halui_export_pin_IN_s32(&(halui_data->fo_counts), "halui.feed-override.counts"));
+    CHK(halui_export_pin_IN_bit(&(halui_data->fo_count_enable), "halui.feed-override.count-enable"));
+    hal_set_bool(halui_data->fo_count_enable, 1);
+    CHK(halui_export_pin_IN_bit(&(halui_data->fo_direct_value), "halui.feed-override.direct-value"));
+    CHK(halui_export_pin_IN_float(&(halui_data->fo_scale), "halui.feed-override.scale"));
+    CHK(halui_export_pin_IN_bit(&(halui_data->fo_increase), "halui.feed-override.increase"));
+    CHK(halui_export_pin_IN_bit(&(halui_data->fo_decrease), "halui.feed-override.decrease"));
+    CHK(halui_export_pin_IN_bit(&(halui_data->fo_reset), "halui.feed-override.reset"));
 
-    retval = halui_export_pin_IN_s32(&(halui_data->ro_counts), "halui.rapid-override.counts");
-    if (retval < 0) return retval;
-    *halui_data->ro_counts = 0;
-    retval = halui_export_pin_IN_bit(&(halui_data->ro_count_enable), "halui.rapid-override.count-enable");
-    if (retval < 0) return retval;
-    *halui_data->ro_count_enable = 1;
-    retval = halui_export_pin_IN_bit(&(halui_data->ro_direct_value), "halui.rapid-override.direct-value");
-    if (retval < 0) return retval;
-    *halui_data->ro_direct_value = 0;
-    retval = halui_export_pin_IN_float(&(halui_data->ro_scale), "halui.rapid-override.scale");
-    if (retval < 0) return retval;
-    retval = halui_export_pin_IN_bit(&(halui_data->ro_increase), "halui.rapid-override.increase");
-    if (retval < 0) return retval;
-    retval = halui_export_pin_IN_bit(&(halui_data->ro_decrease), "halui.rapid-override.decrease");
-    if (retval < 0) return retval;
-    retval = halui_export_pin_IN_bit(&(halui_data->ro_reset), "halui.rapid-override.reset");
-    if (retval < 0) return retval;
+    CHK(halui_export_pin_IN_s32(&(halui_data->ro_counts), "halui.rapid-override.counts"));
+    CHK(halui_export_pin_IN_bit(&(halui_data->ro_count_enable), "halui.rapid-override.count-enable"));
+    hal_set_bool(halui_data->ro_count_enable, 1);
+    CHK(halui_export_pin_IN_bit(&(halui_data->ro_direct_value), "halui.rapid-override.direct-value"));
+    CHK(halui_export_pin_IN_float(&(halui_data->ro_scale), "halui.rapid-override.scale"));
+    CHK(halui_export_pin_IN_bit(&(halui_data->ro_increase), "halui.rapid-override.increase"));
+    CHK(halui_export_pin_IN_bit(&(halui_data->ro_decrease), "halui.rapid-override.decrease"));
+    CHK(halui_export_pin_IN_bit(&(halui_data->ro_reset), "halui.rapid-override.reset"));
 
     if (have_home_all) {
-        retval = halui_export_pin_IN_bit(&(halui_data->home_all), "halui.home-all");
-        if (retval < 0) return retval;
+        CHK(halui_export_pin_IN_bit(&(halui_data->home_all), "halui.home-all"));
     }
 
-    retval = halui_export_pin_IN_bit(&(halui_data->abort), "halui.abort");
-    if (retval < 0) return retval;
+    CHK(halui_export_pin_IN_bit(&(halui_data->abort), "halui.abort"));
 
-    for (joint=0; joint < num_joints ; joint++) {
-	retval =  hal_pin_bit_newf(HAL_IN, &(halui_data->joint_home[joint]), comp_id, "halui.joint.%d.home", joint);
-	if (retval < 0) return retval;
-	retval =  hal_pin_bit_newf(HAL_IN, &(halui_data->joint_unhome[joint]), comp_id, "halui.joint.%d.unhome", joint);
-	if (retval < 0) return retval;
-	retval =  hal_pin_bit_newf(HAL_IN, &(halui_data->joint_nr_select[joint]), comp_id, "halui.joint.%d.select", joint);
-	if (retval < 0) return retval;
-	retval =  hal_pin_bit_newf(HAL_IN, &(halui_data->jjog_plus[joint]), comp_id, "halui.joint.%d.plus", joint);
-	if (retval < 0) return retval;
-	retval =  hal_pin_bit_newf(HAL_IN, &(halui_data->jjog_minus[joint]), comp_id, "halui.joint.%d.minus", joint);
-	if (retval < 0) return retval;
-	retval =  hal_pin_float_newf(HAL_IN, &(halui_data->jjog_analog[joint]), comp_id, "halui.joint.%d.analog", joint);
-	if (retval < 0) return retval;
-	retval =  hal_pin_float_newf(HAL_IN, &(halui_data->jjog_increment[joint]), comp_id, "halui.joint.%d.increment", joint);
-	if (retval < 0) return retval;
-	retval =  hal_pin_bit_newf(HAL_IN, &(halui_data->jjog_increment_plus[joint]), comp_id, "halui.joint.%d.increment-plus", joint);
-	if (retval < 0) return retval;
-	retval =  hal_pin_bit_newf(HAL_IN, &(halui_data->jjog_increment_minus[joint]), comp_id, "halui.joint.%d.increment-minus", joint);
-	if (retval < 0) return retval;
+    for (int joint = 0; joint < num_joints ; joint++) {
+        CHK(hal_pin_new_bool(comp_id, HAL_IN, &(halui_data->joint_home[joint]), 0, "halui.joint.%d.home", joint));
+        CHK(hal_pin_new_bool(comp_id, HAL_IN, &(halui_data->joint_unhome[joint]), 0, "halui.joint.%d.unhome", joint));
+        CHK(hal_pin_new_bool(comp_id, HAL_IN, &(halui_data->joint_nr_select[joint]), 0, "halui.joint.%d.select", joint));
+        CHK(hal_pin_new_bool(comp_id, HAL_IN, &(halui_data->jjog_plus[joint]), 0, "halui.joint.%d.plus", joint));
+        CHK(hal_pin_new_bool(comp_id, HAL_IN, &(halui_data->jjog_minus[joint]), 0, "halui.joint.%d.minus", joint));
+        CHK(hal_pin_new_real(comp_id, HAL_IN, &(halui_data->jjog_analog[joint]), 0.0, "halui.joint.%d.analog", joint));
+        CHK(hal_pin_new_real(comp_id, HAL_IN, &(halui_data->jjog_increment[joint]), 0.0, "halui.joint.%d.increment", joint));
+        CHK(hal_pin_new_bool(comp_id, HAL_IN, &(halui_data->jjog_increment_plus[joint]), 0, "halui.joint.%d.increment-plus", joint));
+        CHK(hal_pin_new_bool(comp_id, HAL_IN, &(halui_data->jjog_increment_minus[joint]), 0, "halui.joint.%d.increment-minus", joint));
     }
 
-    for (axis_num = 0; axis_num < EMCMOT_MAX_AXIS; axis_num++) {
+    for (int axis_num = 0; axis_num < EMCMOT_MAX_AXIS; axis_num++) {
         char c = "xyzabcuvw"[axis_num];
-        retval =  hal_pin_bit_newf(HAL_IN, &(halui_data->axis_nr_select[axis_num]), comp_id, "halui.axis.%c.select", c);
-        if (retval < 0) return retval;
-        retval =  hal_pin_bit_newf(HAL_IN, &(halui_data->ajog_plus[axis_num]), comp_id, "halui.axis.%c.plus", c);
-        if (retval < 0) return retval;
-        retval =  hal_pin_bit_newf(HAL_IN, &(halui_data->ajog_minus[axis_num]), comp_id, "halui.axis.%c.minus", c);
-        if (retval < 0) return retval;
-        retval =  hal_pin_float_newf(HAL_IN, &(halui_data->ajog_analog[axis_num]), comp_id, "halui.axis.%c.analog", c);
-        if (retval < 0) return retval;
-        retval =  hal_pin_float_newf(HAL_IN, &(halui_data->ajog_increment[axis_num]), comp_id, "halui.axis.%c.increment", c);
-        if (retval < 0) return retval;
-        retval =  hal_pin_bit_newf(HAL_IN, &(halui_data->ajog_increment_plus[axis_num]), comp_id, "halui.axis.%c.increment-plus", c);
-        if (retval < 0) return retval;
-        retval =  hal_pin_bit_newf(HAL_IN, &(halui_data->ajog_increment_minus[axis_num]), comp_id, "halui.axis.%c.increment-minus", c);
-        if (retval < 0) return retval;
+        CHK(hal_pin_new_bool(comp_id, HAL_IN, &(halui_data->axis_nr_select[axis_num]), 0, "halui.axis.%c.select", c));
+        CHK(hal_pin_new_bool(comp_id, HAL_IN, &(halui_data->ajog_plus[axis_num]), 0, "halui.axis.%c.plus", c));
+        CHK(hal_pin_new_bool(comp_id, HAL_IN, &(halui_data->ajog_minus[axis_num]), 0, "halui.axis.%c.minus", c));
+        CHK(hal_pin_new_real(comp_id, HAL_IN, &(halui_data->ajog_analog[axis_num]), 0.0, "halui.axis.%c.analog", c));
+        CHK(hal_pin_new_real(comp_id, HAL_IN, &(halui_data->ajog_increment[axis_num]), 0.0, "halui.axis.%c.increment", c));
+        CHK(hal_pin_new_bool(comp_id, HAL_IN, &(halui_data->ajog_increment_plus[axis_num]), 0, "halui.axis.%c.increment-plus", c));
+        CHK(hal_pin_new_bool(comp_id, HAL_IN, &(halui_data->ajog_increment_minus[axis_num]), 0, "halui.axis.%c.increment-minus", c));
     }
 
-    retval =  hal_pin_bit_newf(HAL_IN, &(halui_data->joint_home[num_joints]), comp_id, "halui.joint.selected.home");
-    if (retval < 0) return retval;
-    retval =  hal_pin_bit_newf(HAL_IN, &(halui_data->joint_unhome[num_joints]), comp_id, "halui.joint.selected.unhome");
-    if (retval < 0) return retval;
-    retval =  hal_pin_bit_newf(HAL_IN, &(halui_data->jjog_plus[num_joints]), comp_id, "halui.joint.selected.plus");
-    if (retval < 0) return retval;
-    retval =  hal_pin_bit_newf(HAL_IN, &(halui_data->jjog_minus[num_joints]), comp_id, "halui.joint.selected.minus");
-    if (retval < 0) return retval;
-    retval =  hal_pin_float_newf(HAL_IN, &(halui_data->jjog_increment[num_joints]), comp_id, "halui.joint.selected.increment");
-    if (retval < 0) return retval;
-    retval =  hal_pin_bit_newf(HAL_IN, &(halui_data->jjog_increment_plus[num_joints]), comp_id, "halui.joint.selected.increment-plus");
-    if (retval < 0) return retval;
-    retval =  hal_pin_bit_newf(HAL_IN, &(halui_data->jjog_increment_minus[num_joints]), comp_id, "halui.joint.selected.increment-minus");
-    if (retval < 0) return retval;
-    retval =  hal_pin_bit_newf(HAL_IN, &(halui_data->ajog_plus[EMCMOT_MAX_AXIS]), comp_id, "halui.axis.selected.plus");
-    if (retval < 0) return retval;
-    retval =  hal_pin_bit_newf(HAL_IN, &(halui_data->ajog_minus[EMCMOT_MAX_AXIS]), comp_id, "halui.axis.selected.minus");
-    if (retval < 0) return retval;
-    retval =  hal_pin_float_newf(HAL_IN, &(halui_data->ajog_increment[EMCMOT_MAX_AXIS]), comp_id, "halui.axis.selected.increment");
-    if (retval < 0) return retval;
-    retval =  hal_pin_bit_newf(HAL_IN, &(halui_data->ajog_increment_plus[EMCMOT_MAX_AXIS]), comp_id, "halui.axis.selected.increment-plus");
-    if (retval < 0) return retval;
-    retval =  hal_pin_bit_newf(HAL_IN, &(halui_data->ajog_increment_minus[EMCMOT_MAX_AXIS]), comp_id, "halui.axis.selected.increment-minus");
-    if (retval < 0) return retval;
+    CHK(hal_pin_new_bool(comp_id, HAL_IN, &(halui_data->joint_home[num_joints]), 0, "halui.joint.selected.home"));
+    CHK(hal_pin_new_bool(comp_id, HAL_IN, &(halui_data->joint_unhome[num_joints]), 0, "halui.joint.selected.unhome"));
+    CHK(hal_pin_new_bool(comp_id, HAL_IN, &(halui_data->jjog_plus[num_joints]), 0, "halui.joint.selected.plus"));
+    CHK(hal_pin_new_bool(comp_id, HAL_IN, &(halui_data->jjog_minus[num_joints]), 0, "halui.joint.selected.minus"));
+    CHK(hal_pin_new_real(comp_id, HAL_IN, &(halui_data->jjog_increment[num_joints]), 0.0, "halui.joint.selected.increment"));
+    CHK(hal_pin_new_bool(comp_id, HAL_IN, &(halui_data->jjog_increment_plus[num_joints]), 0, "halui.joint.selected.increment-plus"));
+    CHK(hal_pin_new_bool(comp_id, HAL_IN, &(halui_data->jjog_increment_minus[num_joints]), 0, "halui.joint.selected.increment-minus"));
+    CHK(hal_pin_new_bool(comp_id, HAL_IN, &(halui_data->ajog_plus[EMCMOT_MAX_AXIS]), 0, "halui.axis.selected.plus"));
+    CHK(hal_pin_new_bool(comp_id, HAL_IN, &(halui_data->ajog_minus[EMCMOT_MAX_AXIS]), 0, "halui.axis.selected.minus"));
+    CHK(hal_pin_new_real(comp_id, HAL_IN, &(halui_data->ajog_increment[EMCMOT_MAX_AXIS]), 0.0, "halui.axis.selected.increment"));
+    CHK(hal_pin_new_bool(comp_id, HAL_IN, &(halui_data->ajog_increment_plus[EMCMOT_MAX_AXIS]), 0, "halui.axis.selected.increment-plus"));
+    CHK(hal_pin_new_bool(comp_id, HAL_IN, &(halui_data->ajog_increment_minus[EMCMOT_MAX_AXIS]), 0, "halui.axis.selected.increment-minus"));
 
-    retval = halui_export_pin_IN_float(&(halui_data->jjog_speed), "halui.joint.jog-speed");
-    if (retval < 0) return retval;
-    retval = halui_export_pin_IN_float(&(halui_data->jjog_deadband), "halui.joint.jog-deadband");
-    if (retval < 0) return retval;
+    CHK(halui_export_pin_IN_float(&(halui_data->jjog_speed), "halui.joint.jog-speed"));
+    CHK(halui_export_pin_IN_float(&(halui_data->jjog_deadband), "halui.joint.jog-deadband"));
 
-    retval = halui_export_pin_IN_float(&(halui_data->ajog_speed), "halui.axis.jog-speed");
-    if (retval < 0) return retval;
-    retval = halui_export_pin_IN_float(&(halui_data->ajog_deadband), "halui.axis.jog-deadband");
-    if (retval < 0) return retval;
+    CHK(halui_export_pin_IN_float(&(halui_data->ajog_speed), "halui.axis.jog-speed"));
+    CHK(halui_export_pin_IN_float(&(halui_data->ajog_deadband), "halui.axis.jog-deadband"));
 
-    for (int n=0; n<num_mdi_commands; n++) {
-        retval = hal_pin_bit_newf(HAL_IN, &(halui_data->mdi_commands[n]), comp_id, "halui.mdi-command-%02d", n);
-        if (retval < 0) return retval;
+    for (int n = 0; n < num_mdi_commands; n++) {
+        CHK(hal_pin_new_bool(comp_id, HAL_IN, &(halui_data->mdi_commands[n]), 0, "halui.mdi-command-%02d", n));
     }
 
     hal_ready(comp_id);
@@ -1011,7 +862,7 @@ static int sendMdiCommand(int n)
     halui_sent_mdi = 1;
 
     if (num_mdi_commands>0){
-    *(halui_data->halui_mdi_is_running) = halui_sent_mdi;
+    hal_set_bool(halui_data->halui_mdi_is_running, halui_sent_mdi);
     updateStatus();
     }
     
@@ -1498,63 +1349,63 @@ static void hal_init_pins()
     int axis_num;
     int spindle;
 
-    *(halui_data->machine_on) = old_halui_data.machine_on = 0;
-    *(halui_data->machine_off) = old_halui_data.machine_off = 0;
+    hal_set_bool(halui_data->machine_on, old_halui_data.machine_on = 0);
+    hal_set_bool(halui_data->machine_off, old_halui_data.machine_off = 0);
 
-    *(halui_data->estop_activate) = old_halui_data.estop_activate = 0;
-    *(halui_data->estop_reset) = old_halui_data.estop_reset = 0;
+    hal_set_bool(halui_data->estop_activate, old_halui_data.estop_activate = 0);
+    hal_set_bool(halui_data->estop_reset, old_halui_data.estop_reset = 0);
 
 
     for (joint=0; joint < num_joints; joint++) {
-	*(halui_data->joint_home[joint]) = old_halui_data.joint_home[joint] = 0;
-	*(halui_data->joint_unhome[joint]) = old_halui_data.joint_unhome[joint] = 0;
-	*(halui_data->joint_nr_select[joint]) = old_halui_data.joint_nr_select[joint] = 0;
-	*(halui_data->jjog_minus[joint]) = old_halui_data.jjog_minus[joint] = 0;
-	*(halui_data->jjog_plus[joint]) = old_halui_data.jjog_plus[joint] = 0;
-	*(halui_data->jjog_analog[joint]) = old_halui_data.jjog_analog[joint] = 0;
-	*(halui_data->jjog_increment[joint]) = old_halui_data.jjog_increment[joint] = 0.0;
-	*(halui_data->jjog_increment_plus[joint]) = old_halui_data.jjog_increment_plus[joint] = 0;
-	*(halui_data->jjog_increment_minus[joint]) = old_halui_data.jjog_increment_minus[joint] = 0;
+	hal_set_bool(halui_data->joint_home[joint], old_halui_data.joint_home[joint] = 0);
+	hal_set_bool(halui_data->joint_unhome[joint], old_halui_data.joint_unhome[joint] = 0);
+	hal_set_bool(halui_data->joint_nr_select[joint], old_halui_data.joint_nr_select[joint] = 0);
+	hal_set_bool(halui_data->jjog_minus[joint], old_halui_data.jjog_minus[joint] = 0);
+	hal_set_bool(halui_data->jjog_plus[joint], old_halui_data.jjog_plus[joint] = 0);
+	hal_set_real(halui_data->jjog_analog[joint], old_halui_data.jjog_analog[joint] = 0.0);
+	hal_set_real(halui_data->jjog_increment[joint], old_halui_data.jjog_increment[joint] = 0.0);
+	hal_set_bool(halui_data->jjog_increment_plus[joint], old_halui_data.jjog_increment_plus[joint] = 0);
+	hal_set_bool(halui_data->jjog_increment_minus[joint], old_halui_data.jjog_increment_minus[joint] = 0);
     }
 
     for (axis_num = 0; axis_num < EMCMOT_MAX_AXIS; axis_num++) {
         if ( !(axis_mask & (1 << axis_num)) ) { continue; }
-        *(halui_data->axis_nr_select[axis_num]) = old_halui_data.axis_nr_select[axis_num] = 0;
-	*(halui_data->ajog_minus[axis_num]) = old_halui_data.ajog_minus[axis_num] = 0;
-	*(halui_data->ajog_plus[axis_num]) = old_halui_data.ajog_plus[axis_num] = 0;
-	*(halui_data->ajog_analog[axis_num]) = old_halui_data.ajog_analog[axis_num] = 0;
-	*(halui_data->ajog_increment[axis_num]) = old_halui_data.ajog_increment[axis_num] = 0.0;
-	*(halui_data->ajog_increment_plus[axis_num]) = old_halui_data.ajog_increment_plus[axis_num] = 0;
-	*(halui_data->ajog_increment_minus[axis_num]) = old_halui_data.ajog_increment_minus[axis_num] = 0;
+        hal_set_bool(halui_data->axis_nr_select[axis_num], old_halui_data.axis_nr_select[axis_num] = 0);
+	hal_set_bool(halui_data->ajog_minus[axis_num], old_halui_data.ajog_minus[axis_num] = 0);
+	hal_set_bool(halui_data->ajog_plus[axis_num], old_halui_data.ajog_plus[axis_num] = 0);
+	hal_set_real(halui_data->ajog_analog[axis_num], old_halui_data.ajog_analog[axis_num] = 0);
+	hal_set_real(halui_data->ajog_increment[axis_num], old_halui_data.ajog_increment[axis_num] = 0.0);
+	hal_set_bool(halui_data->ajog_increment_plus[axis_num], old_halui_data.ajog_increment_plus[axis_num] = 0);
+	hal_set_bool(halui_data->ajog_increment_minus[axis_num], old_halui_data.ajog_increment_minus[axis_num] = 0);
     }
 
-    *(halui_data->joint_home[num_joints]) = old_halui_data.joint_home[num_joints] = 0;
-    *(halui_data->jjog_minus[num_joints]) = old_halui_data.jjog_minus[num_joints] = 0;
-    *(halui_data->jjog_plus[num_joints]) = old_halui_data.jjog_plus[num_joints] = 0;
-    *(halui_data->jjog_increment[num_joints]) = old_halui_data.jjog_increment[num_joints] = 0.0;
-    *(halui_data->jjog_increment_plus[num_joints]) = old_halui_data.jjog_increment_plus[num_joints] = 0;
-    *(halui_data->jjog_increment_minus[num_joints]) = old_halui_data.jjog_increment_minus[num_joints] = 0;
-    *(halui_data->jjog_deadband) = 0.2;
-    *(halui_data->jjog_speed) = 0;
-    *(halui_data->ajog_minus[EMCMOT_MAX_AXIS]) = old_halui_data.ajog_minus[EMCMOT_MAX_AXIS] = 0;
-    *(halui_data->ajog_plus[EMCMOT_MAX_AXIS]) = old_halui_data.ajog_plus[EMCMOT_MAX_AXIS] = 0;
-    *(halui_data->ajog_increment[EMCMOT_MAX_AXIS]) = old_halui_data.ajog_increment[EMCMOT_MAX_AXIS] = 0.0;
-    *(halui_data->ajog_increment_plus[EMCMOT_MAX_AXIS]) = old_halui_data.ajog_increment_plus[EMCMOT_MAX_AXIS] = 0;
-    *(halui_data->ajog_increment_minus[EMCMOT_MAX_AXIS]) = old_halui_data.ajog_increment_minus[EMCMOT_MAX_AXIS] = 0;
-    *(halui_data->ajog_deadband) = 0.2;
-    *(halui_data->ajog_speed) = 0;
+    hal_set_bool(halui_data->joint_home[num_joints], old_halui_data.joint_home[num_joints] = 0);
+    hal_set_bool(halui_data->jjog_minus[num_joints], old_halui_data.jjog_minus[num_joints] = 0);
+    hal_set_bool(halui_data->jjog_plus[num_joints], old_halui_data.jjog_plus[num_joints] = 0);
+    hal_set_real(halui_data->jjog_increment[num_joints], old_halui_data.jjog_increment[num_joints] = 0.0);
+    hal_set_bool(halui_data->jjog_increment_plus[num_joints], old_halui_data.jjog_increment_plus[num_joints] = 0);
+    hal_set_bool(halui_data->jjog_increment_minus[num_joints], old_halui_data.jjog_increment_minus[num_joints] = 0);
+    hal_set_real(halui_data->jjog_deadband, 0.2);
+    hal_set_real(halui_data->jjog_speed, 0);
+    hal_set_bool(halui_data->ajog_minus[EMCMOT_MAX_AXIS], old_halui_data.ajog_minus[EMCMOT_MAX_AXIS] = 0);
+    hal_set_bool(halui_data->ajog_plus[EMCMOT_MAX_AXIS], old_halui_data.ajog_plus[EMCMOT_MAX_AXIS] = 0);
+    hal_set_real(halui_data->ajog_increment[EMCMOT_MAX_AXIS], old_halui_data.ajog_increment[EMCMOT_MAX_AXIS] = 0.0);
+    hal_set_bool(halui_data->ajog_increment_plus[EMCMOT_MAX_AXIS], old_halui_data.ajog_increment_plus[EMCMOT_MAX_AXIS] = 0);
+    hal_set_bool(halui_data->ajog_increment_minus[EMCMOT_MAX_AXIS], old_halui_data.ajog_increment_minus[EMCMOT_MAX_AXIS] = 0);
+    hal_set_real(halui_data->ajog_deadband, 0.2);
+    hal_set_real(halui_data->ajog_speed, 0);
 
-    *(halui_data->joint_selected) = 0; // select joint 0 by default
-    *(halui_data->axis_selected) = 0; // select axis 0 by default
+    hal_set_ui32(halui_data->joint_selected, 0); // select joint 0 by default
+    hal_set_ui32(halui_data->axis_selected, 0); // select axis 0 by default
 
-    *(halui_data->fo_scale) = old_halui_data.fo_scale = 0.1; //sane default
-    *(halui_data->ro_scale) = old_halui_data.ro_scale = 0.1; //sane default
+    hal_set_real(halui_data->fo_scale, old_halui_data.fo_scale = 0.1); //sane default
+    hal_set_real(halui_data->ro_scale, old_halui_data.ro_scale = 0.1); //sane default
     for (spindle = 0; spindle < num_spindles; spindle++){
-        *(halui_data->so_scale[spindle]) = old_halui_data.so_scale[spindle] = 0.1; //sane default
-        *(halui_data->so_increase[spindle]) = old_halui_data.so_increase[spindle] = 0;
-        *(halui_data->so_decrease[spindle]) = old_halui_data.so_decrease[spindle] = 0;
-        *(halui_data->spindle_increase[spindle]) = old_halui_data.spindle_increase[spindle] = 0;
-        *(halui_data->spindle_decrease[spindle]) = old_halui_data.spindle_decrease[spindle] = 0;
+        hal_set_real(halui_data->so_scale[spindle], old_halui_data.so_scale[spindle] = 0.1); //sane default
+        hal_set_bool(halui_data->so_increase[spindle], old_halui_data.so_increase[spindle] = 0);
+        hal_set_bool(halui_data->so_decrease[spindle], old_halui_data.so_decrease[spindle] = 0);
+        hal_set_bool(halui_data->spindle_increase[spindle], old_halui_data.spindle_increase[spindle] = 0);
+        hal_set_bool(halui_data->spindle_decrease[spindle], old_halui_data.spindle_decrease[spindle] = 0);
     }
 }
 
@@ -1569,9 +1420,18 @@ static int check_bit_changed(bool halpin, bool &newpin)
 
 static void copy_hal_data(const halui_str &i, local_halui_str &j)
 {
-    int x;
-#define FIELD(t,f) j.f = (i.f)?*i.f:0;
-#define ARRAY(t,f,n) do { for (x = 0; x < n; x++) j.f[x] = (i.f[x])?*i.f[x]:0; } while (0);
+#define FIELD(t,f) do { \
+        if(i.f) { \
+            j.f = hal_get_##t(i.f); \
+        } else { j.f = 0; } \
+    } while(0);
+#define ARRAY(t,f,n) do { \
+        for (int x = 0; x < n; x++) { \
+            if(i.f[x]) { \
+                j.f[x] = hal_get_##t(i.f[x]); \
+            } else { j.f[x] = 0; } \
+        } \
+    } while (0);
     HAL_FIELDS
 #undef FIELD
 #undef ARRAY
@@ -1605,19 +1465,18 @@ static bool jogging_selected_axis(local_halui_str &hal) {
 // and sends appropriate messages if so
 static void check_hal_changes()
 {
-    hal_s32_t counts;
+    rtapi_s32 counts;
     int jselect_changed, joint;
     int aselect_changed, axis_num;
-    hal_bit_t bit;
+    rtapi_bool bit;
     int js;
-    hal_float_t floatt;
+    rtapi_real floatt;
     int jjog_speed_changed;
     int ajog_speed_changed;
 
     local_halui_str new_halui_data_mutable;
     copy_hal_data(*halui_data, new_halui_data_mutable);
     const local_halui_str &new_halui_data = new_halui_data_mutable;
-
 
     //check if machine_on pin has changed (the rest work exactly the same)
     if (check_bit_changed(new_halui_data.machine_on, old_halui_data.machine_on) != 0)
@@ -1891,7 +1750,7 @@ static void check_hal_changes()
 	bit = new_halui_data.joint_nr_select[joint];
 	if (bit != old_halui_data.joint_nr_select[joint]) {
 	    if (bit != 0) {
-		*halui_data->joint_selected = joint;
+		hal_set_ui32(halui_data->joint_selected, joint);
 		jselect_changed = joint; // flag that we changed the selected joint
 	    }
 	    old_halui_data.joint_nr_select[joint] = bit;
@@ -1902,15 +1761,15 @@ static void check_hal_changes()
     if (jselect_changed >= 0) {
 	for (joint = 0; joint < num_joints; joint++) {
 	    if (joint != jselect_changed) {
-		*(halui_data->joint_is_selected[joint]) = 0;
+		hal_set_bool(halui_data->joint_is_selected[joint], 0);
                 if (jogging_selected_joint(old_halui_data) && !jogging_joint(old_halui_data, joint)) {
                     sendJogStop(joint,JOGJOINT);
                 }
             } else {
-		*(halui_data->joint_is_selected[joint]) = 1;
-                if (*halui_data->jjog_plus[num_joints]) {
+		hal_set_bool(halui_data->joint_is_selected[joint], 1);
+                if (hal_get_bool(halui_data->jjog_plus[num_joints])) {
                     sendJogCont(joint, new_halui_data.jjog_speed,JOGJOINT);
-                } else if (*halui_data->jjog_minus[num_joints]) {
+                } else if (hal_get_bool(halui_data->jjog_minus[num_joints])) {
                     sendJogCont(joint, -new_halui_data.jjog_speed,JOGJOINT);
                 }
 	    }
@@ -1965,7 +1824,7 @@ static void check_hal_changes()
 	bit = new_halui_data.axis_nr_select[axis_num];
 	if (bit != old_halui_data.axis_nr_select[axis_num]) {
 	    if (bit != 0) {
-		*halui_data->axis_selected = axis_num;
+		hal_set_ui32(halui_data->axis_selected, axis_num);
 		aselect_changed = axis_num; // flag that we changed the selected axis
 	    }
 	    old_halui_data.axis_nr_select[axis_num] = bit;
@@ -1976,15 +1835,15 @@ static void check_hal_changes()
     for (axis_num = 0; axis_num < EMCMOT_MAX_AXIS; axis_num++) {
         if ( !(axis_mask & (1 << axis_num)) ) { continue; }
 	    if (axis_num != aselect_changed) {
-		*(halui_data->axis_is_selected[axis_num]) = 0;
+		hal_set_bool(halui_data->axis_is_selected[axis_num], 0);
                 if (jogging_selected_axis(old_halui_data) && !jogging_axis(old_halui_data, axis_num)) {
                     sendJogStop(axis_num,JOGTELEOP);
                 }
             } else {
-		*(halui_data->axis_is_selected[axis_num]) = 1;
-                if (*halui_data->ajog_plus[num_axes]) {
+		hal_set_bool(halui_data->axis_is_selected[axis_num], 1);
+                if (hal_get_bool(halui_data->ajog_plus[num_axes])) {
                     sendJogCont(axis_num, new_halui_data.ajog_speed,JOGTELEOP);
-                } else if (*halui_data->ajog_minus[num_axes]) {
+                } else if (hal_get_bool(halui_data->ajog_minus[num_axes])) {
                     sendJogCont(axis_num, -new_halui_data.ajog_speed,JOGTELEOP);
                 }
 	    }
@@ -2082,17 +1941,8 @@ static void modify_hal_pins()
     int joint;
     int spindle;
 
-    if (emcStatus->task.state == EMC_TASK_STATE::ON) {
-	*(halui_data->machine_is_on)=1;
-    } else {
-	*(halui_data->machine_is_on)=0;
-    }
-
-    if (emcStatus->task.state == EMC_TASK_STATE::ESTOP) {
-	*(halui_data->estop_is_activated)=1;
-    } else {
-	*(halui_data->estop_is_activated)=0;
-    }
+    hal_set_bool(halui_data->machine_is_on, emcStatus->task.state == EMC_TASK_STATE::ON);
+    hal_set_bool(halui_data->estop_is_activated, emcStatus->task.state == EMC_TASK_STATE::ESTOP);
 
     if (halui_sent_mdi) { // we have an ongoing MDI command
 	if (emcStatus->status == RCS_STATUS::DONE) { //which seems to have finished
@@ -2106,40 +1956,16 @@ static void modify_hal_pins()
     }
 	
 
-    if (emcStatus->task.mode == EMC_TASK_MODE::MANUAL) {
-	*(halui_data->mode_is_manual)=1;
-    } else {
-	*(halui_data->mode_is_manual)=0;
-    }
+    hal_set_bool(halui_data->mode_is_manual, emcStatus->task.mode == EMC_TASK_MODE::MANUAL);
+    hal_set_bool(halui_data->mode_is_auto,   emcStatus->task.mode == EMC_TASK_MODE::AUTO);
+    hal_set_bool(halui_data->mode_is_mdi,    emcStatus->task.mode == EMC_TASK_MODE::MDI);
+    hal_set_bool(halui_data->mode_is_teleop, emcStatus->motion.traj.mode == EMC_TRAJ_MODE::TELEOP);
+    hal_set_bool(halui_data->mode_is_joint,  emcStatus->motion.traj.mode == EMC_TRAJ_MODE::FREE);
 
-    if (emcStatus->task.mode == EMC_TASK_MODE::AUTO) {
-	*(halui_data->mode_is_auto)=1;
-    } else {
-	*(halui_data->mode_is_auto)=0;
-    }
-
-    if (emcStatus->task.mode == EMC_TASK_MODE::MDI) {
-	*(halui_data->mode_is_mdi)=1;
-    } else {
-	*(halui_data->mode_is_mdi)=0;
-    }
-
-    if (emcStatus->motion.traj.mode == EMC_TRAJ_MODE::TELEOP) {
-	*(halui_data->mode_is_teleop)=1;
-    } else {
-	*(halui_data->mode_is_teleop)=0;
-    }
-
-    if (emcStatus->motion.traj.mode == EMC_TRAJ_MODE::FREE) {
-	*(halui_data->mode_is_joint)=1;
-    } else {
-	*(halui_data->mode_is_joint)=0;
-    }
-
-    *(halui_data->program_is_paused) = emcStatus->task.interpState == EMC_TASK_INTERP::PAUSED;
-    *(halui_data->program_is_running) = emcStatus->task.interpState == EMC_TASK_INTERP::READING ||
-                                        emcStatus->task.interpState == EMC_TASK_INTERP::WAITING;
-    *(halui_data->program_is_idle) = emcStatus->task.interpState == EMC_TASK_INTERP::IDLE;
+    hal_set_bool(halui_data->program_is_paused,  emcStatus->task.interpState == EMC_TASK_INTERP::PAUSED);
+    hal_set_bool(halui_data->program_is_running, emcStatus->task.interpState == EMC_TASK_INTERP::READING ||
+                                                 emcStatus->task.interpState == EMC_TASK_INTERP::WAITING);
+    hal_set_bool(halui_data->program_is_idle,    emcStatus->task.interpState == EMC_TASK_INTERP::IDLE);
     
     if (num_mdi_commands>0){
 		// we wants initialize program_is_idle and mode_is_mdi before halui_sent_mdi
@@ -2151,34 +1977,34 @@ static void modify_hal_pins()
 			esleep(0.02); //sleep for a while
 			}
 		}
-		*(halui_data->halui_mdi_is_running) = halui_sent_mdi;
+		hal_set_bool(halui_data->halui_mdi_is_running, halui_sent_mdi);
 	}
 
 
     
-    *(halui_data->program_os_is_on) = emcStatus->task.optional_stop_state;
-    *(halui_data->program_bd_is_on) = emcStatus->task.block_delete_state;
+    hal_set_bool(halui_data->program_os_is_on, emcStatus->task.optional_stop_state);
+    hal_set_bool(halui_data->program_bd_is_on, emcStatus->task.block_delete_state);
 
-    *(halui_data->mv_value) = emcStatus->motion.traj.maxVelocity;
-    *(halui_data->fo_value) = emcStatus->motion.traj.scale; //feedoverride from 0 to 1 for 100%
-    *(halui_data->ro_value) = emcStatus->motion.traj.rapid_scale; //rapid override from 0 to 1 for 100%
+    hal_set_real(halui_data->mv_value, emcStatus->motion.traj.maxVelocity);
+    hal_set_real(halui_data->fo_value, emcStatus->motion.traj.scale); //feedoverride from 0 to 1 for 100%
+    hal_set_real(halui_data->ro_value, emcStatus->motion.traj.rapid_scale); //rapid override from 0 to 1 for 100%
 
-    *(halui_data->mist_is_on) = emcStatus->io.coolant.mist;
-    *(halui_data->flood_is_on) = emcStatus->io.coolant.flood;
+    hal_set_bool(halui_data->mist_is_on, emcStatus->io.coolant.mist);
+    hal_set_bool(halui_data->flood_is_on, emcStatus->io.coolant.flood);
 
-    *(halui_data->tool_number) = emcStatus->io.tool.toolInSpindle;
-    *(halui_data->tool_length_offset_x) = emcStatus->task.toolOffset.tran.x;
-    *(halui_data->tool_length_offset_y) = emcStatus->task.toolOffset.tran.y;
-    *(halui_data->tool_length_offset_z) = emcStatus->task.toolOffset.tran.z;
-    *(halui_data->tool_length_offset_a) = emcStatus->task.toolOffset.a;
-    *(halui_data->tool_length_offset_b) = emcStatus->task.toolOffset.b;
-    *(halui_data->tool_length_offset_c) = emcStatus->task.toolOffset.c;
-    *(halui_data->tool_length_offset_u) = emcStatus->task.toolOffset.u;
-    *(halui_data->tool_length_offset_v) = emcStatus->task.toolOffset.v;
-    *(halui_data->tool_length_offset_w) = emcStatus->task.toolOffset.w;
+    hal_set_ui32(halui_data->tool_number, emcStatus->io.tool.toolInSpindle);
+    hal_set_real(halui_data->tool_length_offset_x, emcStatus->task.toolOffset.tran.x);
+    hal_set_real(halui_data->tool_length_offset_y, emcStatus->task.toolOffset.tran.y);
+    hal_set_real(halui_data->tool_length_offset_z, emcStatus->task.toolOffset.tran.z);
+    hal_set_real(halui_data->tool_length_offset_a, emcStatus->task.toolOffset.a);
+    hal_set_real(halui_data->tool_length_offset_b, emcStatus->task.toolOffset.b);
+    hal_set_real(halui_data->tool_length_offset_c, emcStatus->task.toolOffset.c);
+    hal_set_real(halui_data->tool_length_offset_u, emcStatus->task.toolOffset.u);
+    hal_set_real(halui_data->tool_length_offset_v, emcStatus->task.toolOffset.v);
+    hal_set_real(halui_data->tool_length_offset_w, emcStatus->task.toolOffset.w);
 
     if (emcStatus->io.tool.toolInSpindle == 0) {
-        *(halui_data->tool_diameter) = 0.0;
+        hal_set_real(halui_data->tool_diameter, 0.0);
     } else {
         int idx;
         for (idx = 0; idx <= tooldata_last_index_get(); idx ++) { // note <=
@@ -2187,101 +2013,102 @@ static void modify_hal_pins()
                 fprintf(stderr,"UNEXPECTED idx %s %d\n",__FILE__,__LINE__);
             }
             if (tdata.toolno == emcStatus->io.tool.toolInSpindle) {
-                *(halui_data->tool_diameter) = tdata.diameter;
+                hal_set_real(halui_data->tool_diameter, tdata.diameter);
                 break;
             }
         }
         if (idx == CANON_POCKETS_MAX) {
             // didn't find the tool
-            *(halui_data->tool_diameter) = 0.0;
+            hal_set_real(halui_data->tool_diameter, 0.0);
         }
     }
 
     for (spindle = 0; spindle < num_spindles; spindle++){
-        *(halui_data->spindle_is_on[spindle]) = (emcStatus->motion.spindle[spindle].enabled);
-        *(halui_data->spindle_runs_forward[spindle]) = (emcStatus->motion.spindle[spindle].direction == 1);
-        *(halui_data->spindle_runs_backward[spindle]) = (emcStatus->motion.spindle[spindle].direction == -1);
-        *(halui_data->spindle_brake_is_on[spindle]) = emcStatus->motion.spindle[spindle].brake;
-        *(halui_data->so_value[spindle]) = emcStatus->motion.spindle[spindle].spindle_scale; //spindle-speed-override from 0 to 1 for 100%
+        hal_set_bool(halui_data->spindle_is_on[spindle], (emcStatus->motion.spindle[spindle].enabled));
+        hal_set_bool(halui_data->spindle_runs_forward[spindle], (emcStatus->motion.spindle[spindle].direction == 1));
+        hal_set_bool(halui_data->spindle_runs_backward[spindle], (emcStatus->motion.spindle[spindle].direction == -1));
+        hal_set_bool(halui_data->spindle_brake_is_on[spindle], emcStatus->motion.spindle[spindle].brake);
+        hal_set_real(halui_data->so_value[spindle], emcStatus->motion.spindle[spindle].spindle_scale); //spindle-speed-override from 0 to 1 for 100%
     }
 
     for (joint=0; joint < num_joints; joint++) {
-	*(halui_data->joint_is_homed[joint]) = emcStatus->motion.joint[joint].homed;
-	*(halui_data->joint_on_soft_min_limit[joint]) = emcStatus->motion.joint[joint].minSoftLimit;
-	*(halui_data->joint_on_soft_max_limit[joint]) = emcStatus->motion.joint[joint].maxSoftLimit;
-	*(halui_data->joint_on_hard_min_limit[joint]) = emcStatus->motion.joint[joint].minHardLimit;
-	*(halui_data->joint_on_hard_max_limit[joint]) = emcStatus->motion.joint[joint].maxHardLimit;
-	*(halui_data->joint_override_limits[joint]) = emcStatus->motion.joint[joint].overrideLimits;
-	*(halui_data->joint_has_fault[joint]) = emcStatus->motion.joint[joint].fault;
+	hal_set_bool(halui_data->joint_is_homed[joint], emcStatus->motion.joint[joint].homed);
+	hal_set_bool(halui_data->joint_on_soft_min_limit[joint], emcStatus->motion.joint[joint].minSoftLimit);
+	hal_set_bool(halui_data->joint_on_soft_max_limit[joint], emcStatus->motion.joint[joint].maxSoftLimit);
+	hal_set_bool(halui_data->joint_on_hard_min_limit[joint], emcStatus->motion.joint[joint].minHardLimit);
+	hal_set_bool(halui_data->joint_on_hard_max_limit[joint], emcStatus->motion.joint[joint].maxHardLimit);
+	hal_set_bool(halui_data->joint_override_limits[joint], emcStatus->motion.joint[joint].overrideLimits);
+	hal_set_bool(halui_data->joint_has_fault[joint], emcStatus->motion.joint[joint].fault);
     }
 
     if (axis_mask & 0x0001) {
-      *(halui_data->axis_pos_commanded[0]) = emcStatus->motion.traj.position.tran.x;
-      *(halui_data->axis_pos_feedback[0]) = emcStatus->motion.traj.actualPosition.tran.x;
+      hal_set_real(halui_data->axis_pos_commanded[0], emcStatus->motion.traj.position.tran.x);
+      hal_set_real(halui_data->axis_pos_feedback[0], emcStatus->motion.traj.actualPosition.tran.x);
       double x = emcStatus->motion.traj.actualPosition.tran.x - emcStatus->task.g5x_offset.tran.x - emcStatus->task.toolOffset.tran.x;
       double y = emcStatus->motion.traj.actualPosition.tran.y - emcStatus->task.g5x_offset.tran.y - emcStatus->task.toolOffset.tran.y;
       x = x * cos(-emcStatus->task.rotation_xy * TO_RAD) - y * sin(-emcStatus->task.rotation_xy * TO_RAD);
-      *(halui_data->axis_pos_relative[0]) = x - emcStatus->task.g92_offset.tran.x;
+      hal_set_real(halui_data->axis_pos_relative[0], x - emcStatus->task.g92_offset.tran.x);
     }
 
     if (axis_mask & 0x0002) {
-      *(halui_data->axis_pos_commanded[1]) = emcStatus->motion.traj.position.tran.y;
-      *(halui_data->axis_pos_feedback[1]) = emcStatus->motion.traj.actualPosition.tran.y;
+      hal_set_real(halui_data->axis_pos_commanded[1], emcStatus->motion.traj.position.tran.y);
+      hal_set_real(halui_data->axis_pos_feedback[1], emcStatus->motion.traj.actualPosition.tran.y);
       double x = emcStatus->motion.traj.actualPosition.tran.x - emcStatus->task.g5x_offset.tran.x - emcStatus->task.toolOffset.tran.x;
       double y = emcStatus->motion.traj.actualPosition.tran.y - emcStatus->task.g5x_offset.tran.y - emcStatus->task.toolOffset.tran.y;
       y = y * cos(-emcStatus->task.rotation_xy * TO_RAD) + x * sin(-emcStatus->task.rotation_xy * TO_RAD);
-      *(halui_data->axis_pos_relative[1]) = y - emcStatus->task.g92_offset.tran.y;
+      hal_set_real(halui_data->axis_pos_relative[1], y - emcStatus->task.g92_offset.tran.y);
     }
 
     if (axis_mask & 0x0004) {
-      *(halui_data->axis_pos_commanded[2]) = emcStatus->motion.traj.position.tran.z;
-      *(halui_data->axis_pos_feedback[2]) = emcStatus->motion.traj.actualPosition.tran.z;
-      *(halui_data->axis_pos_relative[2]) = emcStatus->motion.traj.actualPosition.tran.z - emcStatus->task.g5x_offset.tran.z - emcStatus->task.g92_offset.tran.z - emcStatus->task.toolOffset.tran.z;
+      hal_set_real(halui_data->axis_pos_commanded[2], emcStatus->motion.traj.position.tran.z);
+      hal_set_real(halui_data->axis_pos_feedback[2], emcStatus->motion.traj.actualPosition.tran.z);
+      hal_set_real(halui_data->axis_pos_relative[2], emcStatus->motion.traj.actualPosition.tran.z - emcStatus->task.g5x_offset.tran.z - emcStatus->task.g92_offset.tran.z - emcStatus->task.toolOffset.tran.z);
     }
 
     if (axis_mask & 0x0008) {
-      *(halui_data->axis_pos_commanded[3]) = emcStatus->motion.traj.position.a;
-      *(halui_data->axis_pos_feedback[3]) = emcStatus->motion.traj.actualPosition.a;
-      *(halui_data->axis_pos_relative[3]) = emcStatus->motion.traj.actualPosition.a - emcStatus->task.g5x_offset.a - emcStatus->task.g92_offset.a - emcStatus->task.toolOffset.a;
+      hal_set_real(halui_data->axis_pos_commanded[3], emcStatus->motion.traj.position.a);
+      hal_set_real(halui_data->axis_pos_feedback[3], emcStatus->motion.traj.actualPosition.a);
+      hal_set_real(halui_data->axis_pos_relative[3], emcStatus->motion.traj.actualPosition.a - emcStatus->task.g5x_offset.a - emcStatus->task.g92_offset.a - emcStatus->task.toolOffset.a);
     }
 
     if (axis_mask & 0x0010) {
-      *(halui_data->axis_pos_commanded[4]) = emcStatus->motion.traj.position.b;
-      *(halui_data->axis_pos_feedback[4]) = emcStatus->motion.traj.actualPosition.b;
-      *(halui_data->axis_pos_relative[4]) = emcStatus->motion.traj.actualPosition.b - emcStatus->task.g5x_offset.b - emcStatus->task.g92_offset.b - emcStatus->task.toolOffset.b;
+      hal_set_real(halui_data->axis_pos_commanded[4], emcStatus->motion.traj.position.b);
+      hal_set_real(halui_data->axis_pos_feedback[4], emcStatus->motion.traj.actualPosition.b);
+      hal_set_real(halui_data->axis_pos_relative[4], emcStatus->motion.traj.actualPosition.b - emcStatus->task.g5x_offset.b - emcStatus->task.g92_offset.b - emcStatus->task.toolOffset.b);
     }
 
     if (axis_mask & 0x0020) {
-      *(halui_data->axis_pos_commanded[5]) = emcStatus->motion.traj.position.c;
-      *(halui_data->axis_pos_feedback[5]) = emcStatus->motion.traj.actualPosition.c;
-      *(halui_data->axis_pos_relative[5]) = emcStatus->motion.traj.actualPosition.c - emcStatus->task.g5x_offset.c - emcStatus->task.g92_offset.c - emcStatus->task.toolOffset.c;
+      hal_set_real(halui_data->axis_pos_commanded[5], emcStatus->motion.traj.position.c);
+      hal_set_real(halui_data->axis_pos_feedback[5], emcStatus->motion.traj.actualPosition.c);
+      hal_set_real(halui_data->axis_pos_relative[5], emcStatus->motion.traj.actualPosition.c - emcStatus->task.g5x_offset.c - emcStatus->task.g92_offset.c - emcStatus->task.toolOffset.c);
     }
 
     if (axis_mask & 0x0040) {
-      *(halui_data->axis_pos_commanded[6]) = emcStatus->motion.traj.position.u;
-      *(halui_data->axis_pos_feedback[6]) = emcStatus->motion.traj.actualPosition.u;
-      *(halui_data->axis_pos_relative[6]) = emcStatus->motion.traj.actualPosition.u - emcStatus->task.g5x_offset.u - emcStatus->task.g92_offset.u - emcStatus->task.toolOffset.u;
+      hal_set_real(halui_data->axis_pos_commanded[6], emcStatus->motion.traj.position.u);
+      hal_set_real(halui_data->axis_pos_feedback[6], emcStatus->motion.traj.actualPosition.u);
+      hal_set_real(halui_data->axis_pos_relative[6], emcStatus->motion.traj.actualPosition.u - emcStatus->task.g5x_offset.u - emcStatus->task.g92_offset.u - emcStatus->task.toolOffset.u);
     }
 
     if (axis_mask & 0x0080) {
-      *(halui_data->axis_pos_commanded[7]) = emcStatus->motion.traj.position.v;
-      *(halui_data->axis_pos_feedback[7]) = emcStatus->motion.traj.actualPosition.v;
-      *(halui_data->axis_pos_relative[7]) = emcStatus->motion.traj.actualPosition.v - emcStatus->task.g5x_offset.v - emcStatus->task.g92_offset.v - emcStatus->task.toolOffset.v;
+      hal_set_real(halui_data->axis_pos_commanded[7], emcStatus->motion.traj.position.v);
+      hal_set_real(halui_data->axis_pos_feedback[7], emcStatus->motion.traj.actualPosition.v);
+      hal_set_real(halui_data->axis_pos_relative[7], emcStatus->motion.traj.actualPosition.v - emcStatus->task.g5x_offset.v - emcStatus->task.g92_offset.v - emcStatus->task.toolOffset.v);
     }
 
     if (axis_mask & 0x0100) {
-      *(halui_data->axis_pos_commanded[8]) = emcStatus->motion.traj.position.w;
-      *(halui_data->axis_pos_feedback[8]) = emcStatus->motion.traj.actualPosition.w;
-      *(halui_data->axis_pos_relative[8]) = emcStatus->motion.traj.actualPosition.w - emcStatus->task.g5x_offset.w - emcStatus->task.g92_offset.w - emcStatus->task.toolOffset.w;
+      hal_set_real(halui_data->axis_pos_commanded[8], emcStatus->motion.traj.position.w);
+      hal_set_real(halui_data->axis_pos_feedback[8], emcStatus->motion.traj.actualPosition.w);
+      hal_set_real(halui_data->axis_pos_relative[8], emcStatus->motion.traj.actualPosition.w - emcStatus->task.g5x_offset.w - emcStatus->task.g92_offset.w - emcStatus->task.toolOffset.w);
     }
 
-    *(halui_data->joint_is_homed[num_joints]) = emcStatus->motion.joint[*(halui_data->joint_selected)].homed;
-    *(halui_data->joint_on_soft_min_limit[num_joints]) = emcStatus->motion.joint[*(halui_data->joint_selected)].minSoftLimit;
-    *(halui_data->joint_on_soft_max_limit[num_joints]) = emcStatus->motion.joint[*(halui_data->joint_selected)].maxSoftLimit;
-    *(halui_data->joint_on_hard_min_limit[num_joints]) = emcStatus->motion.joint[*(halui_data->joint_selected)].minHardLimit;
-    *(halui_data->joint_override_limits[num_joints]) = emcStatus->motion.joint[*(halui_data->joint_selected)].overrideLimits;
-    *(halui_data->joint_on_hard_max_limit[num_joints]) = emcStatus->motion.joint[*(halui_data->joint_selected)].maxHardLimit;
-    *(halui_data->joint_has_fault[num_joints]) = emcStatus->motion.joint[*(halui_data->joint_selected)].fault;
+    rtapi_u32 joint_selected = hal_get_ui32(halui_data->joint_selected);
+    hal_set_bool(halui_data->joint_is_homed[num_joints], emcStatus->motion.joint[joint_selected].homed);
+    hal_set_bool(halui_data->joint_on_soft_min_limit[num_joints], emcStatus->motion.joint[joint_selected].minSoftLimit);
+    hal_set_bool(halui_data->joint_on_soft_max_limit[num_joints], emcStatus->motion.joint[joint_selected].maxSoftLimit);
+    hal_set_bool(halui_data->joint_on_hard_min_limit[num_joints], emcStatus->motion.joint[joint_selected].minHardLimit);
+    hal_set_bool(halui_data->joint_override_limits[num_joints], emcStatus->motion.joint[joint_selected].overrideLimits);
+    hal_set_bool(halui_data->joint_on_hard_max_limit[num_joints], emcStatus->motion.joint[joint_selected].maxHardLimit);
+    hal_set_bool(halui_data->joint_has_fault[num_joints], emcStatus->motion.joint[joint_selected].fault);
 
 }
 
@@ -2340,7 +2167,7 @@ int main(int argc, char *argv[])
            // wait for task to establish nonzero linearUnits
            if (emcStatus->motion.traj.linearUnits != 0) {
               // set once at startup, no changes are expected:
-              *(halui_data->units_per_mm) = emcStatus->motion.traj.linearUnits;
+              hal_set_real(halui_data->units_per_mm, emcStatus->motion.traj.linearUnits);
               task_start_synced = 1;
            }
         }


### PR DESCRIPTION
The conversion of inihal and halui are quite straight forward albeit many pins. The challenge is in the dual use of the structure construct where it both handled creation of the version in HAL memory with the pins and a copy structure using the underlying types.
There is a caveat where the code needs to change when we do the 64-bit cleanup. The expansion used with the macros is based on concatenation and both 32-bit and 64-bit integers are using the same hal type (hal_[su]int_t), but the getter/setter is called hal_[gs]et_[us]i32(). The sint/uint vs ui32/si32 mismatch is solved by a temporary typedef, but that excludes using both 64- and 32-bit versions simultaneously because the compiler would see the overlap and complain. There are at present no 64-bit pins in these components so the problem is not serious and should solve itself when we do the 64-bit cleanup.

The motion-logger update is rather trivial.