### PR TITLE
gantry: refuse to load when personality is zero

### DIFF
--- a/src/hal/components/gantry.comp
+++ b/src/hal/components/gantry.comp
@@ -63,8 +63,9 @@ Drives multiple physical motors (joints) from a single axis input
 --- End deprecation notice
 Drives multiple physical motors (joints) from a single axis input
 
-The `personality' value is the number of joints to control.  Two is typical, but
-up to seven is supported (a three joint setup has been tested with hardware).
+The `personality' value is the number of joints to control and must be at least one.
+Two is typical, but up to seven is supported (a three joint setup has been tested
+with hardware).
 
 All controlled joints track the commanded position (with a per-joint offset) unless in the process of homing.
 Homing is when the commanded position is moving towards the homing switches
@@ -81,6 +82,7 @@ When a joint home switch trips, the commanded velocity will drop immediately fro
 license "GPL";
 author "Charles Steinkuehler";
 option period no;
+option extra_setup;
 variable rtapi_real offset[7] = 0.0;
 variable rtapi_real prev_cmd = 0.0;
 variable int   fb_joint = 0;
@@ -169,3 +171,19 @@ FUNCTION(write) {
     }
 }
 
+EXTRA_SETUP() {
+    (void)prefix;
+    (void)extra_arg;
+
+    // Without a personality value no joint pins are created, and the
+    // FUNCTION(read) and FUNCTION(write) bodies dereference joint_home(0)
+    // before the personality-sized loop, which segfaults rtapi_app as soon
+    // as the function runs.  Reject the misconfiguration at load time so
+    // the failure is visible up front instead of crashing later.
+    if (personality < 1) {
+        rtapi_print_msg(RTAPI_MSG_ERR,
+            "gantry: personality must be >= 1 (use personality=N to set the number of joints)\n");
+        return -EINVAL;
+    }
+    return 0;
+}


### PR DESCRIPTION
Fixes #4302.

`loadrt gantry` with no personality modparam exports no joint pins, but
`FUNCTION(read)` and `FUNCTION(write)` unconditionally dereference
`joint_home(0)` before the personality-sized loop, so the next thread
tick segfaults `rtapi_app`.

Reject the misconfiguration in an `EXTRA_SETUP` hook so the failure
shows up at `loadrt` time (clear error + `-EINVAL`) instead of crashing
the realtime process later. Documented usage with `personality=N` is
unaffected.

Rebased on top of #4296 (gantry getter/setter rewrite); build and
both repro/happy-path tests pass on the post-#4296 base.

Repro (uspace sim, RIP build):

    loadrt threads name1=t period1=1000000 fp1=0
    loadrt gantry
    addf gantry.0.read t
    start

Before: rtapi_app dies as soon as the thread runs.
After:  loadrt errors with
        `gantry: personality must be >= 1 (use personality=N to set the number of joints)`
        and rtapi_app exits with `-EINVAL`.
        `loadrt gantry personality=2` loads and runs unchanged.