### PR TITLE
halcmd: Fix completion selection for setp

### DIFF
--- a/src/hal/utils/halcmd_completion.c
+++ b/src/hal/utils/halcmd_completion.c
@@ -409,7 +409,7 @@ static char *setp_generator(const char *text, int state)
         build_pinparam_list(&gdl, &idx, &len, text, HAL_QTYPE_ANY);
     }
     for(; idx < gdl.n; idx++) {
-        if(0 == (gdl.data[idx].dir & (HAL_WO | HAL_OUT)) || NULL != gdl.data[idx].sig)
+        if(HAL_OUT == gdl.data[idx].dir || HAL_RO == gdl.data[idx].dir || NULL != gdl.data[idx].sig)
             continue; // Not writable or has a signal attached
 	if(!strncmp(text, gdl.data[idx].name, len)) {
             return strdup(gdl.data[idx++].name);


### PR DESCRIPTION
Fixes #4301.

The recent change to use the HAL query API changed the selection in auto-completion for setp. However, it selected on a (wrong) bitmask and must simply exclude HAL_OUT, HAL_RO and pins with signals attached. Fixed in this PR.