### PR TITLE
hal: Update kinematics to getter/setter

### DIFF
--- a/src/emc/kinematics/5axiskins.c
+++ b/src/emc/kinematics/5axiskins.c
@@ -63,8 +63,8 @@
 
 #include "switchkins.h"
 
-struct haldata {
-    hal_float_t *pivot_length;
+static struct haldata {
+    hal_real_t pivot_length;
 } *haldata;
 static int fiveaxis_max_joints;
 
@@ -103,14 +103,15 @@ static int fiveaxis_KinematicsForward(const double *joints,
 {
     (void)fflags;
     (void)iflags;
-    PmCartesian r = s2r(*(haldata->pivot_length) + joints[JW],
+    rtapi_real pivot_length = hal_get_real(haldata->pivot_length);
+    PmCartesian r = s2r(pivot_length + joints[JW],
                         joints[JC],
                         180.0 - joints[JB]);
 
     // Note: 'principal' joints are used
     pos->tran.x = joints[JX] + r.x;
     pos->tran.y = joints[JY] + r.y;
-    pos->tran.z = joints[JZ] + *(haldata->pivot_length) + r.z;
+    pos->tran.z = joints[JZ] + pivot_length + r.z;
     pos->b      = joints[JB];
     pos->c      = joints[JC];
     pos->w      = joints[JW];
@@ -130,14 +131,15 @@ static int fiveaxis_KinematicsInverse(const EmcPose * pos,
 {
     (void)iflags;
     (void)fflags;
-    PmCartesian r = s2r(*(haldata->pivot_length) + pos->w,
+    rtapi_real pivot_length = hal_get_real(haldata->pivot_length);
+    PmCartesian r = s2r(pivot_length + pos->w,
                         pos->c,
                         180.0 - pos->b);
 
     EmcPose P;  // computed position
     P.tran.x = pos->tran.x - r.x;
     P.tran.y = pos->tran.y - r.y;
-    P.tran.z = pos->tran.z - *(haldata->pivot_length) - r.z;
+    P.tran.z = pos->tran.z - pivot_length - r.z;
 
     P.b = pos->b;
     P.c = pos->c;
@@ -210,13 +212,12 @@ int fiveaxis_KinematicsSetup(const  int   comp_id,
         if (axis_idx_for_jno[jno] == 8) {if (JW == -1) JW=jno;}
     }
 
-    haldata = hal_malloc(sizeof(struct haldata));
+    haldata = hal_malloc(sizeof(*haldata));
+    if(!haldata) goto error;
 
-    result = hal_pin_float_newf(HAL_IN,&(haldata->pivot_length),comp_id,
-                                "%s.pivot-length",kp->halprefix);
+    result = hal_pin_new_real(comp_id, HAL_IN, &(haldata->pivot_length),
+                              DEFAULT_PIVOT_LENGTH, "%s.pivot-length", kp->halprefix);
     if(result < 0) goto error;
-
-    *haldata->pivot_length = DEFAULT_PIVOT_LENGTH;
 
     rtapi_print("Kinematics Module %s\n",__FILE__);
     rtapi_print("  module name = %s\n"
@@ -225,7 +226,7 @@ int fiveaxis_KinematicsSetup(const  int   comp_id,
                 kp->kinsname,
                 coordinates,fiveaxis_max_joints,
                 kp->sparm?kp->sparm:"NOTSPECIFIED");
-    rtapi_print("  default pivot-length = %.3f\n",*haldata->pivot_length);
+    rtapi_print("  default pivot-length = %.3f\n", hal_get_real(haldata->pivot_length));
 
     return 0;
 

--- a/src/emc/kinematics/corexykins.c
+++ b/src/emc/kinematics/corexykins.c
@@ -5,17 +5,9 @@
 ********************************************************************/
 
 #include <rtapi.h>
-#include <rtapi.h>
 #include <rtapi_app.h>
-#include <rtapi_math.h>
-#include <rtapi_string.h>
 #include <hal.h>
-#include <emcmotcfg.h>
 #include <kinematics.h>
-
-static struct data {
-    hal_s32_t joints[EMCMOT_MAX_JOINTS];
-} *data;
 
 int kinematicsForward(const double *joints
                      ,EmcPose *pos
@@ -79,8 +71,6 @@ static int comp_id;
 int rtapi_app_main(void) {
     comp_id = hal_init("corexykins");
     if(comp_id < 0) return comp_id;
-
-    data = hal_malloc(sizeof(struct data));
 
     hal_ready(comp_id);
     return 0;

--- a/src/emc/kinematics/genhexkins.c
+++ b/src/emc/kinematics/genhexkins.c
@@ -116,46 +116,46 @@
 #include "switchkins.h"
 
 static struct haldata {
-    hal_float_t *basex[NUM_STRUTS];
-    hal_float_t *basey[NUM_STRUTS];
-    hal_float_t *basez[NUM_STRUTS];
-    hal_float_t *platformx[NUM_STRUTS];
-    hal_float_t *platformy[NUM_STRUTS];
-    hal_float_t *platformz[NUM_STRUTS];
-    hal_float_t *basenx[NUM_STRUTS];
-    hal_float_t *baseny[NUM_STRUTS];
-    hal_float_t *basenz[NUM_STRUTS];
-    hal_float_t *platformnx[NUM_STRUTS];
-    hal_float_t *platformny[NUM_STRUTS];
-    hal_float_t *platformnz[NUM_STRUTS];
-    hal_float_t *correction[NUM_STRUTS];
-    hal_float_t *screw_lead;
-    hal_u32_t   *last_iter;
-    hal_u32_t   *max_iter;
-    hal_u32_t   *iter_limit;
-    hal_float_t *max_error;
-    hal_float_t *conv_criterion;
-    hal_float_t *tool_offset;
-    hal_float_t *spindle_offset;
-    hal_bit_t   *fwd_kins_fail;
+    hal_real_t basex[NUM_STRUTS];
+    hal_real_t basey[NUM_STRUTS];
+    hal_real_t basez[NUM_STRUTS];
+    hal_real_t platformx[NUM_STRUTS];
+    hal_real_t platformy[NUM_STRUTS];
+    hal_real_t platformz[NUM_STRUTS];
+    hal_real_t basenx[NUM_STRUTS];
+    hal_real_t baseny[NUM_STRUTS];
+    hal_real_t basenz[NUM_STRUTS];
+    hal_real_t platformnx[NUM_STRUTS];
+    hal_real_t platformny[NUM_STRUTS];
+    hal_real_t platformnz[NUM_STRUTS];
+    hal_real_t correction[NUM_STRUTS];
+    hal_real_t screw_lead;
+    hal_uint_t last_iter;
+    hal_uint_t max_iter;
+    hal_uint_t iter_limit;
+    hal_real_t max_error;
+    hal_real_t conv_criterion;
+    hal_real_t tool_offset;
+    hal_real_t spindle_offset;
+    hal_bool_t fwd_kins_fail;
 
-    hal_float_t *gui_x;
-    hal_float_t *gui_y;
-    hal_float_t *gui_z;
-    hal_float_t *gui_a;
-    hal_float_t *gui_b;
-    hal_float_t *gui_c;
+    hal_real_t gui_x;
+    hal_real_t gui_y;
+    hal_real_t gui_z;
+    hal_real_t gui_a;
+    hal_real_t gui_b;
+    hal_real_t gui_c;
 
 } *haldata;
 
 static int genhex_gui_forward_kins(EmcPose *pos)
 {
-    *haldata->gui_x = pos->tran.x;
-    *haldata->gui_y = pos->tran.y;
-    *haldata->gui_z = pos->tran.z;
-    *haldata->gui_a = pos->a;
-    *haldata->gui_b = pos->b;
-    *haldata->gui_c = pos->c;
+    hal_set_real(haldata->gui_x, pos->tran.x);
+    hal_set_real(haldata->gui_y, pos->tran.y);
+    hal_set_real(haldata->gui_z, pos->tran.z);
+    hal_set_real(haldata->gui_a, pos->a);
+    hal_set_real(haldata->gui_b, pos->b);
+    hal_set_real(haldata->gui_c, pos->c);
     return 0;
 } // genhex_gui_forward_kins
 
@@ -275,20 +275,22 @@ static int genhex_read_hal_pins(void) {
     int t;
 
   /* set the base and platform coordinates from hal pin values */
+    rtapi_real spindle_offset = hal_get_real(haldata->spindle_offset);
+    rtapi_real tool_offset = hal_get_real(haldata->tool_offset);
     for (t = 0; t < NUM_STRUTS; t++) {
-        b[t].x   = *haldata->basex[t];
-        b[t].y   = *haldata->basey[t];
-        b[t].z   = *haldata->basez[t] + *haldata->spindle_offset + *haldata->tool_offset;
-        a[t].x   = *haldata->platformx[t];
-        a[t].y   = *haldata->platformy[t];
-        a[t].z   = *haldata->platformz[t] + *haldata->spindle_offset + *haldata->tool_offset;
+        b[t].x   = hal_get_real(haldata->basex[t]);
+        b[t].y   = hal_get_real(haldata->basey[t]);
+        b[t].z   = hal_get_real(haldata->basez[t]) + spindle_offset + tool_offset;
+        a[t].x   = hal_get_real(haldata->platformx[t]);
+        a[t].y   = hal_get_real(haldata->platformy[t]);
+        a[t].z   = hal_get_real(haldata->platformz[t]) + spindle_offset + tool_offset;
 
-        nb1[t].x = *haldata->basenx[t];
-        nb1[t].y = *haldata->baseny[t];
-        nb1[t].z = *haldata->basenz[t];
-        na0[t].x = *haldata->platformnx[t];
-        na0[t].y = *haldata->platformny[t];
-        na0[t].z = *haldata->platformnz[t];
+        nb1[t].x = hal_get_real(haldata->basenx[t]);
+        nb1[t].y = hal_get_real(haldata->baseny[t]);
+        nb1[t].z = hal_get_real(haldata->basenz[t]);
+        na0[t].x = hal_get_real(haldata->platformnx[t]);
+        na0[t].y = hal_get_real(haldata->platformny[t]);
+        na0[t].z = hal_get_real(haldata->platformnz[t]);
 
     }
     return 0;
@@ -317,7 +319,7 @@ static int StrutLengthCorrection(const PmCartesian * StrutVectUnit,
   /* define dot product */
   pmCartCartDot(&nb3, &na2, &dotprod);
 
-  *correction = *haldata->screw_lead * asin(dotprod) / PM_2_PI;
+  *correction = hal_get_real(haldata->screw_lead) * asin(dotprod) / PM_2_PI;
 
   return 0;
 } // StrutLengthCorrection()
@@ -374,12 +376,13 @@ static int genhexKinematicsForward(const double * joints,
   q_trans.z = pos->tran.z;
 
   /* Enter Newton-Raphson iterative method   */
+  rtapi_real max_error = hal_get_real(haldata->max_error);
   while (iterate) {
     /* check for large error and return error flag if no convergence */
-    if ((conv_err > +(*haldata->max_error)) ||
-        (conv_err < -(*haldata->max_error))) {
+    if ((conv_err > +max_error) ||
+        (conv_err < -max_error)) {
       /* we can't converge */
-      *haldata->fwd_kins_fail = 1;
+      hal_set_bool(haldata->fwd_kins_fail, 1);
       return -2;
     };
 
@@ -387,9 +390,9 @@ static int genhexKinematicsForward(const double * joints,
 
     /* check iteration to see if the kinematics can reach the
        convergence criterion and return error flag if it can't */
-    if (iteration > *haldata->iter_limit) {
+    if (iteration > hal_get_ui32(haldata->iter_limit)) {
       /* we can't converge */
-      *haldata->fwd_kins_fail = 1;
+      hal_set_bool(haldata->fwd_kins_fail, 1);
       return -5;
     }
 
@@ -404,12 +407,12 @@ static int genhexKinematicsForward(const double * joints,
       pmCartCartAdd(&q_trans, &RMatrix_a, &aw);
       pmCartCartSub(&aw, &b[i], &InvKinStrutVect);
       if (0 != pmCartUnit(&InvKinStrutVect, &InvKinStrutVectUnit)) {
-        *haldata->fwd_kins_fail = 1;
+        hal_set_bool(haldata->fwd_kins_fail, 1);
         return -1;
       }
       pmCartMag(&InvKinStrutVect, &InvKinStrutLength);
 
-      if (*haldata->screw_lead != 0.0) {
+      if (hal_get_real(haldata->screw_lead) != 0.0) {
         /* enable strut length correction */
         StrutLengthCorrection(&InvKinStrutVectUnit, &RMatrix, i, &corr);
         /* define corrected joint lengths */
@@ -452,8 +455,9 @@ static int genhexKinematicsForward(const double * joints,
 
     /* enter loop to determine if a strut needs another iteration */
     iterate = 0;            /*assume iteration is done */
+    rtapi_real conv_criterion = hal_get_real(haldata->conv_criterion);
     for (i = 0; i < NUM_STRUTS; i++) {
-      if (fabs(StrutLengthDiff[i]) > *haldata->conv_criterion) {
+      if (fabs(StrutLengthDiff[i]) > conv_criterion) {
     iterate = 1;
       }
     }
@@ -469,12 +473,12 @@ static int genhexKinematicsForward(const double * joints,
   pos->tran.y = q_trans.y;
   pos->tran.z = q_trans.z;
 
-  *haldata->last_iter = iteration;
+  hal_set_ui32(haldata->last_iter, iteration);
 
-  if (iteration > *haldata->max_iter){
-    *haldata->max_iter = iteration;
+  if (iteration > hal_get_ui32(haldata->max_iter)){
+    hal_set_ui32(haldata->max_iter, iteration);
   }
-  *haldata->fwd_kins_fail = 0;
+  hal_set_bool(haldata->fwd_kins_fail, 0);
 
   genhex_gui_forward_kins(pos);
 
@@ -522,7 +526,7 @@ static int genhexKinematicsInverse(const EmcPose * pos,
     pmCartCartSub(&aw, &b[i], &InvKinStrutVect);
     pmCartMag(&InvKinStrutVect, &InvKinStrutLength);
 
-    if (*haldata->screw_lead != 0.0) {
+    if (hal_get_real(haldata->screw_lead) != 0.0) {
       /* enable strut length correction */
       /* define unit strut vector */
       if (0 != pmCartUnit(&InvKinStrutVect, &InvKinStrutVectUnit)) {
@@ -530,7 +534,7 @@ static int genhexKinematicsInverse(const EmcPose * pos,
       }
       /* define correction value and corrected joint lengths */
       StrutLengthCorrection(&InvKinStrutVectUnit, &RMatrix, i, &corr);
-      *haldata->correction[i] = corr;
+      hal_set_real(haldata->correction[i], corr);
       InvKinStrutLength += corr;
     }
 
@@ -540,6 +544,57 @@ static int genhexKinematicsInverse(const EmcPose * pos,
   return 0;
 } //genhexKinematicsInverse()
 
+// HAL pin initializaion values. In small arrays so we can easily
+// address them in the pin creation loop.
+static const rtapi_real init_basex[NUM_STRUTS] = {
+    DEFAULT_BASE_0_X, DEFAULT_BASE_1_X, DEFAULT_BASE_2_X,
+    DEFAULT_BASE_3_X, DEFAULT_BASE_4_X, DEFAULT_BASE_5_X,
+};
+static const rtapi_real init_basey[NUM_STRUTS] = {
+    DEFAULT_BASE_0_Y, DEFAULT_BASE_1_Y, DEFAULT_BASE_2_Y,
+    DEFAULT_BASE_3_Y, DEFAULT_BASE_4_Y, DEFAULT_BASE_5_Y,
+};
+static const rtapi_real init_basez[NUM_STRUTS] = {
+    DEFAULT_BASE_0_Z, DEFAULT_BASE_1_Z, DEFAULT_BASE_2_Z,
+    DEFAULT_BASE_3_Z, DEFAULT_BASE_4_Z, DEFAULT_BASE_5_Z,
+};
+static const rtapi_real init_platformx[NUM_STRUTS] = {
+    DEFAULT_PLATFORM_0_X, DEFAULT_PLATFORM_1_X, DEFAULT_PLATFORM_2_X,
+    DEFAULT_PLATFORM_3_X, DEFAULT_PLATFORM_4_X, DEFAULT_PLATFORM_5_X,
+};
+static const rtapi_real init_platformy[NUM_STRUTS] = {
+    DEFAULT_PLATFORM_0_Y, DEFAULT_PLATFORM_1_Y, DEFAULT_PLATFORM_2_Y,
+    DEFAULT_PLATFORM_3_Y, DEFAULT_PLATFORM_4_Y, DEFAULT_PLATFORM_5_Y,
+};
+static const rtapi_real init_platformz[NUM_STRUTS] = {
+    DEFAULT_PLATFORM_0_Z, DEFAULT_PLATFORM_1_Z, DEFAULT_PLATFORM_2_Z,
+    DEFAULT_PLATFORM_3_Z, DEFAULT_PLATFORM_4_Z, DEFAULT_PLATFORM_5_Z,
+};
+static const rtapi_real init_basenx[NUM_STRUTS] = {
+    DEFAULT_BASE_0_NX, DEFAULT_BASE_1_NX, DEFAULT_BASE_2_NX,
+    DEFAULT_BASE_3_NX, DEFAULT_BASE_4_NX, DEFAULT_BASE_5_NX,
+};
+static const rtapi_real init_baseny[NUM_STRUTS] = {
+    DEFAULT_BASE_0_NY, DEFAULT_BASE_1_NY, DEFAULT_BASE_2_NY,
+    DEFAULT_BASE_3_NY, DEFAULT_BASE_4_NY, DEFAULT_BASE_5_NY,
+};
+static const rtapi_real init_basenz[NUM_STRUTS] = {
+    DEFAULT_BASE_0_NZ, DEFAULT_BASE_1_NZ, DEFAULT_BASE_2_NZ,
+    DEFAULT_BASE_3_NZ, DEFAULT_BASE_4_NZ, DEFAULT_BASE_5_NZ,
+};
+static const rtapi_real init_platformnx[NUM_STRUTS] = {
+    DEFAULT_PLATFORM_0_NX, DEFAULT_PLATFORM_1_NX, DEFAULT_PLATFORM_2_NX,
+    DEFAULT_PLATFORM_3_NX, DEFAULT_PLATFORM_4_NX, DEFAULT_PLATFORM_5_NX,
+};
+static const rtapi_real init_platformny[NUM_STRUTS] = {
+    DEFAULT_PLATFORM_0_NY, DEFAULT_PLATFORM_1_NY, DEFAULT_PLATFORM_2_NY,
+    DEFAULT_PLATFORM_3_NY, DEFAULT_PLATFORM_4_NY, DEFAULT_PLATFORM_5_NY,
+};
+static const rtapi_real init_platformnz[NUM_STRUTS] = {
+    DEFAULT_PLATFORM_0_NZ, DEFAULT_PLATFORM_1_NZ, DEFAULT_PLATFORM_2_NZ,
+    DEFAULT_PLATFORM_3_NZ, DEFAULT_PLATFORM_4_NZ, DEFAULT_PLATFORM_5_NZ,
+};
+
 static
 int genhexKinematicsSetup(const  int   comp_id,
                           const  char* coordinates,
@@ -548,6 +603,12 @@ int genhexKinematicsSetup(const  int   comp_id,
     (void)coordinates;
     int i,res=0;
 
+    if (kp->max_joints < 0 || kp->max_joints > NUM_STRUTS) {
+        rtapi_print_msg(RTAPI_MSG_ERR, "genhexKinematicsSetup: max_joints %d less than 0 or larger NUM_STRUTS %d\n",
+                        kp->max_joints, NUM_STRUTS);
+        return -1;
+    }
+
     haldata = hal_malloc(sizeof(struct haldata));
     if (!haldata) {
         rtapi_print_msg(RTAPI_MSG_ERR,"genhexKinematicsSetup: hal_malloc fail\n");
@@ -555,150 +616,64 @@ int genhexKinematicsSetup(const  int   comp_id,
     }
 
     for (i = 0; i < kp->max_joints; i++) {
-        res += hal_pin_float_newf(HAL_IN, &(haldata->basex[i]), comp_id,
-            "%s.base.%d.x", kp->halprefix, i);
-        res += hal_pin_float_newf(HAL_IN, &haldata->basey[i], comp_id,
-            "%s.base.%d.y", kp->halprefix, i);
-        res += hal_pin_float_newf(HAL_IN, &haldata->basez[i], comp_id,
-            "%s.base.%d.z", kp->halprefix, i);
-        res += hal_pin_float_newf(HAL_IN, &haldata->platformx[i], comp_id,
-            "%s.platform.%d.x", kp->halprefix, i);
-        res += hal_pin_float_newf(HAL_IN, &haldata->platformy[i], comp_id,
-            "%s.platform.%d.y", kp->halprefix, i);
-        res += hal_pin_float_newf(HAL_IN, &haldata->platformz[i], comp_id,
-            "%s.platform.%d.z", kp->halprefix, i);
-        res += hal_pin_float_newf(HAL_IN, &haldata->basenx[i], comp_id,
-            "%s.base-n.%d.x", kp->halprefix, i);
-        res += hal_pin_float_newf(HAL_IN, &haldata->baseny[i], comp_id,
-            "%s.base-n.%d.y", kp->halprefix, i);
-        res += hal_pin_float_newf(HAL_IN, &haldata->basenz[i], comp_id,
-            "%s.base-n.%d.z", kp->halprefix, i);
-        res += hal_pin_float_newf(HAL_IN, &haldata->platformnx[i], comp_id,
-            "%s.platform-n.%d.x", kp->halprefix, i);
-        res += hal_pin_float_newf(HAL_IN, &haldata->platformny[i], comp_id,
-            "%s.platform-n.%d.y", kp->halprefix, i);
-        res += hal_pin_float_newf(HAL_IN, &haldata->platformnz[i], comp_id,
-            "%s.platform-n.%d.z", kp->halprefix, i);
-        res += hal_pin_float_newf(HAL_OUT, &haldata->correction[i], comp_id,
-            "%s.correction.%d", kp->halprefix, i);
+        res += hal_pin_new_real(comp_id, HAL_IN, &(haldata->basex[i]),
+                                init_basex[i], "%s.base.%d.x", kp->halprefix, i);
+        res += hal_pin_new_real(comp_id, HAL_IN, &haldata->basey[i],
+                                init_basey[i], "%s.base.%d.y", kp->halprefix, i);
+        res += hal_pin_new_real(comp_id, HAL_IN, &haldata->basez[i],
+                                init_basez[i], "%s.base.%d.z", kp->halprefix, i);
+        res += hal_pin_new_real(comp_id, HAL_IN, &haldata->platformx[i],
+                                init_platformx[i], "%s.platform.%d.x", kp->halprefix, i);
+        res += hal_pin_new_real(comp_id, HAL_IN, &haldata->platformy[i],
+                                init_platformy[i], "%s.platform.%d.y", kp->halprefix, i);
+        res += hal_pin_new_real(comp_id, HAL_IN, &haldata->platformz[i],
+                                init_platformz[i], "%s.platform.%d.z", kp->halprefix, i);
+        res += hal_pin_new_real(comp_id, HAL_IN, &haldata->basenx[i],
+                                init_basenx[i], "%s.base-n.%d.x", kp->halprefix, i);
+        res += hal_pin_new_real(comp_id, HAL_IN, &haldata->baseny[i],
+                                init_baseny[i], "%s.base-n.%d.y", kp->halprefix, i);
+        res += hal_pin_new_real(comp_id, HAL_IN, &haldata->basenz[i],
+                                init_basenz[i], "%s.base-n.%d.z", kp->halprefix, i);
+        res += hal_pin_new_real(comp_id, HAL_IN, &haldata->platformnx[i],
+                                init_platformnx[i], "%s.platform-n.%d.x", kp->halprefix, i);
+        res += hal_pin_new_real(comp_id, HAL_IN, &haldata->platformny[i],
+                                init_platformny[i], "%s.platform-n.%d.y", kp->halprefix, i);
+        res += hal_pin_new_real(comp_id, HAL_IN, &haldata->platformnz[i],
+                                init_platformnz[i], "%s.platform-n.%d.z", kp->halprefix, i);
+        res += hal_pin_new_real(comp_id, HAL_OUT, &haldata->correction[i],
+                                0.0, "%s.correction.%d", kp->halprefix, i);
         if (res) {goto error;}
-        *haldata->correction[i] = 0.0;
-
     }
 
-    res += hal_pin_u32_newf(HAL_OUT, &haldata->last_iter, comp_id,
-        "genhexkins.last-iterations");
-    *haldata->last_iter = 0;
-    res += hal_pin_u32_newf(HAL_OUT, &haldata->max_iter, comp_id,
-        "genhexkins.max-iterations");
-    *haldata->max_iter = 0;
-    res += hal_pin_float_newf(HAL_IN, &haldata->max_error, comp_id,
-        "genhexkins.max-error");
-    *haldata->max_error = 500.0;
-    res += hal_pin_float_newf(HAL_IN, &haldata->conv_criterion, comp_id,
-        "genhexkins.convergence-criterion");
-    *haldata->conv_criterion = 1e-9;
-    res += hal_pin_u32_newf(HAL_IN, &haldata->iter_limit, comp_id,
-        "genhexkins.limit-iterations");
-    *haldata->iter_limit = 120;
-    res += hal_pin_float_newf(HAL_IN, &haldata->tool_offset, comp_id,
-        "genhexkins.tool-offset");
-    *haldata->tool_offset = 0.0;
-    res += hal_pin_float_newf(HAL_IN, &haldata->spindle_offset, comp_id,
-        "genhexkins.spindle-offset");
-    *haldata->spindle_offset = 0.0;
-    res += hal_pin_float_newf(HAL_IN, &haldata->screw_lead, comp_id,
-        "genhexkins.screw-lead");
-    *haldata->screw_lead = DEFAULT_SCREW_LEAD;
+    res += hal_pin_new_ui32(comp_id, HAL_OUT, &haldata->last_iter,
+                            0, "genhexkins.last-iterations");
+    res += hal_pin_new_ui32(comp_id, HAL_OUT, &haldata->max_iter,
+                            0, "genhexkins.max-iterations");
+    res += hal_pin_new_real(comp_id, HAL_IN, &haldata->max_error,
+                            500.0, "genhexkins.max-error");
+    res += hal_pin_new_real(comp_id, HAL_IN, &haldata->conv_criterion,
+                            1e-9, "genhexkins.convergence-criterion");
+    res += hal_pin_new_ui32(comp_id, HAL_IN, &haldata->iter_limit,
+                            120, "genhexkins.limit-iterations");
+    res += hal_pin_new_real(comp_id, HAL_IN, &haldata->tool_offset,
+                            0.0, "genhexkins.tool-offset");
+    res += hal_pin_new_real(comp_id, HAL_IN, &haldata->spindle_offset,
+                            0.0, "genhexkins.spindle-offset");
+    res += hal_pin_new_real(comp_id, HAL_IN, &haldata->screw_lead,
+                            DEFAULT_SCREW_LEAD, "genhexkins.screw-lead");
 
     if (res) {goto error;}
 
-    *haldata->basex[0] = DEFAULT_BASE_0_X;
-    *haldata->basey[0] = DEFAULT_BASE_0_Y;
-    *haldata->basez[0] = DEFAULT_BASE_0_Z;
-    *haldata->basex[1] = DEFAULT_BASE_1_X;
-    *haldata->basey[1] = DEFAULT_BASE_1_Y;
-    *haldata->basez[1] = DEFAULT_BASE_1_Z;
-    *haldata->basex[2] = DEFAULT_BASE_2_X;
-    *haldata->basey[2] = DEFAULT_BASE_2_Y;
-    *haldata->basez[2] = DEFAULT_BASE_2_Z;
-    *haldata->basex[3] = DEFAULT_BASE_3_X;
-    *haldata->basey[3] = DEFAULT_BASE_3_Y;
-    *haldata->basez[3] = DEFAULT_BASE_3_Z;
-    *haldata->basex[4] = DEFAULT_BASE_4_X;
-    *haldata->basey[4] = DEFAULT_BASE_4_Y;
-    *haldata->basez[4] = DEFAULT_BASE_4_Z;
-    *haldata->basex[5] = DEFAULT_BASE_5_X;
-    *haldata->basey[5] = DEFAULT_BASE_5_Y;
-    *haldata->basez[5] = DEFAULT_BASE_5_Z;
-
-    *haldata->platformx[0] = DEFAULT_PLATFORM_0_X;
-    *haldata->platformy[0] = DEFAULT_PLATFORM_0_Y;
-    *haldata->platformz[0] = DEFAULT_PLATFORM_0_Z;
-    *haldata->platformx[1] = DEFAULT_PLATFORM_1_X;
-    *haldata->platformy[1] = DEFAULT_PLATFORM_1_Y;
-    *haldata->platformz[1] = DEFAULT_PLATFORM_1_Z;
-    *haldata->platformx[2] = DEFAULT_PLATFORM_2_X;
-    *haldata->platformy[2] = DEFAULT_PLATFORM_2_Y;
-    *haldata->platformz[2] = DEFAULT_PLATFORM_2_Z;
-    *haldata->platformx[3] = DEFAULT_PLATFORM_3_X;
-    *haldata->platformy[3] = DEFAULT_PLATFORM_3_Y;
-    *haldata->platformz[3] = DEFAULT_PLATFORM_3_Z;
-    *haldata->platformx[4] = DEFAULT_PLATFORM_4_X;
-    *haldata->platformy[4] = DEFAULT_PLATFORM_4_Y;
-    *haldata->platformz[4] = DEFAULT_PLATFORM_4_Z;
-    *haldata->platformx[5] = DEFAULT_PLATFORM_5_X;
-    *haldata->platformy[5] = DEFAULT_PLATFORM_5_Y;
-    *haldata->platformz[5] = DEFAULT_PLATFORM_5_Z;
-
-    *haldata->basenx[0] = DEFAULT_BASE_0_NX;
-    *haldata->baseny[0] = DEFAULT_BASE_0_NY;
-    *haldata->basenz[0] = DEFAULT_BASE_0_NZ;
-    *haldata->basenx[1] = DEFAULT_BASE_1_NX;
-    *haldata->baseny[1] = DEFAULT_BASE_1_NY;
-    *haldata->basenz[1] = DEFAULT_BASE_1_NZ;
-    *haldata->basenx[2] = DEFAULT_BASE_2_NX;
-    *haldata->baseny[2] = DEFAULT_BASE_2_NY;
-    *haldata->basenz[2] = DEFAULT_BASE_2_NZ;
-    *haldata->basenx[3] = DEFAULT_BASE_3_NX;
-    *haldata->baseny[3] = DEFAULT_BASE_3_NY;
-    *haldata->basenz[3] = DEFAULT_BASE_3_NZ;
-    *haldata->basenx[4] = DEFAULT_BASE_4_NX;
-    *haldata->baseny[4] = DEFAULT_BASE_4_NY;
-    *haldata->basenz[4] = DEFAULT_BASE_4_NZ;
-    *haldata->basenx[5] = DEFAULT_BASE_5_NX;
-    *haldata->baseny[5] = DEFAULT_BASE_5_NY;
-    *haldata->basenz[5] = DEFAULT_BASE_5_NZ;
-
-    *haldata->platformnx[0] = DEFAULT_PLATFORM_0_NX;
-    *haldata->platformny[0] = DEFAULT_PLATFORM_0_NY;
-    *haldata->platformnz[0] = DEFAULT_PLATFORM_0_NZ;
-    *haldata->platformnx[1] = DEFAULT_PLATFORM_1_NX;
-    *haldata->platformny[1] = DEFAULT_PLATFORM_1_NY;
-    *haldata->platformnz[1] = DEFAULT_PLATFORM_1_NZ;
-    *haldata->platformnx[2] = DEFAULT_PLATFORM_2_NX;
-    *haldata->platformny[2] = DEFAULT_PLATFORM_2_NY;
-    *haldata->platformnz[2] = DEFAULT_PLATFORM_2_NZ;
-    *haldata->platformnx[3] = DEFAULT_PLATFORM_3_NX;
-    *haldata->platformny[3] = DEFAULT_PLATFORM_3_NY;
-    *haldata->platformnz[3] = DEFAULT_PLATFORM_3_NZ;
-    *haldata->platformnx[4] = DEFAULT_PLATFORM_4_NX;
-    *haldata->platformny[4] = DEFAULT_PLATFORM_4_NY;
-    *haldata->platformnz[4] = DEFAULT_PLATFORM_4_NZ;
-    *haldata->platformnx[5] = DEFAULT_PLATFORM_5_NX;
-    *haldata->platformny[5] = DEFAULT_PLATFORM_5_NY;
-    *haldata->platformnz[5] = DEFAULT_PLATFORM_5_NZ;
-
     //note: switchkins does not uses these as it provides gui.x, gui.y, etc.
-    res += hal_pin_float_newf(HAL_IN, &haldata->gui_x, comp_id, "genhexkins.x");
-    res += hal_pin_float_newf(HAL_IN, &haldata->gui_y, comp_id, "genhexkins.y");
-    res += hal_pin_float_newf(HAL_IN, &haldata->gui_z, comp_id, "genhexkins.z");
-    res += hal_pin_float_newf(HAL_IN, &haldata->gui_a, comp_id, "genhexkins.a");
-    res += hal_pin_float_newf(HAL_IN, &haldata->gui_b, comp_id, "genhexkins.b");
-    res += hal_pin_float_newf(HAL_IN, &haldata->gui_c, comp_id, "genhexkins.c");
+    res += hal_pin_new_real(comp_id, HAL_IN, &haldata->gui_x, 0.0, "genhexkins.x");
+    res += hal_pin_new_real(comp_id, HAL_IN, &haldata->gui_y, 0.0, "genhexkins.y");
+    res += hal_pin_new_real(comp_id, HAL_IN, &haldata->gui_z, 0.0, "genhexkins.z");
+    res += hal_pin_new_real(comp_id, HAL_IN, &haldata->gui_a, 0.0, "genhexkins.a");
+    res += hal_pin_new_real(comp_id, HAL_IN, &haldata->gui_b, 0.0, "genhexkins.b");
+    res += hal_pin_new_real(comp_id, HAL_IN, &haldata->gui_c, 0.0, "genhexkins.c");
 
-    res += hal_pin_bit_newf(HAL_OUT, &haldata->fwd_kins_fail, comp_id,
-        "genhexkins.fwd-kins-fail");
+    res += hal_pin_new_bool(comp_id, HAL_OUT, &haldata->fwd_kins_fail,
+                            0, "genhexkins.fwd-kins-fail");
 
     if (res) goto error;
     return 0;

--- a/src/emc/kinematics/genserfuncs.c
+++ b/src/emc/kinematics/genserfuncs.c
@@ -53,12 +53,12 @@
 #endif
 
 static struct haldata {
-    hal_u32_t     *max_iterations;
-    hal_u32_t     *last_iterations;
-    hal_float_t   *a[GENSER_MAX_JOINTS];
-    hal_float_t   *alpha[GENSER_MAX_JOINTS];
-    hal_float_t   *d[GENSER_MAX_JOINTS];
-    hal_s32_t     *unrotate[GENSER_MAX_JOINTS];
+    hal_uint_t max_iterations;
+    hal_uint_t last_iterations;
+    hal_real_t a[GENSER_MAX_JOINTS];
+    hal_real_t alpha[GENSER_MAX_JOINTS];
+    hal_real_t d[GENSER_MAX_JOINTS];
+    hal_sint_t unrotate[GENSER_MAX_JOINTS];
     genser_struct *kins;
     go_pose *pos; // used in various functions, we malloc it
                   // only once in genserKinematicsSetup()
@@ -66,10 +66,6 @@ static struct haldata {
 
 static int total_joints;
 double j[GENSER_MAX_JOINTS];
-
-#define A(i) (*(haldata->a[i]))
-#define ALPHA(i) (*(haldata->alpha[i]))
-#define D(i) (*(haldata->d[i]))
 
 #define KINS_PTR (haldata->kins)
 
@@ -87,9 +83,9 @@ int genser_kin_init(void) {
     /* init them all and make them revolute joints */
     /* FIXME: should allow LINEAR joints based on HAL param too */
     for (t = 0; t < GENSER_MAX_JOINTS; t++) {
-        genser->links[t].u.dh.a = A(t);
-        genser->links[t].u.dh.alpha = ALPHA(t);
-        genser->links[t].u.dh.d = D(t);
+        genser->links[t].u.dh.a = hal_get_real(haldata->a[t]);
+        genser->links[t].u.dh.alpha = hal_get_real(haldata->alpha[t]);
+        genser->links[t].u.dh.d = hal_get_real(haldata->d[t]);
         genser->links[t].u.dh.theta = 0;
         genser->links[t].type = GO_LINK_DH;
         genser->links[t].quantity = GO_QUANTITY_ANGLE;
@@ -341,8 +337,9 @@ int genserKinematicsForward(const double *joint,
         if (!GO_ROT_CLOSE(j[i],joint[i])) changed = 1;
         // convert to radians to pass to genser_kin_fwd
         jcopy[i] = joint[i] * PM_PI / 180;
-        if ((i) && *(haldata->unrotate[i]))
-            jcopy[i] -= *(haldata->unrotate[i])*jcopy[i-1];
+        rtapi_s32 unrotate = hal_get_si32(haldata->unrotate[i]);
+        if ((i) && unrotate)
+            jcopy[i] -= unrotate * jcopy[i-1];
     }
 
     if (changed) {
@@ -473,9 +470,9 @@ int genserKinematicsInverse(const EmcPose * world,
     }
 
     for (genser->iterations = 0;
-         genser->iterations < *haldata->max_iterations;
+         genser->iterations < hal_get_ui32(haldata->max_iterations);
          genser->iterations++) {
-         *(haldata->last_iterations) = genser->iterations;
+         hal_set_ui32(haldata->last_iterations, genser->iterations);
         /* update the Jacobians */
         for (link = 0; link < genser->link_num; link++) {
             go_link_joint_set(&genser->links[link], jest[link], &linkout[link]);
@@ -557,8 +554,9 @@ int genserKinematicsInverse(const EmcPose * world,
             for (link = 0; link < genser->link_num; link++) {
                 // convert from radians back to angles
                 joints[link] = jest[link] * 180 / PM_PI;
-                if ((link) && *(haldata->unrotate[link]))
-                    joints[link] += *(haldata->unrotate[link]) * joints[link-1];
+                rtapi_s32 unrotate = hal_get_si32(haldata->unrotate[link]);
+                if ((link) && unrotate)
+                    joints[link] += unrotate * joints[link-1];
             }
             //rtapi_print("DONEkineInverse(joints: %f %f %f %f %f %f), (iterations=%d)\n",
             //     joints[0],joints[1],joints[2],joints[3],joints[4],joints[5], genser->iterations);
@@ -591,14 +589,25 @@ int genser_kin_inv_iterations(genser_struct * genser)
 int genser_kin_inv_set_max_iterations(int i)
 {
     if (i <= 0) return GO_RESULT_ERROR;
-    *haldata->max_iterations = i;
+    hal_set_ui32(haldata->max_iterations, i);
     return GO_RESULT_OK;
 }
 
 int genser_kin_inv_get_max_iterations()
 {
-    return *haldata->max_iterations;
+    return hal_get_ui32(haldata->max_iterations);
 }
+
+static const rtapi_real init_a[GENSER_MAX_JOINTS] = {
+    DEFAULT_A1, DEFAULT_A2, DEFAULT_A3, DEFAULT_A4, DEFAULT_A5, DEFAULT_A6
+};
+static const rtapi_real init_alpha[GENSER_MAX_JOINTS] = {
+    DEFAULT_ALPHA1, DEFAULT_ALPHA2, DEFAULT_ALPHA3, DEFAULT_ALPHA4, DEFAULT_ALPHA5, DEFAULT_ALPHA6
+};
+static const rtapi_real init_d[GENSER_MAX_JOINTS] = {
+    DEFAULT_D1, DEFAULT_D2, DEFAULT_D3, DEFAULT_D4, DEFAULT_D5, DEFAULT_D6
+};
+
 
 int genserKinematicsSetup(const int comp_id,
                     const char* coordinates,
@@ -613,52 +622,27 @@ int genserKinematicsSetup(const int comp_id,
     total_joints = kp->max_joints;
 
     // only the first 6 joints have A,ALPHA,D,unrotate pins
-    for (i = 0; i < 6; i++) {
-        res += hal_pin_float_newf(HAL_IN, &(haldata->a[i]), comp_id,
-               "%s.A-%d", kp->halprefix, i);
-        *(haldata->a[i])=0;
-        res += hal_pin_float_newf(HAL_IN, &(haldata->alpha[i]), comp_id,
-               "%s.ALPHA-%d", kp->halprefix, i);
-        *(haldata->alpha[i])=0;
-        res += hal_pin_float_newf(HAL_IN, &(haldata->d[i]), comp_id,
-               "%s.D-%d", kp->halprefix, i);
-        *(haldata->d[i])=0;
-        res += hal_pin_s32_newf(HAL_IN, &(haldata->unrotate[i]), comp_id,
-              "%s.unrotate-%d", kp->halprefix, i);
-        *haldata->unrotate[i]=0;
+    for (i = 0; i < GENSER_MAX_JOINTS; i++) {
+        res += hal_pin_new_real(comp_id, HAL_IN, &(haldata->a[i]),
+                                init_a[i], "%s.A-%d", kp->halprefix, i);
+        res += hal_pin_new_real(comp_id, HAL_IN, &(haldata->alpha[i]),
+                                init_alpha[i], "%s.ALPHA-%d", kp->halprefix, i);
+        res += hal_pin_new_real(comp_id, HAL_IN, &(haldata->d[i]),
+                                init_d[i], "%s.D-%d", kp->halprefix, i);
+        res += hal_pin_new_si32(comp_id, HAL_IN, &(haldata->unrotate[i]),
+                                0, "%s.unrotate-%d", kp->halprefix, i);
     }
-    res += hal_pin_u32_newf(HAL_OUT, &(haldata->last_iterations), comp_id,
-          "%s.last-iterations",kp->halprefix);
+    res += hal_pin_new_ui32(comp_id, HAL_OUT, &(haldata->last_iterations),
+                            0, "%s.last-iterations",kp->halprefix);
 
     KINS_PTR = hal_malloc(sizeof(genser_struct));
     haldata->pos = (go_pose *) hal_malloc(sizeof(go_pose));
     if (KINS_PTR     == NULL) {goto error;}
     if (haldata->pos == NULL) {goto error;}
-    res += hal_pin_u32_newf(HAL_IN, &haldata->max_iterations, comp_id,
-          "%s.max-iterations",kp->halprefix);
+    res += hal_pin_new_ui32(comp_id, HAL_IN, &haldata->max_iterations,
+                            GENSER_DEFAULT_MAX_ITERATIONS, "%s.max-iterations",kp->halprefix);
 
     if (res) {goto error;}
-
-    *haldata->max_iterations = GENSER_DEFAULT_MAX_ITERATIONS;
-
-    A(0) = DEFAULT_A1;
-    A(1) = DEFAULT_A2;
-    A(2) = DEFAULT_A3;
-    A(3) = DEFAULT_A4;
-    A(4) = DEFAULT_A5;
-    A(5) = DEFAULT_A6;
-    ALPHA(0) = DEFAULT_ALPHA1;
-    ALPHA(1) = DEFAULT_ALPHA2;
-    ALPHA(2) = DEFAULT_ALPHA3;
-    ALPHA(3) = DEFAULT_ALPHA4;
-    ALPHA(4) = DEFAULT_ALPHA5;
-    ALPHA(5) = DEFAULT_ALPHA6;
-    D(0) = DEFAULT_D1;
-    D(1) = DEFAULT_D2;
-    D(2) = DEFAULT_D3;
-    D(3) = DEFAULT_D4;
-    D(4) = DEFAULT_D5;
-    D(5) = DEFAULT_D6;
 
     genser_hal_inited = 1;
     return 0;

--- a/src/emc/kinematics/genserkins.h
+++ b/src/emc/kinematics/genserkins.h
@@ -76,7 +76,7 @@
 typedef struct {
   go_link links[GENSER_MAX_JOINTS]; /*!< The link description of the device. */
   int link_num;                /*!< How many are actually present. */
-  hal_u32_t iterations;        /*!< How many iterations were actually used to compute the inverse kinematics. */
+  unsigned iterations;         /*!< How many iterations were actually used to compute the inverse kinematics. */
 } genser_struct;
 
 extern int genser_kin_size(void);

--- a/src/emc/kinematics/lineardeltakins.c
+++ b/src/emc/kinematics/lineardeltakins.c
@@ -21,12 +21,13 @@
 
 #include "lineardeltakins-common.h"
 
-struct haldata
+static struct haldata
 {
-    hal_float_t *r, *l;
+    hal_real_t r;
+    hal_real_t l;
 } *haldata;
 
-int comp_id;
+static int comp_id;
 
 int kinematicsForward(const double * joints,
                       EmcPose * pos,
@@ -34,7 +35,7 @@ int kinematicsForward(const double * joints,
                       KINEMATICS_INVERSE_FLAGS * iflags) {
     (void)fflags;
     (void)iflags;
-    set_geometry(*haldata->r, *haldata->l);
+    set_geometry(hal_get_real(haldata->r), hal_get_real(haldata->l));
     return kinematics_forward(joints, pos);
 }
 
@@ -43,7 +44,7 @@ int kinematicsInverse(const EmcPose *pos, double *joints,
         KINEMATICS_FORWARD_FLAGS *fflags) {
     (void)iflags;
     (void)fflags;
-    set_geometry(*haldata->r, *haldata->l);
+    set_geometry(hal_get_real(haldata->r), hal_get_real(haldata->l));
     return kinematics_inverse(pos, joints);
 }
 
@@ -54,35 +55,24 @@ KINEMATICS_TYPE kinematicsType()
 
 int rtapi_app_main(void)
 {
-    int retval = 0;
+    int retval;
 
     comp_id = hal_init("lineardeltakins");
-    if(comp_id < 0) retval = comp_id;
+    if(comp_id < 0) return comp_id;
 
-    if(retval == 0)
-    {
-        haldata = hal_malloc(sizeof(struct haldata));
-        retval = !haldata;
-    }
+    haldata = hal_malloc(sizeof(*haldata));
+    if(!haldata) { retval = -ENOMEM; goto error; }
 
-    if(retval == 0)
-        retval = hal_pin_float_newf(HAL_IN, &haldata->r, comp_id,
-                "lineardeltakins.R");
-    if(retval == 0)
-        retval = hal_pin_float_newf(HAL_IN, &haldata->l, comp_id,
-                "lineardeltakins.L");
+    if((retval = hal_pin_new_real(comp_id, HAL_IN, &haldata->r, DELTA_RADIUS, "lineardeltakins.R")) < 0)
+        goto error;
+    if((retval = hal_pin_new_real(comp_id, HAL_IN, &haldata->l, DELTA_DIAGONAL_ROD, "lineardeltakins.L")) < 0)
+        goto error;
 
-    if(retval == 0)
-    {
-        *haldata->r = DELTA_RADIUS;
-        *haldata->l = DELTA_DIAGONAL_ROD;
-    }
+    hal_ready(comp_id);
+    return 0;
 
-    if(retval == 0)
-    {
-        hal_ready(comp_id);
-    }
-
+error:
+    hal_exit(comp_id);
     return retval;
 }
 

--- a/src/emc/kinematics/maxkins.c
+++ b/src/emc/kinematics/maxkins.c
@@ -29,9 +29,9 @@
 #define hypot(a,b) (sqrt((a)*(a)+(b)*(b)))
 #endif
 
-struct haldata {
-    hal_float_t *pivot_length;
-    hal_bit_t *conventional_directions; //default is false
+static struct haldata {
+    hal_real_t pivot_length;
+    hal_bool_t conventional_directions; //default is false
 } *haldata;
 
 int kinematicsForward(const double *joints,
@@ -42,11 +42,12 @@ int kinematicsForward(const double *joints,
     (void)fflags;
     (void)iflags;
 
-    const real_t con = *(haldata->conventional_directions) ? 1.0 : -1.0;
+    rtapi_real con = hal_get_bool(haldata->conventional_directions) ? 1.0 : -1.0;
+    rtapi_real pivot_length = hal_get_real(haldata->pivot_length);
 
     // B correction
-    const double zb = (*(haldata->pivot_length) + joints[8]) * cos(d2r(joints[4]));
-    const double xb = (*(haldata->pivot_length) + joints[8]) * sin(d2r(joints[4]));
+    const double zb = (pivot_length + joints[8]) * cos(d2r(joints[4]));
+    const double xb = (pivot_length + joints[8]) * sin(d2r(joints[4]));
         
     // C correction
     const double xyr = hypot(joints[0], joints[1]);
@@ -60,7 +61,7 @@ int kinematicsForward(const double *joints,
 
     pos->tran.x = xyr * cos(xytheta) - (con * xb) - xv;
     pos->tran.y = xyr * sin(xytheta) - joints[7];
-    pos->tran.z = joints[2] - zb - (con * zv) + *(haldata->pivot_length);
+    pos->tran.z = joints[2] - zb - (con * zv) + pivot_length;
 
     pos->a = joints[3];
     pos->b = joints[4];
@@ -80,11 +81,12 @@ int kinematicsInverse(const EmcPose * pos,
     (void)iflags;
     (void)fflags;
 
-    const real_t con = *(haldata->conventional_directions) ? 1.0 : -1.0;
+    rtapi_real con = hal_get_bool(haldata->conventional_directions) ? 1.0 : -1.0;
+    rtapi_real pivot_length = hal_get_real(haldata->pivot_length);
 
     // B correction
-    const double zb = (*(haldata->pivot_length) + pos->w) * cos(d2r(pos->b));
-    const double xb = (*(haldata->pivot_length) + pos->w) * sin(d2r(pos->b));
+    const double zb = (pivot_length + pos->w) * cos(d2r(pos->b));
+    const double xb = (pivot_length + pos->w) * sin(d2r(pos->b));
         
     // C correction
     const double xyr = hypot(pos->tran.x, pos->tran.y);
@@ -98,7 +100,7 @@ int kinematicsInverse(const EmcPose * pos,
 
     joints[0] = xyr * cos(xytheta) + (con * xb) + xv;
     joints[1] = xyr * sin(xytheta) + pos->v;
-    joints[2] = pos->tran.z + zb - (con * zv) - *(haldata->pivot_length);
+    joints[2] = pos->tran.z + zb - (con * zv) - pivot_length;
 
     joints[3] = pos->a;
     joints[4] = pos->b;
@@ -121,22 +123,21 @@ EXPORT_SYMBOL(kinematicsInverse);
 EXPORT_SYMBOL(kinematicsForward);
 MODULE_LICENSE("GPL");
 
-int comp_id;
+static int comp_id;
 int rtapi_app_main(void) {
     int result;
     comp_id = hal_init("maxkins");
     if(comp_id < 0) return comp_id;
 
-    haldata = hal_malloc(sizeof(struct haldata));
+    haldata = hal_malloc(sizeof(*haldata));
+    if(!haldata) { result = -ENOMEM; goto error; }
 
-    result = hal_pin_float_new("maxkins.pivot-length", HAL_IO, &(haldata->pivot_length), comp_id);
-
-    result += hal_pin_bit_new("maxkins.conventional-directions", HAL_IN, &(haldata->conventional_directions), comp_id);
+    result  = hal_pin_new_real(comp_id, HAL_IO, &(haldata->pivot_length), 0.666, "maxkins.pivot-length");
+    // default is unconventional
+    result += hal_pin_new_bool(comp_id, HAL_IN, &(haldata->conventional_directions), 0, "maxkins.conventional-directions");
 
     if(result < 0) goto error;
 
-    *(haldata->pivot_length) = 0.666;
-    *(haldata->conventional_directions) = 0; // default is unconventional
     hal_ready(comp_id);
     return 0;
 

--- a/src/emc/kinematics/pentakins.c
+++ b/src/emc/kinematics/pentakins.c
@@ -56,17 +56,17 @@
 #include "pentakins.h"
 
 struct haldata {
-    hal_float_t basex[NUM_STRUTS];
-    hal_float_t basey[NUM_STRUTS];
-    hal_float_t basez[NUM_STRUTS];
-    hal_float_t effectorr[NUM_STRUTS];
-    hal_float_t effectorz[NUM_STRUTS];
-    hal_u32_t *last_iter;
-    hal_u32_t *max_iter;
-    hal_u32_t *iter_limit;
-    hal_float_t *max_error;
-    hal_float_t *conv_criterion;
-    hal_float_t *tool_offset;
+    hal_real_t basex[NUM_STRUTS];
+    hal_real_t basey[NUM_STRUTS];
+    hal_real_t basez[NUM_STRUTS];
+    hal_real_t effectorr[NUM_STRUTS];
+    hal_real_t effectorz[NUM_STRUTS];
+    hal_uint_t last_iter;
+    hal_uint_t max_iter;
+    hal_uint_t iter_limit;
+    hal_real_t max_error;
+    hal_real_t conv_criterion;
+    hal_real_t tool_offset;
 } *haldata;
 
 
@@ -189,12 +189,13 @@ int pentakins_read_hal_pins(void) {
     int t;
 
   /* set the base and effector coordinates from hal pin values */
+    rtapi_real tool_offset = hal_get_real(haldata->tool_offset);
     for (t = 0; t < NUM_STRUTS; t++) {
-        b[t].x = haldata->basex[t];
-        b[t].y = haldata->basey[t];
-        b[t].z = haldata->basez[t] + *haldata->tool_offset;
-        ra[t] = haldata->effectorr[t];
-        za[t] = haldata->effectorz[t] + *haldata->tool_offset;
+        b[t].x = hal_get_real(haldata->basex[t]);
+        b[t].y = hal_get_real(haldata->basey[t]);
+        b[t].z = hal_get_real(haldata->basez[t]) + tool_offset;
+        ra[t] = hal_get_real(haldata->effectorr[t]);
+        za[t] = hal_get_real(haldata->effectorz[t]) + tool_offset;
     }
     return 0;
 }
@@ -285,10 +286,11 @@ int kinematicsForward(const double * joints,
   coord[4] = pos->b * PM_PI / 180.0;
 
   /* Enter Newton-Raphson iterative method   */
+  rtapi_real max_error = hal_get_real(haldata->max_error);
   while (iterate) {
     /* check for large error and return error flag if no convergence */
-    if ((conv_err > +(*haldata->max_error)) ||
-    (conv_err < -(*haldata->max_error))) {
+    if ((conv_err > +(max_error)) ||
+    (conv_err < -(max_error))) {
       /* we can't converge */
       return -2;
     };
@@ -297,7 +299,7 @@ int kinematicsForward(const double * joints,
 
     /* check iteration to see if the kinematics can reach the
        convergence criterion and return error flag if it can't */
-    if (iteration > *haldata->iter_limit) {
+    if (iteration > hal_get_ui32(haldata->iter_limit)) {
       /* we can't converge */
       return -5;
     }
@@ -340,8 +342,9 @@ int kinematicsForward(const double * joints,
 
     /* enter loop to determine if a strut needs another iteration */
     iterate = 0;            /*assume iteration is done */
+    rtapi_real conv_criterion = hal_get_real(haldata->conv_criterion);
     for (i = 0; i < NUM_STRUTS; i++) {
-      if (fabs(StrutLengthDiff[i]) > *haldata->conv_criterion) {
+      if (fabs(StrutLengthDiff[i]) > conv_criterion) {
     iterate = 1;
       }
     }
@@ -354,10 +357,10 @@ int kinematicsForward(const double * joints,
   pos->a = coord[3] * 180.0 / PM_PI;
   pos->b = coord[4] * 180.0 / PM_PI;
 
-  *haldata->last_iter = iteration;
+  hal_set_ui32(haldata->last_iter, iteration);
 
-  if (iteration > *haldata->max_iter){
-    *haldata->max_iter = iteration;
+  if (iteration > hal_get_ui32(haldata->max_iter)){
+    hal_set_ui32(haldata->max_iter, iteration);
   }
   return 0;
 }
@@ -410,6 +413,22 @@ MODULE_LICENSE("GPL");
 
 int comp_id;
 
+static const rtapi_real init_basex[NUM_STRUTS] = {
+    DEFAULT_BASE_0_X, DEFAULT_BASE_1_X, DEFAULT_BASE_2_X, DEFAULT_BASE_3_X, DEFAULT_BASE_4_X
+};
+static const rtapi_real init_basey[NUM_STRUTS] = {
+    DEFAULT_BASE_0_Y, DEFAULT_BASE_1_Y, DEFAULT_BASE_2_Y, DEFAULT_BASE_3_Y, DEFAULT_BASE_4_Y
+};
+static const rtapi_real init_basez[NUM_STRUTS] = {
+    DEFAULT_BASE_0_Z, DEFAULT_BASE_1_Z, DEFAULT_BASE_2_Z, DEFAULT_BASE_3_Z, DEFAULT_BASE_4_Z
+};
+static const rtapi_real init_effectorr[NUM_STRUTS] = {
+    DEFAULT_EFFECTOR_0_R, DEFAULT_EFFECTOR_1_R, DEFAULT_EFFECTOR_2_R, DEFAULT_EFFECTOR_3_R, DEFAULT_EFFECTOR_4_R
+};
+static const rtapi_real init_effectorz[NUM_STRUTS] = {
+    DEFAULT_EFFECTOR_0_Z, DEFAULT_EFFECTOR_1_Z, DEFAULT_EFFECTOR_2_Z, DEFAULT_EFFECTOR_3_Z, DEFAULT_EFFECTOR_4_Z
+};
+
 int rtapi_app_main(void)
 {
     int res = 0, i;
@@ -423,86 +442,52 @@ int rtapi_app_main(void)
     goto error;
 
 
-    for (i = 0; i < 6; i++) {
+    for (i = 0; i < NUM_STRUTS; i++) {
 
-        if ((res = hal_param_float_newf(HAL_RW, &(haldata->basex[i]), comp_id,
-            "pentakins.base.%d.x", i)) < 0)
-        goto error;
+        if ((res = hal_param_new_real(comp_id, HAL_RW, &(haldata->basex[i]),
+                                      init_basex[i], "pentakins.base.%d.x", i)) < 0)
+            goto error;
 
-        if ((res = hal_param_float_newf(HAL_RW, &haldata->basey[i], comp_id,
-            "pentakins.base.%d.y", i)) < 0)
-        goto error;
+        if ((res = hal_param_new_real(comp_id, HAL_RW, &haldata->basey[i],
+                                      init_basey[i], "pentakins.base.%d.y", i)) < 0)
+            goto error;
 
-        if ((res = hal_param_float_newf(HAL_RW, &haldata->basez[i], comp_id,
-            "pentakins.base.%d.z", i)) < 0)
-        goto error;
+        if ((res = hal_param_new_real(comp_id, HAL_RW, &haldata->basez[i],
+                                      init_basez[i], "pentakins.base.%d.z", i)) < 0)
+            goto error;
 
-        if ((res = hal_param_float_newf(HAL_RW, &haldata->effectorr[i], comp_id,
-            "pentakins.effector.%d.r", i)) < 0)
-        goto error;
+        if ((res = hal_param_new_real(comp_id, HAL_RW, &haldata->effectorr[i],
+                                      init_effectorr[i], "pentakins.effector.%d.r", i)) < 0)
+            goto error;
 
-        if ((res = hal_param_float_newf(HAL_RW, &haldata->effectorz[i], comp_id,
-            "pentakins.effector.%d.z", i)) < 0)
-        goto error;
+        if ((res = hal_param_new_real(comp_id, HAL_RW, &haldata->effectorz[i],
+                                      init_effectorz[i], "pentakins.effector.%d.z", i)) < 0)
+            goto error;
     }
 
-    if ((res = hal_pin_u32_newf(HAL_OUT, &haldata->last_iter, comp_id,
-        "pentakins.last-iterations")) < 0)
-    goto error;
-    *haldata->last_iter = 0;
+    if ((res = hal_pin_new_ui32(comp_id, HAL_OUT, &haldata->last_iter,
+                                0, "pentakins.last-iterations")) < 0)
+        goto error;
 
-    if ((res = hal_pin_u32_newf(HAL_OUT, &haldata->max_iter, comp_id,
-        "pentakins.max-iterations")) < 0)
-    goto error;
-    *haldata->max_iter = 0;
+    if ((res = hal_pin_new_ui32(comp_id, HAL_OUT, &haldata->max_iter,
+                                0, "pentakins.max-iterations")) < 0)
+        goto error;
 
-    if ((res = hal_pin_float_newf(HAL_IO, &haldata->max_error, comp_id,
-        "pentakins.max-error")) < 0)
-    goto error;
-    *haldata->max_error = 100;
+    if ((res = hal_pin_new_real(comp_id, HAL_IO, &haldata->max_error,
+                                100.0, "pentakins.max-error")) < 0)
+        goto error;
 
-    if ((res = hal_pin_float_newf(HAL_IO, &haldata->conv_criterion, comp_id,
-        "pentakins.convergence-criterion")) < 0)
-    goto error;
-    *haldata->conv_criterion = 1e-9;
+    if ((res = hal_pin_new_real(comp_id, HAL_IO, &haldata->conv_criterion,
+                                1e-9, "pentakins.convergence-criterion")) < 0)
+        goto error;
 
-    if ((res = hal_pin_u32_newf(HAL_IO, &haldata->iter_limit, comp_id,
-        "pentakins.limit-iterations")) < 0)
-    goto error;
-    *haldata->iter_limit = 120;
+    if ((res = hal_pin_new_ui32(comp_id, HAL_IO, &haldata->iter_limit,
+                                120, "pentakins.limit-iterations")) < 0)
+        goto error;
 
-    if ((res = hal_pin_float_newf(HAL_IN, &haldata->tool_offset, comp_id,
-        "pentakins.tool-offset")) < 0)
-    goto error;
-    *haldata->tool_offset = 0.0;
-
-    haldata->basex[0] = DEFAULT_BASE_0_X;
-    haldata->basey[0] = DEFAULT_BASE_0_Y;
-    haldata->basez[0] = DEFAULT_BASE_0_Z;
-    haldata->basex[1] = DEFAULT_BASE_1_X;
-    haldata->basey[1] = DEFAULT_BASE_1_Y;
-    haldata->basez[1] = DEFAULT_BASE_1_Z;
-    haldata->basex[2] = DEFAULT_BASE_2_X;
-    haldata->basey[2] = DEFAULT_BASE_2_Y;
-    haldata->basez[2] = DEFAULT_BASE_2_Z;
-    haldata->basex[3] = DEFAULT_BASE_3_X;
-    haldata->basey[3] = DEFAULT_BASE_3_Y;
-    haldata->basez[3] = DEFAULT_BASE_3_Z;
-    haldata->basex[4] = DEFAULT_BASE_4_X;
-    haldata->basey[4] = DEFAULT_BASE_4_Y;
-    haldata->basez[4] = DEFAULT_BASE_4_Z;
-
-    haldata->effectorz[0] = DEFAULT_EFFECTOR_0_Z;
-    haldata->effectorz[1] = DEFAULT_EFFECTOR_1_Z;
-    haldata->effectorz[2] = DEFAULT_EFFECTOR_2_Z;
-    haldata->effectorz[3] = DEFAULT_EFFECTOR_3_Z;
-    haldata->effectorz[4] = DEFAULT_EFFECTOR_4_Z;
-
-    haldata->effectorr[0] = DEFAULT_EFFECTOR_0_R;
-    haldata->effectorr[1] = DEFAULT_EFFECTOR_1_R;
-    haldata->effectorr[2] = DEFAULT_EFFECTOR_2_R;
-    haldata->effectorr[3] = DEFAULT_EFFECTOR_3_R;
-    haldata->effectorr[4] = DEFAULT_EFFECTOR_4_R;
+    if ((res = hal_pin_new_real(comp_id, HAL_IN, &haldata->tool_offset,
+                                0.0, "pentakins.tool-offset")) < 0)
+        goto error;
 
     hal_ready(comp_id);
     return 0;

--- a/src/emc/kinematics/pumakins.c
+++ b/src/emc/kinematics/pumakins.c
@@ -26,14 +26,8 @@
 #include "switchkins.h"
 
 struct haldata {
-    hal_float_t *a2, *a3, *d3, *d4, *d6;
-} *haldata = 0;
-
-#define PUMA_A2 (*(haldata->a2))
-#define PUMA_A3 (*(haldata->a3))
-#define PUMA_D3 (*(haldata->d3))
-#define PUMA_D4 (*(haldata->d4))
-#define PUMA_D6 (*(haldata->d6))
+    hal_real_t a2, a3, d3, d4, d6;
+} *haldata = NULL;
 
 static int pumaKinematicsForward(const double * joint,
                                  EmcPose * world,
@@ -105,6 +99,11 @@ static int pumaKinematicsForward(const double * joint,
    hom.rot.z.y = -s1 * t1 + c1 * s4 * s5;
    hom.rot.z.z = s23 * c4 * s5 - c23 * c5;
 
+   rtapi_real PUMA_A2 = hal_get_real(haldata->a2);
+   rtapi_real PUMA_A3 = hal_get_real(haldata->a3);
+   rtapi_real PUMA_D3 = hal_get_real(haldata->d3);
+   rtapi_real PUMA_D4 = hal_get_real(haldata->d4);
+
    /* Calculate term to be used in definition of...  */
    /* position vector.                               */
    t1 = PUMA_A2 * c2 + PUMA_A3 * c23 - PUMA_D4 * s23;
@@ -156,6 +155,7 @@ static int pumaKinematicsForward(const double * joint,
        *iflags |= PUMA_WRIST_FLIP;
      }
    }
+   rtapi_real PUMA_D6 = hal_get_real(haldata->d6);
   /*  add effect of d6 parameter */
     hom.tran.x = hom.tran.x + hom.rot.z.x*PUMA_D6;
     hom.tran.y = hom.tran.y + hom.rot.z.y*PUMA_D6;
@@ -213,6 +213,12 @@ static int pumaKinematicsInverse(const EmcPose * world,
    rpy.y = world->c*PM_PI/180.0;
    pmRpyQuatConvert(&rpy,&worldPose.rot);
    pmPoseHomConvert(&worldPose, &hom);
+
+   rtapi_real PUMA_A2 = hal_get_real(haldata->a2);
+   rtapi_real PUMA_A3 = hal_get_real(haldata->a3);
+   rtapi_real PUMA_D3 = hal_get_real(haldata->d3);
+   rtapi_real PUMA_D4 = hal_get_real(haldata->d4);
+   rtapi_real PUMA_D6 = hal_get_real(haldata->d6);
 
   /* remove effect of d6 parameter */
    px = hom.tran.x - PUMA_D6*hom.rot.z.x;
@@ -336,18 +342,12 @@ int pumaKinematicsSetup(const  int   comp_id,
     if (!haldata) goto error;
 
 
-    res += hal_pin_float_newf(HAL_IN, &(haldata->a2), comp_id,"%s.A2",kp->halprefix);
-    res += hal_pin_float_newf(HAL_IN, &(haldata->a3), comp_id,"%s.A3",kp->halprefix);
-    res += hal_pin_float_newf(HAL_IN, &(haldata->d3), comp_id,"%s.D3",kp->halprefix);
-    res += hal_pin_float_newf(HAL_IN, &(haldata->d4), comp_id,"%s.D4",kp->halprefix);
-    res += hal_pin_float_newf(HAL_IN, &(haldata->d6), comp_id,"%s.D6",kp->halprefix);
+    res += hal_pin_new_real(comp_id, HAL_IN, &(haldata->a2), DEFAULT_PUMA560_A2, "%s.A2", kp->halprefix);
+    res += hal_pin_new_real(comp_id, HAL_IN, &(haldata->a3), DEFAULT_PUMA560_A3, "%s.A3", kp->halprefix);
+    res += hal_pin_new_real(comp_id, HAL_IN, &(haldata->d3), DEFAULT_PUMA560_D3, "%s.D3", kp->halprefix);
+    res += hal_pin_new_real(comp_id, HAL_IN, &(haldata->d4), DEFAULT_PUMA560_D4, "%s.D4", kp->halprefix);
+    res += hal_pin_new_real(comp_id, HAL_IN, &(haldata->d6), DEFAULT_PUMA560_D6, "%s.D6", kp->halprefix);
     if (res) { goto error; }
-
-    PUMA_A2 = DEFAULT_PUMA560_A2;
-    PUMA_A3 = DEFAULT_PUMA560_A3;
-    PUMA_D3 = DEFAULT_PUMA560_D3;
-    PUMA_D4 = DEFAULT_PUMA560_D4;
-    PUMA_D6 = DEFAULT_PUMA560_D6;
 
     return 0;
 

--- a/src/emc/kinematics/rosekins.c
+++ b/src/emc/kinematics/rosekins.c
@@ -32,10 +32,10 @@ MODULE_LICENSE("GPL");
 #define hypot(a,b) (sqrt((a)*(a)+(b)*(b)))
 #endif
 
-struct haldata {
-    hal_float_t *revolutions;
-    hal_float_t *theta_degrees;
-    hal_float_t *bigtheta_degrees;
+static struct haldata {
+    hal_real_t revolutions;
+    hal_real_t theta_degrees;
+    hal_real_t bigtheta_degrees;
 } *haldata;
 
 int kinematicsForward(const double *joints,
@@ -94,9 +94,9 @@ int kinematicsInverse(const EmcPose * pos,
     theta     = atan2(y,x);
     bigtheta  = theta + PM_2_PI * revolutions;
 
-    *(haldata->revolutions) = revolutions;
-    *(haldata->theta_degrees) = theta * TO_DEG;
-    *(haldata->bigtheta_degrees) = bigtheta * TO_DEG;
+    hal_set_real(haldata->revolutions, revolutions);
+    hal_set_real(haldata->theta_degrees, theta * TO_DEG);
+    hal_set_real(haldata->bigtheta_degrees, bigtheta * TO_DEG);
 
     joints[0] = hypot(x,y);
     joints[1] = z;
@@ -126,18 +126,20 @@ int rtapi_app_main(void) {
     comp_id = hal_init("rosekins");
     if(comp_id < 0) return comp_id;
 
-    haldata = hal_malloc(sizeof(struct haldata));
+    haldata = hal_malloc(sizeof(*haldata));
+    if(!haldata) { ans = -ENOMEM; goto error; }
 
-    if((ans = hal_pin_float_new("rosekins.revolutions",
-              HAL_OUT, &(haldata->revolutions), comp_id)) < 0) goto error;
-    if((ans = hal_pin_float_new("rosekins.theta_degrees",
-              HAL_OUT, &(haldata->theta_degrees), comp_id)) < 0) goto error;
-    if((ans = hal_pin_float_new("rosekins.bigtheta_degrees",
-              HAL_OUT, &(haldata->bigtheta_degrees), comp_id)) < 0) goto error;
+    if((ans = hal_pin_new_real(comp_id, HAL_OUT, &(haldata->revolutions), 0.0, "rosekins.revolutions")) < 0)
+        goto error;
+    if((ans = hal_pin_new_real(comp_id, HAL_OUT, &(haldata->theta_degrees), 0.0, "rosekins.theta_degrees")) < 0)
+        goto error;
+    if((ans = hal_pin_new_real(comp_id, HAL_OUT, &(haldata->bigtheta_degrees), 0.0, "rosekins.bigtheta_degrees")) < 0)
+        goto error;
 
     hal_ready(comp_id);
     return 0;
 
 error:
+    hal_exit(comp_id);
     return ans;
 }

--- a/src/emc/kinematics/rotarydeltakins.c
+++ b/src/emc/kinematics/rotarydeltakins.c
@@ -22,15 +22,15 @@
 
 #include "rotarydeltakins-common.h"
 
-struct haldata
+static struct haldata
 {
-    hal_float_t *pfr;
-    hal_float_t *tl;
-    hal_float_t *sl;
-    hal_float_t *fr;
+    hal_real_t pfr;
+    hal_real_t tl;
+    hal_real_t sl;
+    hal_real_t fr;
 } *haldata;
 
-int comp_id;
+static int comp_id;
 
 int kinematicsForward(const double * joints,
                       EmcPose * pos,
@@ -38,7 +38,7 @@ int kinematicsForward(const double * joints,
                       KINEMATICS_INVERSE_FLAGS * iflags) {
     (void)fflags;
     (void)iflags;
-    set_geometry(*haldata->pfr, *haldata->tl, *haldata->sl, *haldata->fr);
+    set_geometry(hal_get_real(haldata->pfr), hal_get_real(haldata->tl), hal_get_real(haldata->sl), hal_get_real(haldata->fr));
     return kinematics_forward(joints, pos);
 }
 
@@ -47,7 +47,7 @@ int kinematicsInverse(const EmcPose *pos, double *joints,
         KINEMATICS_FORWARD_FLAGS *fflags) {
     (void)iflags;
     (void)fflags;
-    set_geometry(*haldata->pfr, *haldata->tl, *haldata->sl, *haldata->fr);
+    set_geometry(hal_get_real(haldata->pfr), hal_get_real(haldata->tl), hal_get_real(haldata->sl), hal_get_real(haldata->fr));
     return kinematics_inverse(pos, joints);
 }
 
@@ -58,43 +58,28 @@ KINEMATICS_TYPE kinematicsType()
 
 int rtapi_app_main(void)
 {
-    int retval = 0;
+    int retval;
 
     comp_id = hal_init("rotarydeltakins");
-    if(comp_id < 0) retval = comp_id;
+    if(comp_id < 0) return comp_id;
 
-    if(retval == 0)
-    {
-        haldata = hal_malloc(sizeof(struct haldata));
-        retval = !haldata;
-    }
+    haldata = hal_malloc(sizeof(*haldata));
+    if(!haldata) { retval = -ENOMEM; goto error; }
 
-    if(retval == 0)
-        retval = hal_pin_float_newf(HAL_IN, &haldata->pfr, comp_id,
-                "rotarydeltakins.platformradius");
-    if(retval == 0)
-        retval = hal_pin_float_newf(HAL_IN, &haldata->tl, comp_id,
-                "rotarydeltakins.thighlength");
-    if(retval == 0)
-        retval = hal_pin_float_newf(HAL_IN, &haldata->sl, comp_id,
-                "rotarydeltakins.shinlength");
-    if(retval == 0)
-        retval = hal_pin_float_newf(HAL_IN, &haldata->fr, comp_id,
-                "rotarydeltakins.footradius");
+    if((retval = hal_pin_new_real(comp_id, HAL_IN, &haldata->pfr, RDELTA_PFR, "rotarydeltakins.platformradius")) < 0)
+        goto error;
+    if((retval = hal_pin_new_real(comp_id, HAL_IN, &haldata->tl, RDELTA_TL, "rotarydeltakins.thighlength")) < 0)
+        goto error;
+    if((retval = hal_pin_new_real(comp_id, HAL_IN, &haldata->sl, RDELTA_SL, "rotarydeltakins.shinlength")) < 0)
+        goto error;
+    if((retval = hal_pin_new_real(comp_id, HAL_IN, &haldata->fr, RDELTA_FR, "rotarydeltakins.footradius")) < 0)
+        goto error;
 
-    if(retval == 0)
-    {
-        *haldata->pfr = RDELTA_PFR;
-        *haldata->tl = RDELTA_TL;
-        *haldata->sl = RDELTA_SL;
-        *haldata->fr = RDELTA_FR;
-    }
+    hal_ready(comp_id);
+    return 0;
 
-    if(retval == 0)
-    {
-        hal_ready(comp_id);
-    }
-
+error:
+    hal_exit(comp_id);
     return retval;
 }
 

--- a/src/emc/kinematics/scarakins.c
+++ b/src/emc/kinematics/scarakins.c
@@ -23,9 +23,9 @@
 
 #include "switchkins.h"
 
-struct scara_data {
-    hal_float_t *d1, *d2, *d3, *d4, *d5, *d6;
-} *haldata = 0;
+static struct scara_data {
+    hal_real_t d1, d2, d3, d4, d5, d6;
+} *haldata = NULL;
 
 /* key dimensions
 
@@ -63,13 +63,6 @@ struct scara_data {
                 on the value of joint[3].
 */
 
-#define D1 (*(haldata->d1))
-#define D2 (*(haldata->d2))
-#define D3 (*(haldata->d3))
-#define D4 (*(haldata->d4))
-#define D5 (*(haldata->d5))
-#define D6 (*(haldata->d6))
-
 /* joint[0], joint[1] and joint[3] are in degrees and joint[2] is in length units */
 static
 int scaraKinematicsForward(const double * joint,
@@ -90,6 +83,13 @@ int scaraKinematicsForward(const double * joint,
 
     a1 = a1 + a0;
     a3 = a3 + a1;
+
+    rtapi_real D1 = hal_get_real(haldata->d1);
+    rtapi_real D2 = hal_get_real(haldata->d2);
+    rtapi_real D3 = hal_get_real(haldata->d3);
+    rtapi_real D4 = hal_get_real(haldata->d4);
+    rtapi_real D5 = hal_get_real(haldata->d5);
+    rtapi_real D6 = hal_get_real(haldata->d6);
 
     x = D2*cos(a0) + D4*cos(a1) + D6*cos(a3);
     y = D2*sin(a0) + D4*sin(a1) + D6*sin(a3);
@@ -128,6 +128,13 @@ static int scaraKinematicsInverse(const EmcPose * world,
 
     /* convert degrees to radians */
     a3 = c * ( PM_PI / 180 );
+
+    rtapi_real D1 = hal_get_real(haldata->d1);
+    rtapi_real D2 = hal_get_real(haldata->d2);
+    rtapi_real D3 = hal_get_real(haldata->d3);
+    rtapi_real D4 = hal_get_real(haldata->d4);
+    rtapi_real D5 = hal_get_real(haldata->d5);
+    rtapi_real D6 = hal_get_real(haldata->d6);
 
     /* center of end effector (correct for D6) */
     xt = x - D6*cos(a3);
@@ -188,20 +195,13 @@ static int scaraKinematicsSetup(const  int   comp_id,
     haldata = hal_malloc(sizeof(*haldata));
     if (!haldata) goto error;
 
-    res += hal_pin_float_newf(HAL_IN, &(haldata->d1), comp_id,"%s.D1",kp->halprefix);
-    res += hal_pin_float_newf(HAL_IN, &(haldata->d2), comp_id,"%s.D2",kp->halprefix);
-    res += hal_pin_float_newf(HAL_IN, &(haldata->d3), comp_id,"%s.D3",kp->halprefix);
-    res += hal_pin_float_newf(HAL_IN, &(haldata->d4), comp_id,"%s.D4",kp->halprefix);
-    res += hal_pin_float_newf(HAL_IN, &(haldata->d5), comp_id,"%s.D5",kp->halprefix);
-    res += hal_pin_float_newf(HAL_IN, &(haldata->d6), comp_id,"%s.D6",kp->halprefix);
+    res += hal_pin_new_real(comp_id, HAL_IN, &(haldata->d1), DEFAULT_D1, "%s.D1", kp->halprefix);
+    res += hal_pin_new_real(comp_id, HAL_IN, &(haldata->d2), DEFAULT_D2, "%s.D2", kp->halprefix);
+    res += hal_pin_new_real(comp_id, HAL_IN, &(haldata->d3), DEFAULT_D3, "%s.D3", kp->halprefix);
+    res += hal_pin_new_real(comp_id, HAL_IN, &(haldata->d4), DEFAULT_D4, "%s.D4", kp->halprefix);
+    res += hal_pin_new_real(comp_id, HAL_IN, &(haldata->d5), DEFAULT_D5, "%s.D5", kp->halprefix);
+    res += hal_pin_new_real(comp_id, HAL_IN, &(haldata->d6), DEFAULT_D6, "%s.D6", kp->halprefix);
     if (res) { goto error; }
-
-    D1 = DEFAULT_D1;
-    D2 = DEFAULT_D2;
-    D3 = DEFAULT_D3;
-    D4 = DEFAULT_D4;
-    D5 = DEFAULT_D5;
-    D6 = DEFAULT_D6;
 
     return 0;
 

--- a/src/emc/kinematics/switchkins.c
+++ b/src/emc/kinematics/switchkins.c
@@ -38,26 +38,26 @@
 // kinematic functions (default=0 for err detection):
 static kparms kp; // kinematics parms (common all types)
 
-static KF kfwd0 = 0; // 0==switchkins_type kinematics forward
-static KF kfwd1 = 0; // 1
-static KF kfwd2 = 0; // 2
+static KF kfwd0 = NULL; // 0==switchkins_type kinematics forward
+static KF kfwd1 = NULL; // 1
+static KF kfwd2 = NULL; // 2
 
-static KI kinv0 = 0; // 0==switchkins_type kinematics inverse
-static KI kinv1 = 0; // 1
-static KI kinv2 = 0; // 2
+static KI kinv0 = NULL; // 0==switchkins_type kinematics inverse
+static KI kinv1 = NULL; // 1
+static KI kinv2 = NULL; // 2
 
-static hal_u32_t switchkins_type;
+static int switchkins_type;
 static struct swdata {
-    hal_bit_t   *kinstype_is_0;
-    hal_bit_t   *kinstype_is_1;
-    hal_bit_t   *kinstype_is_2;
+    hal_bool_t kinstype_is_0;
+    hal_bool_t kinstype_is_1;
+    hal_bool_t kinstype_is_2;
 
-    hal_float_t *gui_x;
-    hal_float_t *gui_y;
-    hal_float_t *gui_z;
-    hal_float_t *gui_a;
-    hal_float_t *gui_b;
-    hal_float_t *gui_c;
+    hal_real_t gui_x;
+    hal_real_t gui_y;
+    hal_real_t gui_z;
+    hal_real_t gui_a;
+    hal_real_t gui_b;
+    hal_real_t gui_c;
 } *swdata;
 
 // Note: parallel kinematics (like genhexkins) often
@@ -113,12 +113,12 @@ static int gui_forward_kins(const double *joints)
                   kp.gui_kinstype);
                   return -1;
      }
-    *swdata->gui_x = lastpose[kp.gui_kinstype].tran.x;
-    *swdata->gui_y = lastpose[kp.gui_kinstype].tran.y;
-    *swdata->gui_z = lastpose[kp.gui_kinstype].tran.z;
-    *swdata->gui_a = lastpose[kp.gui_kinstype].a;
-    *swdata->gui_b = lastpose[kp.gui_kinstype].b;
-    *swdata->gui_c = lastpose[kp.gui_kinstype].c;
+    hal_set_real(swdata->gui_x, lastpose[kp.gui_kinstype].tran.x);
+    hal_set_real(swdata->gui_y, lastpose[kp.gui_kinstype].tran.y);
+    hal_set_real(swdata->gui_z, lastpose[kp.gui_kinstype].tran.z);
+    hal_set_real(swdata->gui_a, lastpose[kp.gui_kinstype].a);
+    hal_set_real(swdata->gui_b, lastpose[kp.gui_kinstype].b);
+    hal_set_real(swdata->gui_c, lastpose[kp.gui_kinstype].c);
     return res;
 } // gui_forward_kins
 
@@ -134,28 +134,28 @@ int kinematicsSwitch(int new_switchkins_type)
     switch (switchkins_type) {
         case 0: rtapi_print_msg(RTAPI_MSG_INFO,
                 "kinematicsSwitch:TYPE0\n");
-                *swdata->kinstype_is_0 = 1;
-                *swdata->kinstype_is_1 = 0;
-                *swdata->kinstype_is_2 = 0;
+                hal_set_bool(swdata->kinstype_is_0, 1);
+                hal_set_bool(swdata->kinstype_is_1, 0);
+                hal_set_bool(swdata->kinstype_is_2, 0);
                 break;
         case 1: rtapi_print_msg(RTAPI_MSG_INFO,
                 "kinematicsSwitch:TYPE1\n");
-                *swdata->kinstype_is_0 = 0;
-                *swdata->kinstype_is_1 = 1;
-                *swdata->kinstype_is_2 = 0;
+                hal_set_bool(swdata->kinstype_is_0, 0);
+                hal_set_bool(swdata->kinstype_is_1, 1);
+                hal_set_bool(swdata->kinstype_is_2, 0);
                 break;
         case 2: rtapi_print_msg(RTAPI_MSG_INFO,
                 "kinematicsSwitch:TYPE2\n");
-                *swdata->kinstype_is_0 = 0;
-                *swdata->kinstype_is_1 = 0;
-                *swdata->kinstype_is_2 = 1;
+                hal_set_bool(swdata->kinstype_is_0, 0);
+                hal_set_bool(swdata->kinstype_is_1, 0);
+                hal_set_bool(swdata->kinstype_is_2, 1);
                 break;
        default: rtapi_print_msg(RTAPI_MSG_ERR,
                 "kinematicsSwitch:BAD VALUE <%d>\n",
                 switchkins_type);
-                *swdata->kinstype_is_1 = 0;
-                *swdata->kinstype_is_0 = 0;
-                *swdata->kinstype_is_2 = 0;
+                hal_set_bool(swdata->kinstype_is_1, 0);
+                hal_set_bool(swdata->kinstype_is_0, 0);
+                hal_set_bool(swdata->kinstype_is_2, 0);
                 return -1; // FAIL
     }
     if (fwd_iterates[switchkins_type]) {
@@ -259,9 +259,9 @@ int rtapi_app_main(void)
 
     kp.sparm = sparm; // module parm passed to kins
 
-    KS ksetup0 = 0;
-    KS ksetup1 = 0;
-    KS ksetup2 = 0;
+    KS ksetup0 = NULL;
+    KS ksetup1 = NULL;
+    KS ksetup2 = NULL;
 
     res = switchkinsSetup(&kp,
                           &ksetup0, &ksetup1, &ksetup2,
@@ -306,17 +306,17 @@ int rtapi_app_main(void)
     swdata = hal_malloc(sizeof(struct swdata));
     if (!swdata) goto error;
 
-    res += hal_pin_bit_new("kinstype.is-0", HAL_OUT, &(swdata->kinstype_is_0), comp_id);
-    res += hal_pin_bit_new("kinstype.is-1", HAL_OUT, &(swdata->kinstype_is_1), comp_id);
-    res += hal_pin_bit_new("kinstype.is-2", HAL_OUT, &(swdata->kinstype_is_2), comp_id);
+    res += hal_pin_new_bool(comp_id, HAL_OUT, &(swdata->kinstype_is_0), 0, "kinstype.is-0");
+    res += hal_pin_new_bool(comp_id, HAL_OUT, &(swdata->kinstype_is_1), 0, "kinstype.is-1");
+    res += hal_pin_new_bool(comp_id, HAL_OUT, &(swdata->kinstype_is_2), 0, "kinstype.is-2");
 
     if (kp.gui_kinstype >=0) {
-        res += hal_pin_float_newf(HAL_IN, &swdata->gui_x, comp_id, "skgui.x");
-        res += hal_pin_float_newf(HAL_IN, &swdata->gui_y, comp_id, "skgui.y");
-        res += hal_pin_float_newf(HAL_IN, &swdata->gui_z, comp_id, "skgui.z");
-        res += hal_pin_float_newf(HAL_IN, &swdata->gui_a, comp_id, "skgui.a");
-        res += hal_pin_float_newf(HAL_IN, &swdata->gui_b, comp_id, "skgui.b");
-        res += hal_pin_float_newf(HAL_IN, &swdata->gui_c, comp_id, "skgui.c");
+        res += hal_pin_new_real(comp_id, HAL_IN, &swdata->gui_x, 0.0, "skgui.x");
+        res += hal_pin_new_real(comp_id, HAL_IN, &swdata->gui_y, 0.0, "skgui.y");
+        res += hal_pin_new_real(comp_id, HAL_IN, &swdata->gui_z, 0.0, "skgui.z");
+        res += hal_pin_new_real(comp_id, HAL_IN, &swdata->gui_a, 0.0, "skgui.a");
+        res += hal_pin_new_real(comp_id, HAL_IN, &swdata->gui_b, 0.0, "skgui.b");
+        res += hal_pin_new_real(comp_id, HAL_IN, &swdata->gui_c, 0.0, "skgui.c");
         if (res) {emsg = "hal pin create fail";goto error;}
     }
 

--- a/src/emc/kinematics/tripodkins.c
+++ b/src/emc/kinematics/tripodkins.c
@@ -75,13 +75,11 @@
 #endif
 #endif
 
-struct haldata {
-    hal_float_t *bx, *cx, *cy;
-} *haldata = 0;
-
-#define Bx (*(haldata->bx))
-#define Cx (*(haldata->cx))
-#define Cy (*(haldata->cy))
+static struct haldata {
+    hal_real_t bx;
+    hal_real_t cx;
+    hal_real_t cy;
+} *haldata = NULL;
 
 #define sq(x) ((x)*(x))
 
@@ -139,6 +137,9 @@ int kinematicsForward(const double * joints,
 #define Dz (pos->tran.z)
   double P, Q, R;
   double s, t, u;
+  rtapi_real Bx = hal_get_real(haldata->bx);
+  rtapi_real Cx = hal_get_real(haldata->cx);
+  rtapi_real Cy = hal_get_real(haldata->cy);
 
   P = sq(AD);
   Q = sq(BD) - sq(Bx);
@@ -194,6 +195,9 @@ int kinematicsInverse(const EmcPose * pos,
 #define Dx (pos->tran.x)
 #define Dy (pos->tran.y)
 #define Dz (pos->tran.z)
+  rtapi_real Bx = hal_get_real(haldata->bx);
+  rtapi_real Cx = hal_get_real(haldata->cx);
+  rtapi_real Cy = hal_get_real(haldata->cy);
 
   AD = sqrt(sq(Dx) + sq(Dy) + sq(Dz));
   BD = sqrt(sq(Dx - Bx) + sq(Dy) + sq(Dz));
@@ -357,7 +361,7 @@ MODULE_LICENSE("GPL");
 
 
 
-int comp_id;
+static int comp_id;
 int rtapi_app_main(void) {
     int res = 0;
 
@@ -367,11 +371,10 @@ int rtapi_app_main(void) {
     haldata = hal_malloc(sizeof(struct haldata));
     if(!haldata) goto error;
 
-    if((res = hal_pin_float_new("tripodkins.Bx", HAL_IO, &(haldata->bx), comp_id)) < 0) goto error;
-    if((res = hal_pin_float_new("tripodkins.Cx", HAL_IO, &(haldata->cx), comp_id)) < 0) goto error;
-    if((res = hal_pin_float_new("tripodkins.Cy", HAL_IO, &(haldata->cy), comp_id)) < 0) goto error;
+    if((res = hal_pin_new_real(comp_id, HAL_IO, &(haldata->bx), 1.0, "tripodkins.Bx")) < 0) goto error;
+    if((res = hal_pin_new_real(comp_id, HAL_IO, &(haldata->cx), 1.0, "tripodkins.Cx")) < 0) goto error;
+    if((res = hal_pin_new_real(comp_id, HAL_IO, &(haldata->cy), 1.0, "tripodkins.Cy")) < 0) goto error;
 
-    Bx = Cx = Cy = 1.0;
     hal_ready(comp_id);
     return 0;
 

--- a/src/emc/kinematics/trtfuncs.c
+++ b/src/emc/kinematics/trtfuncs.c
@@ -54,14 +54,14 @@ static int JV = -1;
 static int JW = -1;
 
 struct haldata {
-    hal_float_t *x_rot_point;
-    hal_float_t *y_rot_point;
-    hal_float_t *z_rot_point;
-    hal_float_t *x_offset;
-    hal_float_t *y_offset;
-    hal_float_t *z_offset;
-    hal_float_t *tool_offset;
-    hal_bit_t *conventional_directions; // default: false
+    hal_real_t x_rot_point;
+    hal_real_t y_rot_point;
+    hal_real_t z_rot_point;
+    hal_real_t x_offset;
+    hal_real_t y_offset;
+    hal_real_t z_offset;
+    hal_real_t tool_offset;
+    hal_bool_t conventional_directions; // default: false
 } *haldata;
 
 
@@ -128,22 +128,22 @@ int trtKinematicsSetup(const int   comp_id,
     haldata = hal_malloc(sizeof(struct haldata));
     if (!haldata) {goto error;}
 
-    res += hal_pin_float_newf(HAL_IN, &(haldata->x_rot_point), comp_id,
-                 "%s.x-rot-point",kp->halprefix);
-    res += hal_pin_float_newf(HAL_IN, &(haldata->y_rot_point), comp_id,
-                 "%s.y-rot-point",kp->halprefix);
-    res += hal_pin_float_newf(HAL_IN, &(haldata->z_rot_point), comp_id,
-                 "%s.z-rot-point",kp->halprefix);
-    res += hal_pin_float_newf(HAL_IN, &(haldata->x_offset),    comp_id,
-                 "%s.x-offset",kp->halprefix);
-    res += hal_pin_float_newf(HAL_IN, &(haldata->y_offset),    comp_id,
-                 "%s.y-offset",kp->halprefix);
-    res += hal_pin_float_newf(HAL_IN, &(haldata->z_offset),    comp_id,
-                 "%s.z-offset",kp->halprefix);
-    res += hal_pin_float_newf(HAL_IN, &(haldata->tool_offset), comp_id,
-                 "%s.tool-offset",kp->halprefix);
-    res += hal_pin_bit_newf(HAL_IN, &(haldata->conventional_directions), comp_id,
-                 "%s.conventional-directions", kp->halprefix);
+    res += hal_pin_new_real(comp_id, HAL_IN, &(haldata->x_rot_point),
+                            0.0, "%s.x-rot-point",kp->halprefix);
+    res += hal_pin_new_real(comp_id, HAL_IN, &(haldata->y_rot_point),
+                            0.0, "%s.y-rot-point",kp->halprefix);
+    res += hal_pin_new_real(comp_id, HAL_IN, &(haldata->z_rot_point),
+                            0.0, "%s.z-rot-point",kp->halprefix);
+    res += hal_pin_new_real(comp_id, HAL_IN, &(haldata->x_offset),
+                            0.0, "%s.x-offset",kp->halprefix);
+    res += hal_pin_new_real(comp_id, HAL_IN, &(haldata->y_offset),
+                            0.0, "%s.y-offset",kp->halprefix);
+    res += hal_pin_new_real(comp_id, HAL_IN, &(haldata->z_offset),
+                            0.0, "%s.z-offset",kp->halprefix);
+    res += hal_pin_new_real(comp_id, HAL_IN, &(haldata->tool_offset),
+                            0.0, "%s.tool-offset",kp->halprefix);
+    res += hal_pin_new_bool(comp_id, HAL_IN, &(haldata->conventional_directions),
+                            0, "%s.conventional-directions", kp->halprefix);
     if (res) {goto error;}
     return 0;
 
@@ -159,16 +159,16 @@ int xyzacKinematicsForward(const double *joints,
 {
     (void)fflags;
     (void)iflags;
-    const double x_rot_point = *(haldata->x_rot_point);
-    const double y_rot_point = *(haldata->y_rot_point);
-    const double z_rot_point = *(haldata->z_rot_point);
-    const double          dt = *(haldata->tool_offset);
-    const double          dy = *(haldata->y_offset);
-    const double          dz = *(haldata->z_offset) + dt;
+    const double x_rot_point = hal_get_real(haldata->x_rot_point);
+    const double y_rot_point = hal_get_real(haldata->y_rot_point);
+    const double z_rot_point = hal_get_real(haldata->z_rot_point);
+    const double          dt = hal_get_real(haldata->tool_offset);
+    const double          dy = hal_get_real(haldata->y_offset);
+    const double          dz = hal_get_real(haldata->z_offset) + dt;
     const double       a_rad = joints[JA]*TO_RAD;
     const double       c_rad = joints[JC]*TO_RAD;
 
-    const real_t con = *(haldata->conventional_directions) ? 1.0 : -1.0;
+    rtapi_real con = hal_get_bool(haldata->conventional_directions) ? 1.0 : -1.0;
 
     pos->tran.x = +       cos(c_rad)              * (joints[JX]      - x_rot_point)
                   - con * sin(c_rad) * cos(a_rad) * (joints[JY] - dy - y_rot_point)
@@ -207,16 +207,16 @@ int xyzacKinematicsInverse(const EmcPose * pos,
 {
     (void)iflags;
     (void)fflags;
-    const double x_rot_point = *(haldata->x_rot_point);
-    const double y_rot_point = *(haldata->y_rot_point);
-    const double z_rot_point = *(haldata->z_rot_point);
-    const double         dy  = *(haldata->y_offset);
-    const double         dt  = *(haldata->tool_offset);
-    const double         dz  = *(haldata->z_offset) + dt;
+    const double x_rot_point = hal_get_real(haldata->x_rot_point);
+    const double y_rot_point = hal_get_real(haldata->y_rot_point);
+    const double z_rot_point = hal_get_real(haldata->z_rot_point);
+    const double         dy  = hal_get_real(haldata->y_offset);
+    const double         dt  = hal_get_real(haldata->tool_offset);
+    const double         dz  = hal_get_real(haldata->z_offset) + dt;
     const double      a_rad  = pos->a*TO_RAD;
     const double      c_rad  = pos->c*TO_RAD;
 
-    const real_t con = *(haldata->conventional_directions) ? 1.0 : -1.0;
+    rtapi_real con = hal_get_bool(haldata->conventional_directions) ? 1.0 : -1.0;
 
     EmcPose P; // computed position
 
@@ -268,16 +268,16 @@ int xyzbcKinematicsForward(const double *joints,
     (void)fflags;
     (void)iflags;
     // Note: 'principal' joints are used
-    const double x_rot_point = *(haldata->x_rot_point);
-    const double y_rot_point = *(haldata->y_rot_point);
-    const double z_rot_point = *(haldata->z_rot_point);
-    const double          dx = *(haldata->x_offset);
-    const double          dt = *(haldata->tool_offset);
-    const double          dz = *(haldata->z_offset) + dt;
+    const double x_rot_point = hal_get_real(haldata->x_rot_point);
+    const double y_rot_point = hal_get_real(haldata->y_rot_point);
+    const double z_rot_point = hal_get_real(haldata->z_rot_point);
+    const double          dx = hal_get_real(haldata->x_offset);
+    const double          dt = hal_get_real(haldata->tool_offset);
+    const double          dz = hal_get_real(haldata->z_offset) + dt;
     const double       b_rad = joints[JB]*TO_RAD;
     const double       c_rad = joints[JC]*TO_RAD;
 
-    const real_t con = *(haldata->conventional_directions) ? 1.0 : -1.0;
+    rtapi_real con = hal_get_bool(haldata->conventional_directions) ? 1.0 : -1.0;
 
     pos->tran.x =         cos(c_rad) * cos(b_rad) * (joints[JX] - dx - x_rot_point)
                   - con * sin(c_rad) *              (joints[JY]      - y_rot_point)
@@ -315,18 +315,18 @@ int xyzbcKinematicsInverse(const EmcPose * pos,
 {
     (void)iflags;
     (void)fflags;
-    const double x_rot_point = *(haldata->x_rot_point);
-    const double y_rot_point = *(haldata->y_rot_point);
-    const double z_rot_point = *(haldata->z_rot_point);
-    const double          dx = *(haldata->x_offset);
-    const double          dt = *(haldata->tool_offset);
-    const double          dz = *(haldata->z_offset) + dt;
+    const double x_rot_point = hal_get_real(haldata->x_rot_point);
+    const double y_rot_point = hal_get_real(haldata->y_rot_point);
+    const double z_rot_point = hal_get_real(haldata->z_rot_point);
+    const double          dx = hal_get_real(haldata->x_offset);
+    const double          dt = hal_get_real(haldata->tool_offset);
+    const double          dz = hal_get_real(haldata->z_offset) + dt;
     const double       b_rad = pos->b*TO_RAD;
     const double       c_rad = pos->c*TO_RAD;
     const double         dpx = -cos(b_rad)*dx + sin(b_rad)*dz + dx;
     const double         dpz = -sin(b_rad)*dx - cos(b_rad)*dz + dz;
 
-    const real_t con = *(haldata->conventional_directions) ? 1.0 : -1.0;
+    rtapi_real con = hal_get_bool(haldata->conventional_directions) ? 1.0 : -1.0;
 
     EmcPose P; // computed position
 

--- a/src/emc/kinematics/userkfuncs.c
+++ b/src/emc/kinematics/userkfuncs.c
@@ -28,8 +28,8 @@
 
 static int userk_inited = 0;
 static struct udata {
-    hal_s32_t *fct;
-    hal_s32_t *ict;
+    hal_sint_t fct;
+    hal_sint_t ict;
 } *udata;
 
 //**********************************************************************
@@ -48,8 +48,8 @@ int userkKinematicsSetup(const int   comp_id,
     if (!udata) goto error;
 
     // HAL_IO used to allow resetting demo pins:
-    res += hal_pin_s32_new("userk.fct", HAL_IO, &(udata->fct), comp_id);
-    res += hal_pin_s32_new("userk.ict", HAL_IO, &(udata->ict), comp_id);
+    res += hal_pin_new_si32(comp_id, HAL_IO, &(udata->fct), 0, "userk.fct");
+    res += hal_pin_new_si32(comp_id, HAL_IO, &(udata->ict), 0, "userk.ict");
     if (res) goto error;
 
     userk_inited = 1;
@@ -69,7 +69,7 @@ int userkKinematicsForward(const double *joint,
              "userkKinematics: not initialized\n");
         return -1;
     }
-    (*udata->fct)++;
+    hal_set_si32(udata->fct, hal_get_si32(udata->fct) + 1);
     return identityKinematicsForward(joint,world,fflags,iflags);
 }
 
@@ -78,6 +78,6 @@ int userkKinematicsInverse(const EmcPose * pos,
                            const KINEMATICS_INVERSE_FLAGS * iflags,
                            KINEMATICS_FORWARD_FLAGS * fflags)
 {
-    (*udata->ict)++;
+    hal_set_si32(udata->ict, hal_get_si32(udata->ict) + 1);
     return identityKinematicsInverse(pos,joint,iflags,fflags);
 }


### PR DESCRIPTION
This updates the kinematics components to getter/setter. Most of this is very straight forward.
(there appear to be more kinematics files in hal/components, like matrixkins, will be done later)

There are several kinematics that have pins/params with initial values. They are created in a loop and the initial values are now taken from a few static const arrays so the loop can easily address and set the initial value for the specific pin/param. Having a few bytes of added .rodata should be no problem.

A few kinematics modules have some fixes to add `static` to some local variables like the component ID and the haldata pointer. These are exclusively local to the module. Some error checking in rtapi_app_main() was improved and streamlined when it could be easily done without needing to go into rewrite/refactor mode.

A few obvious and easy to fix cases of multiple reads of a pin/param were altered into cached reads.

Corexykins had all its completely unused pins structure and halmem allocation removed (all from copy/paste coding). Also unused headers were removed.