### PR TITLE
tests/pyvcp: filter the halcmd "Waiting for component" pacifier from result

### DIFF
--- a/tests/pyvcp/test.sh
+++ b/tests/pyvcp/test.sh
@@ -3,6 +3,8 @@
 set -e
 
 xvfb-run halrun -s do-test.hal
-sed -i '/mypanel/!d' result
+# Ubuntu's xvfb-run merges stderr into stdout, so on a slow machine the
+# halcmd "Waiting for component" pacifier can end up in result. Drop it.
+sed -i -e '/^Waiting for component/d' -e '/mypanel/!d' result
 
 exit 0


### PR DESCRIPTION
Fixes #4287.

## Problem

The pyvcp test flakes on slow or busy CI:

```
+Waiting for component 'mypanel' to become ready....
 mypanel float OUT 0 mypanel.dial-a-out
 ...
```

The "Waiting for component..." pacifier is printed by halcmd's `loadusr -Wn` to **stderr** after 2 s of waiting. It lands in the test's `result` file anyway because Ubuntu 24.04's `xvfb-run` executes the wrapped command with `"$@" 2>&1`, merging stderr into stdout (Debian's and upstream xorg's xvfb-run keep the streams separate). On a loaded ubuntu CI runner, pyvcp takes >2 s to become ready, the pacifier fires, and the merged line survives the `sed '/mypanel/!d'` filter because it contains the component name, breaking the compare against `expected`.

I reproduced this byte-identically on a Debian host by extracting Ubuntu noble's `xvfb-run` (`xvfb_21.1.12-1ubuntu1.8_amd64.deb`), delaying pyvcp startup with a `sleep` wrapper, and saturating the CPU.

## Fix

Drop the pacifier line in the sed expression that already sanitizes `result`, as suggested by @BsAtHome.

## Testing

- Ubuntu xvfb-run + delayed pyvcp + saturated CPU: was XFAIL with the exact CI diff, now passes, `result` identical to `expected`.
- Normal test run passes.
