### PR TITLE
hal: Update motion to getter/setter.

### DIFF
--- a/src/emc/motion/axis.c
+++ b/src/emc/motion/axis.c
@@ -28,26 +28,26 @@ typedef struct {
 } emcmot_axis_t;
 
 typedef struct {
-    hal_float_t *pos_cmd;           /* RPI: commanded position */
-    hal_float_t *teleop_vel_cmd;    /* RPI: commanded velocity */
-    hal_float_t *teleop_pos_cmd;    /* RPI: teleop traj planner pos cmd */
-    hal_float_t *teleop_vel_lim;    /* RPI: teleop traj planner vel limit */
-    hal_bit_t   *teleop_tp_enable;  /* RPI: teleop traj planner is running */
+    hal_real_t pos_cmd;           /* RPI: commanded position */
+    hal_real_t teleop_vel_cmd;    /* RPI: commanded velocity */
+    hal_real_t teleop_pos_cmd;    /* RPI: teleop traj planner pos cmd */
+    hal_real_t teleop_vel_lim;    /* RPI: teleop traj planner vel limit */
+    hal_bool_t teleop_tp_enable;  /* RPI: teleop traj planner is running */
 
-    hal_s32_t   *ajog_counts;       /* WPI: jogwheel position input */
-    hal_bit_t   *ajog_enable;       /* RPI: enable jogwheel */
-    hal_float_t *ajog_scale;        /* RPI: distance to jog on each count */
-    hal_float_t *ajog_accel_fraction;  /* RPI: to limit wheel jog accel */
-    hal_bit_t   *ajog_vel_mode;     /* RPI: true for "velocity mode" jogwheel */
-    hal_bit_t   *kb_ajog_active;    /* RPI: executing keyboard jog */
-    hal_bit_t   *wheel_ajog_active; /* RPI: executing handwheel jog */
+    hal_sint_t ajog_counts;       /* WPI: jogwheel position input */
+    hal_bool_t ajog_enable;       /* RPI: enable jogwheel */
+    hal_real_t ajog_scale;        /* RPI: distance to jog on each count */
+    hal_real_t ajog_accel_fraction;  /* RPI: to limit wheel jog accel */
+    hal_bool_t ajog_vel_mode;     /* RPI: true for "velocity mode" jogwheel */
+    hal_bool_t kb_ajog_active;    /* RPI: executing keyboard jog */
+    hal_bool_t wheel_ajog_active; /* RPI: executing handwheel jog */
 
-    hal_bit_t   *eoffset_enable;
-    hal_bit_t   *eoffset_clear;
-    hal_s32_t   *eoffset_counts;
-    hal_float_t *eoffset_scale;
-    hal_float_t *external_offset;
-    hal_float_t *external_offset_requested;
+    hal_bool_t eoffset_enable;
+    hal_bool_t eoffset_clear;
+    hal_sint_t eoffset_counts;
+    hal_real_t eoffset_scale;
+    hal_real_t external_offset;
+    hal_real_t external_offset_requested;
 } axis_hal_t;
 
 
@@ -79,8 +79,8 @@ void axis_initialize_external_offsets(void)
     for (n = 0; n < EMCMOT_MAX_AXIS; n++) {
         axis_data = &hal_data->axis[n];
 
-        *(axis_data->external_offset) = 0;
-        *(axis_data->external_offset_requested) = 0;
+        hal_set_real(axis_data->external_offset, 0);
+        hal_set_real(axis_data->external_offset_requested, 0);
         axis_array[n].ext_offset_tp.pos_cmd  = 0;
         axis_array[n].ext_offset_tp.curr_pos = 0;
         axis_array[n].ext_offset_tp.curr_vel = 0;
@@ -100,15 +100,15 @@ static int export_axis(int mot_comp_id, char c, axis_hal_t * addr)
     msg = rtapi_get_msg_level();
     rtapi_set_msg_level(RTAPI_MSG_WARN);
 
-    CALL_CHECK(hal_pin_bit_newf(HAL_IN, &(addr->ajog_enable), mot_comp_id,"axis.%c.jog-enable", c));
-    CALL_CHECK(hal_pin_float_newf(HAL_IN, &(addr->ajog_scale), mot_comp_id,"axis.%c.jog-scale", c));
-    CALL_CHECK(hal_pin_s32_newf(HAL_IN, &(addr->ajog_counts), mot_comp_id,"axis.%c.jog-counts", c));
-    CALL_CHECK(hal_pin_bit_newf(HAL_IN, &(addr->ajog_vel_mode), mot_comp_id,"axis.%c.jog-vel-mode", c));
-    CALL_CHECK(hal_pin_bit_newf(HAL_OUT, &(addr->kb_ajog_active), mot_comp_id,"axis.%c.kb-jog-active", c));
-    CALL_CHECK(hal_pin_bit_newf(HAL_OUT, &(addr->wheel_ajog_active), mot_comp_id,"axis.%c.wheel-jog-active", c));
+    CALL_CHECK(hal_pin_new_bool(mot_comp_id, HAL_IN, &(addr->ajog_enable), 0, "axis.%c.jog-enable", c));
+    CALL_CHECK(hal_pin_new_real(mot_comp_id, HAL_IN, &(addr->ajog_scale), 0.0, "axis.%c.jog-scale", c));
+    CALL_CHECK(hal_pin_new_si32(mot_comp_id, HAL_IN, &(addr->ajog_counts), 0, "axis.%c.jog-counts", c));
+    CALL_CHECK(hal_pin_new_bool(mot_comp_id, HAL_IN, &(addr->ajog_vel_mode), 0, "axis.%c.jog-vel-mode", c));
+    CALL_CHECK(hal_pin_new_bool(mot_comp_id, HAL_OUT, &(addr->kb_ajog_active), 0, "axis.%c.kb-jog-active", c));
+    CALL_CHECK(hal_pin_new_bool(mot_comp_id, HAL_OUT, &(addr->wheel_ajog_active), 0, "axis.%c.wheel-jog-active", c));
 
-    CALL_CHECK(hal_pin_float_newf(HAL_IN,&(addr->ajog_accel_fraction), mot_comp_id,"axis.%c.jog-accel-fraction", c));
-    *addr->ajog_accel_fraction = 1.0; // fraction of accel for wheel ajogs
+    // init: 1.0  fraction of accel for wheel ajogs
+    CALL_CHECK(hal_pin_new_real(mot_comp_id, HAL_IN, &(addr->ajog_accel_fraction), 1.0, "axis.%c.jog-accel-fraction", c));
 
     rtapi_set_msg_level(msg);
     return 0;
@@ -128,18 +128,18 @@ int axis_init_hal_io(int mot_comp_id)
     for (n = 0; n < EMCMOT_MAX_AXIS; n++) {
         char c = "xyzabcuvw"[n];
         axis_hal_t *axis_data = &(hal_data->axis[n]);
-        CALL_CHECK(hal_pin_float_newf(HAL_OUT, &axis_data->pos_cmd, mot_comp_id, "axis.%c.pos-cmd", c));
-        CALL_CHECK(hal_pin_float_newf(HAL_OUT, &axis_data->teleop_vel_cmd, mot_comp_id, "axis.%c.teleop-vel-cmd", c));
-        CALL_CHECK(hal_pin_float_newf(HAL_OUT, &axis_data->teleop_pos_cmd, mot_comp_id, "axis.%c.teleop-pos-cmd", c));
-        CALL_CHECK(hal_pin_float_newf(HAL_OUT, &axis_data->teleop_vel_lim, mot_comp_id, "axis.%c.teleop-vel-lim", c));
-        CALL_CHECK(hal_pin_bit_newf(HAL_OUT, &axis_data->teleop_tp_enable, mot_comp_id, "axis.%c.teleop-tp-enable",c));
-        CALL_CHECK(hal_pin_bit_newf(HAL_IN, &axis_data->eoffset_enable, mot_comp_id, "axis.%c.eoffset-enable", c));
-        CALL_CHECK(hal_pin_bit_newf(HAL_IN, &axis_data->eoffset_clear, mot_comp_id, "axis.%c.eoffset-clear", c));
-        CALL_CHECK(hal_pin_s32_newf(HAL_IN, &axis_data->eoffset_counts, mot_comp_id, "axis.%c.eoffset-counts", c));
-        CALL_CHECK(hal_pin_float_newf(HAL_IN, &axis_data->eoffset_scale, mot_comp_id, "axis.%c.eoffset-scale", c));
-        CALL_CHECK(hal_pin_float_newf(HAL_OUT, &axis_data->external_offset, mot_comp_id, "axis.%c.eoffset", c));
-        CALL_CHECK(hal_pin_float_newf(HAL_OUT, &axis_data->external_offset_requested,
-           mot_comp_id, "axis.%c.eoffset-request", c));
+        CALL_CHECK(hal_pin_new_real(mot_comp_id, HAL_OUT, &axis_data->pos_cmd, 0.0, "axis.%c.pos-cmd", c));
+        CALL_CHECK(hal_pin_new_real(mot_comp_id, HAL_OUT, &axis_data->teleop_vel_cmd, 0.0, "axis.%c.teleop-vel-cmd", c));
+        CALL_CHECK(hal_pin_new_real(mot_comp_id, HAL_OUT, &axis_data->teleop_pos_cmd, 0.0, "axis.%c.teleop-pos-cmd", c));
+        CALL_CHECK(hal_pin_new_real(mot_comp_id, HAL_OUT, &axis_data->teleop_vel_lim, 0.0, "axis.%c.teleop-vel-lim", c));
+        CALL_CHECK(hal_pin_new_bool(mot_comp_id, HAL_OUT, &axis_data->teleop_tp_enable, 0, "axis.%c.teleop-tp-enable",c));
+        CALL_CHECK(hal_pin_new_bool(mot_comp_id, HAL_IN, &axis_data->eoffset_enable, 0, "axis.%c.eoffset-enable", c));
+        CALL_CHECK(hal_pin_new_bool(mot_comp_id, HAL_IN, &axis_data->eoffset_clear, 0, "axis.%c.eoffset-clear", c));
+        CALL_CHECK(hal_pin_new_si32(mot_comp_id, HAL_IN, &axis_data->eoffset_counts, 0, "axis.%c.eoffset-counts", c));
+        CALL_CHECK(hal_pin_new_real(mot_comp_id, HAL_IN, &axis_data->eoffset_scale, 0.0, "axis.%c.eoffset-scale", c));
+        CALL_CHECK(hal_pin_new_real(mot_comp_id, HAL_OUT, &axis_data->external_offset, 0.0, "axis.%c.eoffset", c));
+        CALL_CHECK(hal_pin_new_real(mot_comp_id, HAL_OUT, &axis_data->external_offset_requested,
+           0.0, "axis.%c.eoffset-request", c));
 
         retval = export_axis(mot_comp_id, c, axis_data);
         if (retval) {
@@ -159,16 +159,16 @@ void axis_output_to_hal(double *pcmd_p[])
     for (n = 0; n < EMCMOT_MAX_AXIS; n++) {
         emcmot_axis_t *axis = &axis_array[n];
         axis_hal_t *axis_data = &hal_data->axis[n];
-        *(axis_data->teleop_vel_cmd)    = axis->teleop_vel_cmd;
-        *(axis_data->teleop_pos_cmd)    = axis->teleop_tp.pos_cmd;
-        *(axis_data->teleop_vel_lim)    = axis->teleop_tp.max_vel;
-        *(axis_data->teleop_tp_enable)  = axis->teleop_tp.enable;
-        *(axis_data->kb_ajog_active)    = axis->kb_ajog_active;
-        *(axis_data->wheel_ajog_active) = axis->wheel_ajog_active;
+        hal_set_real(axis_data->teleop_vel_cmd,    axis->teleop_vel_cmd);
+        hal_set_real(axis_data->teleop_pos_cmd,    axis->teleop_tp.pos_cmd);
+        hal_set_real(axis_data->teleop_vel_lim,    axis->teleop_tp.max_vel);
+        hal_set_bool(axis_data->teleop_tp_enable,  axis->teleop_tp.enable);
+        hal_set_bool(axis_data->kb_ajog_active,    axis->kb_ajog_active);
+        hal_set_bool(axis_data->wheel_ajog_active, axis->wheel_ajog_active);
 
         // hal pins: axis.L.pos-cmd reported without applied offsets:
-        *(axis_data->pos_cmd) = *pcmd_p[n]
-                              - axis->ext_offset_tp.curr_pos;
+        hal_set_real(axis_data->pos_cmd, *pcmd_p[n]
+                              - axis->ext_offset_tp.curr_pos);
      }
 }
 
@@ -380,14 +380,15 @@ void axis_handle_jogwheels(bool motion_teleop_flag, bool motion_enable_flag, boo
         axis_data = &hal_data->axis[axis_num];
 
         // disallow accel bogus fractions
-        if (   (*(axis_data->ajog_accel_fraction) > 1)
-            || (*(axis_data->ajog_accel_fraction) < 0) ) {
+        rtapi_real ajog_accel_fraction = hal_get_real(axis_data->ajog_accel_fraction);
+        if (   (ajog_accel_fraction > 1)
+            || (ajog_accel_fraction < 0) ) {
             aaccel_limit = axis->acc_limit;
         } else {
-            aaccel_limit = *(axis_data->ajog_accel_fraction) * axis->acc_limit;
+            aaccel_limit = ajog_accel_fraction * axis->acc_limit;
         }
 
-        new_ajog_counts = *(axis_data->ajog_counts);
+        new_ajog_counts = hal_get_si32(axis_data->ajog_counts);
         delta = new_ajog_counts - axis->old_ajog_counts;
         axis->old_ajog_counts = new_ajog_counts;
         if ( first_pass ) { continue; }
@@ -400,7 +401,7 @@ void axis_handle_jogwheels(bool motion_teleop_flag, bool motion_enable_flag, boo
             return;
         }
         if (!motion_enable_flag)              { continue; }
-        if ( *(axis_data->ajog_enable) == 0 ) { continue; }
+        if (!hal_get_bool(axis_data->ajog_enable)) { continue; }
         if (homing_is_active)                 { continue; }
         if (axis->kb_ajog_active)             { continue; }
 
@@ -411,9 +412,9 @@ void axis_handle_jogwheels(bool motion_teleop_flag, bool motion_enable_flag, boo
             continue;
         }
 
-        distance = delta * *(axis_data->ajog_scale);
+        distance = delta * hal_get_real(axis_data->ajog_scale);
         pos = axis->teleop_tp.pos_cmd + distance;
-        if ( *(axis_data->ajog_vel_mode) ) {
+        if ( hal_get_bool(axis_data->ajog_vel_mode) ) {
             double v = axis->vel_limit;
             /* compute stopping distance at max speed */
             stop_dist = v * v / ( 2 * aaccel_limit);
@@ -488,9 +489,7 @@ bool axis_plan_external_offsets(double servo_period, bool motion_enable_flag, bo
     int new_eoffset_counts, delta;
     static int last_eoffset_enable[EMCMOT_MAX_AXIS];
     double ext_offset_epsilon;
-    hal_bit_t eoffset_active;
-
-    eoffset_active = 0;
+    bool eoffset_active = 0;
 
     for (n = 0; n < EMCMOT_MAX_AXIS; n++) {
         axis = &axis_array[n];
@@ -500,29 +499,29 @@ bool axis_plan_external_offsets(double servo_period, bool motion_enable_flag, bo
 
         axis_data = &hal_data->axis[n];
 
-        new_eoffset_counts       = *(axis_data->eoffset_counts);
+        new_eoffset_counts       = hal_get_si32(axis_data->eoffset_counts);
         delta                    = new_eoffset_counts - axis->old_eoffset_counts;
         axis->old_eoffset_counts = new_eoffset_counts;
 
-        *(axis_data->external_offset)  = axis->ext_offset_tp.curr_pos;
+        hal_set_real(axis_data->external_offset, axis->ext_offset_tp.curr_pos);
         axis->ext_offset_tp.enable = 1;
         if ( first_pass ) {
-            *(axis_data->external_offset) = 0;
+            hal_set_real(axis_data->external_offset, 0);
             continue;
         }
 
         // Use stopping criterion of simple_tp.c:
         ext_offset_epsilon = TINY_DP(axis->ext_offset_tp.max_acc, servo_period);
-        if (fabs(*(axis_data->external_offset)) > ext_offset_epsilon) {
+        if (fabs(hal_get_real(axis_data->external_offset)) > ext_offset_epsilon) {
             eoffset_active = 1;
         }
-        if ( !*(axis_data->eoffset_enable) ) {
+        if ( !hal_get_bool(axis_data->eoffset_enable) ) {
             axis->ext_offset_tp.enable = 0;
             // Detect disabling of eoffsets:
             //   At very high accel, simple planner may terminate with
             //   a larger position value than occurs at more realistic accels.
             if (last_eoffset_enable[n]
-                && (fabs(*(axis_data->external_offset)) > ext_offset_epsilon)
+                && (fabs(hal_get_real(axis_data->external_offset)) > ext_offset_epsilon)
                 && motion_enable_flag
                 && axis->ext_offset_tp.enable) {
                 // to stdout only:
@@ -531,7 +530,7 @@ bool axis_plan_external_offsets(double servo_period, bool motion_enable_flag, bo
                            "*** External Offset disabled while NON-zero\n"
                            "*** To clear: re-enable & zero or use Machine-Off\n",
                            "XYZABCUVW"[n],
-                           *(axis_data->external_offset),
+                           hal_get_real(axis_data->external_offset),
                            ext_offset_epsilon);
             }
             last_eoffset_enable[n] = 0;
@@ -540,17 +539,17 @@ bool axis_plan_external_offsets(double servo_period, bool motion_enable_flag, bo
                       //       useful for eoffset_pid hold
         }
         last_eoffset_enable[n] = 1;
-        if (*(axis_data->eoffset_clear)) {
+        if (hal_get_bool(axis_data->eoffset_clear)) {
             axis->ext_offset_tp.pos_cmd             = 0;
-            *(axis_data->external_offset_requested) = 0;
+            hal_set_real(axis_data->external_offset_requested, 0);
             continue;
         }
         if (delta == 0)           { continue; }
         if (!all_homed)           { continue; }
         if (!motion_enable_flag)  { continue; }
 
-        axis->ext_offset_tp.pos_cmd   += delta *  *(axis_data->eoffset_scale);
-        *(axis_data->external_offset_requested) = axis->ext_offset_tp.pos_cmd;
+        axis->ext_offset_tp.pos_cmd   += delta *  hal_get_real(axis_data->eoffset_scale);
+        hal_set_real(axis_data->external_offset_requested, axis->ext_offset_tp.pos_cmd);
     } // for n
     first_pass = 0;
 

--- a/src/emc/motion/command.c
+++ b/src/emc/motion/command.c
@@ -305,7 +305,7 @@ void emcmotSetRotaryUnlock(int jnum, int unlock) {
         jnum,1<<jnum);
         return;
     }
-    *(emcmot_hal_data->joint[jnum].unlock) = unlock;
+    hal_set_bool(emcmot_hal_data->joint[jnum].unlock, unlock);
 }
 
 int emcmotGetRotaryIsUnlocked(int jnum) {
@@ -320,7 +320,7 @@ int emcmotGetRotaryIsUnlocked(int jnum) {
         gave_message = 1;
         return 0;
     }
-    return *(emcmot_hal_data->joint[jnum].is_unlocked);
+    return hal_get_bool(emcmot_hal_data->joint[jnum].is_unlocked);
 }
 
 /*! \function emcmotDioWrite()
@@ -336,11 +336,7 @@ void emcmotDioWrite(int index, char value)
     if ((index >= emcmotConfig->numDIO) || (index < 0)) {
 	rtapi_print_msg(RTAPI_MSG_ERR, "ERROR: index out of range, %d not in [0..%d] (increase num_dio/EMCMOT_MAX_DIO=%d)\n", index, emcmotConfig->numDIO, EMCMOT_MAX_DIO);
     } else {
-	if (value != 0) {
-	    *(emcmot_hal_data->synch_do[index])=1;
-	} else {
-	    *(emcmot_hal_data->synch_do[index])=0;
-	}
+	hal_set_bool(emcmot_hal_data->synch_do[index], value != 0);
     }
 }
 
@@ -357,7 +353,7 @@ void emcmotAioWrite(int index, double value)
     if ((index >= emcmotConfig->numAIO) || (index < 0)) {
 	rtapi_print_msg(RTAPI_MSG_ERR, "ERROR: index out of range, %d not in [0..%d] (increase num_aio/EMCMOT_MAX_AIO=%d)\n", index, emcmotConfig->numAIO, EMCMOT_MAX_AIO);
     } else {
-        *(emcmot_hal_data->analog_output[index]) = value;
+        hal_set_real(emcmot_hal_data->analog_output[index], value);
     }
 }
 
@@ -550,13 +546,13 @@ void emcmotCommandHandler_locked(void *arg, long servo_period)
 	    emcmotStatus->atspeed_next_feed = 0;
 	    // Clear pins on abort so tests see a clean state
 		if (emcmot_hal_data) {
-				*(emcmot_hal_data->interp_arc_radius) = 0.0;
-				*(emcmot_hal_data->interp_arc_center_x) = 0.0;
-				*(emcmot_hal_data->interp_arc_center_y) = 0.0;
-				*(emcmot_hal_data->interp_arc_center_z) = 0.0;
-				*(emcmot_hal_data->interp_straight_heading) = 0.0;
-				*(emcmot_hal_data->interp_normal_heading) = 0.0;
-				*(emcmot_hal_data->iscircle) = 0.0;
+				hal_set_real(emcmot_hal_data->interp_arc_radius, 0.0);
+				hal_set_real(emcmot_hal_data->interp_arc_center_x, 0.0);
+				hal_set_real(emcmot_hal_data->interp_arc_center_y, 0.0);
+				hal_set_real(emcmot_hal_data->interp_arc_center_z, 0.0);
+				hal_set_real(emcmot_hal_data->interp_straight_heading, 0.0);
+				hal_set_real(emcmot_hal_data->interp_normal_heading, 0.0);
+				hal_set_bool(emcmot_hal_data->iscircle, 0);
 		}
 	    break;
 
@@ -809,7 +805,7 @@ void emcmotCommandHandler_locked(void *arg, long servo_period)
 		break;
 	    }
             // cannot jog if jog-inhibit is TRUE
-            if (*(emcmot_hal_data->jog_inhibit)){
+            if (hal_get_bool(emcmot_hal_data->jog_inhibit)){
                     reportError(_("Cannot jog while jog-inhibit is active."));
                 break;
             }
@@ -878,7 +874,7 @@ void emcmotCommandHandler_locked(void *arg, long servo_period)
 		break;
 	    }
             // cannot jog if jog-inhibit is TRUE
-            if (*(emcmot_hal_data->jog_inhibit)){
+            if (hal_get_bool(emcmot_hal_data->jog_inhibit)){
                     reportError(_("Cannot jog while jog-inhibit is active."));
                 break;
             }
@@ -958,7 +954,7 @@ void emcmotCommandHandler_locked(void *arg, long servo_period)
 		break;
 	    }
             // cannot jog if jog-inhibit is TRUE
-            if (*(emcmot_hal_data->jog_inhibit)){
+            if (hal_get_bool(emcmot_hal_data->jog_inhibit)){
                     reportError(_("Cannot jog while jog-inhibit is active."));
                 break;
             }
@@ -1373,7 +1369,7 @@ void emcmotCommandHandler_locked(void *arg, long servo_period)
 	    /* set the emcmotInternal->enabling flag to defer enable until
 	       controller cycle */
 	    rtapi_print_msg(RTAPI_MSG_DBG, "ENABLE");
-	    if ( *(emcmot_hal_data->enable) == 0 ) {
+	    if ( !hal_get_bool(emcmot_hal_data->enable) ) {
 		reportError(_("can't enable motion, enable input is false"));
 	    } else {
 		emcmotInternal->enabling = 1;
@@ -1421,7 +1417,7 @@ void emcmotCommandHandler_locked(void *arg, long servo_period)
 		reportError(_("must be in joint mode to home"));
 		return;
 	    }
-	    if (*(emcmot_hal_data->homing_inhibit)) {
+	    if (hal_get_bool(emcmot_hal_data->homing_inhibit)) {
 	        reportError(_("Homing denied by motion.homing-inhibit joint=%d\n"),
 	                   joint_num);
                 return;
@@ -1497,7 +1493,7 @@ void emcmotCommandHandler_locked(void *arg, long servo_period)
 	    } else if (!(emcmotCommand->probe_type & 1)) {
                 // if suppress errors = off...
 
-                int probeval = !!*(emcmot_hal_data->probe_input);
+                int probeval = hal_get_bool(emcmot_hal_data->probe_input);
                 int probe_whenclears = !!(emcmotCommand->probe_type & 2);
 
                 if (probeval != probe_whenclears) {
@@ -1662,12 +1658,12 @@ void emcmotCommandHandler_locked(void *arg, long servo_period)
         }
         for (n = s0; n<=s1; n++){
 
-	        if (*(emcmot_hal_data->spindle[n].spindle_orient))
+	        if (hal_get_bool(emcmot_hal_data->spindle[n].spindle_orient))
 	    	rtapi_print_msg(RTAPI_MSG_DBG, "SPINDLE_ORIENT cancelled by SPINDLE_ON\n");
-	        if (*(emcmot_hal_data->spindle[n].spindle_locked))
+	        if (hal_get_bool(emcmot_hal_data->spindle[n].spindle_locked))
 		    rtapi_print_msg(RTAPI_MSG_DBG, "spindle-locked cleared by SPINDLE_ON\n");
-	        *(emcmot_hal_data->spindle[n].spindle_locked) = 0;
-	        *(emcmot_hal_data->spindle[n].spindle_orient) = 0;
+	        hal_set_bool(emcmot_hal_data->spindle[n].spindle_locked, 0);
+	        hal_set_bool(emcmot_hal_data->spindle[n].spindle_orient, 0);
 	        emcmotStatus->spindle_status[n].orient_state = EMCMOT_ORIENT_NONE;
 
 	        /* if (emcmotStatus->spindle.orient) { */
@@ -1719,13 +1715,13 @@ void emcmotCommandHandler_locked(void *arg, long servo_period)
 	        emcmotStatus->spindle_status[n].speed = 0;
 	        emcmotStatus->spindle_status[n].direction = 0;
 	        emcmotStatus->spindle_status[n].brake = 1; // engage brake
-	        if (*(emcmot_hal_data->spindle[n].spindle_orient))
+	        if (hal_get_bool(emcmot_hal_data->spindle[n].spindle_orient))
 		    rtapi_print_msg(RTAPI_MSG_DBG, "SPINDLE_ORIENT cancelled by SPINDLE_OFF");
-	        if (*(emcmot_hal_data->spindle[n].spindle_locked)){
+	        if (hal_get_bool(emcmot_hal_data->spindle[n].spindle_locked)){
 		    rtapi_print_msg(RTAPI_MSG_DBG, "spindle-locked cleared by SPINDLE_OFF");
-	            *(emcmot_hal_data->spindle[n].spindle_locked) = 0;
+	            hal_set_bool(emcmot_hal_data->spindle[n].spindle_locked, 0);
             }
-	        *(emcmot_hal_data->spindle[n].spindle_orient) = 0;
+	        hal_set_bool(emcmot_hal_data->spindle[n].spindle_orient, 0);
 	        emcmotStatus->spindle_status[n].orient_state = EMCMOT_ORIENT_NONE;
         }
         /* Optionally make the spindle stop an at-speed barrier: the next feed
@@ -1754,7 +1750,7 @@ void emcmotCommandHandler_locked(void *arg, long servo_period)
                 rtapi_print_msg(RTAPI_MSG_ERR, "spindle number <%d> too high in M19",n);
                 break;
 	        }
-	        if (*(emcmot_hal_data->spindle[n].spindle_orient)) {
+	        if (hal_get_bool(emcmot_hal_data->spindle[n].spindle_orient)) {
 		    rtapi_print_msg(RTAPI_MSG_DBG, "orient already in progress");
 
 		    // mah:FIXME unsure whether this is ok or an error
@@ -1771,13 +1767,13 @@ void emcmotCommandHandler_locked(void *arg, long servo_period)
 
             // https://github.com/LinuxCNC/linuxcnc/issues/3389
             emcmotStatus->spindle_status[n].state = 0;
-            *(emcmot_hal_data->spindle[n].spindle_on) = 0;
+            hal_set_bool(emcmot_hal_data->spindle[n].spindle_on, 0);
             // https://github.com/LinuxCNC/linuxcnc/issues/3389
 
-	        *(emcmot_hal_data->spindle[n].spindle_orient_angle) = emcmotCommand->orientation;
-	        *(emcmot_hal_data->spindle[n].spindle_orient_mode) = emcmotCommand->mode;
-	        *(emcmot_hal_data->spindle[n].spindle_locked) = 0;
-	        *(emcmot_hal_data->spindle[n].spindle_orient) = 1;
+	        hal_set_real(emcmot_hal_data->spindle[n].spindle_orient_angle, emcmotCommand->orientation);
+	        hal_set_si32(emcmot_hal_data->spindle[n].spindle_orient_mode, emcmotCommand->mode);
+	        hal_set_bool(emcmot_hal_data->spindle[n].spindle_locked, 0);
+	        hal_set_bool(emcmot_hal_data->spindle[n].spindle_orient, 1);
 
 	        // mirror in spindle status
 	        emcmotStatus->spindle_status[n].orient_fault = 0; // this pin read during spindle-orient == 1

--- a/src/emc/motion/control.c
+++ b/src/emc/motion/control.c
@@ -227,7 +227,7 @@ void emcmotController(void *arg, long period)
 
     long long int now = rtapi_get_time();
     long int this_run = (long int)(now - last);
-    *(emcmot_hal_data->last_period) = this_run;
+    hal_set_ui32(emcmot_hal_data->last_period, this_run);
 
     // we need this for next time
     last = now;
@@ -252,10 +252,10 @@ void emcmotController(void *arg, long period)
     process_probe_inputs();
     check_for_faults();
     set_operating_mode();
-    if (!*emcmot_hal_data->jog_inhibit) {
+    if (!hal_get_bool(emcmot_hal_data->jog_inhibit)) {
         handle_jjogwheels();
     }
-    if (!emcmotStatus->on_soft_limit && !*emcmot_hal_data->jog_inhibit) {  // change from teleop to move off joint soft limit
+    if (!emcmotStatus->on_soft_limit && !hal_get_bool(emcmot_hal_data->jog_inhibit)) {  // change from teleop to move off joint soft limit
         axis_handle_jogwheels(GET_MOTION_TELEOP_FLAG(), GET_MOTION_ENABLE_FLAG(), get_homing_is_active());
     }
     if (   (emcmotStatus->motion_state == EMCMOT_MOTION_FREE)
@@ -265,7 +265,7 @@ void emcmotController(void *arg, long period)
 
     get_pos_cmds(period);
     compute_screw_comp();
-    *(emcmot_hal_data->eoffset_active) = axis_plan_external_offsets(servo_period, GET_MOTION_ENABLE_FLAG(), get_allhomed());
+    hal_set_bool(emcmot_hal_data->eoffset_active, axis_plan_external_offsets(servo_period, GET_MOTION_ENABLE_FLAG(), get_allhomed()));
     output_to_hal();
     write_homing_out_pins(ALL_JOINTS);
     update_status();
@@ -299,7 +299,7 @@ static void handle_kinematicsSwitch(void) {
     int hal_switchkins_type = 0;
 
     if (!kinematicsSwitchable()) return;
-    hal_switchkins_type = (int)*emcmot_hal_data->switchkins_type;
+    hal_switchkins_type = (int)hal_get_real(emcmot_hal_data->switchkins_type);
     if (switchkins_type == hal_switchkins_type) return;
 
     switchkins_type = hal_switchkins_type;
@@ -316,7 +316,7 @@ static void handle_kinematicsSwitch(void) {
 
     if (kinematicsSwitch(switchkins_type)) {
         rtapi_print_msg(RTAPI_MSG_ERR,"kinematicsSwitch() FAIL<%f>\n",
-                        *emcmot_hal_data->switchkins_type);
+                        hal_get_real(emcmot_hal_data->switchkins_type));
         SET_MOTION_ERROR_FLAG(1);  // abort
         return; // no updates for abort
     }
@@ -354,11 +354,11 @@ static void process_inputs(void)
     /* read spindle angle (for threading, etc) */
     for (spindle_num = 0; spindle_num < emcmotConfig->numSpindles; spindle_num++){
 		emcmotStatus->spindle_status[spindle_num].spindleRevs =
-				*emcmot_hal_data->spindle[spindle_num].spindle_revs;
+				hal_get_real(emcmot_hal_data->spindle[spindle_num].spindle_revs);
 		emcmotStatus->spindle_status[spindle_num].spindleSpeedIn =
-				*emcmot_hal_data->spindle[spindle_num].spindle_speed_in;
+				hal_get_real(emcmot_hal_data->spindle[spindle_num].spindle_speed_in);
 		emcmotStatus->spindle_status[spindle_num].at_speed =
-				*emcmot_hal_data->spindle[spindle_num].spindle_is_atspeed;
+				hal_get_bool(emcmot_hal_data->spindle[spindle_num].spindle_is_atspeed);
     }
     /* compute net feed and spindle scale factors */
     if ( emcmotStatus->motion_state == EMCMOT_MOTION_COORD ) {
@@ -380,7 +380,7 @@ static void process_inputs(void)
     }
     if ( enables & AF_ENABLED ) {
         /* read and clamp adaptive feed HAL pin */
-        double adaptive_feed_in = *emcmot_hal_data->adaptive_feed;
+        double adaptive_feed_in = hal_get_real(emcmot_hal_data->adaptive_feed);
         // Clip range to +/- MAX_FEED_OVERRIDE from the [DISPLAY] section of the ini file
         if (adaptive_feed_in > emcmotConfig->maxFeedScale) {
             adaptive_feed_in = emcmotConfig->maxFeedScale;
@@ -409,12 +409,12 @@ static void process_inputs(void)
     }
     if ( enables & FH_ENABLED ) {
 	/* read feed hold HAL pin */
-	if ( *emcmot_hal_data->feed_hold ) {
+	if ( hal_get_bool(emcmot_hal_data->feed_hold) ) {
 	    scale = 0;
 	}
     }
     /*non maskable (except during spinndle synch move) feed hold inhibit pin */
-	if ( enables & *emcmot_hal_data->feed_inhibit ) {
+	if ( enables & hal_get_bool(emcmot_hal_data->feed_inhibit) ) {
 	    scale = 0;
 	}
     /* save the resulting combined scale factor */
@@ -427,7 +427,7 @@ static void process_inputs(void)
 			scale *= emcmotStatus->spindle_status[spindle_num].scale;
 		}
 		/*non maskable (except during spindle synch move) spindle inhibit pin */
-		if ( enables & *emcmot_hal_data->spindle[spindle_num].spindle_inhibit ) {
+		if ( enables & hal_get_bool(emcmot_hal_data->spindle[spindle_num].spindle_inhibit) ) {
 			scale = 0;
 		}
 		/* save the resulting combined scale factor */
@@ -445,7 +445,7 @@ static void process_inputs(void)
 	    continue;
 	}
 	/* copy data from HAL to joint structure */
-	joint->motor_pos_fb = *(joint_data->motor_pos_fb);
+	joint->motor_pos_fb = hal_get_real(joint_data->motor_pos_fb);
 	/* calculate pos_fb */
 	if (( get_homing_at_index_search_wait(joint_num) ) &&
 	    ( get_index_enable(joint_num) == 0 )) {
@@ -490,12 +490,12 @@ static void process_inputs(void)
 	}
 
 	/* read limit switches */
-	if (*(joint_data->pos_lim_sw)) {
+	if (hal_get_bool(joint_data->pos_lim_sw)) {
 	    SET_JOINT_PHL_FLAG(joint, 1);
 	} else {
 	    SET_JOINT_PHL_FLAG(joint, 0);
 	}
-	if (*(joint_data->neg_lim_sw)) {
+	if (hal_get_bool(joint_data->neg_lim_sw)) {
 	    SET_JOINT_NHL_FLAG(joint, 1);
 	} else {
 	    SET_JOINT_NHL_FLAG(joint, 0);
@@ -503,7 +503,7 @@ static void process_inputs(void)
 	joint->on_pos_limit = GET_JOINT_PHL_FLAG(joint);
 	joint->on_neg_limit = GET_JOINT_NHL_FLAG(joint);
 	/* read amp fault input */
-	if (*(joint_data->amp_fault)) {
+	if (hal_get_bool(joint_data->amp_fault)) {
 	    SET_JOINT_FAULT_FLAG(joint, 1);
 	} else {
 	    SET_JOINT_FAULT_FLAG(joint, 0);
@@ -513,25 +513,25 @@ static void process_inputs(void)
     // a fault was signalled during a spindle-orient in progress
     // signal error, and cancel the orient
     for (spindle_num = 0; spindle_num < emcmotConfig->numSpindles; spindle_num++){
-        if(*(emcmot_hal_data->spindle[spindle_num].spindle_amp_fault)){
+        if(hal_get_bool(emcmot_hal_data->spindle[spindle_num].spindle_amp_fault)){
             emcmotStatus->spindle_status[spindle_num].fault = 1;
         }else{
             emcmotStatus->spindle_status[spindle_num].fault = 0;
         }
-		if (*(emcmot_hal_data->spindle[spindle_num].spindle_orient)) {
-			if (*(emcmot_hal_data->spindle[spindle_num].spindle_orient_fault)) {
+		if (hal_get_bool(emcmot_hal_data->spindle[spindle_num].spindle_orient)) {
+			if (hal_get_si32(emcmot_hal_data->spindle[spindle_num].spindle_orient_fault)) {
 				emcmotStatus->spindle_status[spindle_num].orient_state = EMCMOT_ORIENT_FAULTED;
-				*(emcmot_hal_data->spindle[spindle_num].spindle_orient) = 0;
+				hal_set_bool(emcmot_hal_data->spindle[spindle_num].spindle_orient, 0);
 				emcmotStatus->spindle_status[spindle_num].orient_fault =
-						*(emcmot_hal_data->spindle[spindle_num].spindle_orient_fault);
+						hal_get_si32(emcmot_hal_data->spindle[spindle_num].spindle_orient_fault);
 				reportError(_("fault %d during orient in progress"),
 						emcmotStatus->spindle_status[spindle_num].orient_fault);
 				emcmotStatus->commandStatus = EMCMOT_COMMAND_INVALID_COMMAND;
 				tpAbort(&emcmotInternal->coord_tp);
 				SET_MOTION_ERROR_FLAG(1);
-			} else if (*(emcmot_hal_data->spindle[spindle_num].spindle_is_oriented)) {
-				*(emcmot_hal_data->spindle[spindle_num].spindle_orient) = 0;
-				*(emcmot_hal_data->spindle[spindle_num].spindle_locked) = 1;
+			} else if (hal_get_bool(emcmot_hal_data->spindle[spindle_num].spindle_is_oriented)) {
+				hal_set_bool(emcmot_hal_data->spindle[spindle_num].spindle_orient, 0);
+				hal_set_bool(emcmot_hal_data->spindle[spindle_num].spindle_locked, 1);
 				emcmotStatus->spindle_status[spindle_num].locked = 1;
 				emcmotStatus->spindle_status[spindle_num].brake = 1;
 				emcmotStatus->spindle_status[spindle_num].orient_state = EMCMOT_ORIENT_COMPLETE;
@@ -540,10 +540,10 @@ static void process_inputs(void)
 		}
     }
     // if jog in progress stop the jog if requested
-    if (enables & *(emcmot_hal_data->jog_is_active) && (*(emcmot_hal_data->jog_stop) || *(emcmot_hal_data->jog_stop_immediate))) {
-        joint_jog_abort_all(*(emcmot_hal_data->jog_stop_immediate));
-        axis_jog_abort_all(*(emcmot_hal_data->jog_stop_immediate));
-        if (*(emcmot_hal_data->jog_stop_immediate)) {
+    if (enables & hal_get_bool(emcmot_hal_data->jog_is_active) && (hal_get_bool(emcmot_hal_data->jog_stop) || hal_get_bool(emcmot_hal_data->jog_stop_immediate))) {
+        joint_jog_abort_all(hal_get_bool(emcmot_hal_data->jog_stop_immediate));
+        axis_jog_abort_all(hal_get_bool(emcmot_hal_data->jog_stop_immediate));
+        if (hal_get_bool(emcmot_hal_data->jog_stop_immediate)) {
           reportError("Jog aborted by jog-stop-immediate");
         } else {
           reportError("Jog aborted by jog-stop");
@@ -688,7 +688,7 @@ static void process_probe_inputs(void)
     char probe_whenclears = !!(probe_type & 2);
 
     /* read probe input */
-    emcmotStatus->probeVal = !!*(emcmot_hal_data->probe_input);
+    emcmotStatus->probeVal = hal_get_bool(emcmot_hal_data->probe_input);
     if (emcmotStatus->probing) {
         /* check if the probe has been tripped */
         if (emcmotStatus->probeVal ^ probe_whenclears) {
@@ -788,7 +788,7 @@ static void check_for_faults(void)
     /* check for various global fault conditions */
     /* only check enable input if running */
     if ( GET_MOTION_ENABLE_FLAG() != 0 ) {
-	if ( *(emcmot_hal_data->enable) == 0 ) {
+	if ( !hal_get_bool(emcmot_hal_data->enable) ) {
 	    reportError(_("motion stopped by enable input"));
 	    emcmotInternal->enabling = 0;
 	}
@@ -896,10 +896,10 @@ static void set_operating_mode(void)
 
     /* check for emcmotInternal->enabling */
     if (emcmotInternal->enabling && !GET_MOTION_ENABLE_FLAG()) {
-        if (*(emcmot_hal_data->eoffset_limited)) {
+        if (hal_get_bool(emcmot_hal_data->eoffset_limited)) {
             reportError("Note: Motion enabled after reaching a coordinate "
                         "soft limit with active external offsets");
-            *(emcmot_hal_data->eoffset_limited) = 0;
+            hal_set_bool(emcmot_hal_data->eoffset_limited, 0);
         }
         axis_initialize_external_offsets();
         tpSetPos(&emcmotInternal->coord_tp, &emcmotStatus->carte_pos_cmd);
@@ -936,7 +936,7 @@ static void set_operating_mode(void)
 		if (joint_num < NO_OF_KINS_JOINTS) {
 		/* point to joint data */
 		    joint = &joints[joint_num];
-		    if (coord_cubic_active && *(emcmot_hal_data->eoffset_active)) {
+		    if (coord_cubic_active && hal_get_bool(emcmot_hal_data->eoffset_active)) {
 		        //skip
 		    } else {
 		        cubicDrain(&(joint->cubic));
@@ -1055,14 +1055,15 @@ static void handle_jjogwheels(void)
 	}
 
         // disallow accel bogus fractions
-        if (    (*(joint_data->jjog_accel_fraction) > 1)
-             || (*(joint_data->jjog_accel_fraction) < 0) ) {
+        rtapi_real jjog_accel_fraction = hal_get_real(joint_data->jjog_accel_fraction);
+        if (    (jjog_accel_fraction > 1)
+             || (jjog_accel_fraction < 0) ) {
             jaccel_limit = joint->acc_limit;
         } else {
-            jaccel_limit = (*(joint_data->jjog_accel_fraction)) * joint->acc_limit;
+            jaccel_limit = jjog_accel_fraction * joint->acc_limit;
         }
 	/* get counts from jogwheel */
-	new_jjog_counts = *(joint_data->jjog_counts);
+	new_jjog_counts = hal_get_si32(joint_data->jjog_counts);
 	delta = new_jjog_counts - joint->old_jjog_counts;
 	/* save value for next time */
 	joint->old_jjog_counts = new_jjog_counts;
@@ -1087,7 +1088,7 @@ static void handle_jjogwheels(void)
 	    continue;
 	}
 	/* the jogwheel input for this joint must be enabled */
-	if ( *(joint_data->jjog_enable) == 0 ) {
+	if ( !hal_get_bool(joint_data->jjog_enable) ) {
 	    continue;
 	}
 	/* must not be homing */
@@ -1120,7 +1121,7 @@ static void handle_jjogwheels(void)
             continue;
         }
 	/* calculate distance to jog */
-	distance = delta * *(joint_data->jjog_scale);
+	distance = delta * hal_get_real(joint_data->jjog_scale);
 	/* check for joint already on hard limit */
 	if (distance > 0.0 && GET_JOINT_PHL_FLAG(joint)) {
 	    continue;
@@ -1145,7 +1146,7 @@ static void handle_jjogwheels(void)
 	   commanded distance.  Velocity mode is for those folks.  If
 	   the command is faster than the machine can track, excess
 	   command is simply dropped. */
-	if ( *(joint_data->jjog_vel_mode) ) {
+	if ( hal_get_bool(joint_data->jjog_vel_mode) ) {
             double v = joint->vel_limit * emcmotStatus->net_feed_scale;
 	    /* compute stopping distance at max speed */
 	    stop_dist = v * v / ( 2 * jaccel_limit);
@@ -1245,11 +1246,12 @@ static void get_pos_cmds(long period)
                 double jaccel_limit;
                 joint_hal_t *joint_data;
                 joint_data = &(emcmot_hal_data->joint[joint_num]);
-                if (    (*(joint_data->jjog_accel_fraction) > 1)
-                     || (*(joint_data->jjog_accel_fraction) < 0) ) {
+                rtapi_real jjog_accel_fraction = hal_get_real(joint_data->jjog_accel_fraction);
+                if (    (jjog_accel_fraction > 1)
+                     || (jjog_accel_fraction < 0) ) {
                      jaccel_limit = joint->acc_limit;
                 } else {
-                   jaccel_limit = (*(joint_data->jjog_accel_fraction)) * joint->acc_limit;
+                   jaccel_limit = jjog_accel_fraction * joint->acc_limit;
                 }
                 joint->free_tp.max_acc = jaccel_limit;
             } else {
@@ -1582,9 +1584,9 @@ static void get_pos_cmds(long period)
         axis_jog_abort_all(1);
     }
     if (ext_offset_teleop_limit || ext_offset_coord_limit) {
-        *(emcmot_hal_data->eoffset_limited) = 1;
+        hal_set_bool(emcmot_hal_data->eoffset_limited, 1);
     } else {
-        *(emcmot_hal_data->eoffset_limited) = 0;
+        hal_set_bool(emcmot_hal_data->eoffset_limited, 0);
     }
 } // get_pos_cmds()
 
@@ -1879,20 +1881,20 @@ static void output_to_hal(void)
     static int old_hal_index[EMCMOT_MAX_SPINDLES] = {0};
 
     /* output machine info to HAL for scoping, etc */
-    *(emcmot_hal_data->motion_enabled) = GET_MOTION_ENABLE_FLAG();
-    *(emcmot_hal_data->in_position) = GET_MOTION_INPOS_FLAG();
-    *(emcmot_hal_data->coord_mode) = GET_MOTION_COORD_FLAG();
-    *(emcmot_hal_data->teleop_mode) = GET_MOTION_TELEOP_FLAG();
-    *(emcmot_hal_data->coord_error) = GET_MOTION_ERROR_FLAG();
-    *(emcmot_hal_data->on_soft_limit) = emcmotStatus->on_soft_limit;
+    hal_set_bool(emcmot_hal_data->motion_enabled, GET_MOTION_ENABLE_FLAG());
+    hal_set_bool(emcmot_hal_data->in_position, GET_MOTION_INPOS_FLAG());
+    hal_set_bool(emcmot_hal_data->coord_mode, GET_MOTION_COORD_FLAG());
+    hal_set_bool(emcmot_hal_data->teleop_mode, GET_MOTION_TELEOP_FLAG());
+    hal_set_bool(emcmot_hal_data->coord_error, GET_MOTION_ERROR_FLAG());
+    hal_set_bool(emcmot_hal_data->on_soft_limit, emcmotStatus->on_soft_limit);
 
     /* Performance Metadata */
-    *(emcmot_hal_data->interp_feedrate)         = emcmotStatus->tag.fields_float[GM_FIELD_FLOAT_FEED];
+    hal_set_real(emcmot_hal_data->interp_feedrate, emcmotStatus->tag.fields_float[GM_FIELD_FLOAT_FEED]);
 
     /* Line and Motion Type (Casting to int for s32 HAL pins) */
-    *(emcmot_hal_data->interp_line_number)      = (int)emcmotStatus->tag.fields[GM_FIELD_LINE_NUMBER];
-    *(emcmot_hal_data->interp_motion_type)      = (int)emcmotStatus->tag.fields[GM_FIELD_MOTION_MODE];
-    *(emcmot_hal_data->iscircle)                = (hal_bit_t)((emcmotStatus->tag.packed_flags & (1UL << GM_FLAG_IS_CIRCLE)) != 0);
+    hal_set_si32(emcmot_hal_data->interp_line_number, (int)emcmotStatus->tag.fields[GM_FIELD_LINE_NUMBER]);
+    hal_set_si32(emcmot_hal_data->interp_motion_type, (int)emcmotStatus->tag.fields[GM_FIELD_MOTION_MODE]);
+    hal_set_bool(emcmot_hal_data->iscircle, (emcmotStatus->tag.packed_flags & (1UL << GM_FLAG_IS_CIRCLE)) != 0);
     switch (emcmotStatus->motionType) {
         case EMC_MOTION_TYPE_FEED: //fall thru
         case EMC_MOTION_TYPE_ARC:
@@ -1901,19 +1903,19 @@ static void output_to_hal(void)
             } else {
                 inch_mult = 1 / 25.4;
             }
-            *(emcmot_hal_data->feed_upm) = emcmotStatus->tag.fields_float[GM_FIELD_FLOAT_FEED]
-                                         * emcmotStatus->net_feed_scale;
-            *(emcmot_hal_data->feed_inches_per_minute) = *emcmot_hal_data->feed_upm * inch_mult;
-            *(emcmot_hal_data->feed_inches_per_second) = *emcmot_hal_data->feed_inches_per_minute / 60;
-            *(emcmot_hal_data->feed_mm_per_minute) = *emcmot_hal_data->feed_inches_per_minute * 25.4;
-            *(emcmot_hal_data->feed_mm_per_second) = *emcmot_hal_data->feed_mm_per_minute / 60;
+            hal_set_real(emcmot_hal_data->feed_upm, emcmotStatus->tag.fields_float[GM_FIELD_FLOAT_FEED]
+                                                    * emcmotStatus->net_feed_scale);
+            hal_set_real(emcmot_hal_data->feed_inches_per_minute, hal_get_real(emcmot_hal_data->feed_upm) * inch_mult);
+            hal_set_real(emcmot_hal_data->feed_inches_per_second, hal_get_real(emcmot_hal_data->feed_inches_per_minute) / 60);
+            hal_set_real(emcmot_hal_data->feed_mm_per_minute, hal_get_real(emcmot_hal_data->feed_inches_per_minute) * 25.4);
+            hal_set_real(emcmot_hal_data->feed_mm_per_second, hal_get_real(emcmot_hal_data->feed_mm_per_minute) / 60);
             break;
         default:
-            *(emcmot_hal_data->feed_upm) = 0;
-            *(emcmot_hal_data->feed_inches_per_minute) = 0;
-            *(emcmot_hal_data->feed_inches_per_second) = 0;
-            *(emcmot_hal_data->feed_mm_per_minute) = 0;
-            *(emcmot_hal_data->feed_mm_per_second) = 0;
+            hal_set_real(emcmot_hal_data->feed_upm, 0);
+            hal_set_real(emcmot_hal_data->feed_inches_per_minute, 0);
+            hal_set_real(emcmot_hal_data->feed_inches_per_second, 0);
+            hal_set_real(emcmot_hal_data->feed_mm_per_minute, 0);
+            hal_set_real(emcmot_hal_data->feed_mm_per_second, 0);
     }
 
     for (spindle_num = 0; spindle_num < emcmotConfig->numSpindles; spindle_num++){
@@ -1952,31 +1954,29 @@ static void output_to_hal(void)
             }
         }
 
-	*(emcmot_hal_data->spindle[spindle_num].spindle_speed_out) = speed;
-	*(emcmot_hal_data->spindle[spindle_num].spindle_speed_out_rps) = speed/60.;
-	*(emcmot_hal_data->spindle[spindle_num].spindle_speed_out_abs) = fabs(speed);
-	*(emcmot_hal_data->spindle[spindle_num].spindle_speed_out_rps_abs) = fabs(speed / 60);
-	*(emcmot_hal_data->spindle[spindle_num].spindle_on) = 
-        ((emcmotStatus->spindle_status[spindle_num].state) !=0) ? 1 : 0;
-	*(emcmot_hal_data->spindle[spindle_num].spindle_forward) = (speed > 0) ? 1 : 0;
-	*(emcmot_hal_data->spindle[spindle_num].spindle_reverse) = (speed < 0) ? 1 : 0;
-	*(emcmot_hal_data->spindle[spindle_num].spindle_brake) =
-		    (emcmotStatus->spindle_status[spindle_num].brake != 0) ? 1 : 0;
+	hal_set_real(emcmot_hal_data->spindle[spindle_num].spindle_speed_out, speed);
+	hal_set_real(emcmot_hal_data->spindle[spindle_num].spindle_speed_out_rps, speed/60.);
+	hal_set_real(emcmot_hal_data->spindle[spindle_num].spindle_speed_out_abs, fabs(speed));
+	hal_set_real(emcmot_hal_data->spindle[spindle_num].spindle_speed_out_rps_abs, fabs(speed / 60));
+	hal_set_bool(emcmot_hal_data->spindle[spindle_num].spindle_on, (emcmotStatus->spindle_status[spindle_num].state) != 0);
+	hal_set_bool(emcmot_hal_data->spindle[spindle_num].spindle_forward, speed > 0);
+	hal_set_bool(emcmot_hal_data->spindle[spindle_num].spindle_reverse, speed < 0);
+	hal_set_bool(emcmot_hal_data->spindle[spindle_num].spindle_brake, emcmotStatus->spindle_status[spindle_num].brake != 0);
         // What is this for? Docs don't say
-        *(emcmot_hal_data->spindle[spindle_num].spindle_speed_cmd_rps) =
-				emcmotStatus->spindle_status[spindle_num].speed / 60.;
+        hal_set_real(emcmot_hal_data->spindle[spindle_num].spindle_speed_cmd_rps,
+				emcmotStatus->spindle_status[spindle_num].speed / 60.);
     }
 
-    *(emcmot_hal_data->program_line) = emcmotStatus->id;
-    *(emcmot_hal_data->tp_reverse) = emcmotStatus->reverse_run;
-    *(emcmot_hal_data->motion_type) = emcmotStatus->motionType;
-    *(emcmot_hal_data->distance_to_go) = emcmotStatus->distance_to_go;
+    hal_set_si32(emcmot_hal_data->program_line, emcmotStatus->id);
+    hal_set_bool(emcmot_hal_data->tp_reverse, emcmotStatus->reverse_run);
+    hal_set_si32(emcmot_hal_data->motion_type, emcmotStatus->motionType);
+    hal_set_real(emcmot_hal_data->distance_to_go, emcmotStatus->distance_to_go);
     if(GET_MOTION_COORD_FLAG()) {
-        *(emcmot_hal_data->current_vel) = emcmotStatus->current_vel;
-        *(emcmot_hal_data->requested_vel) = emcmotStatus->requested_vel;
+        hal_set_real(emcmot_hal_data->current_vel, emcmotStatus->current_vel);
+        hal_set_real(emcmot_hal_data->requested_vel, emcmotStatus->requested_vel);
     } else if (GET_MOTION_TELEOP_FLAG()) {
-        emcmotStatus->current_vel = (*emcmot_hal_data->current_vel) = axis_get_compound_velocity();
-        *(emcmot_hal_data->requested_vel) = 0.0;
+        emcmotStatus->current_vel = hal_set_real(emcmot_hal_data->current_vel, axis_get_compound_velocity());
+        hal_set_real(emcmot_hal_data->requested_vel, 0.0);
     } else {
         int i;
         double v2 = 0.0;
@@ -1984,10 +1984,10 @@ static void output_to_hal(void)
             if(GET_JOINT_ACTIVE_FLAG(&(joints[i])) && joints[i].free_tp.active)
                 v2 += joints[i].vel_cmd * joints[i].vel_cmd;
         if(v2 > 0.0)
-            emcmotStatus->current_vel = (*emcmot_hal_data->current_vel) = sqrt(v2);
+            emcmotStatus->current_vel = hal_set_real(emcmot_hal_data->current_vel, sqrt(v2));
         else
-            emcmotStatus->current_vel = (*emcmot_hal_data->current_vel) = 0.0;
-        *(emcmot_hal_data->requested_vel) = 0.0;
+            emcmotStatus->current_vel = hal_set_real(emcmot_hal_data->current_vel, 0.0);
+        hal_set_real(emcmot_hal_data->requested_vel, 0.0);
     }
 
     /* These params can be used to examine any internal variable. */
@@ -1995,24 +1995,24 @@ static void output_to_hal(void)
        to one of the debug parameters.  You can also comment out these lines
        and copy elsewhere if you want to observe an automatic variable that
        isn't in scope here. */
-    emcmot_hal_data->debug_bit_0 = joints[1].free_tp.active;
-    emcmot_hal_data->debug_bit_1 = emcmotStatus->enables_new & AF_ENABLED;
-    emcmot_hal_data->debug_float_0 = emcmotStatus->spindle_status[0].speed;
-    emcmot_hal_data->debug_float_1 = emcmotStatus->spindleSync;
-    emcmot_hal_data->debug_float_2 = emcmotStatus->vel;
-    emcmot_hal_data->debug_float_3 = emcmotStatus->spindle_status[0].net_scale;
-    emcmot_hal_data->debug_s32_0 = emcmotStatus->overrideLimitMask;
-    emcmot_hal_data->debug_s32_1 = emcmotStatus->tcqlen;
+    hal_set_bool(emcmot_hal_data->debug_bit_0, joints[1].free_tp.active);
+    hal_set_bool(emcmot_hal_data->debug_bit_1, emcmotStatus->enables_new & AF_ENABLED);
+    hal_set_real(emcmot_hal_data->debug_float_0, emcmotStatus->spindle_status[0].speed);
+    hal_set_real(emcmot_hal_data->debug_float_1, emcmotStatus->spindleSync);
+    hal_set_real(emcmot_hal_data->debug_float_2, emcmotStatus->vel);
+    hal_set_real(emcmot_hal_data->debug_float_3, emcmotStatus->spindle_status[0].net_scale);
+    hal_set_si32(emcmot_hal_data->debug_s32_0, emcmotStatus->overrideLimitMask);
+    hal_set_si32(emcmot_hal_data->debug_s32_1, emcmotStatus->tcqlen);
 
     /* two way handshaking for the spindle encoder */
     for (spindle_num = 0; spindle_num < emcmotConfig->numSpindles; spindle_num++){
 		if(emcmotStatus->spindle_status[spindle_num].spindle_index_enable
 				&& !old_motion_index[spindle_num]) {
-			*emcmot_hal_data->spindle[spindle_num].spindle_index_enable = 1;
+			hal_set_bool(emcmot_hal_data->spindle[spindle_num].spindle_index_enable, 1);
 			rtapi_print_msg(RTAPI_MSG_DBG, "setting index-enable on spindle %d\n", spindle_num);
 		}
 
-		if(!*emcmot_hal_data->spindle[spindle_num].spindle_index_enable
+		if(!hal_get_bool(emcmot_hal_data->spindle[spindle_num].spindle_index_enable)
 				&& old_hal_index[spindle_num]) {
 			emcmotStatus->spindle_status[spindle_num].spindle_index_enable = 0;
 		}
@@ -2020,18 +2020,18 @@ static void output_to_hal(void)
 		old_motion_index[spindle_num] =
 				emcmotStatus->spindle_status[spindle_num].spindle_index_enable;
 		old_hal_index[spindle_num] =
-				*emcmot_hal_data->spindle[spindle_num].spindle_index_enable;
+				hal_get_bool(emcmot_hal_data->spindle[spindle_num].spindle_index_enable);
     }
 
-    *(emcmot_hal_data->tooloffset_x) = emcmotStatus->tool_offset.tran.x;
-    *(emcmot_hal_data->tooloffset_y) = emcmotStatus->tool_offset.tran.y;
-    *(emcmot_hal_data->tooloffset_z) = emcmotStatus->tool_offset.tran.z;
-    *(emcmot_hal_data->tooloffset_a) = emcmotStatus->tool_offset.a;
-    *(emcmot_hal_data->tooloffset_b) = emcmotStatus->tool_offset.b;
-    *(emcmot_hal_data->tooloffset_c) = emcmotStatus->tool_offset.c;
-    *(emcmot_hal_data->tooloffset_u) = emcmotStatus->tool_offset.u;
-    *(emcmot_hal_data->tooloffset_v) = emcmotStatus->tool_offset.v;
-    *(emcmot_hal_data->tooloffset_w) = emcmotStatus->tool_offset.w;
+    hal_set_real(emcmot_hal_data->tooloffset_x, emcmotStatus->tool_offset.tran.x);
+    hal_set_real(emcmot_hal_data->tooloffset_y, emcmotStatus->tool_offset.tran.y);
+    hal_set_real(emcmot_hal_data->tooloffset_z, emcmotStatus->tool_offset.tran.z);
+    hal_set_real(emcmot_hal_data->tooloffset_a, emcmotStatus->tool_offset.a);
+    hal_set_real(emcmot_hal_data->tooloffset_b, emcmotStatus->tool_offset.b);
+    hal_set_real(emcmot_hal_data->tooloffset_c, emcmotStatus->tool_offset.c);
+    hal_set_real(emcmot_hal_data->tooloffset_u, emcmotStatus->tool_offset.u);
+    hal_set_real(emcmot_hal_data->tooloffset_v, emcmotStatus->tool_offset.v);
+    hal_set_real(emcmot_hal_data->tooloffset_w, emcmotStatus->tool_offset.w);
 
     /* output joint info to HAL for scoping, etc */
     for (joint_num = 0; joint_num < ALL_JOINTS; joint_num++) {
@@ -2044,39 +2044,39 @@ static void output_to_hal(void)
 	    joint->pos_cmd + joint->backlash_filt + joint->motor_offset;
 	/* point to HAL data */
 	/* write to HAL pins */
-	*(joint_data->motor_offset) = joint->motor_offset;
-	*(joint_data->motor_pos_cmd) = joint->motor_pos_cmd;
-	*(joint_data->joint_pos_cmd) = joint->pos_cmd;
-	*(joint_data->joint_pos_fb) = joint->pos_fb;
-	*(joint_data->amp_enable) = GET_JOINT_ENABLE_FLAG(joint);
+	hal_set_real(joint_data->motor_offset, joint->motor_offset);
+	hal_set_real(joint_data->motor_pos_cmd, joint->motor_pos_cmd);
+	hal_set_real(joint_data->joint_pos_cmd, joint->pos_cmd);
+	hal_set_real(joint_data->joint_pos_fb, joint->pos_fb);
+	hal_set_bool(joint_data->amp_enable, GET_JOINT_ENABLE_FLAG(joint));
 
-	*(joint_data->coarse_pos_cmd) = joint->coarse_pos;
-	*(joint_data->joint_vel_cmd) = joint->vel_cmd;
-	*(joint_data->joint_acc_cmd) = joint->acc_cmd;
-    *(joint_data->joint_jerk_cmd) = joint->jerk_cmd;
-	*(joint_data->backlash_corr) = joint->backlash_corr;
-	*(joint_data->backlash_filt) = joint->backlash_filt;
-	*(joint_data->backlash_vel) = joint->backlash_vel;
-	*(joint_data->f_error) = joint->ferror;
-	*(joint_data->f_error_lim) = joint->ferror_limit;
+	hal_set_real(joint_data->coarse_pos_cmd, joint->coarse_pos);
+	hal_set_real(joint_data->joint_vel_cmd, joint->vel_cmd);
+	hal_set_real(joint_data->joint_acc_cmd, joint->acc_cmd);
+	hal_set_real(joint_data->joint_jerk_cmd, joint->jerk_cmd);
+	hal_set_real(joint_data->backlash_corr, joint->backlash_corr);
+	hal_set_real(joint_data->backlash_filt, joint->backlash_filt);
+	hal_set_real(joint_data->backlash_vel, joint->backlash_vel);
+	hal_set_real(joint_data->f_error, joint->ferror);
+	hal_set_real(joint_data->f_error_lim, joint->ferror_limit);
 
-	*(joint_data->free_pos_cmd) = joint->free_tp.pos_cmd;
-	*(joint_data->free_vel_lim) = joint->free_tp.max_vel;
-	*(joint_data->free_tp_enable) = joint->free_tp.enable;
-	*(joint_data->kb_jjog_active) = joint->kb_jjog_active;
-	*(joint_data->wheel_jjog_active) = joint->wheel_jjog_active;
+	hal_set_real(joint_data->free_pos_cmd, joint->free_tp.pos_cmd);
+	hal_set_real(joint_data->free_vel_lim, joint->free_tp.max_vel);
+	hal_set_bool(joint_data->free_tp_enable, joint->free_tp.enable);
+	hal_set_bool(joint_data->kb_jjog_active, joint->kb_jjog_active);
+	hal_set_bool(joint_data->wheel_jjog_active, joint->wheel_jjog_active);
 
-	*(joint_data->active) = GET_JOINT_ACTIVE_FLAG(joint);
-	*(joint_data->in_position) = GET_JOINT_INPOS_FLAG(joint);
-	*(joint_data->error) = GET_JOINT_ERROR_FLAG(joint);
-	*(joint_data->phl) = GET_JOINT_PHL_FLAG(joint);
-	*(joint_data->nhl) = GET_JOINT_NHL_FLAG(joint);
-	*(joint_data->f_errored) = GET_JOINT_FERROR_FLAG(joint);
-	*(joint_data->faulted) = GET_JOINT_FAULT_FLAG(joint);
+	hal_set_bool(joint_data->active, GET_JOINT_ACTIVE_FLAG(joint));
+	hal_set_bool(joint_data->in_position, GET_JOINT_INPOS_FLAG(joint));
+	hal_set_bool(joint_data->error, GET_JOINT_ERROR_FLAG(joint));
+	hal_set_bool(joint_data->phl, GET_JOINT_PHL_FLAG(joint));
+	hal_set_bool(joint_data->nhl, GET_JOINT_NHL_FLAG(joint));
+	hal_set_bool(joint_data->f_errored, GET_JOINT_FERROR_FLAG(joint));
+	hal_set_bool(joint_data->faulted, GET_JOINT_FAULT_FLAG(joint));
 
         // conditionally remove outstanding requests to unlock rotaries:
         if  ( !GET_MOTION_ENABLE_FLAG() && (joint_is_lockable(joint_num))) {
-             *(joint_data->unlock) = 0;
+             hal_set_bool(joint_data->unlock, 0);
         }
 
 	if (IS_EXTRA_JOINT(joint_num) && get_homed(joint_num)) {
@@ -2085,15 +2085,15 @@ static void output_to_hal(void)
 	    extrajoint_hal_t *ejoint_data;
 	    int e = joint_num - NO_OF_KINS_JOINTS;
 	    ejoint_data = &(emcmot_hal_data->ejoint[e]);
-	    *(joint_data->motor_pos_cmd) = *(ejoint_data->posthome_cmd)
-	                                 + joint->motor_offset;
+	    hal_set_real(joint_data->motor_pos_cmd, hal_get_real(ejoint_data->posthome_cmd)
+	                                 + joint->motor_offset);
 	    continue;
 	}
     } // for joint_num
 
     axis_output_to_hal(pcmd_p);
 
-    *(emcmot_hal_data->jog_is_active) = axis_jog_is_active() || joint_jog_is_active();
+    hal_set_bool(emcmot_hal_data->jog_is_active, axis_jog_is_active() || joint_jog_is_active());
 
 }
 
@@ -2151,9 +2151,9 @@ static void update_status(void)
 	joint_status->max_ferror = joint->max_ferror;
     }
     if (get_allhomed()) {
-        *emcmot_hal_data->is_all_homed = 1;
+        hal_set_bool(emcmot_hal_data->is_all_homed, 1);
     } else {
-        *emcmot_hal_data->is_all_homed = 0;
+        hal_set_bool(emcmot_hal_data->is_all_homed, 0);
     }
 
 
@@ -2175,23 +2175,23 @@ static void update_status(void)
     emcmotStatus->eoffset_pose.v      = axis_get_ext_offset_curr_pos(7);
     emcmotStatus->eoffset_pose.w      = axis_get_ext_offset_curr_pos(8);
 
-    emcmotStatus->external_offsets_applied = *(emcmot_hal_data->eoffset_active);
+    emcmotStatus->external_offsets_applied = hal_get_bool(emcmot_hal_data->eoffset_active);
 
     for (dio = 0; dio < emcmotConfig->numDIO; dio++) {
-	emcmotStatus->synch_di[dio] = *(emcmot_hal_data->synch_di[dio]);
-	emcmotStatus->synch_do[dio] = *(emcmot_hal_data->synch_do[dio]);
+	emcmotStatus->synch_di[dio] = hal_get_bool(emcmot_hal_data->synch_di[dio]);
+	emcmotStatus->synch_do[dio] = hal_get_bool(emcmot_hal_data->synch_do[dio]);
     }
 
     for (aio = 0; aio < emcmotConfig->numAIO; aio++) {
-	emcmotStatus->analog_input[aio] = *(emcmot_hal_data->analog_input[aio]);
-	emcmotStatus->analog_output[aio] = *(emcmot_hal_data->analog_output[aio]);
+	emcmotStatus->analog_input[aio] = hal_get_real(emcmot_hal_data->analog_input[aio]);
+	emcmotStatus->analog_output[aio] = hal_get_real(emcmot_hal_data->analog_output[aio]);
     }
 
     for (misc_error=0; misc_error < emcmotConfig->numMiscError; misc_error++){
-      emcmotStatus->misc_error[misc_error] = *(emcmot_hal_data->misc_error[misc_error]);
+      emcmotStatus->misc_error[misc_error] = hal_get_bool(emcmot_hal_data->misc_error[misc_error]);
     }
 
-    emcmotStatus->jogging_active = *(emcmot_hal_data->jog_is_active);
+    emcmotStatus->jogging_active = hal_get_bool(emcmot_hal_data->jog_is_active);
 
     /*! \todo FIXME - the rest of this function is stuff that was apparently
        dropped in the initial move from emcmot.c to control.c.  I
@@ -2220,23 +2220,23 @@ static void update_status(void)
     // Get the current executing trajectory component (the "Source of Truth")
     /* Update the HAL Output Pins from the active tag */
     // Line and Motion Type
-    *(emcmot_hal_data->interp_line_number) = (int)emcmotStatus->tag.fields[GM_FIELD_LINE_NUMBER];
+    hal_set_si32(emcmot_hal_data->interp_line_number, (int)emcmotStatus->tag.fields[GM_FIELD_LINE_NUMBER]);
 
     // Performance Metadata
-    *(emcmot_hal_data->interp_feedrate) = emcmotStatus->tag.fields_float[GM_FIELD_FLOAT_FEED];
+    hal_set_real(emcmot_hal_data->interp_feedrate, emcmotStatus->tag.fields_float[GM_FIELD_FLOAT_FEED]);
 
     // Geometric Metadata
-    *(emcmot_hal_data->interp_arc_radius) = emcmotStatus->tag.fields_float[GM_FIELD_FLOAT_ARC_RADIUS];
-    *(emcmot_hal_data->interp_arc_center_x) = emcmotStatus->tag.fields_float[GM_FIELD_FLOAT_ARC_CENTER_X];
-    *(emcmot_hal_data->interp_arc_center_y) = emcmotStatus->tag.fields_float[GM_FIELD_FLOAT_ARC_CENTER_Y];
-    *(emcmot_hal_data->interp_arc_center_z) = emcmotStatus->tag.fields_float[GM_FIELD_FLOAT_ARC_CENTER_Z];
+    hal_set_real(emcmot_hal_data->interp_arc_radius, emcmotStatus->tag.fields_float[GM_FIELD_FLOAT_ARC_RADIUS]);
+    hal_set_real(emcmot_hal_data->interp_arc_center_x, emcmotStatus->tag.fields_float[GM_FIELD_FLOAT_ARC_CENTER_X]);
+    hal_set_real(emcmot_hal_data->interp_arc_center_y, emcmotStatus->tag.fields_float[GM_FIELD_FLOAT_ARC_CENTER_Y]);
+    hal_set_real(emcmot_hal_data->interp_arc_center_z, emcmotStatus->tag.fields_float[GM_FIELD_FLOAT_ARC_CENTER_Z]);
 
     // Get the current motion type from the tag (1=G1, 2=G2, 3=G3)
     int motion_type = (int)emcmotStatus->tag.fields[GM_FIELD_MOTION_MODE];
     if (motion_type == 10 || motion_type == 0) {
         /* --- G1/G0 STATIC HEADING --- */
         // For linear moves, the heading doesn't change during the segment.
-        *(emcmot_hal_data->interp_straight_heading) = emcmotStatus->tag.fields_float[GM_FIELD_FLOAT_STRAIGHT_HEADING];
+        hal_set_real(emcmot_hal_data->interp_straight_heading, emcmotStatus->tag.fields_float[GM_FIELD_FLOAT_STRAIGHT_HEADING]);
     }
     else if (motion_type == 20 || motion_type == 30) {
         /* --- G2/G3: DYNAMIC ARC HEADING --- */
@@ -2270,7 +2270,7 @@ static void update_status(void)
         double normal_deg = (angle_rad * (180.0 / M_PI)) + 180.0;
         while (normal_deg < 0) normal_deg += 360.0;
         while (normal_deg >= 360.0) normal_deg -= 360.0;
-        *(emcmot_hal_data->interp_normal_heading) = normal_deg;
+        hal_set_real(emcmot_hal_data->interp_normal_heading, normal_deg);
 
         // 5. Calculate Tangent Heading (Direction of Travel)
         double tangent_rad = (motion_type == 30) ? (angle_rad + (M_PI / 2.0)) : (angle_rad - (M_PI / 2.0));
@@ -2281,7 +2281,7 @@ static void update_status(void)
         while (heading_deg >= 360.0) heading_deg -= 360.0;
 
         if (emcmot_hal_data->interp_straight_heading) {
-        *(emcmot_hal_data->interp_straight_heading) = heading_deg;
+        hal_set_real(emcmot_hal_data->interp_straight_heading, heading_deg);
         }
     }
 #ifdef WATCH_FLAGS

--- a/src/emc/motion/homing.c
+++ b/src/emc/motion/homing.c
@@ -129,12 +129,12 @@ static  home_local_data H[EMCMOT_MAX_JOINTS];
 
 // data for per-joint homing-specific hal pins:
 typedef struct {
-    hal_bit_t *home_sw;      // home switch input
-    hal_bit_t *homing;       // joint is homing
-    hal_bit_t *homed;        // joint was homed
-    hal_bit_t *index_enable; // motmod sets: request reset on index
+    hal_bool_t home_sw;      // home switch input
+    hal_bool_t homing;       // joint is homing
+    hal_bool_t homed;        // joint was homed
+    hal_bool_t index_enable; // motmod sets: request reset on index
                              //        encoder clears: index arrived
-    hal_s32_t *home_state;   // homing state machine state
+    hal_sint_t home_state;   // homing state machine state
 } one_joint_home_data_t;
 
 typedef struct {
@@ -233,7 +233,7 @@ static int base_make_joint_home_pins(int id,int njoints)
     int jno,retval;
     one_joint_home_data_t *addr;
 
-    joint_home_data = hal_malloc(sizeof(all_joints_home_data_t));
+    joint_home_data = hal_malloc(sizeof(*joint_home_data));
     if (joint_home_data == 0) {
         rtapi_print_msg(RTAPI_MSG_ERR, _("HOMING: all_joints_home_data_t malloc failed\n"));
         return -1;
@@ -243,16 +243,16 @@ static int base_make_joint_home_pins(int id,int njoints)
     for (jno = 0; jno < njoints; jno++) {
         addr = &(joint_home_data->jhd[jno]);
 
-        retval += hal_pin_bit_newf(HAL_IN, &(addr->home_sw), id,
-                                  "joint.%d.home-sw-in", jno);
-        retval += hal_pin_bit_newf(HAL_OUT, &(addr->homing), id,
-                                  "joint.%d.homing", jno);
-        retval += hal_pin_bit_newf(HAL_OUT, &(addr->homed), id,
-                                  "joint.%d.homed", jno);
-        retval += hal_pin_s32_newf(HAL_OUT, &(addr->home_state), id,
-                                  "joint.%d.home-state", jno);
-        retval += hal_pin_bit_newf(HAL_IO, &(addr->index_enable), id,
-                                  "joint.%d.index-enable", jno);
+        retval += hal_pin_new_bool(id, HAL_IN, &(addr->home_sw),
+                                   0, "joint.%d.home-sw-in", jno);
+        retval += hal_pin_new_bool(id, HAL_OUT, &(addr->homing),
+                                   0, "joint.%d.homing", jno);
+        retval += hal_pin_new_bool(id, HAL_OUT, &(addr->homed),
+                                   0, "joint.%d.homed", jno);
+        retval += hal_pin_new_si32(id, HAL_OUT, &(addr->home_state),
+                                   0, "joint.%d.home-state", jno);
+        retval += hal_pin_new_bool(id, HAL_IO, &(addr->index_enable),
+                                   0, "joint.%d.index-enable", jno);
     }
     return retval;
 } // base_make_joint_home_pins()
@@ -533,8 +533,8 @@ static void base_read_homing_in_pins(int njoints)
     one_joint_home_data_t *addr;
     for (jno = 0; jno < njoints; jno++) {
         addr = &(joint_home_data->jhd[jno]);
-        H[jno].home_sw      = *(addr->home_sw);      // IN
-        H[jno].index_enable = *(addr->index_enable); // IO
+        H[jno].home_sw      = hal_get_bool(addr->home_sw);      // IN
+        H[jno].index_enable = hal_get_bool(addr->index_enable); // IO
     }
 }
 
@@ -544,7 +544,7 @@ static void base_write_homing_out_pins(int njoints)
     one_joint_home_data_t *addr;
     for (jno = 0; jno < njoints; jno++) {
         addr = &(joint_home_data->jhd[jno]);
-        if(!(*(addr->homing) && !H[jno].homing && homing_active)) {
+        if(!(hal_get_bool(addr->homing) && !H[jno].homing && homing_active)) {
             // Prevent race condition.
             // (See also emc/motion/control.c: update_status())
             // The homing status variable turns false before homing_active state
@@ -555,19 +555,19 @@ static void base_write_homing_out_pins(int njoints)
             // Do not update the homing status when going from homing --> not homing
             // and the state machine is still active. The homing status deassertion
             // must be delayed until the state machine is done.
-            *(addr->homing) = H[jno].homing;
+            hal_set_bool(addr->homing, H[jno].homing);
         }
-        *(addr->homing)       = H[jno].homing;       // OUT
-        *(addr->homed)        = H[jno].homed;        // OUT
-        *(addr->home_state)   = H[jno].home_state;   // OUT
+        hal_set_bool(addr->homing,     H[jno].homing);     // OUT
+        hal_set_bool(addr->homed,      H[jno].homed);      // OUT
+        hal_set_si32(addr->home_state, H[jno].home_state); // OUT
         // index_enable is a HAL_IO pin: the encoder driver also writes it
         // (clears it on the index pulse). We do not own it, so we must not
         // clamp it every cycle; drive it only on our own edges and otherwise
         // leave it to whoever else is on the signal.
         if (H[jno].index_enable && !H[jno].index_enable_prev) {
-            *(addr->index_enable) = 1; // arm the index search
+            hal_set_bool(addr->index_enable, 1); // arm the index search
         } else if (!H[jno].index_enable && H[jno].index_enable_prev) {
-            *(addr->index_enable) = 0; // release if aborted while armed
+            hal_set_bool(addr->index_enable, 0); // release if aborted while armed
         }
         H[jno].index_enable_prev = H[jno].index_enable;
     }

--- a/src/emc/motion/mot_priv.h
+++ b/src/emc/motion/mot_priv.h
@@ -35,182 +35,182 @@ typedef struct {
     // the user needs only a subset of these
 
     // simplest way of spindle control (output start/stop)
-    hal_bit_t *spindle_on;  /* spindle spin output */
+    hal_bool_t spindle_on;  /* spindle spin output */
 
     // same thing for 2 directions
-    hal_bit_t *spindle_forward; /* spindle spin-forward output */
-    hal_bit_t *spindle_reverse; /* spindle spin-reverse output */
+    hal_bool_t spindle_forward; /* spindle spin-forward output */
+    hal_bool_t spindle_reverse; /* spindle spin-reverse output */
 
     // simple velocity control (as long as the output is active the spindle
     //                          should accelerate/decelerate
-    hal_bit_t *spindle_incr_speed;  /* spindle spin-increase output */
-    hal_bit_t *spindle_decr_speed;  /* spindle spin-decrease output */
+    hal_bool_t spindle_incr_speed;  /* spindle spin-increase output */
+    hal_bool_t spindle_decr_speed;  /* spindle spin-decrease output */
 
     // simple output for brake
-    hal_bit_t *spindle_brake;   /* spindle brake output */
+    hal_bool_t spindle_brake;   /* spindle brake output */
 
     // output of a prescribed speed (to hook-up to a velocity controller)
-    hal_float_t *spindle_speed_out; /* spindle speed output */
-    hal_float_t *spindle_speed_out_rps; /* spindle speed output */
-    hal_float_t *spindle_speed_out_abs; /* spindle speed output absolute*/
-    hal_float_t *spindle_speed_out_rps_abs; /* spindle speed output absolute*/
-    hal_float_t *spindle_speed_cmd_rps; /* spindle speed command without SO applied */
-    hal_float_t *spindle_speed_in;  /* spindle speed measured */
-    hal_bit_t *spindle_index_enable; /* spindle inde I/O pin */
-    hal_bit_t *spindle_inhibit;
-    hal_float_t *spindle_revs;
-    hal_bit_t *spindle_is_atspeed;
-    hal_bit_t *spindle_amp_fault;
+    hal_real_t spindle_speed_out; /* spindle speed output */
+    hal_real_t spindle_speed_out_rps; /* spindle speed output */
+    hal_real_t spindle_speed_out_abs; /* spindle speed output absolute*/
+    hal_real_t spindle_speed_out_rps_abs; /* spindle speed output absolute*/
+    hal_real_t spindle_speed_cmd_rps; /* spindle speed command without SO applied */
+    hal_real_t spindle_speed_in;  /* spindle speed measured */
+    hal_bool_t spindle_index_enable; /* spindle inde I/O pin */
+    hal_bool_t spindle_inhibit;
+    hal_real_t spindle_revs;
+    hal_bool_t spindle_is_atspeed;
+    hal_bool_t spindle_amp_fault;
 
     // spindle orient
-    hal_float_t *spindle_orient_angle;  /* out: desired spindle angle, degrees */
-    hal_s32_t   *spindle_orient_mode;   /* out: 0: least travel; 1: cw; 2: ccw */
-    hal_bit_t   *spindle_orient;    /* out: signal orient in progress */
-    hal_bit_t   *spindle_locked;    /* out: signal orient complete, spindle locked */
-    hal_bit_t   *spindle_is_oriented;   /* in: orientation completed */
-    hal_s32_t   *spindle_orient_fault;  /* in: error code of failed operation */
+    hal_real_t spindle_orient_angle;  /* out: desired spindle angle, degrees */
+    hal_sint_t spindle_orient_mode;   /* out: 0: least travel; 1: cw; 2: ccw */
+    hal_bool_t spindle_orient;    /* out: signal orient in progress */
+    hal_bool_t spindle_locked;    /* out: signal orient complete, spindle locked */
+    hal_bool_t spindle_is_oriented;   /* in: orientation completed */
+    hal_sint_t spindle_orient_fault;  /* in: error code of failed operation */
 
 } spindle_hal_t;
 
 typedef struct {
-    hal_float_t *coarse_pos_cmd;/* RPI: commanded position, w/o comp */
-    hal_float_t *joint_vel_cmd;	/* RPI: commanded velocity, w/o comp */
-    hal_float_t *joint_acc_cmd;	/* RPI: commanded acceleration, w/o comp */
-    hal_float_t *joint_jerk_cmd;/* RPI: commanded jerk, w/o comp */
-    hal_float_t *backlash_corr;	/* RPI: correction for backlash */
-    hal_float_t *backlash_filt;	/* RPI: filtered backlash correction */
-    hal_float_t *backlash_vel;	/* RPI: backlash speed variable */
-    hal_float_t *motor_offset;	/* RPI: motor offset, for checking homing stability */
-    hal_float_t *motor_pos_cmd;	/* WPI: commanded position, with comp */
-    hal_float_t *motor_pos_fb;	/* RPI: position feedback, with comp */
-    hal_float_t *joint_pos_cmd;	/* WPI: commanded position w/o comp, not ofs */
-    hal_float_t *joint_pos_fb;	/* RPI: position feedback, w/o comp */
-    hal_float_t *f_error;	/* RPI: following error */
-    hal_float_t *f_error_lim;	/* RPI: following error limit */
+    hal_real_t coarse_pos_cmd;/* RPI: commanded position, w/o comp */
+    hal_real_t joint_vel_cmd;	/* RPI: commanded velocity, w/o comp */
+    hal_real_t joint_acc_cmd;	/* RPI: commanded acceleration, w/o comp */
+    hal_real_t joint_jerk_cmd;/* RPI: commanded jerk, w/o comp */
+    hal_real_t backlash_corr;	/* RPI: correction for backlash */
+    hal_real_t backlash_filt;	/* RPI: filtered backlash correction */
+    hal_real_t backlash_vel;	/* RPI: backlash speed variable */
+    hal_real_t motor_offset;	/* RPI: motor offset, for checking homing stability */
+    hal_real_t motor_pos_cmd;	/* WPI: commanded position, with comp */
+    hal_real_t motor_pos_fb;	/* RPI: position feedback, with comp */
+    hal_real_t joint_pos_cmd;	/* WPI: commanded position w/o comp, not ofs */
+    hal_real_t joint_pos_fb;	/* RPI: position feedback, w/o comp */
+    hal_real_t f_error;	/* RPI: following error */
+    hal_real_t f_error_lim;	/* RPI: following error limit */
 
-    hal_float_t *free_pos_cmd;	/* RPI: free traj planner pos cmd */
-    hal_float_t *free_vel_lim;	/* RPI: free traj planner vel limit */
-    hal_bit_t *free_tp_enable;	/* RPI: free traj planner is running */
-    hal_bit_t *kb_jjog_active;   /* RPI: executing keyboard jog */
-    hal_bit_t *wheel_jjog_active;/* RPI: executing handwheel jog */
+    hal_real_t free_pos_cmd;	/* RPI: free traj planner pos cmd */
+    hal_real_t free_vel_lim;	/* RPI: free traj planner vel limit */
+    hal_bool_t free_tp_enable;	/* RPI: free traj planner is running */
+    hal_bool_t kb_jjog_active;   /* RPI: executing keyboard jog */
+    hal_bool_t wheel_jjog_active;/* RPI: executing handwheel jog */
 
-    hal_bit_t *active;		/* RPI: joint is active, whatever that means */
-    hal_bit_t *in_position;	/* RPI: joint is in position */
-    hal_bit_t *error;		/* RPI: joint has an error */
-    hal_bit_t *phl;		/* RPI: joint is at positive hard limit */
-    hal_bit_t *nhl;		/* RPI: joint is at negative hard limit */
-    hal_bit_t *f_errored;	/* RPI: joint had too much following error */
-    hal_bit_t *faulted;		/* RPI: joint amp faulted */
-    hal_bit_t *pos_lim_sw;	/* RPI: positive limit switch input */
-    hal_bit_t *neg_lim_sw;	/* RPI: negative limit switch input */
-    hal_bit_t *amp_fault;	/* RPI: amp fault input */
-    hal_bit_t *amp_enable;	/* WPI: amp enable output */
+    hal_bool_t active;		/* RPI: joint is active, whatever that means */
+    hal_bool_t in_position;	/* RPI: joint is in position */
+    hal_bool_t error;		/* RPI: joint has an error */
+    hal_bool_t phl;		/* RPI: joint is at positive hard limit */
+    hal_bool_t nhl;		/* RPI: joint is at negative hard limit */
+    hal_bool_t f_errored;	/* RPI: joint had too much following error */
+    hal_bool_t faulted;		/* RPI: joint amp faulted */
+    hal_bool_t pos_lim_sw;	/* RPI: positive limit switch input */
+    hal_bool_t neg_lim_sw;	/* RPI: negative limit switch input */
+    hal_bool_t amp_fault;	/* RPI: amp fault input */
+    hal_bool_t amp_enable;	/* WPI: amp enable output */
 
-    hal_bit_t *unlock;          /* WPI: command that axis should unlock for rotation */
-    hal_bit_t *is_unlocked;     /* RPI: axis is currently unlocked */
+    hal_bool_t unlock;          /* WPI: command that axis should unlock for rotation */
+    hal_bool_t is_unlocked;     /* RPI: axis is currently unlocked */
 
-    hal_s32_t   *jjog_counts;	/* WPI: jogwheel position input */
-    hal_bit_t   *jjog_enable;	/* RPI: enable jogwheel */
-    hal_float_t *jjog_scale;	/* RPI: distance to jog on each count */
-    hal_float_t *jjog_accel_fraction;	/* RPI: to limit wheel jog accel */
-    hal_bit_t   *jjog_vel_mode;	/* RPI: true for "velocity mode" jogwheel */
+    hal_sint_t jjog_counts;	/* WPI: jogwheel position input */
+    hal_bool_t jjog_enable;	/* RPI: enable jogwheel */
+    hal_real_t jjog_scale;	/* RPI: distance to jog on each count */
+    hal_real_t jjog_accel_fraction;	/* RPI: to limit wheel jog accel */
+    hal_bool_t jjog_vel_mode;	/* RPI: true for "velocity mode" jogwheel */
 } joint_hal_t;
 
 typedef struct {
-    hal_float_t *posthome_cmd; //  IN pin extrajoint
+    hal_real_t posthome_cmd; //  IN pin extrajoint
 } extrajoint_hal_t;
 
 /* machine data */
 
 typedef struct {
-    hal_bit_t *probe_input;	/* RPI: probe switch input */
-    hal_bit_t *enable;		/* RPI: motion inhibit input */
-    hal_float_t *adaptive_feed;	/* RPI: adaptive feedrate, 0.0 to 1.0 */
-    hal_bit_t *feed_hold;	/* RPI: set TRUE to stop motion maskable with g53 P1*/
-    hal_bit_t *feed_inhibit;	/* RPI: set TRUE to stop motion (non maskable)*/
-    hal_bit_t *homing_inhibit;	/* RPI: set TRUE to inhibit homing*/
-    hal_bit_t *jog_inhibit;	/* RPI: set TRUE to inhibit jogging*/
-    hal_bit_t *jog_stop;	/* RPI: set TRUE to stop jogging following accel values*/
-    hal_bit_t *jog_stop_immediate;	/* RPI: set TRUE to stop jogging immediately*/
-    hal_bit_t *jog_is_active;	/* RPI: TRUE if active jogging*/
-    hal_bit_t *tp_reverse;	/* Set true if trajectory planner is running in reverse*/
-    hal_bit_t *motion_enabled;	/* RPI: motion enable for all joints */
-    hal_bit_t *is_all_homed;	/* RPI: TRUE if all active joints is homed */
-    hal_bit_t *in_position;	/* RPI: all joints are in position */
-    hal_bit_t *coord_mode;	/* RPA: TRUE if coord, FALSE if free */
-    hal_bit_t *teleop_mode;	/* RPA: TRUE if teleop mode */
-    hal_bit_t *coord_error;	/* RPA: TRUE if coord mode error */
-    hal_bit_t *on_soft_limit;	/* RPA: TRUE if outside a limit */
+    hal_bool_t probe_input;	/* RPI: probe switch input */
+    hal_bool_t enable;		/* RPI: motion inhibit input */
+    hal_real_t adaptive_feed;	/* RPI: adaptive feedrate, 0.0 to 1.0 */
+    hal_bool_t feed_hold;	/* RPI: set TRUE to stop motion maskable with g53 P1*/
+    hal_bool_t feed_inhibit;	/* RPI: set TRUE to stop motion (non maskable)*/
+    hal_bool_t homing_inhibit;	/* RPI: set TRUE to inhibit homing*/
+    hal_bool_t jog_inhibit;	/* RPI: set TRUE to inhibit jogging*/
+    hal_bool_t jog_stop;	/* RPI: set TRUE to stop jogging following accel values*/
+    hal_bool_t jog_stop_immediate;	/* RPI: set TRUE to stop jogging immediately*/
+    hal_bool_t jog_is_active;	/* RPI: TRUE if active jogging*/
+    hal_bool_t tp_reverse;	/* Set true if trajectory planner is running in reverse*/
+    hal_bool_t motion_enabled;	/* RPI: motion enable for all joints */
+    hal_bool_t is_all_homed;	/* RPI: TRUE if all active joints is homed */
+    hal_bool_t in_position;	/* RPI: all joints are in position */
+    hal_bool_t coord_mode;	/* RPA: TRUE if coord, FALSE if free */
+    hal_bool_t teleop_mode;	/* RPA: TRUE if teleop mode */
+    hal_bool_t coord_error;	/* RPA: TRUE if coord mode error */
+    hal_bool_t on_soft_limit;	/* RPA: TRUE if outside a limit */
 
-    hal_s32_t *program_line;    /* RPA: program line causing current motion */
-    hal_s32_t *motion_type;	/* RPA: type (feed/rapid) of currently commanded motion */
-    hal_float_t *current_vel;   /* RPI: velocity magnitude in machine units */
-    hal_float_t *requested_vel;   /* RPI: requested velocity magnitude in machine units */
-    hal_float_t *distance_to_go;/* RPI: distance to go in current move*/
+    hal_sint_t program_line;    /* RPA: program line causing current motion */
+    hal_sint_t motion_type;	/* RPA: type (feed/rapid) of currently commanded motion */
+    hal_real_t current_vel;	/* RPI: velocity magnitude in machine units */
+    hal_real_t requested_vel;   /* RPI: requested velocity magnitude in machine units */
+    hal_real_t distance_to_go;	/* RPI: distance to go in current move*/
 
-    hal_bit_t debug_bit_0;	/* RPA: generic param, for debugging */
-    hal_bit_t debug_bit_1;	/* RPA: generic param, for debugging */
-    hal_float_t debug_float_0;	/* RPA: generic param, for debugging */
-    hal_float_t debug_float_1;	/* RPA: generic param, for debugging */
-    hal_float_t debug_float_2;	/* RPA: generic param, for debugging */
-    hal_float_t debug_float_3;	/* RPA: generic param, for debugging */
-    hal_s32_t debug_s32_0;	/* RPA: generic param, for debugging */
-    hal_s32_t debug_s32_1;	/* RPA: generic param, for debugging */
+    hal_bool_t debug_bit_0;	/* RPA: generic param, for debugging */
+    hal_bool_t debug_bit_1;	/* RPA: generic param, for debugging */
+    hal_real_t debug_float_0;	/* RPA: generic param, for debugging */
+    hal_real_t debug_float_1;	/* RPA: generic param, for debugging */
+    hal_real_t debug_float_2;	/* RPA: generic param, for debugging */
+    hal_real_t debug_float_3;	/* RPA: generic param, for debugging */
+    hal_sint_t debug_s32_0;	/* RPA: generic param, for debugging */
+    hal_sint_t debug_s32_1;	/* RPA: generic param, for debugging */
 
-    hal_bit_t *synch_do[EMCMOT_MAX_DIO]; /* WPI array: output pins for motion synched IO */
-    hal_bit_t *synch_di[EMCMOT_MAX_DIO]; /* RPI array: input pins for motion synched IO */
-    hal_float_t *analog_input[EMCMOT_MAX_AIO]; /* RPI array: input pins for analog Inputs */
-    hal_float_t *analog_output[EMCMOT_MAX_AIO]; /* RPI array: output pins for analog Inputs */
-    hal_bit_t *misc_error[EMCMOT_MAX_MISC_ERROR]; /* RPI array: output pins for misc error Inputs */
+    hal_bool_t synch_do[EMCMOT_MAX_DIO]; /* WPI array: output pins for motion synched IO */
+    hal_bool_t synch_di[EMCMOT_MAX_DIO]; /* RPI array: input pins for motion synched IO */
+    hal_real_t analog_input[EMCMOT_MAX_AIO]; /* RPI array: input pins for analog Inputs */
+    hal_real_t analog_output[EMCMOT_MAX_AIO]; /* RPI array: output pins for analog Inputs */
+    hal_bool_t misc_error[EMCMOT_MAX_MISC_ERROR]; /* RPI array: output pins for misc error Inputs */
 
     // FIXME - debug only, remove later
-    hal_float_t traj_pos_out;	/* RPA: traj internals, for debugging */
-    hal_float_t traj_vel_out;	/* RPA: traj internals, for debugging */
-    hal_u32_t traj_active_tc;	/* RPA: traj internals, for debugging */
-    hal_float_t tc_pos[4];	/* RPA: traj internals, for debugging */
-    hal_float_t tc_vel[4];	/* RPA: traj internals, for debugging */
-    hal_float_t tc_acc[4];	/* RPA: traj internals, for debugging */
+    hal_real_t traj_pos_out;	/* RPA: traj internals, for debugging */
+    hal_real_t traj_vel_out;	/* RPA: traj internals, for debugging */
+    hal_uint_t traj_active_tc;	/* RPA: traj internals, for debugging */
+    hal_real_t tc_pos[4];	/* RPA: traj internals, for debugging */
+    hal_real_t tc_vel[4];	/* RPA: traj internals, for debugging */
+    hal_real_t tc_acc[4];	/* RPA: traj internals, for debugging */
 
     // realtime overrun detection
-    hal_u32_t   *last_period;	/* pin: last period in nanoseconds */
+    hal_uint_t last_period;	/* pin: last period in nanoseconds */
 
-    hal_float_t *tooloffset_x;
-    hal_float_t *tooloffset_y;
-    hal_float_t *tooloffset_z;
-    hal_float_t *tooloffset_a;
-    hal_float_t *tooloffset_b;
-    hal_float_t *tooloffset_c;
-    hal_float_t *tooloffset_u;
-    hal_float_t *tooloffset_v;
-    hal_float_t *tooloffset_w;
+    hal_real_t tooloffset_x;
+    hal_real_t tooloffset_y;
+    hal_real_t tooloffset_z;
+    hal_real_t tooloffset_a;
+    hal_real_t tooloffset_b;
+    hal_real_t tooloffset_c;
+    hal_real_t tooloffset_u;
+    hal_real_t tooloffset_v;
+    hal_real_t tooloffset_w;
 
     spindle_hal_t spindle[EMCMOT_MAX_SPINDLES];     /*spindle data */
     joint_hal_t joint[EMCMOT_MAX_JOINTS];	/* data for each joint */
     extrajoint_hal_t ejoint[EMCMOT_MAX_EXTRAJOINTS]; /* data for each extrajoint */
 
-    hal_bit_t   *eoffset_active; /* ext offsets active */
-    hal_bit_t   *eoffset_limited; /* ext offsets exceed limit */
+    hal_bool_t eoffset_active; /* ext offsets active */
+    hal_bool_t eoffset_limited; /* ext offsets exceed limit */
 
-    hal_float_t *feed_upm; /* feed G-code units per minute*/
-    hal_float_t *feed_inches_per_minute; /* feed inches per minute*/
-    hal_float_t *feed_inches_per_second; /* feed inches per second*/
-    hal_float_t *feed_mm_per_minute; /* feed mm per minute*/
-    hal_float_t *feed_mm_per_second; /* feed mm per second*/
+    hal_real_t feed_upm; /* feed G-code units per minute*/
+    hal_real_t feed_inches_per_minute; /* feed inches per minute*/
+    hal_real_t feed_inches_per_second; /* feed inches per second*/
+    hal_real_t feed_mm_per_minute; /* feed mm per minute*/
+    hal_real_t feed_mm_per_second; /* feed mm per second*/
 
-    hal_float_t *switchkins_type;
+    hal_real_t switchkins_type;
     /* Interp State Pins */
-    hal_s32_t   *interp_line_number;
-    hal_s32_t   *interp_motion_type;
-    hal_float_t *interp_feedrate;
+    hal_sint_t interp_line_number;
+    hal_sint_t interp_motion_type;
+    hal_real_t interp_feedrate;
 
     /* New Geometric Metadata Pins */
-    hal_float_t *interp_arc_radius;
-    hal_float_t *interp_arc_center_x;
-    hal_float_t *interp_arc_center_y;
-    hal_float_t *interp_arc_center_z;
-    hal_float_t *interp_straight_heading;
-    hal_float_t *interp_normal_heading;
-    hal_bit_t   *iscircle;
+    hal_real_t interp_arc_radius;
+    hal_real_t interp_arc_center_x;
+    hal_real_t interp_arc_center_y;
+    hal_real_t interp_arc_center_z;
+    hal_real_t interp_straight_heading;
+    hal_real_t interp_normal_heading;
+    hal_bool_t iscircle;
 } emcmot_hal_data_t;
 
 /***********************************************************************

--- a/src/emc/motion/motion.c
+++ b/src/emc/motion/motion.c
@@ -515,38 +515,44 @@ static int init_hal_io(void)
     }
 
     /* export machine wide hal pins */
-    CALL_CHECK(hal_pin_bit_newf(HAL_IN, &(emcmot_hal_data->probe_input), mot_comp_id, "motion.probe-input"));
-    CALL_CHECK(hal_pin_float_newf(HAL_IN, &(emcmot_hal_data->adaptive_feed), mot_comp_id, "motion.adaptive-feed"));
-    CALL_CHECK(hal_pin_bit_newf(HAL_IN, &(emcmot_hal_data->feed_hold), mot_comp_id, "motion.feed-hold"));
-    CALL_CHECK(hal_pin_bit_newf(HAL_IN, &(emcmot_hal_data->feed_inhibit), mot_comp_id, "motion.feed-inhibit"));
-    CALL_CHECK(hal_pin_bit_newf(HAL_IN, &(emcmot_hal_data->homing_inhibit), mot_comp_id, "motion.homing-inhibit"));
-    CALL_CHECK(hal_pin_bit_newf(HAL_IN, &(emcmot_hal_data->jog_inhibit), mot_comp_id, "motion.jog-inhibit"));
-    CALL_CHECK(hal_pin_bit_newf(HAL_IN, &(emcmot_hal_data->jog_stop), mot_comp_id, "motion.jog-stop"));
-    CALL_CHECK(hal_pin_bit_newf(HAL_IN, &(emcmot_hal_data->jog_stop_immediate), mot_comp_id, "motion.jog-stop-immediate"));
-    CALL_CHECK(hal_pin_bit_newf(HAL_OUT, &(emcmot_hal_data->tp_reverse), mot_comp_id, "motion.tp-reverse"));
-    CALL_CHECK(hal_pin_bit_newf(HAL_IN, &(emcmot_hal_data->enable), mot_comp_id, "motion.enable"));
-    CALL_CHECK(hal_pin_bit_newf(HAL_OUT, &(emcmot_hal_data->is_all_homed), mot_comp_id, "motion.is-all-homed"));
+    CALL_CHECK(hal_pin_new_bool(mot_comp_id, HAL_IN, &(emcmot_hal_data->probe_input), 0, "motion.probe-input"));
+    CALL_CHECK(hal_pin_new_real(mot_comp_id, HAL_IN, &(emcmot_hal_data->adaptive_feed), 1.0, "motion.adaptive-feed"));
+    CALL_CHECK(hal_pin_new_bool(mot_comp_id, HAL_IN, &(emcmot_hal_data->feed_hold), 0, "motion.feed-hold"));
+    CALL_CHECK(hal_pin_new_bool(mot_comp_id, HAL_IN, &(emcmot_hal_data->feed_inhibit), 0, "motion.feed-inhibit"));
+    CALL_CHECK(hal_pin_new_bool(mot_comp_id, HAL_IN, &(emcmot_hal_data->homing_inhibit), 0, "motion.homing-inhibit"));
+    CALL_CHECK(hal_pin_new_bool(mot_comp_id, HAL_IN, &(emcmot_hal_data->jog_inhibit), 0, "motion.jog-inhibit"));
+    CALL_CHECK(hal_pin_new_bool(mot_comp_id, HAL_IN, &(emcmot_hal_data->jog_stop), 0, "motion.jog-stop"));
+    CALL_CHECK(hal_pin_new_bool(mot_comp_id, HAL_IN, &(emcmot_hal_data->jog_stop_immediate), 0, "motion.jog-stop-immediate"));
+    CALL_CHECK(hal_pin_new_bool(mot_comp_id, HAL_OUT, &(emcmot_hal_data->tp_reverse), 0, "motion.tp-reverse"));
+    // default value of enable is TRUE, so simple machines can leave it disconnected
+    CALL_CHECK(hal_pin_new_bool(mot_comp_id, HAL_IN, &(emcmot_hal_data->enable), 1, "motion.enable"));
+    CALL_CHECK(hal_pin_new_bool(mot_comp_id, HAL_OUT, &(emcmot_hal_data->is_all_homed), 0, "motion.is-all-homed"));
 
     /* state tags pins */
-    CALL_CHECK(hal_pin_float_newf(HAL_OUT, &(emcmot_hal_data->feed_upm), mot_comp_id, "motion.feed-upm"));
-    CALL_CHECK(hal_pin_float_newf(HAL_OUT, &(emcmot_hal_data->feed_inches_per_minute), mot_comp_id, "motion.feed-inches-per-minute"));
-    CALL_CHECK(hal_pin_float_newf(HAL_OUT, &(emcmot_hal_data->feed_inches_per_second), mot_comp_id, "motion.feed-inches-per-second"));
-    CALL_CHECK(hal_pin_float_newf(HAL_OUT, &(emcmot_hal_data->feed_mm_per_minute), mot_comp_id, "motion.feed-mm-per-minute"));
-    CALL_CHECK(hal_pin_float_newf(HAL_OUT, &(emcmot_hal_data->feed_mm_per_second), mot_comp_id, "motion.feed-mm-per-second"));
+    CALL_CHECK(hal_pin_new_real(mot_comp_id, HAL_OUT, &(emcmot_hal_data->feed_upm), 0.0, "motion.feed-upm"));
+    CALL_CHECK(hal_pin_new_real(mot_comp_id, HAL_OUT, &(emcmot_hal_data->feed_inches_per_minute), 0.0, "motion.feed-inches-per-minute"));
+    CALL_CHECK(hal_pin_new_real(mot_comp_id, HAL_OUT, &(emcmot_hal_data->feed_inches_per_second), 0.0, "motion.feed-inches-per-second"));
+    CALL_CHECK(hal_pin_new_real(mot_comp_id, HAL_OUT, &(emcmot_hal_data->feed_mm_per_minute), 0.0, "motion.feed-mm-per-minute"));
+    CALL_CHECK(hal_pin_new_real(mot_comp_id, HAL_OUT, &(emcmot_hal_data->feed_mm_per_second), 0.0, "motion.feed-mm-per-second"));
 
     /* export motion-synched digital output pins */
     /* export motion digital input pins */
     in = 0, out = 0;
+    /* motion synched dio, init to not enabled */
     for (n = 0; n < num_dio; n++) {
         if (n < num_din && names_din[n]) {
-            CALL_CHECK(hal_pin_bit_newf(HAL_IN, &(emcmot_hal_data->synch_di[n]), mot_comp_id, "motion.din-%s", names_din[n]));
+            CALL_CHECK(hal_pin_new_bool(mot_comp_id, HAL_IN, &(emcmot_hal_data->synch_di[n]),
+                                        0, "motion.din-%s", names_din[n]));
         } else {
-            CALL_CHECK(hal_pin_bit_newf(HAL_IN, &(emcmot_hal_data->synch_di[n]), mot_comp_id, "motion.digital-in-%02d", in++));
+            CALL_CHECK(hal_pin_new_bool(mot_comp_id, HAL_IN, &(emcmot_hal_data->synch_di[n]),
+                                        0, "motion.digital-in-%02d", in++));
         }
         if (n < num_dout && names_dout[n]) {
-            CALL_CHECK(hal_pin_bit_newf(HAL_OUT, &(emcmot_hal_data->synch_do[n]), mot_comp_id, "motion.dout-%s", names_dout[n]));
+            CALL_CHECK(hal_pin_new_bool(mot_comp_id, HAL_OUT, &(emcmot_hal_data->synch_do[n]),
+                                        0, "motion.dout-%s", names_dout[n]));
         } else {
-            CALL_CHECK(hal_pin_bit_newf(HAL_OUT, &(emcmot_hal_data->synch_do[n]), mot_comp_id, "motion.digital-out-%02d",out++));
+            CALL_CHECK(hal_pin_new_bool(mot_comp_id, HAL_OUT, &(emcmot_hal_data->synch_do[n]),
+                                        0, "motion.digital-out-%02d",out++));
         }
     }
 
@@ -555,149 +561,104 @@ static int init_hal_io(void)
     in = 0, out = 0;
     for (n = 0; n < num_aio; n++) {
         if (n < num_ain && names_ain[n]) {
-            CALL_CHECK(hal_pin_float_newf(HAL_IN, &(emcmot_hal_data->analog_input[n]), mot_comp_id, "motion.ain-%s", names_ain[n]));
+            CALL_CHECK(hal_pin_new_real(mot_comp_id, HAL_IN, &(emcmot_hal_data->analog_input[n]),
+                                        0.0, "motion.ain-%s", names_ain[n]));
         } else {
-            CALL_CHECK(hal_pin_float_newf(HAL_IN, &(emcmot_hal_data->analog_input[n]), mot_comp_id, "motion.analog-in-%02d", in++));
+            CALL_CHECK(hal_pin_new_real(mot_comp_id, HAL_IN, &(emcmot_hal_data->analog_input[n]),
+                                        0.0, "motion.analog-in-%02d", in++));
         }
         if (n < num_aout && names_aout[n]) {
-            CALL_CHECK(hal_pin_float_newf(HAL_OUT, &(emcmot_hal_data->analog_output[n]), mot_comp_id, "motion.aout-%s", names_aout[n]));
+            CALL_CHECK(hal_pin_new_real(mot_comp_id, HAL_OUT, &(emcmot_hal_data->analog_output[n]),
+                                        0.0, "motion.aout-%s", names_aout[n]));
         } else {
-            CALL_CHECK(hal_pin_float_newf(HAL_OUT, &(emcmot_hal_data->analog_output[n]), mot_comp_id, "motion.analog-out-%02d", out++));
+            CALL_CHECK(hal_pin_new_real(mot_comp_id, HAL_OUT, &(emcmot_hal_data->analog_output[n]),
+                                        0.0, "motion.analog-out-%02d", out++));
         }
     }
 
     if (names_misc_errors[0]) {
         for (n = 0; n < num_misc_error; n++) {
             if (names_misc_errors[n] == NULL || (*names_misc_errors[n] == 0)) {break;}
-            CALL_CHECK(hal_pin_bit_newf(HAL_IN, &(emcmot_hal_data->misc_error[n]), mot_comp_id, "motion.err-%s", names_misc_errors[n]));
+            CALL_CHECK(hal_pin_new_bool(mot_comp_id, HAL_IN, &(emcmot_hal_data->misc_error[n]), 0, "motion.err-%s", names_misc_errors[n]));
         }
     } else {
         /* export misc error input pins */
         for (n = 0; n < num_misc_error; n++) {
-            CALL_CHECK(hal_pin_bit_newf(HAL_IN, &(emcmot_hal_data->misc_error[n]), mot_comp_id, "motion.misc-error-%02d", n));
+            CALL_CHECK(hal_pin_new_bool(mot_comp_id, HAL_IN, &(emcmot_hal_data->misc_error[n]), 0, "motion.misc-error-%02d", n));
         }
     }
 
     /* export machine wide hal pins */
-    CALL_CHECK(hal_pin_bit_newf(HAL_OUT, &(emcmot_hal_data->motion_enabled), mot_comp_id, "motion.motion-enabled"));
-    CALL_CHECK(hal_pin_bit_newf(HAL_OUT, &(emcmot_hal_data->in_position), mot_comp_id, "motion.in-position"));
-    CALL_CHECK(hal_pin_s32_newf(HAL_OUT, &(emcmot_hal_data->motion_type), mot_comp_id, "motion.motion-type"));
-    CALL_CHECK(hal_pin_bit_newf(HAL_OUT, &(emcmot_hal_data->coord_mode), mot_comp_id, "motion.coord-mode"));
-    CALL_CHECK(hal_pin_bit_newf(HAL_OUT, &(emcmot_hal_data->teleop_mode), mot_comp_id, "motion.teleop-mode"));
-    CALL_CHECK(hal_pin_bit_newf(HAL_OUT, &(emcmot_hal_data->coord_error), mot_comp_id, "motion.coord-error"));
-    CALL_CHECK(hal_pin_bit_newf(HAL_OUT, &(emcmot_hal_data->on_soft_limit), mot_comp_id, "motion.on-soft-limit"));
-    CALL_CHECK(hal_pin_float_newf(HAL_OUT, &(emcmot_hal_data->current_vel), mot_comp_id, "motion.current-vel"));
-    CALL_CHECK(hal_pin_float_newf(HAL_OUT, &(emcmot_hal_data->requested_vel), mot_comp_id, "motion.requested-vel"));
-    CALL_CHECK(hal_pin_float_newf(HAL_OUT, &(emcmot_hal_data->distance_to_go), mot_comp_id, "motion.distance-to-go"));
-    CALL_CHECK(hal_pin_s32_newf(HAL_OUT, &(emcmot_hal_data->program_line), mot_comp_id, "motion.program-line"));
-    CALL_CHECK(hal_pin_bit_newf(HAL_OUT, &(emcmot_hal_data->jog_is_active), mot_comp_id, "motion.jog-is-active"));
+    CALL_CHECK(hal_pin_new_bool(mot_comp_id, HAL_OUT, &(emcmot_hal_data->motion_enabled), 0, "motion.motion-enabled"));
+    CALL_CHECK(hal_pin_new_bool(mot_comp_id, HAL_OUT, &(emcmot_hal_data->in_position), 0, "motion.in-position"));
+    CALL_CHECK(hal_pin_new_si32(mot_comp_id, HAL_OUT, &(emcmot_hal_data->motion_type), 0, "motion.motion-type"));
+    CALL_CHECK(hal_pin_new_bool(mot_comp_id, HAL_OUT, &(emcmot_hal_data->coord_mode), 0, "motion.coord-mode"));
+    CALL_CHECK(hal_pin_new_bool(mot_comp_id, HAL_OUT, &(emcmot_hal_data->teleop_mode), 0, "motion.teleop-mode"));
+    CALL_CHECK(hal_pin_new_bool(mot_comp_id, HAL_OUT, &(emcmot_hal_data->coord_error), 0, "motion.coord-error"));
+    CALL_CHECK(hal_pin_new_bool(mot_comp_id, HAL_OUT, &(emcmot_hal_data->on_soft_limit), 0, "motion.on-soft-limit"));
+    CALL_CHECK(hal_pin_new_real(mot_comp_id, HAL_OUT, &(emcmot_hal_data->current_vel), 0.0, "motion.current-vel"));
+    CALL_CHECK(hal_pin_new_real(mot_comp_id, HAL_OUT, &(emcmot_hal_data->requested_vel), 0.0, "motion.requested-vel"));
+    CALL_CHECK(hal_pin_new_real(mot_comp_id, HAL_OUT, &(emcmot_hal_data->distance_to_go), 0.0, "motion.distance-to-go"));
+    CALL_CHECK(hal_pin_new_si32(mot_comp_id, HAL_OUT, &(emcmot_hal_data->program_line), 0, "motion.program-line"));
+    CALL_CHECK(hal_pin_new_bool(mot_comp_id, HAL_OUT, &(emcmot_hal_data->jog_is_active), 0, "motion.jog-is-active"));
 
     /* Standard Interp State Pins */
-    CALL_CHECK(hal_pin_s32_newf(HAL_OUT, &(emcmot_hal_data->interp_line_number), mot_comp_id, "motion.interp.line-number"));
-    CALL_CHECK(hal_pin_s32_newf(HAL_OUT, &(emcmot_hal_data->interp_motion_type), mot_comp_id, "motion.interp.motion-type"));
-    CALL_CHECK(hal_pin_float_newf(HAL_OUT, &(emcmot_hal_data->interp_feedrate), mot_comp_id, "motion.interp.feedrate"));
+    CALL_CHECK(hal_pin_new_si32(mot_comp_id, HAL_OUT, &(emcmot_hal_data->interp_line_number), 0, "motion.interp.line-number"));
+    CALL_CHECK(hal_pin_new_si32(mot_comp_id, HAL_OUT, &(emcmot_hal_data->interp_motion_type), 0, "motion.interp.motion-type"));
+    CALL_CHECK(hal_pin_new_real(mot_comp_id, HAL_OUT, &(emcmot_hal_data->interp_feedrate), 0.0, "motion.interp.feedrate"));
 
     /* New Geometric Metadata Pins */
-    CALL_CHECK(hal_pin_float_newf(HAL_OUT, &(emcmot_hal_data->interp_arc_radius), mot_comp_id, "motion.interp.arc-radius"));
-    CALL_CHECK(hal_pin_float_newf(HAL_OUT, &(emcmot_hal_data->interp_arc_center_x), mot_comp_id, "motion.interp.arc-center-x"));
-    CALL_CHECK(hal_pin_float_newf(HAL_OUT, &(emcmot_hal_data->interp_arc_center_y), mot_comp_id, "motion.interp.arc-center-y"));
-    CALL_CHECK(hal_pin_float_newf(HAL_OUT, &(emcmot_hal_data->interp_arc_center_z), mot_comp_id, "motion.interp.arc-center-z"));
-    CALL_CHECK(hal_pin_float_newf(HAL_OUT, &(emcmot_hal_data->interp_straight_heading), mot_comp_id, "motion.interp.heading"));
-    CALL_CHECK(hal_pin_float_newf(HAL_OUT, &(emcmot_hal_data->interp_normal_heading), mot_comp_id, "motion.interp.normal-heading"));
-    CALL_CHECK(hal_pin_bit_newf(HAL_OUT, &emcmot_hal_data->iscircle, mot_comp_id, "motion.interp.iscircle"));
+    CALL_CHECK(hal_pin_new_real(mot_comp_id, HAL_OUT, &(emcmot_hal_data->interp_arc_radius), 0.0, "motion.interp.arc-radius"));
+    CALL_CHECK(hal_pin_new_real(mot_comp_id, HAL_OUT, &(emcmot_hal_data->interp_arc_center_x), 0.0, "motion.interp.arc-center-x"));
+    CALL_CHECK(hal_pin_new_real(mot_comp_id, HAL_OUT, &(emcmot_hal_data->interp_arc_center_y), 0.0, "motion.interp.arc-center-y"));
+    CALL_CHECK(hal_pin_new_real(mot_comp_id, HAL_OUT, &(emcmot_hal_data->interp_arc_center_z), 0.0, "motion.interp.arc-center-z"));
+    CALL_CHECK(hal_pin_new_real(mot_comp_id, HAL_OUT, &(emcmot_hal_data->interp_straight_heading), 0.0, "motion.interp.heading"));
+    CALL_CHECK(hal_pin_new_real(mot_comp_id, HAL_OUT, &(emcmot_hal_data->interp_normal_heading), 0.0, "motion.interp.normal-heading"));
+    CALL_CHECK(hal_pin_new_bool(mot_comp_id, HAL_OUT, &emcmot_hal_data->iscircle, 0, "motion.interp.iscircle"));
 
     /* export debug parameters */
     /* these can be used to view any internal variable, simply change a line
        in control.c:output_to_hal() and recompile */
-    CALL_CHECK(hal_param_bit_newf(HAL_RO, &(emcmot_hal_data->debug_bit_0), mot_comp_id, "motion.debug-bit-0"));
-    CALL_CHECK(hal_param_bit_newf(HAL_RO, &(emcmot_hal_data->debug_bit_1), mot_comp_id, "motion.debug-bit-1"));
-    CALL_CHECK(hal_param_float_newf(HAL_RO, &(emcmot_hal_data->debug_float_0), mot_comp_id, "motion.debug-float-0"));
-    CALL_CHECK(hal_param_float_newf(HAL_RO, &(emcmot_hal_data->debug_float_1), mot_comp_id, "motion.debug-float-1"));
-    CALL_CHECK(hal_param_float_newf(HAL_RO, &(emcmot_hal_data->debug_float_2), mot_comp_id, "motion.debug-float-2"));
-    CALL_CHECK(hal_param_float_newf(HAL_RO, &(emcmot_hal_data->debug_float_3), mot_comp_id, "motion.debug-float-3"));
-    CALL_CHECK(hal_param_s32_newf(HAL_RO, &(emcmot_hal_data->debug_s32_0), mot_comp_id, "motion.debug-s32-0"));
-    CALL_CHECK(hal_param_s32_newf(HAL_RO, &(emcmot_hal_data->debug_s32_1), mot_comp_id, "motion.debug-s32-1"));
+    CALL_CHECK(hal_param_new_bool(mot_comp_id, HAL_RO, &(emcmot_hal_data->debug_bit_0), 0, "motion.debug-bit-0"));
+    CALL_CHECK(hal_param_new_bool(mot_comp_id, HAL_RO, &(emcmot_hal_data->debug_bit_1), 0, "motion.debug-bit-1"));
+    CALL_CHECK(hal_param_new_real(mot_comp_id, HAL_RO, &(emcmot_hal_data->debug_float_0), 0.0, "motion.debug-float-0"));
+    CALL_CHECK(hal_param_new_real(mot_comp_id, HAL_RO, &(emcmot_hal_data->debug_float_1), 0.0, "motion.debug-float-1"));
+    CALL_CHECK(hal_param_new_real(mot_comp_id, HAL_RO, &(emcmot_hal_data->debug_float_2), 0.0, "motion.debug-float-2"));
+    CALL_CHECK(hal_param_new_real(mot_comp_id, HAL_RO, &(emcmot_hal_data->debug_float_3), 0.0, "motion.debug-float-3"));
+    CALL_CHECK(hal_param_new_si32(mot_comp_id, HAL_RO, &(emcmot_hal_data->debug_s32_0), 0, "motion.debug-s32-0"));
+    CALL_CHECK(hal_param_new_si32(mot_comp_id, HAL_RO, &(emcmot_hal_data->debug_s32_1), 0, "motion.debug-s32-1"));
 
     // FIXME - debug only, remove later
     // export HAL parameters for some trajectory planner internal variables
     // so they can be scoped
-    CALL_CHECK(hal_param_float_newf(HAL_RO, &(emcmot_hal_data->traj_pos_out), mot_comp_id, "traj.pos_out"));
-    CALL_CHECK(hal_param_float_newf(HAL_RO, &(emcmot_hal_data->traj_vel_out), mot_comp_id, "traj.vel_out"));
-    CALL_CHECK(hal_param_u32_newf(HAL_RO, &(emcmot_hal_data->traj_active_tc), mot_comp_id, "traj.active_tc"));
+    CALL_CHECK(hal_param_new_real(mot_comp_id, HAL_RO, &(emcmot_hal_data->traj_pos_out), 0.0, "traj.pos_out"));
+    CALL_CHECK(hal_param_new_real(mot_comp_id, HAL_RO, &(emcmot_hal_data->traj_vel_out), 0.0, "traj.vel_out"));
+    CALL_CHECK(hal_param_new_ui32(mot_comp_id, HAL_RO, &(emcmot_hal_data->traj_active_tc), 0, "traj.active_tc"));
 
     for (n = 0; n < 4; n++) {
-        CALL_CHECK(hal_param_float_newf(HAL_RO, &(emcmot_hal_data->tc_pos[n]), mot_comp_id, "tc.%d.pos", n));
-        CALL_CHECK(hal_param_float_newf(HAL_RO, &(emcmot_hal_data->tc_vel[n]), mot_comp_id, "tc.%d.vel", n));
-        CALL_CHECK(hal_param_float_newf(HAL_RO, &(emcmot_hal_data->tc_acc[n]), mot_comp_id, "tc.%d.acc", n));
+        CALL_CHECK(hal_param_new_real(mot_comp_id, HAL_RO, &(emcmot_hal_data->tc_pos[n]), 0.0, "tc.%d.pos", n));
+        CALL_CHECK(hal_param_new_real(mot_comp_id, HAL_RO, &(emcmot_hal_data->tc_vel[n]), 0.0, "tc.%d.vel", n));
+        CALL_CHECK(hal_param_new_real(mot_comp_id, HAL_RO, &(emcmot_hal_data->tc_acc[n]), 0.0, "tc.%d.acc", n));
     }
     // end of exporting trajectory planner internals
 
     // export timing related HAL pins so they can be scoped and/or connected
-    CALL_CHECK(hal_pin_u32_newf(HAL_OUT, &(emcmot_hal_data->last_period), mot_comp_id, "motion.servo.last-period"));
+    CALL_CHECK(hal_pin_new_ui32(mot_comp_id, HAL_OUT, &(emcmot_hal_data->last_period), 0, "motion.servo.last-period"));
 
     // export timing related HAL pins so they can be scoped
-    CALL_CHECK(hal_pin_float_newf(HAL_OUT, &(emcmot_hal_data->tooloffset_x), mot_comp_id, "motion.tooloffset.x"));
-    CALL_CHECK(hal_pin_float_newf(HAL_OUT, &(emcmot_hal_data->tooloffset_y), mot_comp_id, "motion.tooloffset.y"));
-    CALL_CHECK(hal_pin_float_newf(HAL_OUT, &(emcmot_hal_data->tooloffset_z), mot_comp_id, "motion.tooloffset.z"));
-    CALL_CHECK(hal_pin_float_newf(HAL_OUT, &(emcmot_hal_data->tooloffset_a), mot_comp_id, "motion.tooloffset.a"));
-    CALL_CHECK(hal_pin_float_newf(HAL_OUT, &(emcmot_hal_data->tooloffset_b), mot_comp_id, "motion.tooloffset.b"));
-    CALL_CHECK(hal_pin_float_newf(HAL_OUT, &(emcmot_hal_data->tooloffset_c), mot_comp_id, "motion.tooloffset.c"));
-    CALL_CHECK(hal_pin_float_newf(HAL_OUT, &(emcmot_hal_data->tooloffset_u), mot_comp_id, "motion.tooloffset.u"));
-    CALL_CHECK(hal_pin_float_newf(HAL_OUT, &(emcmot_hal_data->tooloffset_v), mot_comp_id, "motion.tooloffset.v"));
-    CALL_CHECK(hal_pin_float_newf(HAL_OUT, &(emcmot_hal_data->tooloffset_w), mot_comp_id, "motion.tooloffset.w"));
+    CALL_CHECK(hal_pin_new_real(mot_comp_id, HAL_OUT, &(emcmot_hal_data->tooloffset_x), 0.0, "motion.tooloffset.x"));
+    CALL_CHECK(hal_pin_new_real(mot_comp_id, HAL_OUT, &(emcmot_hal_data->tooloffset_y), 0.0, "motion.tooloffset.y"));
+    CALL_CHECK(hal_pin_new_real(mot_comp_id, HAL_OUT, &(emcmot_hal_data->tooloffset_z), 0.0, "motion.tooloffset.z"));
+    CALL_CHECK(hal_pin_new_real(mot_comp_id, HAL_OUT, &(emcmot_hal_data->tooloffset_a), 0.0, "motion.tooloffset.a"));
+    CALL_CHECK(hal_pin_new_real(mot_comp_id, HAL_OUT, &(emcmot_hal_data->tooloffset_b), 0.0, "motion.tooloffset.b"));
+    CALL_CHECK(hal_pin_new_real(mot_comp_id, HAL_OUT, &(emcmot_hal_data->tooloffset_c), 0.0, "motion.tooloffset.c"));
+    CALL_CHECK(hal_pin_new_real(mot_comp_id, HAL_OUT, &(emcmot_hal_data->tooloffset_u), 0.0, "motion.tooloffset.u"));
+    CALL_CHECK(hal_pin_new_real(mot_comp_id, HAL_OUT, &(emcmot_hal_data->tooloffset_v), 0.0, "motion.tooloffset.v"));
+    CALL_CHECK(hal_pin_new_real(mot_comp_id, HAL_OUT, &(emcmot_hal_data->tooloffset_w), 0.0, "motion.tooloffset.w"));
 
     if (kinematicsSwitchable()) {
-        CALL_CHECK(hal_pin_float_newf(HAL_IN, &(emcmot_hal_data->switchkins_type), mot_comp_id, "motion.switchkins-type"));
+        CALL_CHECK(hal_pin_new_real(mot_comp_id, HAL_IN, &(emcmot_hal_data->switchkins_type), 0.0, "motion.switchkins-type"));
     }
-    /* initialize machine wide pins and parameters */
-    *(emcmot_hal_data->adaptive_feed) = 1.0;
-    *(emcmot_hal_data->feed_hold) = 0;
-    *(emcmot_hal_data->feed_inhibit) = 0;
-    *(emcmot_hal_data->homing_inhibit) = 0;
-    *(emcmot_hal_data->jog_inhibit) = 0;
-    *(emcmot_hal_data->jog_stop) = 0;
-    *(emcmot_hal_data->jog_stop_immediate) = 0;
-    *(emcmot_hal_data->is_all_homed) = 0;
-
-    *(emcmot_hal_data->probe_input) = 0;
-    /* default value of enable is TRUE, so simple machines
-       can leave it disconnected */
-    *(emcmot_hal_data->enable) = 1;
-
-    /* motion synched dio, init to not enabled */
-    for (n = 0; n < num_dio; n++) {
-        *(emcmot_hal_data->synch_do[n]) = 0;
-        *(emcmot_hal_data->synch_di[n]) = 0;
-    }
-
-    for (n = 0; n < num_aio; n++) {
-        *(emcmot_hal_data->analog_output[n]) = 0.0;
-        *(emcmot_hal_data->analog_input[n]) = 0.0;
-    }
-
-    for (n = 0; n < num_misc_error; n++) {
-        *(emcmot_hal_data->misc_error[n]) = 0;
-    }
-
-    /*! \todo FIXME - these don't really need initialized, since they are written
-       with data from the emcmotStatus struct */
-    *(emcmot_hal_data->motion_enabled) = 0;
-    *(emcmot_hal_data->in_position) = 0;
-    *(emcmot_hal_data->motion_type) = 0;
-    *(emcmot_hal_data->coord_mode) = 0;
-    *(emcmot_hal_data->teleop_mode) = 0;
-    *(emcmot_hal_data->coord_error) = 0;
-    *(emcmot_hal_data->on_soft_limit) = 0;
-
-    /* init debug parameters */
-    emcmot_hal_data->debug_bit_0 = 0;
-    emcmot_hal_data->debug_bit_1 = 0;
-    emcmot_hal_data->debug_float_0 = 0.0;
-    emcmot_hal_data->debug_float_1 = 0.0;
-    emcmot_hal_data->debug_float_2 = 0.0;
-    emcmot_hal_data->debug_float_3 = 0.0;
-
-    *(emcmot_hal_data->last_period) = 0;
 
     /* export spindle pins and params */
     for (n = 0; n < num_spindles; n++) {
@@ -716,7 +677,7 @@ static int init_hal_io(void)
             rtapi_print_msg(RTAPI_MSG_ERR, _("MOTION: joint %d pin/param export failed\n"), n);
             return -1;
         }
-        *(joint_data->amp_enable) = 0;
+        hal_set_bool(joint_data->amp_enable, 0);
 
         /* We'll init the index model to EXT_ENCODER_INDEX_MODEL_RAW for now,
            because it is always supported. */
@@ -733,8 +694,8 @@ static int init_hal_io(void)
 
     CALL_CHECK(axis_init_hal_io(mot_comp_id));
 
-    CALL_CHECK(hal_pin_bit_newf(HAL_OUT, &(emcmot_hal_data->eoffset_limited), mot_comp_id, "motion.eoffset-limited"));
-    CALL_CHECK(hal_pin_bit_newf(HAL_OUT, &(emcmot_hal_data->eoffset_active), mot_comp_id, "motion.eoffset-active"));
+    CALL_CHECK(hal_pin_new_bool(mot_comp_id, HAL_OUT, &(emcmot_hal_data->eoffset_limited), 0, "motion.eoffset-limited"));
+    CALL_CHECK(hal_pin_new_bool(mot_comp_id, HAL_OUT, &(emcmot_hal_data->eoffset_active), 0, "motion.eoffset-active"));
 
     /* Done! */
     rtapi_print_msg(RTAPI_MSG_INFO,	"MOTION: init_hal_io() complete, %d axes.\n", n);
@@ -742,43 +703,35 @@ static int init_hal_io(void)
 }
 
 static int export_spindle(int num, spindle_hal_t * addr){
-	int retval, msg;
-
-    msg = rtapi_get_msg_level();
+    int msg = rtapi_get_msg_level();
     rtapi_set_msg_level(RTAPI_MSG_WARN);
 
-    if ((retval = hal_pin_bit_newf(HAL_IO, &(addr->spindle_index_enable), mot_comp_id, "spindle.%d.index-enable", num)) != 0) return retval;
-
-    if ((retval = hal_pin_bit_newf(HAL_OUT, &(addr->spindle_on), mot_comp_id, "spindle.%d.on", num)) != 0) return retval;
-    if ((retval = hal_pin_bit_newf(HAL_OUT, &(addr->spindle_forward), mot_comp_id, "spindle.%d.forward", num)) != 0) return retval;
-    if ((retval = hal_pin_bit_newf(HAL_OUT, &(addr->spindle_reverse), mot_comp_id, "spindle.%d.reverse", num)) != 0) return retval;
-    if ((retval = hal_pin_bit_newf(HAL_OUT, &(addr->spindle_brake), mot_comp_id, "spindle.%d.brake", num)) != 0) return retval;
-    if ((retval = hal_pin_float_newf(HAL_OUT, &(addr->spindle_speed_out), mot_comp_id, "spindle.%d.speed-out", num)) != 0) return retval;
-    if ((retval = hal_pin_float_newf(HAL_OUT, &(addr->spindle_speed_out_abs), mot_comp_id, "spindle.%d.speed-out-abs", num)) != 0) return retval;
-    if ((retval = hal_pin_float_newf(HAL_OUT, &(addr->spindle_speed_out_rps), mot_comp_id, "spindle.%d.speed-out-rps", num)) != 0) return retval;
-    if ((retval = hal_pin_float_newf(HAL_OUT, &(addr->spindle_speed_out_rps_abs), mot_comp_id, "spindle.%d.speed-out-rps-abs", num)) != 0) return retval;
-    if ((retval = hal_pin_float_newf(HAL_OUT, &(addr->spindle_speed_cmd_rps), mot_comp_id, "spindle.%d.speed-cmd-rps", num)) != 0) return retval;
-    if ((retval = hal_pin_bit_newf(HAL_IN, &(addr->spindle_inhibit), mot_comp_id, "spindle.%d.inhibit", num)) != 0) return retval;
-    if ((retval = hal_pin_bit_newf(HAL_IN, &(addr->spindle_amp_fault), mot_comp_id, "spindle.%d.amp-fault-in", num)) != 0) return retval;
-    *(addr->spindle_inhibit) = 0;
+    CALL_CHECK(hal_pin_new_bool(mot_comp_id, HAL_IO, &(addr->spindle_index_enable), 0, "spindle.%d.index-enable", num));
+    CALL_CHECK(hal_pin_new_bool(mot_comp_id, HAL_OUT, &(addr->spindle_on), 0, "spindle.%d.on", num));
+    CALL_CHECK(hal_pin_new_bool(mot_comp_id, HAL_OUT, &(addr->spindle_forward), 0, "spindle.%d.forward", num));
+    CALL_CHECK(hal_pin_new_bool(mot_comp_id, HAL_OUT, &(addr->spindle_reverse), 0, "spindle.%d.reverse", num));
+    CALL_CHECK(hal_pin_new_bool(mot_comp_id, HAL_OUT, &(addr->spindle_brake), 0, "spindle.%d.brake", num));
+    CALL_CHECK(hal_pin_new_real(mot_comp_id, HAL_OUT, &(addr->spindle_speed_out), 0.0, "spindle.%d.speed-out", num));
+    CALL_CHECK(hal_pin_new_real(mot_comp_id, HAL_OUT, &(addr->spindle_speed_out_abs), 0.0, "spindle.%d.speed-out-abs", num));
+    CALL_CHECK(hal_pin_new_real(mot_comp_id, HAL_OUT, &(addr->spindle_speed_out_rps), 0.0, "spindle.%d.speed-out-rps", num));
+    CALL_CHECK(hal_pin_new_real(mot_comp_id, HAL_OUT, &(addr->spindle_speed_out_rps_abs), 0.0, "spindle.%d.speed-out-rps-abs", num));
+    CALL_CHECK(hal_pin_new_real(mot_comp_id, HAL_OUT, &(addr->spindle_speed_cmd_rps), 0.0, "spindle.%d.speed-cmd-rps", num));
+    CALL_CHECK(hal_pin_new_bool(mot_comp_id, HAL_IN, &(addr->spindle_inhibit), 0, "spindle.%d.inhibit", num));
+    CALL_CHECK(hal_pin_new_bool(mot_comp_id, HAL_IN, &(addr->spindle_amp_fault), 0, "spindle.%d.amp-fault-in", num));
 
     // spindle orient pins
-    if ((retval = hal_pin_float_newf(HAL_OUT, &(addr->spindle_orient_angle), mot_comp_id, "spindle.%d.orient-angle", num)) < 0) return retval;
-    if ((retval = hal_pin_s32_newf(HAL_OUT, &(addr->spindle_orient_mode), mot_comp_id, "spindle.%d.orient-mode", num)) < 0) return retval;
-    if ((retval = hal_pin_bit_newf(HAL_OUT, &(addr->spindle_orient), mot_comp_id, "spindle.%d.orient", num)) < 0) return retval;
-    if ((retval = hal_pin_bit_newf(HAL_OUT, &(addr->spindle_locked), mot_comp_id, "spindle.%d.locked", num)) < 0) return retval;
-    if ((retval = hal_pin_bit_newf(HAL_IN, &(addr->spindle_is_oriented), mot_comp_id, "spindle.%d.is-oriented", num)) < 0) return retval;
-    if ((retval = hal_pin_s32_newf(HAL_IN, &(addr->spindle_orient_fault), mot_comp_id, "spindle.%d.orient-fault", num)) < 0) return retval;
-    *(addr->spindle_orient_angle) = 0.0;
-    *(addr->spindle_orient_mode) = 0;
-    *(addr->spindle_orient) = 0;
+    CALL_CHECK(hal_pin_new_real(mot_comp_id, HAL_OUT, &(addr->spindle_orient_angle), 0.0, "spindle.%d.orient-angle", num));
+    CALL_CHECK(hal_pin_new_si32(mot_comp_id, HAL_OUT, &(addr->spindle_orient_mode), 0, "spindle.%d.orient-mode", num));
+    CALL_CHECK(hal_pin_new_bool(mot_comp_id, HAL_OUT, &(addr->spindle_orient), 0, "spindle.%d.orient", num));
+    CALL_CHECK(hal_pin_new_bool(mot_comp_id, HAL_OUT, &(addr->spindle_locked), 0, "spindle.%d.locked", num));
+    CALL_CHECK(hal_pin_new_bool(mot_comp_id, HAL_IN, &(addr->spindle_is_oriented), 0, "spindle.%d.is-oriented", num));
+    CALL_CHECK(hal_pin_new_si32(mot_comp_id, HAL_IN, &(addr->spindle_orient_fault), 0, "spindle.%d.orient-fault", num));
 
-    if ((retval = hal_pin_float_newf(HAL_IN, &(addr->spindle_revs), mot_comp_id, "spindle.%d.revs", num)) != 0) return retval;
-    if ((retval = hal_pin_float_newf(HAL_IN, &(addr->spindle_speed_in), mot_comp_id, "spindle.%d.speed-in", num)) != 0) return retval;
-    if ((retval = hal_pin_bit_newf(HAL_IN, &(addr->spindle_is_atspeed), mot_comp_id, "spindle.%d.at-speed", num)) != 0) return retval;
+    CALL_CHECK(hal_pin_new_real(mot_comp_id, HAL_IN, &(addr->spindle_revs), 0.0, "spindle.%d.revs", num));
+    CALL_CHECK(hal_pin_new_real(mot_comp_id, HAL_IN, &(addr->spindle_speed_in), 0.0, "spindle.%d.speed-in", num));
     /* Default 1: an unwired at-speed pin must never block motion. Do not
        change to 0 or machines without at-speed wired would idle forever. */
-    *(addr->spindle_is_atspeed) = 1;
+    CALL_CHECK(hal_pin_new_bool(mot_comp_id, HAL_IN, &(addr->spindle_is_atspeed), 1, "spindle.%d.at-speed", num));
     /* restore saved message level */
     rtapi_set_msg_level(msg);
     return 0;
@@ -786,58 +739,56 @@ static int export_spindle(int num, spindle_hal_t * addr){
 
 static int export_joint(int num, joint_hal_t * addr)
 {
-    int retval, msg;
-
     /* This function exports a lot of stuff, which results in a lot of
        logging if msg_level is at INFO or ALL. So we save the current value
        of msg_level and restore it later.  If you actually need to log this
        function's actions, change the second line below */
-    msg = rtapi_get_msg_level();
+    int msg = rtapi_get_msg_level();
     rtapi_set_msg_level(RTAPI_MSG_WARN);
 
     /* export joint pins */
-    if ((retval = hal_pin_float_newf(HAL_OUT, &(addr->coarse_pos_cmd), mot_comp_id, "joint.%d.coarse-pos-cmd", num)) != 0) return retval;
-    if ((retval = hal_pin_float_newf(HAL_OUT, &(addr->joint_pos_cmd), mot_comp_id, "joint.%d.pos-cmd", num)) != 0) return retval;
-    if ((retval = hal_pin_float_newf(HAL_OUT, &(addr->joint_pos_fb), mot_comp_id, "joint.%d.pos-fb", num)) != 0) return retval;
-    if ((retval = hal_pin_float_newf(HAL_OUT, &(addr->motor_pos_cmd), mot_comp_id, "joint.%d.motor-pos-cmd", num)) != 0) return retval;
-    if ((retval = hal_pin_float_newf(HAL_IN, &(addr->motor_pos_fb), mot_comp_id, "joint.%d.motor-pos-fb", num)) != 0) return retval;
-    if ((retval = hal_pin_float_newf(HAL_OUT, &(addr->motor_offset), mot_comp_id, "joint.%d.motor-offset", num)) != 0) return retval;
-    if ((retval = hal_pin_bit_newf(HAL_IN, &(addr->pos_lim_sw), mot_comp_id, "joint.%d.pos-lim-sw-in", num)) != 0) return retval;
-    if ((retval = hal_pin_bit_newf(HAL_IN, &(addr->neg_lim_sw), mot_comp_id, "joint.%d.neg-lim-sw-in", num)) != 0) return retval;
-    if ((retval = hal_pin_bit_newf(HAL_OUT, &(addr->amp_enable), mot_comp_id, "joint.%d.amp-enable-out", num)) != 0) return retval;
-    if ((retval = hal_pin_bit_newf(HAL_IN, &(addr->amp_fault), mot_comp_id, "joint.%d.amp-fault-in", num)) != 0) return retval;
-    if ((retval = hal_pin_s32_newf(HAL_IN,   &(addr->jjog_counts), mot_comp_id, "joint.%d.jog-counts", num)) != 0) return retval;
-    if ((retval = hal_pin_bit_newf(HAL_IN,   &(addr->jjog_enable), mot_comp_id, "joint.%d.jog-enable", num)) != 0) return retval;
-    if ((retval = hal_pin_float_newf(HAL_IN, &(addr->jjog_scale), mot_comp_id, "joint.%d.jog-scale", num)) != 0) return retval;
-    if ((retval = hal_pin_bit_newf(HAL_IN,   &(addr->jjog_vel_mode), mot_comp_id, "joint.%d.jog-vel-mode", num)) != 0) return retval;
-    if ((retval = hal_pin_float_newf(HAL_OUT, &(addr->joint_vel_cmd), mot_comp_id, "joint.%d.vel-cmd", num)) != 0) return retval;
-    if ((retval = hal_pin_float_newf(HAL_OUT, &(addr->joint_acc_cmd), mot_comp_id, "joint.%d.acc-cmd", num)) != 0) return retval;
-    if ((retval = hal_pin_float_newf(HAL_OUT, &(addr->joint_jerk_cmd), mot_comp_id, "joint.%d.jerk-cmd", num)) != 0) return retval;
-    if ((retval = hal_pin_float_newf(HAL_OUT, &(addr->backlash_corr), mot_comp_id, "joint.%d.backlash-corr", num)) != 0) return retval;
-    if ((retval = hal_pin_float_newf(HAL_OUT, &(addr->backlash_filt), mot_comp_id, "joint.%d.backlash-filt", num)) != 0) return retval;
-    if ((retval = hal_pin_float_newf(HAL_OUT, &(addr->backlash_vel), mot_comp_id, "joint.%d.backlash-vel", num)) != 0) return retval;
-    if ((retval = hal_pin_float_newf(HAL_OUT, &(addr->f_error), mot_comp_id, "joint.%d.f-error", num)) != 0) return retval;
-    if ((retval = hal_pin_float_newf(HAL_OUT, &(addr->f_error_lim), mot_comp_id, "joint.%d.f-error-lim", num)) != 0) return retval;
-    if ((retval = hal_pin_float_newf(HAL_OUT, &(addr->free_pos_cmd), mot_comp_id, "joint.%d.free-pos-cmd", num)) != 0) return retval;
-    if ((retval = hal_pin_float_newf(HAL_OUT, &(addr->free_vel_lim), mot_comp_id, "joint.%d.free-vel-lim", num)) != 0) return retval;
-    if ((retval = hal_pin_bit_newf(HAL_OUT, &(addr->free_tp_enable), mot_comp_id, "joint.%d.free-tp-enable", num)) != 0) return retval;
-    if ((retval = hal_pin_bit_newf(HAL_OUT, &(addr->kb_jjog_active), mot_comp_id, "joint.%d.kb-jog-active", num)) != 0) return retval;
-    if ((retval = hal_pin_bit_newf(HAL_OUT, &(addr->wheel_jjog_active), mot_comp_id, "joint.%d.wheel-jog-active", num)) != 0) return retval;
-    if ((retval = hal_pin_bit_newf(HAL_OUT, &(addr->in_position), mot_comp_id, "joint.%d.in-position", num)) != 0) return retval;
-    if ((retval = hal_pin_bit_newf(HAL_OUT, &(addr->phl), mot_comp_id, "joint.%d.pos-hard-limit", num)) != 0) return retval;
-    if ((retval = hal_pin_bit_newf(HAL_OUT, &(addr->nhl), mot_comp_id, "joint.%d.neg-hard-limit", num)) != 0) return retval;
-    if ((retval = hal_pin_bit_newf(HAL_OUT, &(addr->active), mot_comp_id, "joint.%d.active", num)) != 0) return retval;
-    if ((retval = hal_pin_bit_newf(HAL_OUT, &(addr->error), mot_comp_id, "joint.%d.error", num)) != 0) return retval;
-    if ((retval = hal_pin_bit_newf(HAL_OUT, &(addr->f_errored), mot_comp_id, "joint.%d.f-errored", num)) != 0) return retval;
-    if ((retval = hal_pin_bit_newf(HAL_OUT, &(addr->faulted), mot_comp_id, "joint.%d.faulted", num)) != 0) return retval;
-    if ((retval = hal_pin_float_newf(HAL_IN,&(addr->jjog_accel_fraction),mot_comp_id,"joint.%d.jog-accel-fraction", num)) != 0) return retval;
-    *addr->jjog_accel_fraction = 1.0; // fraction of accel for wheel jjogs
+    CALL_CHECK(hal_pin_new_real(mot_comp_id, HAL_OUT, &(addr->coarse_pos_cmd), 0.0, "joint.%d.coarse-pos-cmd", num));
+    CALL_CHECK(hal_pin_new_real(mot_comp_id, HAL_OUT, &(addr->joint_pos_cmd), 0.0, "joint.%d.pos-cmd", num));
+    CALL_CHECK(hal_pin_new_real(mot_comp_id, HAL_OUT, &(addr->joint_pos_fb), 0.0, "joint.%d.pos-fb", num));
+    CALL_CHECK(hal_pin_new_real(mot_comp_id, HAL_OUT, &(addr->motor_pos_cmd), 0.0, "joint.%d.motor-pos-cmd", num));
+    CALL_CHECK(hal_pin_new_real(mot_comp_id, HAL_IN, &(addr->motor_pos_fb), 0.0, "joint.%d.motor-pos-fb", num));
+    CALL_CHECK(hal_pin_new_real(mot_comp_id, HAL_OUT, &(addr->motor_offset), 0.0, "joint.%d.motor-offset", num));
+    CALL_CHECK(hal_pin_new_bool(mot_comp_id, HAL_IN, &(addr->pos_lim_sw), 0, "joint.%d.pos-lim-sw-in", num));
+    CALL_CHECK(hal_pin_new_bool(mot_comp_id, HAL_IN, &(addr->neg_lim_sw), 0, "joint.%d.neg-lim-sw-in", num));
+    CALL_CHECK(hal_pin_new_bool(mot_comp_id, HAL_OUT, &(addr->amp_enable), 0, "joint.%d.amp-enable-out", num));
+    CALL_CHECK(hal_pin_new_bool(mot_comp_id, HAL_IN, &(addr->amp_fault), 0, "joint.%d.amp-fault-in", num));
+    CALL_CHECK(hal_pin_new_si32(mot_comp_id, HAL_IN, &(addr->jjog_counts), 0, "joint.%d.jog-counts", num));
+    CALL_CHECK(hal_pin_new_bool(mot_comp_id, HAL_IN,   &(addr->jjog_enable), 0, "joint.%d.jog-enable", num));
+    CALL_CHECK(hal_pin_new_real(mot_comp_id, HAL_IN, &(addr->jjog_scale), 0.0, "joint.%d.jog-scale", num));
+    CALL_CHECK(hal_pin_new_bool(mot_comp_id, HAL_IN,   &(addr->jjog_vel_mode), 0, "joint.%d.jog-vel-mode", num));
+    CALL_CHECK(hal_pin_new_real(mot_comp_id, HAL_OUT, &(addr->joint_vel_cmd), 0.0, "joint.%d.vel-cmd", num));
+    CALL_CHECK(hal_pin_new_real(mot_comp_id, HAL_OUT, &(addr->joint_acc_cmd), 0.0, "joint.%d.acc-cmd", num));
+    CALL_CHECK(hal_pin_new_real(mot_comp_id, HAL_OUT, &(addr->joint_jerk_cmd), 0.0, "joint.%d.jerk-cmd", num));
+    CALL_CHECK(hal_pin_new_real(mot_comp_id, HAL_OUT, &(addr->backlash_corr), 0.0, "joint.%d.backlash-corr", num));
+    CALL_CHECK(hal_pin_new_real(mot_comp_id, HAL_OUT, &(addr->backlash_filt), 0.0, "joint.%d.backlash-filt", num));
+    CALL_CHECK(hal_pin_new_real(mot_comp_id, HAL_OUT, &(addr->backlash_vel), 0.0, "joint.%d.backlash-vel", num));
+    CALL_CHECK(hal_pin_new_real(mot_comp_id, HAL_OUT, &(addr->f_error), 0.0, "joint.%d.f-error", num));
+    CALL_CHECK(hal_pin_new_real(mot_comp_id, HAL_OUT, &(addr->f_error_lim), 0.0, "joint.%d.f-error-lim", num));
+    CALL_CHECK(hal_pin_new_real(mot_comp_id, HAL_OUT, &(addr->free_pos_cmd), 0.0, "joint.%d.free-pos-cmd", num));
+    CALL_CHECK(hal_pin_new_real(mot_comp_id, HAL_OUT, &(addr->free_vel_lim), 0.0, "joint.%d.free-vel-lim", num));
+    CALL_CHECK(hal_pin_new_bool(mot_comp_id, HAL_OUT, &(addr->free_tp_enable), 0, "joint.%d.free-tp-enable", num));
+    CALL_CHECK(hal_pin_new_bool(mot_comp_id, HAL_OUT, &(addr->kb_jjog_active), 0, "joint.%d.kb-jog-active", num));
+    CALL_CHECK(hal_pin_new_bool(mot_comp_id, HAL_OUT, &(addr->wheel_jjog_active), 0, "joint.%d.wheel-jog-active", num));
+    CALL_CHECK(hal_pin_new_bool(mot_comp_id, HAL_OUT, &(addr->in_position), 0, "joint.%d.in-position", num));
+    CALL_CHECK(hal_pin_new_bool(mot_comp_id, HAL_OUT, &(addr->phl), 0, "joint.%d.pos-hard-limit", num));
+    CALL_CHECK(hal_pin_new_bool(mot_comp_id, HAL_OUT, &(addr->nhl), 0, "joint.%d.neg-hard-limit", num));
+    CALL_CHECK(hal_pin_new_bool(mot_comp_id, HAL_OUT, &(addr->active), 0, "joint.%d.active", num));
+    CALL_CHECK(hal_pin_new_bool(mot_comp_id, HAL_OUT, &(addr->error), 0, "joint.%d.error", num));
+    CALL_CHECK(hal_pin_new_bool(mot_comp_id, HAL_OUT, &(addr->f_errored), 0, "joint.%d.f-errored", num));
+    CALL_CHECK(hal_pin_new_bool(mot_comp_id, HAL_OUT, &(addr->faulted), 0, "joint.%d.faulted", num));
+    // init 1.0: fraction of accel for wheel jjogs
+    CALL_CHECK(hal_pin_new_real(mot_comp_id, HAL_IN, &(addr->jjog_accel_fraction), 1.0, "joint.%d.jog-accel-fraction", num));
 
     if ( joint_is_lockable(num) ) {
         // these pins may be needed for rotary joints
         rtapi_print_msg(RTAPI_MSG_WARN,"motion.c: Creating unlock hal pins for joint %d\n",num);
-        if ((retval = hal_pin_bit_newf(HAL_OUT, &(addr->unlock), mot_comp_id, "joint.%d.unlock", num)) != 0) return retval;
-        if ((retval = hal_pin_bit_newf(HAL_IN, &(addr->is_unlocked), mot_comp_id, "joint.%d.is-unlocked", num)) != 0) return retval;
+        CALL_CHECK(hal_pin_new_bool(mot_comp_id, HAL_OUT, &(addr->unlock), 0, "joint.%d.unlock", num));
+        CALL_CHECK(hal_pin_new_bool(mot_comp_id, HAL_IN, &(addr->is_unlocked), 0, "joint.%d.is-unlocked", num));
     }
 
     /* restore saved message level */
@@ -849,7 +800,7 @@ static int export_extrajoint(int num, extrajoint_hal_t * addr)
 {
     int retval;
     /* export extrajoint pins */
-    if ((retval = hal_pin_float_newf(HAL_IN,  &(addr->posthome_cmd),  mot_comp_id,
+    if ((retval = hal_pin_new_real(mot_comp_id, HAL_IN,  &(addr->posthome_cmd), 0.0,
                                             "joint.%d.posthome-cmd",  num)) != 0) return retval;
     return 0;
 }


### PR DESCRIPTION
Update the motion controller code. It is mostly a trivial conversion, but there are many pins.

Some pin creation was changed to be consistently wrapped in the `CALL_CHECK()` macro. Also, some ternaries or trivial if/else constructs in setting boolean values were reduced to one-liners.
