### PR TITLE
homing: Remove the unconditional assignment to prevent race

### DIFF
--- a/src/emc/motion/homing.c
+++ b/src/emc/motion/homing.c
@@ -557,7 +557,6 @@ static void base_write_homing_out_pins(int njoints)
             // must be delayed until the state machine is done.
             hal_set_bool(addr->homing, H[jno].homing);
         }
-        hal_set_bool(addr->homing,     H[jno].homing);     // OUT
         hal_set_bool(addr->homed,      H[jno].homed);      // OUT
         hal_set_si32(addr->home_state, H[jno].home_state); // OUT
         // index_enable is a HAL_IO pin: the encoder driver also writes it


### PR DESCRIPTION
The race condition identified and fixed in #3800 did not correctly remove the unconditional assignment as noted in #4289. Therefore, the fix was incomplete.
The race issue was present in both controller.c and homing.c. The controller one was correctly addressed and addressed internal consistency whereas the homing.c version addresses a pin and external synchronization.

It is unknown if this fixes #4283 because the linuxcncrsh race does not involve a pin afaics. We'll have to look into that some more.

Fixes #4289.