### PR TITLE
SimConfigs: Clean up obsolete/duplicate information from 'vismach' README

### DIFF
--- a/configs/sim/axis/vismach/README
+++ b/configs/sim/axis/vismach/README
@@ -1,24 +1,7 @@
 The 'vismach' directory contains a number of configurations that display a 3D model of the simulated machine.
 
-The best place to start is with the rolfmill which is a 3 axis mill built
-using primitives. The rolfmill.hal file is heavly commented with step by
-step instructions on how to build the vismach simulation.
-
-These simulations are mostly intended to testing of complex kinematics code by people who don't have those somewhat exotic machines.
+These simulations are mostly intended for testing of complex kinematics code by people who don't have those somewhat exotic machines.
 
 All of these configurations work without realtime and without hardware or drivers.
 
-All of the simulations use the Axis GUI.  It is expected that these configurations will need to be modified as work on joints vs. axes occurs.
-
-Choices are:
-
--- max5triv.ini: Chris Radek's MaxNC which has been modified to have B and C angular axes.  This version uses trivkins, so does not provide proper multi-axis behavior.
-
--- max5kins.ini: Chris Radek's MaxNC which has been modified to have B and C angular axes.  This version uses maxkins, and allows full 9-axis G-code.
-
--- hbm.ini: A large horizontal boring mill.  The quill is configured as the W axis.
-
--- 5axis
--- hexapod-sim
--- puma
--- scara
+All of the simulations use the Axis GUI.

--- a/configs/sim/axis/vismach/hbm/README
+++ b/configs/sim/axis/vismach/hbm/README
@@ -1,0 +1,1 @@
+A large horizontal boring mill.  The quill is configured as the W axis.


### PR DESCRIPTION
Much of the information in the 'vismach' folder README is outdated or duplicated in the README files of the respective sim configs.

Information about the 'hbm' config is moved to a new README in the 'hbm' config folder.