### PR TITLE
hal: Update first batch of C components to use getter/setter

### DIFF
--- a/src/hal/components/counter.c
+++ b/src/hal/components/counter.c
@@ -65,19 +65,19 @@ typedef struct {
     unsigned char oldA;		/* previous value of phase A */
     unsigned char reset_on_index;
     unsigned char pad;		/* padding for alignment */
-    hal_s32_t *raw_count;	/* pin: raw binary count value */
-    hal_bit_t *phaseA;		/* quadrature input */
-    hal_bit_t *phaseZ;		/* index pulse input */
-    hal_bit_t *index_ena;	/* index enable input */
-    hal_bit_t *reset;		/* counter reset input */
-    hal_s32_t *count;		/* captured binary count value */
-    hal_float_t *pos;		/* scaled position (floating point) */
-    hal_float_t *vel;		/* scaled velocity (floating point) */
-    hal_float_t *pos_scale;	/* pin: scaling factor for pos */
+    hal_sint_t raw_count;	/* pin: raw binary count value */
+    hal_bool_t phaseA;		/* quadrature input */
+    hal_bool_t phaseZ;		/* index pulse input */
+    hal_bool_t index_ena;	/* index enable input */
+    hal_bool_t reset;		/* counter reset input */
+    hal_sint_t count;		/* captured binary count value */
+    hal_real_t pos;		/* scaled position (floating point) */
+    hal_real_t vel;		/* scaled velocity (floating point) */
+    hal_real_t pos_scale;	/* pin: scaling factor for pos */
     double old_scale;		/* stored scale value */
     double scale;		/* reciprocal value used for scaling */
-    hal_s32_t last_count;
-    hal_s32_t last_index_count;
+    rtapi_s32 last_count;
+    rtapi_s32 last_index_count;
 } counter_t;
 
 /* pointer to array of counter_t structs in shmem, 1 per counter */
@@ -138,10 +138,10 @@ int rtapi_app_main(void)
 	counter_array[n].oldZ = 0;
 	counter_array[n].oldA = 0;
 	counter_array[n].reset_on_index = 0;
-	*(counter_array[n].raw_count) = 0;
-	*(counter_array[n].count) = 0;
-	*(counter_array[n].pos) = 0.0;
-	*(counter_array[n].pos_scale) = 1.0;
+	hal_set_si32(counter_array[n].raw_count, 0);
+	hal_set_si32(counter_array[n].count, 0);
+	hal_set_real(counter_array[n].pos, 0.0);
+	hal_set_real(counter_array[n].pos_scale, 1.0);
 	counter_array[n].old_scale = 1.0;
 	counter_array[n].scale = 1.0;
     }
@@ -185,16 +185,16 @@ static void update(void *arg, long period)
 
     for (cntr = arg, n = 0; n < num_chan; cntr++, n++) {
         // count on rising edge
-        if(!cntr->oldA && *cntr->phaseA)
-            (*cntr->raw_count)++;
-        cntr->oldA = *cntr->phaseA;
+        if(!cntr->oldA && hal_get_bool(cntr->phaseA))
+            hal_set_si32(cntr->raw_count, hal_get_si32(cntr->raw_count) + 1);
+        cntr->oldA = hal_get_bool(cntr->phaseA);
 
         // reset on rising edge
-        if(cntr->reset_on_index && !cntr->oldZ && *cntr->phaseZ) {
-            cntr->last_index_count = *(cntr->raw_count);
-            *(cntr->index_ena) = 0;
+        if(cntr->reset_on_index && !cntr->oldZ && hal_get_bool(cntr->phaseZ)) {
+            cntr->last_index_count = hal_get_si32(cntr->raw_count);
+            hal_set_bool(cntr->index_ena, 0);
         }
-        cntr->oldZ = *cntr->phaseZ;
+        cntr->oldZ = hal_get_bool(cntr->phaseZ);
     }
 }
 
@@ -207,37 +207,37 @@ static void capture(void *arg, long period)
 	/* check reset input */
         int raw_count;
         int counts;
-	if (*(cntr->reset)) {
+	if (hal_get_bool(cntr->reset)) {
 	    /* reset is active, reset the counter */
-	    *(cntr->raw_count) = 0;
+	    hal_set_si32(cntr->raw_count, 0);
             cntr->last_index_count = 0;
             cntr->last_count = 0;
 	}
 	/* capture raw counts to latches */
-        raw_count = *(cntr->raw_count);
-	*(cntr->count) = raw_count - cntr->last_index_count;
+        raw_count = hal_get_si32(cntr->raw_count);
+	hal_set_si32(cntr->count, raw_count - cntr->last_index_count);
         counts = (raw_count - cntr->last_count);
         cntr->last_count = raw_count;
 
 	/* check for change in scale value */
-	if ( *(cntr->pos_scale) != cntr->old_scale ) {
+	if ( hal_get_real(cntr->pos_scale) != cntr->old_scale ) {
 	    /* save new scale to detect future changes */
-	    cntr->old_scale = *(cntr->pos_scale);
+	    cntr->old_scale = hal_get_real(cntr->pos_scale);
 	    /* scale value has changed, test and update it */
-	    if ((*(cntr->pos_scale) < 1e-20) && (*(cntr->pos_scale) > -1e-20)) {
+	    if ((hal_get_real(cntr->pos_scale) < 1e-20) && (hal_get_real(cntr->pos_scale) > -1e-20)) {
 		/* value too small, divide by zero is a bad thing */
-		*(cntr->pos_scale) = 1.0;
+		hal_set_real(cntr->pos_scale, 1.0);
 	    }
 	    /* we actually want the reciprocal */
-	    cntr->scale = 1.0 / *(cntr->pos_scale);
+	    cntr->scale = 1.0 / hal_get_real(cntr->pos_scale);
 	}
 	/* scale count to make floating point position */
-	*(cntr->pos) = *(cntr->count) * cntr->scale;
+	hal_set_real(cntr->pos, hal_get_si32(cntr->count) * cntr->scale);
 	/* scale counts to make floating point velocity */
-        *(cntr->vel) = counts * cntr->scale * 1e9 / period;
+        hal_set_real(cntr->vel, counts * cntr->scale * 1e9 / period);
 
 	/* update reset_on_index based on index_ena */
-        cntr->reset_on_index = *(cntr->index_ena);
+        cntr->reset_on_index = hal_get_bool(cntr->index_ena);
     }
 }
 
@@ -245,9 +245,17 @@ static void capture(void *arg, long period)
 *                   LOCAL FUNCTION DEFINITIONS                         *
 ************************************************************************/
 
+#define CHK(v) do { \
+        int _rv = (v); \
+        if(0 != _rv) { \
+            rtapi_set_msg_level(msg); \
+            return _rv; \
+        } \
+    } while(0)
+
 static int export_counter(int num, counter_t * addr)
 {
-    int retval, msg;
+    int msg;
 
     /* This function exports a lot of stuff, which results in a lot of
        logging if msg_level is at INFO or ALL. So we save the current value
@@ -257,50 +265,23 @@ static int export_counter(int num, counter_t * addr)
     rtapi_set_msg_level(RTAPI_MSG_WARN);
 
     /* export pins for the quadrature inputs */
-    retval = hal_pin_bit_newf(HAL_IN, &(addr->phaseA), comp_id, "counter.%d.phase-A", num);
-    if (retval != 0) {
-	return retval;
-    }
+    CHK(hal_pin_new_bool(comp_id, HAL_IN, &addr->phaseA, 0, "counter.%d.phase-A", num));
     /* export pin for the index input */
-    retval = hal_pin_bit_newf(HAL_IN, &(addr->phaseZ), comp_id, "counter.%d.phase-Z", num);
-    if (retval != 0) {
-	return retval;
-    }
+    CHK(hal_pin_new_bool(comp_id, HAL_IN, &addr->phaseZ, 0, "counter.%d.phase-Z", num));
     /* export pin for the index enable input */
-    retval = hal_pin_bit_newf(HAL_IO, &(addr->index_ena), comp_id, "counter.%d.index-enable", num);
-    if (retval != 0) {
-	return retval;
-    }
+    CHK(hal_pin_new_bool(comp_id, HAL_IO, &addr->index_ena, 0, "counter.%d.index-enable", num));
     /* export pin for the reset input */
-    retval = hal_pin_bit_newf(HAL_IN, &(addr->reset), comp_id, "counter.%d.reset", num);
-    if (retval != 0) {
-	return retval;
-    }
+    CHK(hal_pin_new_bool(comp_id, HAL_IN, &addr->reset, 0, "counter.%d.reset", num));
     /* export parameter for raw counts */
-    retval = hal_pin_s32_newf(HAL_OUT, &(addr->raw_count), comp_id, "counter.%d.rawcounts", num);
-    if (retval != 0) {
-	return retval;
-    }
+    CHK(hal_pin_new_si32(comp_id, HAL_OUT, &addr->raw_count, 0, "counter.%d.rawcounts", num));
     /* export pin for counts captured by capture() */
-    retval = hal_pin_s32_newf(HAL_OUT, &(addr->count), comp_id, "counter.%d.counts", num);
-    if (retval != 0) {
-	return retval;
-    }
+    CHK(hal_pin_new_si32(comp_id, HAL_OUT, &addr->count, 0, "counter.%d.counts", num));
     /* export pin for scaled position captured by capture() */
-    retval = hal_pin_float_newf(HAL_OUT, &(addr->pos), comp_id, "counter.%d.position", num);
-    if (retval != 0) {
-	return retval;
-    }
+    CHK(hal_pin_new_real(comp_id, HAL_OUT, &addr->pos, 0.0, "counter.%d.position", num));
     /* export pin for scaled velocity captured by capture() */
-    retval = hal_pin_float_newf(HAL_OUT, &(addr->vel), comp_id, "counter.%d.velocity", num);
-    if (retval != 0) {
-	return retval;
-    }
+    CHK(hal_pin_new_real(comp_id, HAL_OUT, &addr->vel, 0.0, "counter.%d.velocity", num));
     /* export parameter for scaling */
-    retval = hal_pin_float_newf(HAL_IO, &(addr->pos_scale), comp_id, "counter.%d.position-scale", num);
-    if (retval != 0) {
-	return retval;
-    }
+    CHK(hal_pin_new_real(comp_id, HAL_IO, &addr->pos_scale, 0.0, "counter.%d.position-scale", num));
     /* restore saved message level */
     rtapi_set_msg_level(msg);
     return 0;

--- a/src/hal/components/debounce.c
+++ b/src/hal/components/debounce.c
@@ -65,9 +65,13 @@ RTAPI_MP_ARRAY_INT(cfg,MAX_GROUP,"Group size for up to "MAX_GROUP_STR" groups");
 /** This structure contains the runtime data for a single filter. */
 
 typedef struct {
-    hal_bit_t *in;		/* pin: input */
-    hal_bit_t *out;		/* pin: output */
-    hal_s32_t state;		/* parameter*: internal state */
+    hal_bool_t in;      /* pin: input */
+    hal_bool_t out;     /* pin: output */
+#ifdef EXPORT_STATE
+    hal_sint_t state;   /* parameter*: internal state */
+#else
+    rtapi_s32 state;    /* parameter*: internal state */
+#endif
 } debounce_t;
 
 /*  *note - this parameter is only exported if EXPORT_STATE is defined */
@@ -75,9 +79,9 @@ typedef struct {
 /** This structure contains the runtime data for a group of filters */
 
 typedef struct {
-    int channels;		/* number of channels in group */
-    hal_s32_t delay;		/* parameter: delay for this group */
-    debounce_t *filter_array;	/* pointer to individual filter data */
+    int channels;               /* number of channels in group */
+    hal_sint_t delay;           /* parameter: delay for this group */
+    debounce_t *filter_array;   /* pointer to individual filter data */
 } debounce_group_t;
 
 /* ptr to array of debounce_group_t structs in shmem, 1 per group */
@@ -135,7 +139,7 @@ int rtapi_app_main(void)
     }
     /* allocate shared memory for filter group array */
     group_array = hal_malloc(num_groups * sizeof(debounce_group_t));
-    if (group_array == 0) {
+    if (group_array == NULL) {
 	rtapi_print_msg(RTAPI_MSG_ERR,
 	    "DEBOUNCE: ERROR: hal_malloc() failed\n");
 	hal_exit(comp_id);
@@ -168,6 +172,14 @@ void rtapi_app_exit(void)
 *                     REALTIME DEBOUNCE FUNCTION                       *
 ************************************************************************/
 
+#ifdef EXPORT_STATE
+static inline rtapi_s32 get_state(hal_sint_t *s) { return hal_get_si32(*s); }
+static inline rtapi_s32 set_state(hal_sint_t *s, rtapi_s32 v) { return hal_set_si32(*s, v); }
+#else
+static inline rtapi_s32 get_state(rtapi_s32 *s) { return *s; }
+static inline rtapi_s32 set_state(rtapi_s32 *s, rtapi_s32 v) { return (*s = v); }
+#endif
+
 /** The debounce filter works by incrementing a counter whenever the
     input is true, and decrementing the counter when it is false.
     If the counter decrements to zero, the output is set false and
@@ -193,33 +205,33 @@ static void debounce(void *arg, long period)
     /* point to filter group */
     group = (debounce_group_t *) arg;
     /* first make sure delay is sane */
-    if (group->delay < 0) {
-	group->delay = 1;
+    if (hal_get_si32(group->delay) < 0) {
+        hal_set_si32(group->delay, 1);
     }
     /* loop thru filters */
     for (n = 0; n < group->channels; n++) {
-	/* point at a filter */
-	filter = &(group->filter_array[n]);
-	/* update this filter */
-	if (*(filter->in)) {
-	    /* input true, is state at threshold? */
-	    if (filter->state < group->delay) {
-		/* no, increment */
-		filter->state++;
-	    } else {
-		/* yes, set output */
-		*(filter->out) = 1;
-	    }
-	} else {
-	    /* input false, is state at zero? */
-	    if (filter->state > 0) {
-		/* no, decrement */
-		filter->state--;
-	    } else {
-		/* yes, clear output */
-		*(filter->out) = 0;
-	    }
-	}
+        /* point at a filter */
+        filter = &(group->filter_array[n]);
+        /* update this filter */
+        if (hal_get_bool(filter->in)) {
+            /* input true, is state at threshold? */
+            if (get_state(&filter->state) < hal_get_si32(group->delay)) {
+                /* no, increment */
+                set_state(&filter->state, get_state(&filter->state) + 1);
+            } else {
+                /* yes, set output */
+                hal_set_bool(filter->out, 1);
+            }
+        } else {
+            /* input false, is state at zero? */
+            if (get_state(&filter->state) > 0) {
+                /* no, decrement */
+                set_state(&filter->state, get_state(&filter->state) - 1);
+            } else {
+                /* yes, clear output */
+                hal_set_bool(filter->out, 0);
+            }
+        }
     }
 }
 
@@ -241,36 +253,31 @@ static int export_group(int num, debounce_group_t * addr, int group_size)
     /* allocate shared memory for this filter group */
     addr->filter_array = hal_malloc(group_size * sizeof(debounce_t));
     if (addr->filter_array == 0) {
-	rtapi_print_msg(RTAPI_MSG_ERR,
-	    "DEBOUNCE: ERROR: hal_malloc() failed\n");
-	return -1;
+        rtapi_print_msg(RTAPI_MSG_ERR, "DEBOUNCE: ERROR: hal_malloc() failed\n");
+        return -1;
     }
     /* export param variable for delay */
-    retval = hal_param_s32_newf(HAL_RW, &(addr->delay), comp_id, "debounce.%d.delay", num);
+    retval = hal_param_new_si32(comp_id, HAL_RW, &addr->delay, 5, "debounce.%d.delay", num);
     if (retval != 0) {
-	rtapi_print_msg(RTAPI_MSG_ERR,
-	    "DEBOUNCE: ERROR: 'debounce.%d.delay' param export failed\n", num);
-	return retval;
+        rtapi_print_msg(RTAPI_MSG_ERR, "DEBOUNCE: ERROR: 'debounce.%d.delay' param export failed\n", num);
+        return retval;
     }
     /* export function */
     retval = hal_export_functf(debounce, addr, 0, 0, comp_id, "debounce.%d", num);
     if (retval != 0) {
-	rtapi_print_msg(RTAPI_MSG_ERR,
-	    "DEBOUNCE: ERROR: 'debounce.%d' funct export failed\n", num);
-	return -1;
+        rtapi_print_msg(RTAPI_MSG_ERR, "DEBOUNCE: ERROR: 'debounce.%d' funct export failed\n", num);
+        return -1;
     }
     /* set default parameter values */
-    addr->delay = 5;
     addr->channels = group_size;
 
     /* loop to export each filter in group */
     for (n = 0; n < group_size; n++) {
-	retval = export_filter(n, &(addr->filter_array[n]), num);
-	if (retval != 0) {
-	    rtapi_print_msg(RTAPI_MSG_ERR,
-		"DEBOUNCE: ERROR: filter %d export failed\n", n);
-	    return -1;
-	}
+        retval = export_filter(n, &(addr->filter_array[n]), num);
+        if (retval != 0) {
+            rtapi_print_msg(RTAPI_MSG_ERR, "DEBOUNCE: ERROR: filter %d export failed\n", n);
+            return -1;
+        }
     }
     /* restore saved message level */
     rtapi_set_msg_level(msg);
@@ -281,35 +288,31 @@ static int export_filter(int num, debounce_t * addr, int group_num)
 {
     int retval;
     char buf[HAL_NAME_LEN + 1];
+    rtapi_snprintf(buf, sizeof(buf), "debounce.%d.%d", group_num, num);
 
     /* export pin for input */
-    rtapi_snprintf(buf, sizeof(buf), "debounce.%d.%d.in", group_num, num);
-    retval = hal_pin_bit_new(buf, HAL_IN, &(addr->in), comp_id);
+    retval = hal_pin_new_bool(comp_id, HAL_IN, &addr->in, 0, "%s.in", buf);
     if (retval != 0) {
-	rtapi_print_msg(RTAPI_MSG_ERR,
-	    "DEBOUNCE: ERROR: '%s' pin export failed\n", buf);
-	return retval;
+        rtapi_print_msg(RTAPI_MSG_ERR, "DEBOUNCE: ERROR: '%s.in' pin export failed\n", buf);
+        return retval;
     }
     /* export pin for output */
-    rtapi_snprintf(buf, sizeof(buf), "debounce.%d.%d.out", group_num, num);
-    retval = hal_pin_bit_new(buf, HAL_OUT, &(addr->out), comp_id);
+    retval = hal_pin_new_bool(comp_id, HAL_OUT, &addr->out, 0, "%s.out", buf);
     if (retval != 0) {
-	rtapi_print_msg(RTAPI_MSG_ERR,
-	    "DEBOUNCE: ERROR: '%s' pin export failed\n", buf);
-	return retval;
+        rtapi_print_msg(RTAPI_MSG_ERR, "DEBOUNCE: ERROR: '%s.out' pin export failed\n", buf);
+        return retval;
     }
 #ifdef EXPORT_STATE
     /* export parameter containing internal state */
-    rtapi_snprintf(buf, sizeof(buf), "debounce.%d.%d.state", group_num, num);
-    retval = hal_param_s32_new(buf, HAL_RO, &(addr->state), comp_id);
+    retval = hal_param_new_si32(comp_id, HAL_RO, &addr->state, 0, "%s.state", buf);
     if (retval != 0) {
-	rtapi_print_msg(RTAPI_MSG_ERR,
-	    "DEBOUNCE: ERROR: '%s' param export failed\n", buf);
-	return retval;
+        rtapi_print_msg(RTAPI_MSG_ERR, "DEBOUNCE: ERROR: '%s.state' param export failed\n", buf);
+        return retval;
     }
+#else
+    // Param is init to zero.
+    // When no param is exported, we need to be sure too.
+    set_state(&addr->state, 0);
 #endif
-    /* set initial parameter and pin values */
-    addr->state = 0;
-    *(addr->out) = 0;
     return 0;
 }

--- a/src/hal/components/enum.c
+++ b/src/hal/components/enum.c
@@ -36,8 +36,8 @@ MODULE_LICENSE("GPL");
 #define MAX_CHAN 256
 
 typedef struct {
-    hal_bit_t *bit;
-    hal_u32_t *en; // note use index 0 differently
+    hal_bool_t bit;
+    hal_uint_t en; // note use index 0 differently
 } enum_hal_t;
 
 typedef struct{
@@ -137,10 +137,10 @@ int rtapi_app_main(void){
 
         // create single per-instance int pin in index 0
         if (inst->dir == HAL_OUT) {
-            retval = hal_pin_u32_newf(HAL_IN, &(inst->hal[0].en), comp_id,
+            retval = hal_pin_new_ui32(comp_id, HAL_IN, &(inst->hal[0].en), 0,
                                     "%s.input", this);
         } else {
-            retval = hal_pin_u32_newf(HAL_OUT, &(inst->hal[0].en), comp_id,
+            retval = hal_pin_new_ui32(comp_id, HAL_OUT, &(inst->hal[0].en), 0,
                                     "%s.output", this);
         }
         v = 0;
@@ -150,12 +150,11 @@ int rtapi_app_main(void){
             //increment for skipped enumerations
             while (*(++token) == 0) v++;
 
-            retval = hal_pin_bit_newf(inst->dir, &(inst->hal[j].bit),
-                    comp_id, "%s.%s-%s",this, token,
+            retval = hal_pin_new_bool(comp_id, inst->dir, &(inst->hal[j].bit),
+                    0, "%s.%s-%s",this, token,
                     (inst->dir == HAL_IN)?"in":"out");
-            retval += hal_pin_u32_newf(HAL_IN, &(inst->hal[j].en),
-                    comp_id, "%s.%s-val",this, token);
-            *(inst->hal[j].en) = v++;
+            retval += hal_pin_new_ui32(comp_id, HAL_IN, &(inst->hal[j].en),
+                    v++, "%s.%s-val",this, token);
 
             if (retval < 0){
                 rtapi_print_msg(RTAPI_MSG_ERR, "Failed to create HAL pins\n");
@@ -191,10 +190,10 @@ static void decode(void *v_inst, long period){
     int i;
     enum_inst_t *inst = v_inst;
     for (i = 1; i <= inst->num_pins; i++){
-        if (*(inst->hal[0].en) == *(inst->hal[i].en)){
-           *(inst->hal[i].bit) = 1;
+        if (hal_get_ui32(inst->hal[0].en) == hal_get_ui32(inst->hal[i].en)){
+           hal_set_bool(inst->hal[i].bit, 1);
         } else {
-           *(inst->hal[i].bit) = 0;
+           hal_set_bool(inst->hal[i].bit, 0);
         }
     }
 }
@@ -202,10 +201,10 @@ static void encode(void *v_inst, long period){
     (void)period;
     int i;
     enum_inst_t *inst = v_inst;
-    *(inst->hal[0].en) = 0;
+    hal_set_ui32(inst->hal[0].en, 0);
     for (i = 1; i <= inst->num_pins; i++){
-        if (*(inst->hal[i].bit)){
-            *(inst->hal[0].en) = *(inst->hal[i].en);
+        if (hal_get_bool(inst->hal[i].bit)){
+            hal_set_ui32(inst->hal[0].en, hal_get_ui32(inst->hal[i].en));
         }
     }
 }

--- a/src/hal/components/joint_axis_mapper.comp
+++ b/src/hal/components/joint_axis_mapper.comp
@@ -18,7 +18,7 @@ net z-fault joint.2.faulted => jam.z-fault
 
 license "GPL";
 
-pin out bit dummy "halcompile requires at least one halpin";
+pin out bool dummy "halcompile requires at least one halpin";
 
 function _;
 option period no;
@@ -34,8 +34,8 @@ int number_joints = 9;
 static int axis_counts[9];
 
 typedef struct{
-    hal_bit_t *fault_in[16];
-    hal_bit_t *fault_out[16];
+    hal_bool_t fault_in[16];
+    hal_bool_t fault_out[16];
 } faults_in_t;
 
 static faults_in_t *faults_in;
@@ -46,7 +46,7 @@ int rtapi_app_main(void) {
     if(comp_id < 0) return comp_id;
 
     number_joints = strlen(coord);
-    faults_in = hal_malloc(sizeof(faults_in_t));
+    faults_in = hal_malloc(sizeof(*faults_in));
 
     rtapi_print_msg(RTAPI_MSG_INFO, "Joint Axis Mapper - Initializing with coords %s\n", coord);
 
@@ -77,12 +77,12 @@ int rtapi_app_main(void) {
         if(coord[i] == 'W' || coord[i] == 'w'){ axis_counts[8]++; this_count = axis_counts[8];  }
 
         if(this_count == 1){
-            hal_pin_bit_newf(HAL_IN,  &(faults_in->fault_in[i]),  comp_id, "jam.%c-fault", coord[i]);
-            hal_pin_bit_newf(HAL_OUT, &(faults_in->fault_out[i]), comp_id, "jam.%c-fault-latched", coord[i]);
+            hal_pin_new_bool(comp_id, HAL_IN,  &faults_in->fault_in[i],  0, "jam.%c-fault", coord[i]);
+            hal_pin_new_bool(comp_id, HAL_OUT, &faults_in->fault_out[i], 0, "jam.%c-fault-latched", coord[i]);
         }
         else if(this_count > 1){
-            hal_pin_bit_newf(HAL_IN,  &(faults_in->fault_in[i]),  comp_id, "jam.%c%d-fault", coord[i], this_count);
-            hal_pin_bit_newf(HAL_OUT, &(faults_in->fault_out[i]), comp_id, "jam.%c%d-fault-latched", coord[i], this_count);
+            hal_pin_new_bool(comp_id, HAL_IN,  &faults_in->fault_in[i],  0, "jam.%c%d-fault", coord[i], this_count);
+            hal_pin_new_bool(comp_id, HAL_OUT, &faults_in->fault_out[i], 0, "jam.%c%d-fault-latched", coord[i], this_count);
         }
         else {
             rtapi_print_msg(RTAPI_MSG_ERR, "Joint Axis Mapper - %c axis not found in coord string\n", coord[i]);
@@ -100,11 +100,11 @@ void rtapi_app_exit(void) {
 
 
 FUNCTION(_) {
-    dummy=0; // if we don't use at least one halpin in FUNCTION we get a compiler warning
+    (void)__comp_inst; // We don't have any pins or anything else that is referenced in the instance
     for(int i = 0; i < number_joints; i++) {
-        if(*faults_in->fault_in[i] && ! *faults_in->fault_out[i]){
+        if(hal_get_bool(faults_in->fault_in[i]) && ! hal_get_bool(faults_in->fault_out[i])){
             rtapi_print_msg(RTAPI_MSG_ERR, "%c Axis fault detected\n", fault_letter[i]);
         }
-        *(faults_in->fault_out[i]) = *(faults_in->fault_in[i]);
+        hal_set_bool(faults_in->fault_out[i], hal_get_bool(faults_in->fault_in[i]));
     }
 }

--- a/src/hal/components/lcd.c
+++ b/src/hal/components/lcd.c
@@ -39,7 +39,7 @@ MODULE_LICENSE("GPL");
 #define MAX_ENTRY 20
 
 typedef struct {
-    void **args;
+    hal_refs_u *args;
     int num_args;
     char *fmt;
     int length;
@@ -48,16 +48,16 @@ typedef struct {
 typedef struct {
     lcd_page_t *pages;
     unsigned num_pages;
-    hal_u32_t *page_num;
-    hal_u32_t last_page;
-    hal_u32_t *out;
-    hal_float_t *contrast;
-    hal_float_t last_contrast;
+    hal_uint_t page_num;
+    hal_uint_t out;
+    hal_real_t contrast;
+    rtapi_u32  last_page;
+    rtapi_real last_contrast;
     char buff[MAX_ENTRY + 1];
     int c_ptr;
     int f_ptr;
     int a_ptr;
-    unsigned int dp;
+    hal_uint_t dp;
 }lcd_inst_t;
 
 typedef struct {
@@ -70,7 +70,7 @@ static lcd_t *lcd;
 static void write(void *arg, long period);
 static void write_one(lcd_inst_t *inst);
 
-static int parse_fmt(char *in, int *ptr, char *out, void *val, char dp);
+static int parse_fmt(char *in, int *ptr, char *out, hal_refs_u *val, char dp);
 
 char *digits = "0123456789ABCDEF";
 
@@ -142,7 +142,7 @@ int rtapi_app_main(void){
                                   fmt_strings[i] + f1);
                 inst->pages[p].length = f - f1 + 2;
                 inst->pages[p].args = hal_malloc(inst->pages[p].num_args
-                                                 * sizeof(hal_float_t));
+                                                 * sizeof(*inst->pages[p].args));
                 f1 = f + 2;
                 {
                     int a = -1, s = -1;
@@ -155,8 +155,8 @@ int rtapi_app_main(void){
                             a++;
                             switch (type){
                                 case 'f':
-                                    retval = hal_pin_float_newf(HAL_IN,
-                                                                (hal_float_t**)&(inst->pages[p].args[a]), comp_id,
+                                    retval = hal_pin_new_real(comp_id, HAL_IN,
+                                                                &(inst->pages[p].args[a].r), 0.0,
                                                                 "lcd.%02i.page.%02i.arg.%02i",
                                                                 i, p, a);
                                     if (retval != 0) {
@@ -165,8 +165,8 @@ int rtapi_app_main(void){
                                     break;
                                 case 'u':
                                 case 'c':
-                                    retval = hal_pin_u32_newf(HAL_IN,
-                                                              (hal_u32_t **)&(inst->pages[p].args[a]), comp_id,
+                                    retval = hal_pin_new_ui32(comp_id, HAL_IN,
+                                                              &(inst->pages[p].args[a].u), 0,
                                                               "lcd.%02i.page.%02i.arg.%02i",
                                                               i, p, a);
                                     if (retval != 0) {
@@ -175,8 +175,8 @@ int rtapi_app_main(void){
                                     
                                     break;
                                 case 's':
-                                    retval = hal_pin_s32_newf(HAL_IN,
-                                                              (hal_s32_t **)&(inst->pages[p].args[a]), comp_id,
+                                    retval = hal_pin_new_si32(comp_id, HAL_IN,
+                                                              &(inst->pages[p].args[a].s), 0,
                                                               "lcd.%02i.page.%02i.arg.%02i",
                                                               i, p, a);
                                     if (retval != 0) {
@@ -184,8 +184,8 @@ int rtapi_app_main(void){
                                     }
                                     break;
                                 case 'b':
-                                    retval = hal_pin_bit_newf(HAL_IN,
-                                                              (hal_bit_t **)&(inst->pages[p].args[a]), comp_id,
+                                    retval = hal_pin_new_bool(comp_id, HAL_IN,
+                                                              &(inst->pages[p].args[a].b), 0,
                                                               "lcd.%02i.page.%02i.arg.%02i",
                                                               i, p, a);
                                     if (retval != 0) {
@@ -207,25 +207,24 @@ int rtapi_app_main(void){
     }
     
     for (i = 0; i < lcd->num_insts; i++){
-        retval = hal_pin_u32_newf(HAL_IN, &(lcd->insts[i].page_num), comp_id,
+        retval = hal_pin_new_ui32(comp_id, HAL_IN, &(lcd->insts[i].page_num), 0,
                                   "lcd.%02i.page_num", i);
         if (retval != 0) {
             return retval;
         }
         lcd->insts[i].last_page = -1; // force screen refresh
-        retval = hal_pin_u32_newf(HAL_OUT, &(lcd->insts[i].out), comp_id,
+        retval = hal_pin_new_ui32(comp_id, HAL_OUT, &(lcd->insts[i].out), 0,
                                   "lcd.%02i.out",i);
         if (retval != 0) {
             return retval;
         }
-        retval = hal_pin_float_newf(HAL_IN, &(lcd->insts[i].contrast), comp_id,
+        retval = hal_pin_new_real(comp_id, HAL_IN, &(lcd->insts[i].contrast), 0.0,
                                     "lcd.%02i.contrast",i);
         if (retval != 0) {
             return retval;
         }
-        retval = hal_param_u32_newf(HAL_RW, &(lcd->insts[i].dp), comp_id,
+        retval = hal_param_new_ui32(comp_id, HAL_RW, &(lcd->insts[i].dp), '.',
                                     "lcd.%02i.decimal-separator",i);
-        lcd->insts[i].dp = '.';
         if (retval != 0) {
             return retval;
         }
@@ -277,18 +276,18 @@ static void write_one(lcd_inst_t *inst){
         return;}
 
     if (inst->buff[inst->c_ptr] != 0){
-        *inst->out = inst->buff[inst->c_ptr++];
+        hal_set_ui32(inst->out, inst->buff[inst->c_ptr++]);
         return;
     }
     
     inst->c_ptr = 0;
     inst->buff[0] = 0;
 
-    if (*inst->page_num >= inst->num_pages) return; // should this error?
+    if (hal_get_ui32(inst->page_num) >= inst->num_pages) return; // should this error?
     
-    if (*inst->page_num != inst->last_page){
-        inst->last_page = *inst->page_num;
-        *inst->out = 0x11; //cursor off
+    if (hal_get_ui32(inst->page_num) != inst->last_page){
+        inst->last_page = hal_get_ui32(inst->page_num);
+        hal_set_ui32(inst->out, 0x11); //cursor off
         inst->buff[0] = 0x1E; //cursor home
         inst->buff[1] = 0x1A; //clear screen
         inst->buff[2] = 0; // end
@@ -298,8 +297,8 @@ static void write_one(lcd_inst_t *inst){
         return;
     }
 
-    if (inst->f_ptr >= inst->pages[*inst->page_num].length){
-        *inst->out = 0x1B; // ESC
+    if (inst->f_ptr >= inst->pages[hal_get_ui32(inst->page_num)].length){
+        hal_set_ui32(inst->out, 0x1B); // ESC
         inst->buff[0] = 0x3D; // =
         inst->buff[1] = 0x20; // Line 0
         inst->buff[2] = 0x20; // Column 0
@@ -310,12 +309,12 @@ static void write_one(lcd_inst_t *inst){
         return;
     }
     
-    if (*inst->contrast != inst->last_contrast){
-        int c = *inst->contrast * 159.0 + 0x20;
+    if (hal_get_real(inst->contrast) != inst->last_contrast){
+        int c = hal_get_real(inst->contrast) * 159.0 + 0x20;
         if (c > 0xBF) c = 0xBF;
         if (c < 0x20) c = 0x20;
-        inst->last_contrast = *inst->contrast;
-        *inst->out = 0x1B;
+        inst->last_contrast = hal_get_real(inst->contrast);
+        hal_set_ui32(inst->out, 0x1B);
         inst->buff[0] = 'C';
         inst->buff[1] = c;
         inst->buff[2] = 0;
@@ -323,9 +322,9 @@ static void write_one(lcd_inst_t *inst){
         return;
     }
     
-    switch (inst->pages[*inst->page_num].fmt[inst->f_ptr]){
+    switch (inst->pages[hal_get_ui32(inst->page_num)].fmt[inst->f_ptr]){
         case '\\': //escape chars
-            c1 = inst->pages[*inst->page_num].fmt[++inst->f_ptr];
+            c1 = inst->pages[hal_get_ui32(inst->page_num)].fmt[++inst->f_ptr];
             switch (c1){
                 case 'n':
                 case 'N':
@@ -351,7 +350,7 @@ static void write_one(lcd_inst_t *inst){
                     /* Fallthrough */
                     
                 default: //check for hex
-                    c2 = inst->pages[*inst->page_num].fmt[++inst->f_ptr];
+                    c2 = inst->pages[hal_get_ui32(inst->page_num)].fmt[++inst->f_ptr];
                     inst->f_ptr++;
                     if (c1 > '9') c1 &= 0xDF; //upper case
                     if (c2 > '9') c2 &= 0xDF;
@@ -363,24 +362,24 @@ static void write_one(lcd_inst_t *inst){
                         inst->buff[0] = 0;
                     }
             }
-            *inst->out = inst->buff[0];
+            hal_set_ui32(inst->out, inst->buff[0]);
             inst->c_ptr = 1;
             return;
         case '%':
-            retval = parse_fmt(inst->pages[*inst->page_num].fmt,
+            retval = parse_fmt(inst->pages[hal_get_ui32(inst->page_num)].fmt,
                                &inst->f_ptr,
                                inst->buff,
-                               inst->pages[*inst->page_num].args[inst->a_ptr++],
-                               (char)inst->dp);
+                               &(inst->pages[hal_get_ui32(inst->page_num)].args[inst->a_ptr++]),
+                               (char)hal_get_ui32(inst->dp));
             if (retval >= 0) {
-                *inst->out = inst->buff[0];
+                hal_set_ui32(inst->out, inst->buff[0]);
                 inst->c_ptr = 1;
                 inst->f_ptr++;
                 return;
             }
             /* Fallthrough */
         default:
-            *inst->out = inst->pages[*inst->page_num].fmt[inst->f_ptr++];
+            hal_set_ui32(inst->out, inst->pages[hal_get_ui32(inst->page_num)].fmt[inst->f_ptr++]);
     }
 }
 
@@ -393,7 +392,7 @@ int num_digits_baseN(rtapi_u64 val, int base){
     return n;
 }
 
-static int parse_fmt(char *in, int *ptr, char *out, void *val, char dp){
+static int parse_fmt(char *in, int *ptr, char *out, hal_refs_u *val, char dp){
     /*parse val into the format in in pointed to by ptr.
      if out is null, then simply return the type of the format
      as u, s or f. a return value of -1 indicates an invalid pointer
@@ -476,7 +475,7 @@ static int parse_fmt(char *in, int *ptr, char *out, void *val, char dp){
             {
                 unsigned int tmp;
                 int i;
-                unsigned int v = *((hal_u32_t*)val);
+                unsigned int v = hal_get_ui32(val->u);
 
                 if (c < 1) c = num_digits_baseN(v, base);
 
@@ -504,7 +503,7 @@ static int parse_fmt(char *in, int *ptr, char *out, void *val, char dp){
             {
                 int tmp, s = 0;
                 int i;
-                int v = *((hal_s32_t*)val);
+                int v = hal_get_si32(val->s);
                 
                 if (sgn == '+') s = 1;
                 if (v < 0) {s = 1; sgn = '-'; v = -v;}
@@ -543,7 +542,7 @@ static int parse_fmt(char *in, int *ptr, char *out, void *val, char dp){
                 if (out == NULL || val == NULL) return 'f';
             {
                 int i;
-                double v = *((hal_float_t*)val);
+                double v = hal_get_real(val->r);
                 rtapi_u64 tmp = 0; //enough bits for 9 decimal digits.
                 int s = 0;
                 
@@ -608,7 +607,7 @@ static int parse_fmt(char *in, int *ptr, char *out, void *val, char dp){
                 if (out == NULL || val == NULL) return 'c';
             {
                 int i;
-                unsigned char v = *((hal_u32_t*)val);
+                unsigned char v = hal_get_ui32(val->u);
                 
                 if (c == 0) c = 1;
                 for (i = 0; i < c; i++){
@@ -622,7 +621,7 @@ static int parse_fmt(char *in, int *ptr, char *out, void *val, char dp){
             {
                 char c1, c2;
                 char bt = 'E', bf = 'E'; // a hint that there is a format error
-                int v = *((hal_bit_t*)val);
+                int v = hal_get_bool(val->b);
                 if (in[++(*ptr)] == '\\'){
                     c1 = in[++(*ptr)];
                     if (c1 > '9') c1 &= 0xDF;

--- a/src/hal/components/modmath.c
+++ b/src/hal/components/modmath.c
@@ -51,14 +51,14 @@ RTAPI_MP_INT(mod_dir, "Modulo direction blocks");
 /** These structures contain the runtime data for a single block. */
 
 typedef struct {
-    hal_bit_t *up;		/* output pin: go up to get to the desired position */
-    hal_bit_t *down;		/* output pin: go down to get to the desired position */
-    hal_bit_t *on_target;	/* output pin: go at desired position */
-    hal_s32_t *actual;		/* input pin: actual position */
-    hal_s32_t *desired;		/* input pin: desired position */
-    hal_s32_t *max_num;		/* input/output pin: highest value to allow */
-    hal_s32_t *min_num;		/* input/output pin: lowest value to allow */
-    hal_bit_t *wrap;		/* input/output pin: set true if the array is circular, false if linear */
+    hal_bool_t up;         /* output pin: go up to get to the desired position */
+    hal_bool_t down;       /* output pin: go down to get to the desired position */
+    hal_bool_t on_target;  /* output pin: go at desired position */
+    hal_sint_t actual;     /* input pin: actual position */
+    hal_sint_t desired;    /* input pin: desired position */
+    hal_sint_t max_num;    /* input/output pin: highest value to allow */
+    hal_sint_t min_num;    /* input/output pin: lowest value to allow */
+    hal_bool_t wrap;       /* input/output pin: set true if the array is circular, false if linear */
 } mod_dir_t;
 
 /* other globals */
@@ -116,43 +116,43 @@ void rtapi_app_exit(void)
 static void mod_dir_funct(void *arg, long period)
 {
     (void)period;
-    mod_dir_t *mod;
-    int range, act, des, to_go;
+    mod_dir_t *mod = (mod_dir_t *)arg; /* point to block data */
 
-    /* point to block data */
-    mod = (mod_dir_t *) arg;
-    range = *(mod->max_num) - *(mod->min_num) + 1;
-    act = *(mod->actual);
-    if (act > *(mod->max_num) || act < *(mod->min_num)) {
-	act = *(mod->min_num) + ((act-*(mod->min_num)) % (range));
+    rtapi_s32 min_num = hal_get_si32(mod->min_num);
+    rtapi_s32 max_num = hal_get_si32(mod->max_num);
+
+    rtapi_s32 range = max_num - min_num + 1;
+    rtapi_s32 act = hal_get_si32(mod->actual);
+    if (act > max_num || act < min_num) {
+        act = min_num + ((act-min_num) % (range));
     }
-    des = *(mod->desired);
-    if (des > *(mod->max_num) || des < *(mod->min_num)) {
-	des = *(mod->min_num) + ((des-*(mod->min_num)) % (range));
+    rtapi_s32 des = hal_get_si32(mod->desired);
+    if (des > max_num || des < min_num) {
+        des = min_num + ((des-min_num) % (range));
     }
 
-    to_go = des-act;
+    rtapi_s32 to_go = des-act;
 
-    if ((*(mod->wrap)) && (to_go > range/2)) {
-	to_go -= range;
+    if ((hal_get_bool(mod->wrap)) && (to_go > range/2)) {
+        to_go -= range;
     }
-    if ((*(mod->wrap)) && (to_go < -range/2)) {
-	to_go += range;
+    if ((hal_get_bool(mod->wrap)) && (to_go < -range/2)) {
+        to_go += range;
     }
 
     /* if (desired-actual) >= (actual+(max-min+1)-desired), output "up" */
     if (to_go == 0) {
-	*(mod->up) = 0;
-	*(mod->down) = 0;
-	*(mod->on_target) = 1;
+        hal_set_bool(mod->up,  0);
+        hal_set_bool(mod->down, 0);
+        hal_set_bool(mod->on_target, 1);
     } else if (to_go > 0 ) {
-	*(mod->down) = 0;
-	*(mod->on_target) = 0;
-	*(mod->up) = 1;
+        hal_set_bool(mod->down, 0);
+        hal_set_bool(mod->on_target, 0);
+        hal_set_bool(mod->up, 1);
     } else {
-	*(mod->up) = 0;
-	*(mod->on_target) = 0;
-	*(mod->down) = 1;
+        hal_set_bool(mod->up, 0);
+        hal_set_bool(mod->on_target, 0);
+        hal_set_bool(mod->down, 1);
     }
 }
 
@@ -160,96 +160,46 @@ static void mod_dir_funct(void *arg, long period)
 *                   LOCAL FUNCTION DEFINITIONS                         *
 ************************************************************************/
 
+#define CHK(v,ps) do { \
+        int _rv = (v); \
+        if(0 != _rv) { \
+            rtapi_print_msg(RTAPI_MSG_ERR, "MODMATH: ERROR: '%s.%s' pin export failed\n", base, (ps)); \
+            return _rv; \
+        } \
+    } while(0)
+
 static int export_mod_dir(int num)
 {
     int retval;
-    char buf[HAL_NAME_LEN + 1];
+    char base[HAL_NAME_LEN + 1];
     mod_dir_t *moddir;
 
     /* allocate shared memory for modulo "closest direction finder" */
     moddir = hal_malloc(sizeof(mod_dir_t));
     if (moddir == 0) {
-	rtapi_print_msg(RTAPI_MSG_ERR,
-	    "MODMATH: ERROR: hal_malloc() failed\n");
-	return -1;
+        rtapi_print_msg(RTAPI_MSG_ERR, "MODMATH: ERROR: hal_malloc() failed\n");
+        return -1;
     }
     /* export output pins */
-    rtapi_snprintf(buf, sizeof(buf), "mod-dir.%d.up", num);
-    retval = hal_pin_bit_new(buf, HAL_OUT, &(moddir->up), comp_id);
-    if (retval != 0) {
-	rtapi_print_msg(RTAPI_MSG_ERR,
-	    "MODMATH: ERROR: '%s' pin export failed\n", buf);
-	return retval;
-    }
-    rtapi_snprintf(buf, sizeof(buf), "mod-dir.%d.down", num);
-    retval = hal_pin_bit_new(buf, HAL_OUT, &(moddir->down), comp_id);
-    if (retval != 0) {
-	rtapi_print_msg(RTAPI_MSG_ERR,
-	    "MODMATH: ERROR: '%s' pin export failed\n", buf);
-	return retval;
-    }
-    rtapi_snprintf(buf, sizeof(buf), "mod-dir.%d.on-target", num);
-    retval = hal_pin_bit_new(buf, HAL_OUT, &(moddir->on_target), comp_id);
-    if (retval != 0) {
-	rtapi_print_msg(RTAPI_MSG_ERR,
-	    "MODMATH: ERROR: '%s' pin export failed\n", buf);
-	return retval;
-    }
+    rtapi_snprintf(base, sizeof(base), "mod-dir.%d", num);
+    CHK(hal_pin_new_bool(comp_id, HAL_OUT, &(moddir->up), 0, "%s.up", base), "up");
+    CHK(hal_pin_new_bool(comp_id, HAL_OUT, &(moddir->down), 0, "%s.down", base), "down");
+    CHK(hal_pin_new_bool(comp_id, HAL_OUT, &(moddir->on_target), 1, "%s.on-target", base), "on-target");
 
     /* export input pins */
-    rtapi_snprintf(buf, sizeof(buf), "mod-dir.%d.actual", num);
-    retval = hal_pin_s32_new(buf, HAL_IN, &(moddir->actual), comp_id);
-    if (retval != 0) {
-	rtapi_print_msg(RTAPI_MSG_ERR,
-	    "MODMATH: ERROR: '%s' pin export failed\n", buf);
-	return retval;
-    }
-    rtapi_snprintf(buf, sizeof(buf), "mod-dir.%d.desired", num);
-    retval = hal_pin_s32_new(buf, HAL_IN, &(moddir->desired), comp_id);
-    if (retval != 0) {
-	rtapi_print_msg(RTAPI_MSG_ERR,
-	    "MODMATH: ERROR: '%s' pin export failed\n", buf);
-	return retval;
-    }
+    CHK(hal_pin_new_si32(comp_id, HAL_IN, &(moddir->actual), 0, "%s.actual", base), "actual");
+    CHK(hal_pin_new_si32(comp_id, HAL_IN, &(moddir->desired), 0, "%s.desired", base), "desired");
 
     /* export pins for max and min values */
-    rtapi_snprintf(buf, sizeof(buf), "mod-dir.%d.min-num", num);
-    retval = hal_pin_s32_new(buf, HAL_IO, &(moddir->min_num), comp_id);
-    if (retval != 0) {
-	rtapi_print_msg(RTAPI_MSG_ERR,
-	    "MODMATH: ERROR: '%s' pin export failed\n", buf);
-	return retval;
-    }
-    rtapi_snprintf(buf, sizeof(buf), "mod-dir.%d.max-num", num);
-    retval = hal_pin_s32_new(buf, HAL_IO, &(moddir->max_num), comp_id);
-    if (retval != 0) {
-	rtapi_print_msg(RTAPI_MSG_ERR,
-	    "MODMATH: ERROR: '%s' pin export failed\n", buf);
-	return retval;
-    }
-    rtapi_snprintf(buf, sizeof(buf), "mod-dir.%d.wrap", num);
-    retval = hal_pin_bit_new(buf, HAL_IO, &(moddir->wrap), comp_id);
-    if (retval != 0) {
-	rtapi_print_msg(RTAPI_MSG_ERR,
-	    "MODMATH: ERROR: '%s' param export failed\n", buf);
-	return retval;
-    }
+    CHK(hal_pin_new_si32(comp_id, HAL_IO, &(moddir->min_num), 0, "%s.min-num", base), "min-num");
+    CHK(hal_pin_new_si32(comp_id, HAL_IO, &(moddir->max_num), 15, "%s.max-num", base), "max-num");
+    CHK(hal_pin_new_bool(comp_id, HAL_IO, &(moddir->wrap), 1, "%s.wrap", base), "wrap");
+
     /* export function */
-    rtapi_snprintf(buf, sizeof(buf), "mod-dir.%d", num);
-    retval = hal_export_funct(buf, mod_dir_funct, moddir, 1, 0, comp_id);
+    retval = hal_export_funct(base, mod_dir_funct, moddir, 1, 0, comp_id);
     if (retval != 0) {
-	rtapi_print_msg(RTAPI_MSG_ERR,
-	    "MODMATH: ERROR: '%s' funct export failed\n", buf);
-	return -1;
+        rtapi_print_msg(RTAPI_MSG_ERR, "MODMATH: ERROR: '%s' funct export failed\n", base);
+        return -1;
     }
-    /* set default parameter values */
-    *(moddir->up) = 0;
-    *(moddir->down) = 0;
-    *(moddir->on_target) = 1;
-    *(moddir->min_num) = 0;
-    *(moddir->max_num) = 15;
-    *(moddir->actual) = 0;
-    *(moddir->desired) = 0;
-    *(moddir->wrap) = 1;		/* wrap by default */
     return 0;
 }

--- a/src/hal/components/siggen.c
+++ b/src/hal/components/siggen.c
@@ -97,17 +97,17 @@ RTAPI_MP_ARRAY_STRING(names, MAX_CHAN, "names of siggen");
 */
 
 typedef struct {
-    hal_float_t *square;	/* pin: output */
-    hal_float_t *sawtooth;	/* pin: output */
-    hal_float_t *triangle;	/* pin: output */
-    hal_float_t *sine;		/* pin: output */
-    hal_float_t *cosine;	/* pin: output */
-    hal_bit_t *clock;		/* pin: output */
-    hal_float_t *frequency;	/* pin: frequency */
-    hal_float_t *amplitude;	/* pin: amplitude */
-    hal_float_t *offset;	/* pin: offset */
-    hal_bit_t *reset;		/* pin: reset */
-    double index;		/* position within output cycle */
+    hal_real_t square;      /* pin: output */
+    hal_real_t sawtooth;    /* pin: output */
+    hal_real_t triangle;    /* pin: output */
+    hal_real_t sine;        /* pin: output */
+    hal_real_t cosine;      /* pin: output */
+    hal_bool_t clock;       /* pin: output */
+    hal_real_t frequency;   /* pin: frequency */
+    hal_real_t amplitude;   /* pin: amplitude */
+    hal_real_t offset;      /* pin: offset */
+    hal_bool_t reset;       /* pin: reset */
+    double index;           /* position within output cycle */
 } hal_siggen_t;
 
 /* pointer to array of siggen_t structs in shared memory, 1 per gen */
@@ -215,14 +215,14 @@ static void calc_siggen(void *arg, long period)
     tmp1 = period * 0.000000001;
 
     /* calculate how much of an output cycle that has passed */
-    tmp2 = *(siggen->frequency) * tmp1;
+    tmp2 = hal_get_real(siggen->frequency) * tmp1;
     /* limit frequency to comply with Nyquist limit */
     if ( tmp2 > 0.5 ) {
-	*(siggen->frequency) = 0.5 / tmp1;
+	hal_set_real(siggen->frequency, 0.5 / tmp1);
 	tmp2 = 0.5;
     }
     /* index ramps from 0.0 to 0.99999 for each output cycle */
-    if ( *(siggen->reset) ) {
+    if ( hal_get_bool(siggen->reset) ) {
 	siggen->index  = 0.5;
     } else {
 	siggen->index += tmp2;
@@ -236,19 +236,21 @@ static void calc_siggen(void *arg, long period)
     /* tmp1 steps from -1.0 to +1.0 when index passes 0.5 */
     if ( siggen->index > 0.5 ) {
 	tmp1 = 1.0;
-	*(siggen->clock) = 1;
+	hal_set_bool(siggen->clock, 1);
     } else {
 	tmp1 = -1.0;
-	*(siggen->clock) = 0;
+	hal_set_bool(siggen->clock, 0);
     }
+    rtapi_real offset = hal_get_real(siggen->offset);
+    rtapi_real amplitude = hal_get_real(siggen->amplitude);
     /* apply scaling and offset, and write to output */
-    *(siggen->square) = (tmp1 * *(siggen->amplitude)) + *(siggen->offset);
+    hal_set_real(siggen->square, (tmp1 * amplitude) + offset);
 
     /* generate the sawtooth wave output */
     /* tmp2 ramps from -1.0 to +1.0 as index goes from 0 to 1 */
     tmp2 = (siggen->index * 2.0) - 1.0;
     /* apply scaling and offset, and write to output */
-    *(siggen->sawtooth) = (tmp2 * *(siggen->amplitude)) + *(siggen->offset);
+    hal_set_real(siggen->sawtooth, (tmp2 * amplitude) + offset);
 
     /* generate the triangle wave output */
     /* tmp2 ramps from -2.0 to +2.0 as index goes from 0 to 1 */
@@ -256,17 +258,17 @@ static void calc_siggen(void *arg, long period)
     /* flip first half of ramp, now goes from +1 to -1 to +1 */
     tmp2 = (tmp2 * tmp1) - 1.0;
     /* apply scaling and offset, and write to output */
-    *(siggen->triangle) = (tmp2 * *(siggen->amplitude)) + *(siggen->offset);
+    hal_set_real(siggen->triangle, (tmp2 * amplitude) + offset);
 
     /* generate the sine wave output */
     /* tmp1 is angle in radians */
     tmp1 = siggen->index * (2.0 * 3.1415927);
     /* get sine, apply scaling and offset, and write to output */
-    *(siggen->sine) = (sin(tmp1) * *(siggen->amplitude)) + *(siggen->offset);
+    hal_set_real(siggen->sine, (sin(tmp1) * amplitude) + offset);
 
     /* generate the cosine wave output */
     /* get cosine, apply scaling and offset, and write to output */
-    *(siggen->cosine) = (cos(tmp1) * *(siggen->amplitude)) + *(siggen->offset);
+    hal_set_real(siggen->cosine, (cos(tmp1) * amplitude) + offset);
     /* done */
 }
 
@@ -279,66 +281,57 @@ static int export_siggen(int num, hal_siggen_t * addr,char* prefix)
     int retval;
 
     /* export pins */
-    retval = hal_pin_float_newf(HAL_OUT, &(addr->square), comp_id,
+    retval = hal_pin_new_real(comp_id, HAL_OUT, &(addr->square), 0.0,
 				"%s.square", prefix);
     if (retval != 0) {
 	return retval;
     }
-    retval = hal_pin_float_newf(HAL_OUT, &(addr->sawtooth), comp_id,
+    retval = hal_pin_new_real(comp_id, HAL_OUT, &(addr->sawtooth), 0.0,
 				"%s.sawtooth", prefix);
     if (retval != 0) {
 	return retval;
     }
-    retval = hal_pin_float_newf(HAL_OUT, &(addr->triangle), comp_id,
+    retval = hal_pin_new_real(comp_id, HAL_OUT, &(addr->triangle), 0.0,
 				"%s.triangle", prefix);
     if (retval != 0) {
 	return retval;
     }
-    retval = hal_pin_float_newf(HAL_OUT, &(addr->sine), comp_id,
+    retval = hal_pin_new_real(comp_id, HAL_OUT, &(addr->sine), 0.0,
 				"%s.sine", prefix);
     if (retval != 0) {
 	return retval;
     }
-    retval = hal_pin_float_newf(HAL_OUT, &(addr->cosine), comp_id,
+    retval = hal_pin_new_real(comp_id, HAL_OUT, &(addr->cosine), 0.0,
 				"%s.cosine", prefix);
     if (retval != 0) {
 	return retval;
     }
-    retval = hal_pin_bit_newf(HAL_OUT, &(addr->clock), comp_id,
+    retval = hal_pin_new_bool(comp_id, HAL_OUT, &(addr->clock), 0,
 				"%s.clock", prefix);
     if (retval != 0) {
 	return retval;
     }
-    retval = hal_pin_float_newf(HAL_IN, &(addr->frequency), comp_id,
+    retval = hal_pin_new_real(comp_id, HAL_IN, &(addr->frequency), 1.0,
 				"%s.frequency", prefix);
     if (retval != 0) {
 	return retval;
     }
-    retval = hal_pin_float_newf(HAL_IN, &(addr->amplitude), comp_id,
+    retval = hal_pin_new_real(comp_id, HAL_IN, &(addr->amplitude), 1.0,
 				"%s.amplitude", prefix);
     if (retval != 0) {
 	return retval;
     }
-    retval = hal_pin_float_newf(HAL_IN, &(addr->offset), comp_id,
+    retval = hal_pin_new_real(comp_id, HAL_IN, &(addr->offset), 0.0,
 				"%s.offset", prefix);
     if (retval != 0) {
 	return retval;
     }
-    retval = hal_pin_bit_newf(HAL_IN, &(addr->reset), comp_id,
+    retval = hal_pin_new_bool(comp_id, HAL_IN, &(addr->reset), 0,
 				"%s.reset", prefix);
     if (retval != 0) {
 	return retval;
     }
     /* init all structure members */
-    *(addr->square) = 0.0;
-    *(addr->sawtooth) = 0.0;
-    *(addr->triangle) = 0.0;
-    *(addr->sine) = 0.0;
-    *(addr->cosine) = 0.0;
-    *(addr->clock) = 0;
-    *(addr->frequency) = 1.0;
-    *(addr->amplitude) = 1.0;
-    *(addr->offset) = 0.0;
     addr->index = 0.0;
     /* export function for this loop */
     retval =

--- a/src/hal/components/sim_encoder.c
+++ b/src/hal/components/sim_encoder.c
@@ -90,13 +90,13 @@ typedef struct {
     unsigned long accum;	/* frequency generator accumulator */
     signed char state;		/* current quadrature state */
     long cycle;			/* current cycle */
-    hal_bit_t *phaseA;		/* pins for output signals */
-    hal_bit_t *phaseB;		/* pins for output signals */
-    hal_bit_t *phaseZ;		/* pins for output signals */
-    hal_u32_t *ppr;		/* pin: pulses per revolution */
-    hal_float_t *scale;		/* pin: pulses per revolution */
-    hal_float_t *speed;		/* pin: speed in revs/second */
-    hal_s32_t *rawcounts;       /* pin: raw counts */
+    hal_bool_t phaseA;		/* pins for output signals */
+    hal_bool_t phaseB;		/* pins for output signals */
+    hal_bool_t phaseZ;		/* pins for output signals */
+    hal_uint_t ppr;		/* pin: pulses per revolution */
+    hal_real_t scale;		/* pin: pulses per revolution */
+    hal_real_t speed;		/* pin: speed in revs/second */
+    hal_sint_t rawcounts;       /* pin: raw counts */
     double old_scale;		/* internal, used to detect changes */
     double scale_mult;		/* internal, reciprocal of scale */
 } sim_enc_t;
@@ -257,7 +257,7 @@ static void make_pulses(void *arg, long period)
 	    /* get direction bit, 1 if negative, 0 if positive */
 	    dir = sim_enc->addval >> 31;
 	    if ( dir ) {
-		(*sim_enc->rawcounts) --;
+		hal_set_si32(sim_enc->rawcounts, hal_get_si32(sim_enc->rawcounts) - 1);
 		/* negative rotation, decrement state, detect underflow */
 		if (--(sim_enc->state) < 0) {
 		    /* state underflow, roll over */
@@ -265,19 +265,19 @@ static void make_pulses(void *arg, long period)
 		    /* decrement cycle, detect underflow */
 		    if (--(sim_enc->cycle) < 0) {
 			/* cycle underflow, roll over */
-			sim_enc->cycle += *(sim_enc->ppr);
+			sim_enc->cycle += hal_get_ui32(sim_enc->ppr);
 		    }
 		}
 	    } else {
-		(*sim_enc->rawcounts) ++;
+		hal_set_si32(sim_enc->rawcounts, hal_get_si32(sim_enc->rawcounts) + 1);
 		/* positive rotation, increment state, detect overflow */
 		if (++(sim_enc->state) > 3) {
 		    /* state overflow, roll over */
 		    sim_enc->state = 0;
 		    /* increment cycle, detect overflow */
-		    if (++(sim_enc->cycle) >= *(sim_enc->ppr)) {
+		    if (++(sim_enc->cycle) >= hal_get_ui32(sim_enc->ppr)) {
 			/* cycle overflow, roll over */
-			sim_enc->cycle -= *(sim_enc->ppr);
+			sim_enc->cycle -= hal_get_ui32(sim_enc->ppr);
 		    }
 		}
 	    }
@@ -285,30 +285,26 @@ static void make_pulses(void *arg, long period)
 	/* generate outputs */
 	switch (sim_enc->state) {
 	case 0:
-	    *(sim_enc->phaseA) = 1;
-	    *(sim_enc->phaseB) = 0;
+	    hal_set_bool(sim_enc->phaseA, 1);
+	    hal_set_bool(sim_enc->phaseB, 0);
 	    break;
 	case 1:
-	    *(sim_enc->phaseA) = 1;
-	    *(sim_enc->phaseB) = 1;
+	    hal_set_bool(sim_enc->phaseA, 1);
+	    hal_set_bool(sim_enc->phaseB, 1);
 	    break;
 	case 2:
-	    *(sim_enc->phaseA) = 0;
-	    *(sim_enc->phaseB) = 1;
+	    hal_set_bool(sim_enc->phaseA, 0);
+	    hal_set_bool(sim_enc->phaseB, 1);
 	    break;
 	case 3:
-	    *(sim_enc->phaseA) = 0;
-	    *(sim_enc->phaseB) = 0;
+	    hal_set_bool(sim_enc->phaseA, 0);
+	    hal_set_bool(sim_enc->phaseB, 0);
 	    break;
 	default:
 	    /* illegal state, reset to legal one */
 	    sim_enc->state = 0;
 	}
-	if ((sim_enc->state == 0) && (sim_enc->cycle == 0)) {
-	    *(sim_enc->phaseZ) = 1;
-	} else {
-	    *(sim_enc->phaseZ) = 0;
-	}
+	hal_set_bool(sim_enc->phaseZ, (sim_enc->state == 0) && (sim_enc->cycle == 0));
 	/* move on to next 'encoder' */
 	sim_enc++;
     }
@@ -337,21 +333,22 @@ static void update_speed(void *arg, long period)
     sim_enc = arg;
     for (n = 0; n < howmany; n++) {
 	/* check for change in scale value */
-	if ( *(sim_enc->scale) != sim_enc->old_scale ) {
+	rtapi_real scale = hal_get_real(sim_enc->scale);
+	if ( scale != sim_enc->old_scale ) {
 	    /* save new scale to detect future changes */
-	    sim_enc->old_scale = *(sim_enc->scale);
+	    sim_enc->old_scale = scale;
 	    /* scale value has changed, test and update it */
-	    if ((*(sim_enc->scale) < 1e-20) && (*(sim_enc->scale) > -1e-20)) {
+	    if ((scale < 1e-20) && (scale > -1e-20)) {
 		/* value too small, divide by zero is a bad thing */
-		*(sim_enc->scale) = 1.0;
+		scale = hal_set_real(sim_enc->scale, 1.0);
 	    }
 	    /* we actually want the reciprocal */
-	    sim_enc->scale_mult = 1.0 / *(sim_enc->scale);
+	    sim_enc->scale_mult = 1.0 / scale;
 	}
 	/* convert speed command (user units) to revs/sec */
-	rev_sec = *(sim_enc->speed) * sim_enc->scale_mult;
+	rev_sec = hal_get_real(sim_enc->speed) * sim_enc->scale_mult;
 	/* convert speed command (revs per sec) to counts/sec */
-	freq = rev_sec * (*(sim_enc->ppr)) * 4.0;
+	freq = rev_sec * (hal_get_ui32(sim_enc->ppr)) * 4.0;
 	/* limit the commanded frequency */
 	if (freq > maxf) {
 	    freq = maxf;
@@ -380,48 +377,45 @@ static int export_sim_enc(sim_enc_t * addr, char *prefix)
     msg = rtapi_get_msg_level();
     rtapi_set_msg_level(RTAPI_MSG_WARN);
     /* export param variable for pulses per rev */
-    retval = hal_pin_u32_newf(HAL_IO, &(addr->ppr), comp_id,
+    retval = hal_pin_new_ui32(comp_id, HAL_IO, &(addr->ppr), 100,
 			      "%s.ppr", prefix);
     if (retval != 0) {
 	return retval;
     }
     /* export param variable for scaling */
-    retval = hal_pin_float_newf(HAL_IO, &(addr->scale), comp_id,
+    retval = hal_pin_new_real(comp_id, HAL_IO, &(addr->scale), 1.0,
 				"%s.scale", prefix);
     if (retval != 0) {
 	return retval;
     }
     /* export pin for speed command */
-    retval = hal_pin_float_newf(HAL_IN, &(addr->speed), comp_id,
+    retval = hal_pin_new_real(comp_id, HAL_IN, &(addr->speed), 0.0,
 				"%s.speed", prefix);
     if (retval != 0) {
 	return retval;
     }
     /* export pins for output phases */
-    retval = hal_pin_bit_newf(HAL_OUT, &(addr->phaseA), comp_id,
+    retval = hal_pin_new_bool(comp_id, HAL_OUT, &(addr->phaseA), 0,
 			      "%s.phase-A", prefix);
     if (retval != 0) {
 	return retval;
     }
-    retval = hal_pin_bit_newf(HAL_OUT, &(addr->phaseB), comp_id,
+    retval = hal_pin_new_bool(comp_id, HAL_OUT, &(addr->phaseB), 0,
 			      "%s.phase-B", prefix);
     if (retval != 0) {
 	return retval;
     }
-    retval = hal_pin_bit_newf(HAL_OUT, &(addr->phaseZ), comp_id,
+    retval = hal_pin_new_bool(comp_id, HAL_OUT, &(addr->phaseZ), 0,
 			      "%s.phase-Z", prefix);
     if (retval != 0) {
 	return retval;
     }
     /* export pin for rawcounts */
-    retval = hal_pin_s32_newf(HAL_IN, &(addr->rawcounts), comp_id,
+    retval = hal_pin_new_si32(comp_id, HAL_IN, &(addr->rawcounts), 0,
 			      "%s.rawcounts", prefix);
     if (retval != 0) {
 	return retval;
     }
-    /* init parameters */
-    *(addr->ppr) = 100;
-    *(addr->scale) = 1.0;
     /* init internal vars */
     addr->old_scale = 0.0;
     addr->scale_mult = 1.0;
@@ -430,10 +424,6 @@ static int export_sim_enc(sim_enc_t * addr, char *prefix)
     addr->addval = 0;
     addr->state = 0;
     addr->cycle = 0;
-    /* init the outputs */
-    *(addr->phaseA) = 0;
-    *(addr->phaseB) = 0;
-    *(addr->phaseZ) = 0;
     /* restore saved message level */
     rtapi_set_msg_level(msg);
     return 0;

--- a/src/hal/components/spindle.comp
+++ b/src/hal/components/spindle.comp
@@ -50,30 +50,30 @@ Each gear has individual control of speeds, acceleration, driver gain and direct
 
 see_also "*motion*(9)";
 
-pin in unsigned select-gear
+pin in ui32 select-gear
 """Select a gear. Must be in the range 0 -> number of available gears -1. If you use this, do not use the select.x input pins.""";
 
-pin in float commanded-speed "Commanded spindle speed (in RPM)";
-pin in float actual-speed """Actual spindle speed from a spindle encoder (in RPS).
+pin in real commanded-speed "Commanded spindle speed (in RPM)";
+pin in real actual-speed """Actual spindle speed from a spindle encoder (in RPS).
 If you do not have a spindle encoder set the simulate_encoder parameter to 1.""";
-pin in bit simulate-encoder "If you do not have an encoder, set this to 1.";
-pin in bit enable "If FALSE, the spindle is stopped at the gear's maximum deceleration.";
-pin in float spindle-lpf """Smooth the spindle-rpm-abs output when at speed, 0 = disabled.
+pin in bool simulate-encoder "If you do not have an encoder, set this to 1.";
+pin in bool enable "If FALSE, the spindle is stopped at the gear's maximum deceleration.";
+pin in real spindle-lpf """Smooth the spindle-rpm-abs output when at speed, 0 = disabled.
 Suitable values are probably between 1 and 20 depending on how stable your spindle is.""";
 
-pin out float spindle-rpm """Current spindle speed in RPM.+ve = forward, -ve = reverse.
+pin out real spindle-rpm """Current spindle speed in RPM.+ve = forward, -ve = reverse.
 Uses the encoder input if available. If not, uses a simulated encoder speed.""";
 
-pin out float spindle-rpm-abs "Absolute spindle speed in RPM. Useful for spindle speed displays.";
-pin out float output "Scaled output";
-pin out unsigned current-gear "Currently selected gear.";
+pin out real spindle-rpm-abs "Absolute spindle speed in RPM. Useful for spindle speed displays.";
+pin out real output "Scaled output";
+pin out ui32 current-gear "Currently selected gear.";
 
-pin out bit at-speed "TRUE when the spindle is at speed";
-pin out bit forward "TRUE for forward rotation";
-pin out bit reverse "TRUE for reverse rotation. Both forward and reverse are false when the spindle is stopped.";
-pin out bit brake "TRUE when decelerating";
-pin out bit zero-speed "TRUE when the spindle is stationary";
-pin out bit limited """TRUE when the commanded spindle speed is >max or <min.""";
+pin out bool at-speed "TRUE when the spindle is at speed";
+pin out bool forward "TRUE for forward rotation";
+pin out bool reverse "TRUE for reverse rotation. Both forward and reverse are false when the spindle is stopped.";
+pin out bool brake "TRUE when decelerating";
+pin out bool zero-speed "TRUE when the spindle is stationary";
+pin out bool limited """TRUE when the commanded spindle speed is >max or <min.""";
 
 notes """
 The following pins are created depending the 'numgears=' parameter.
@@ -146,21 +146,21 @@ FUNCTION(_) {
 
     gear_t * thisgear = gears;
     if(select_gear != 0){
-        current_gear = select_gear;
-        if(current_gear > 15) current_gear = 15;
+        current_gear_set(select_gear);
+        if(current_gear > 15) current_gear_set(15);
         thisgear = &gears[current_gear];
     }else{
-        current_gear = 0;
+        current_gear_set(0);
         for(ct = ngears-1; ct >= 0; ct--){
             thisgear = &gears[ct];
-            if(*(thisgear->select)){
-                current_gear = ct;
+            if(hal_get_bool(thisgear->select)){
+                current_gear_set(ct);
                 break;
             }
         }
     }
     if(!simulate_encoder){
-        spindle_rpm = actual_speed * 60; /*RPS to RPM*/
+        spindle_rpm_set(actual_speed * 60); /*RPS to RPM*/
     }
     curspeed = spindle_rpm;
     if(enable){
@@ -174,21 +174,21 @@ FUNCTION(_) {
     }else{
         tmp = -curspeed;
     }
-    zero_speed = (tmp <= *(thisgear->zero_tolerance));
+    zero_speed_set((tmp <= hal_get_real(thisgear->zero_tolerance)));
     if(spindle_lpf >0 && at_speed){
-        spindle_rpm_abs += (tmp - spindle_rpm_abs) * spindle_lpf * fperiod;
+        spindle_rpm_abs_set(spindle_rpm_abs + (tmp - spindle_rpm_abs) * spindle_lpf * fperiod);
     }else{
-        spindle_rpm_abs = tmp;
+        spindle_rpm_abs_set(tmp);
     }
 
     reversing = (cmdspeed > 0 && curspeed < 0) || (cmdspeed < 0 && curspeed > 0);
 
     diff = cmdspeed - curspeed;
     if(diff <0) diff = -diff;
-    tmp = *(thisgear->speed_tolerance);
-    at_speed = (tmp >0 && tmp >= diff) && !reversing;
+    tmp = hal_get_real(thisgear->speed_tolerance);
+    at_speed_set((tmp >0 && tmp >= diff) && !reversing);
 
-    tmp = *(thisgear->min);
+    tmp = hal_get_real(thisgear->min);
     if(tmp > 0){
         if(cmdspeed > 0){
             if(cmdspeed < tmp){
@@ -202,7 +202,7 @@ FUNCTION(_) {
             }
         }
     }
-    tmp = *(thisgear->max);
+    tmp = hal_get_real(thisgear->max);
     if(tmp > 0){
         if(cmdspeed > 0 && cmdspeed > tmp){
             cmdspeed = tmp;
@@ -220,7 +220,7 @@ FUNCTION(_) {
     if(curspeed > 0 && diff < -curspeed) diff = -curspeed;
     if(curspeed < 0 && diff > -curspeed) diff = -curspeed;
 
-    tmp = *(thisgear->accel);
+    tmp = hal_get_real(thisgear->accel);
     if(tmp > 0 && !reversing){
         if(simulate_encoder) tmp *= fperiod;
         if(cmdspeed > 0 && diff > tmp){
@@ -231,7 +231,7 @@ FUNCTION(_) {
         }
     }
 
-    tmp = *(thisgear->decel);
+    tmp = hal_get_real(thisgear->decel);
     if(tmp > 0){
         if(simulate_encoder) tmp *= fperiod;
         if(reversing){
@@ -250,19 +250,19 @@ FUNCTION(_) {
     }
 
     if(simulate_encoder){
-        spindle_rpm = curspeed;
+        spindle_rpm_set(curspeed);
     }
 
     if(cmdspeed !=0){
-        forward = (curspeed >0);
-        reverse = (curspeed <0);
+        forward_set(curspeed > 0);
+        reverse_set(curspeed < 0);
     }else{ /* don't try to move once stopped */
-        forward = (curspeed >0) && forward;
-        reverse = (curspeed <0) && forward;
+        forward_set((curspeed > 0) && forward);
+        reverse_set((curspeed < 0) && forward);
     }
     if(curspeed < 0) curspeed = -curspeed;
-    output = (curspeed + (*(thisgear->offset))) * (*(thisgear->scale));
-    limited = limit;
+    output_set((curspeed + (hal_get_real(thisgear->offset))) * (hal_get_real(thisgear->scale)));
+    limited_set(limit);
 }
 
 EXTRA_SETUP(){
@@ -278,7 +278,7 @@ EXTRA_SETUP(){
         if(r != 0) return r;
     }
     if(ngears ==1){
-        *(gears[0].select) = true;
+        hal_set_bool(gears[0].select, true);
     }
     return(0);
 }
@@ -286,49 +286,40 @@ EXTRA_SETUP(){
 int add_gear(int index, char *prefix, gear_t * g)
 {
     int r;
-    r = hal_pin_float_newf(HAL_IN, &(g->scale), comp_id,
+    r = hal_pin_new_real(comp_id, HAL_IN, &(g->scale), 1.0,
         "%s.scale.%i", prefix,index);
     if(r != 0) return r;
 
-    r = hal_pin_float_newf(HAL_IN, &(g->min), comp_id,
+    r = hal_pin_new_real(comp_id, HAL_IN, &(g->min), 0.0,
         "%s.min.%i", prefix,index);
     if(r != 0) return r;
 
-    r = hal_pin_float_newf(HAL_IN, &(g->max), comp_id,
+    r = hal_pin_new_real(comp_id, HAL_IN, &(g->max), 0.0,
         "%s.max.%i", prefix,index);
     if(r != 0) return r;
 
-    r = hal_pin_float_newf(HAL_IN, &(g->accel), comp_id,
+    r = hal_pin_new_real(comp_id, HAL_IN, &(g->accel), 0.0,
         "%s.accel.%i", prefix,index);
     if(r != 0) return r;
 
-    r = hal_pin_float_newf(HAL_IN, &(g->decel), comp_id,
+    r = hal_pin_new_real(comp_id, HAL_IN, &(g->decel), 0.0,
         "%s.decel.%i", prefix,index);
     if(r != 0) return r;
 
-    r = hal_pin_float_newf(HAL_IN, &(g->speed_tolerance), comp_id,
+    r = hal_pin_new_real(comp_id, HAL_IN, &(g->speed_tolerance), 20.0,
         "%s.speed-tolerance.%i", prefix,index);
     if(r != 0) return r;
 
-    r = hal_pin_float_newf(HAL_IN, &(g->zero_tolerance), comp_id,
+    r = hal_pin_new_real(comp_id, HAL_IN, &(g->zero_tolerance), 20.0,
         "%s.zero-tolerance.%i", prefix,index);
     if(r != 0) return r;
 
-    r = hal_pin_float_newf(HAL_IN, &(g->offset), comp_id,
+    r = hal_pin_new_real(comp_id, HAL_IN, &(g->offset), 0.0,
         "%s.offset.%i", prefix,index);
     if(r != 0) return r;
 
-    r = hal_pin_bit_newf(HAL_IN, &(g->select), comp_id,
+    r = hal_pin_new_bool(comp_id, HAL_IN, &(g->select), false,
         "%s.select.%i", prefix,index);
     if(r != 0) return r;
-    *g->scale = 1;
-    *g->min = 0;
-    *g->max = 0;
-    *g->accel = 0;
-    *g->decel = 0;
-    *g->speed_tolerance = 20;
-    *g->zero_tolerance = 20;
-    *g->offset = 0;
-    *g->select = false;
     return(0);
 }

--- a/src/hal/components/spindle.h
+++ b/src/hal/components/spindle.h
@@ -10,13 +10,13 @@
 ********************************************************************/
 
 typedef struct {
-    hal_float_t *scale;
-    hal_float_t *min;
-    hal_float_t *max;
-    hal_float_t *accel;
-    hal_float_t *decel;
-    hal_float_t *speed_tolerance;
-    hal_float_t *zero_tolerance;
-    hal_float_t *offset;
-    hal_bit_t *select;
+    hal_real_t scale;
+    hal_real_t min;
+    hal_real_t max;
+    hal_real_t accel;
+    hal_real_t decel;
+    hal_real_t speed_tolerance;
+    hal_real_t zero_tolerance;
+    hal_real_t offset;
+    hal_bool_t select;
 } gear_t;

--- a/src/hal/components/supply.c
+++ b/src/hal/components/supply.c
@@ -63,12 +63,12 @@ RTAPI_MP_INT(num_chan, "number of channels");
 */
 
 typedef struct {
-    hal_bit_t *q;		/* pin: q output of simulated flip-flop */
-    hal_bit_t *_q;		/* pin: /q output of simulated flip-flop */
-    hal_float_t *variable;	/* pin: output set by param "value" */
-    hal_float_t *_variable;	/* pin: output set by param "value" * -1.0 */
-    hal_bit_t *d;		/* pin: d input to simulated flip-flop */
-    hal_float_t *value;		/* pin: value of float pin "variable" */
+    hal_bool_t q;		/* pin: q output of simulated flip-flop */
+    hal_bool_t _q;		/* pin: /q output of simulated flip-flop */
+    hal_real_t variable;	/* pin: output set by param "value" */
+    hal_real_t _variable;	/* pin: output set by param "value" * -1.0 */
+    hal_bool_t d;		/* pin: d input to simulated flip-flop */
+    hal_real_t value;		/* pin: value of float pin "variable" */
 } hal_supply_t;
 
 /* pointer to supply_t struct */
@@ -141,15 +141,16 @@ void rtapi_app_exit(void)
 static void update_supply(void *arg, long l)
 {
     (void)l;
-    hal_supply_t *supply;
-
     /* point to the data */
-    supply = arg;
+    hal_supply_t *supply = arg;
+
     /* set pin = param */
-    *(supply->q) = *(supply->d);
-    *(supply->_q) = !(*(supply->d));
-    *(supply->variable) = *(supply->value);
-    *(supply->_variable) = *(supply->value) * -1.0;
+    rtapi_bool d = hal_get_bool(supply->d);
+    hal_set_bool(supply->q, d);
+    hal_set_bool(supply->_q, !d);
+    rtapi_real value = hal_get_real(supply->value);
+    hal_set_real(supply->variable, value);
+    hal_set_real(supply->_variable, value * -1.0);
     /* done */
 }
 
@@ -162,38 +163,31 @@ static int export_supply(int num, hal_supply_t * addr)
     int retval;
 
     /* export pins */
-    retval = hal_pin_bit_newf(HAL_OUT, &(addr->q), comp_id, "supply.%d.q", num);
+    retval = hal_pin_new_bool(comp_id, HAL_OUT, &(addr->q), 0, "supply.%d.q", num);
     if (retval != 0) {
 	return retval;
     }
-    retval = hal_pin_bit_newf(HAL_OUT, &(addr->_q), comp_id, "supply.%d._q", num);
+    retval = hal_pin_new_bool(comp_id, HAL_OUT, &(addr->_q), 1, "supply.%d._q", num);
     if (retval != 0) {
 	return retval;
     }
-    retval = hal_pin_float_newf(HAL_OUT, &(addr->variable), comp_id,"supply.%d.variable", num);
+    retval = hal_pin_new_real(comp_id, HAL_OUT, &(addr->variable), 0.0,"supply.%d.variable", num);
     if (retval != 0) {
 	return retval;
     }
-    retval = hal_pin_float_newf(HAL_OUT, &(addr->_variable), comp_id, "supply.%d._variable", num);
+    retval = hal_pin_new_real(comp_id, HAL_OUT, &(addr->_variable), 0.0, "supply.%d._variable", num);
     if (retval != 0) {
 	return retval;
     }
     /* export parameters */
-    retval = hal_pin_bit_newf(HAL_IO, &(addr->d), comp_id, "supply.%d.d", num);
+    retval = hal_pin_new_bool(comp_id, HAL_IO, &(addr->d), 0, "supply.%d.d", num);
     if (retval != 0) {
 	return retval;
     }
-    retval = hal_pin_float_newf(HAL_IO, &(addr->value), comp_id, "supply.%d.value", num);
+    retval = hal_pin_new_real(comp_id, HAL_IO, &(addr->value), 0.0, "supply.%d.value", num);
     if (retval != 0) {
 	return retval;
     }
-    /* init all structure members */
-    *(addr->q) = 0;
-    *(addr->_q) = 1;
-    *(addr->variable) = 0.0;
-    *(addr->_variable) = 0.0;
-    *(addr->d) = 0;
-    *(addr->value) = 0.0;
     /* export function for this loop */
     retval =
 	hal_export_functf(update_supply, &(supply_array[num]), 1, 0,

--- a/src/hal/components/watchdog.c
+++ b/src/hal/components/watchdog.c
@@ -38,27 +38,27 @@ RTAPI_MP_INT(num_inputs, "Number of inputs");
 
 /* Data needed for each input */
 typedef struct {
-    hal_bit_t *input;		/* pin: the input bit HAL pin */
-    hal_float_t timeout;	/* param: maximum alloewd timeb without a transition on bit */
-    hal_float_t oldtimeout;	/* internal:  used to determine whether the timeout has changed */
-    hal_s32_t c_secs, c_nsecs;	/* internal:  elapsed seconds and nanoseconds */
-    hal_s32_t t_secs, t_nsecs;	/* internal:  seconds and nanoseconds for timeout */
-    hal_bit_t last;		/* internal:  last value of the input pin */
+    hal_bool_t input;		/* pin: the input bit HAL pin */
+    hal_real_t timeout;		/* param: maximum alloewd timeb without a transition on bit */
+    rtapi_real oldtimeout;	/* internal:  used to determine whether the timeout has changed */
+    rtapi_s32  c_secs, c_nsecs;	/* internal:  elapsed seconds and nanoseconds */
+    rtapi_s32  t_secs, t_nsecs;	/* internal:  seconds and nanoseconds for timeout */
+    rtapi_bool last;		/* internal:  last value of the input pin */
 } watchdog_input_t;
 
 #define MAX_INPUTS	32
 
 /* Base data for a weighted summer. */
 typedef struct {
-  hal_bit_t *output;		/* output pin: high if all inputs are toggling, low otherwise */
-  hal_bit_t *enable;		/* pin: only runs while this is high (kind of like an enable) */
+  hal_bool_t output;		/* output pin: high if all inputs are toggling, low otherwise */
+  hal_bool_t enable;		/* pin: only runs while this is high (kind of like an enable) */
 } watchdog_data_t;
 
 /* other globals */
 static int comp_id;		/* component ID */
 watchdog_input_t *inputs;	/* internal: pointer to the input bits and weights */
 watchdog_data_t *data;		/* common data */
-hal_bit_t old_enable;
+rtapi_bool old_enable;
 /***********************************************************************
 *                  LOCAL FUNCTION DECLARATIONS                         *
 ************************************************************************/
@@ -96,7 +96,7 @@ int rtapi_app_main(void)
     }
 
     /* allocate shared memory for watchdog global and pin info */
-    data = hal_malloc(sizeof(watchdog_data_t));
+    data = hal_malloc(sizeof(*data));
     if (data == 0) {
 	rtapi_print_msg(RTAPI_MSG_ERR,
 	    "WATCHDOG: ERROR: hal_malloc() for common data failed\n");
@@ -104,7 +104,7 @@ int rtapi_app_main(void)
 	goto err;
     }
 
-    inputs = hal_malloc(num_inputs * sizeof(watchdog_input_t));
+    inputs = hal_malloc(num_inputs * sizeof(*inputs));
     if (inputs == 0) {
 	rtapi_print_msg(RTAPI_MSG_ERR,
 	    "WATCHDOG: ERROR: hal_malloc() for input pins failed\n");
@@ -114,34 +114,33 @@ int rtapi_app_main(void)
 
     /* export pins/params for all inputs */
     for (n = 0; n < num_inputs; n++) {
-      retval=hal_pin_bit_newf(HAL_IN, &(inputs[n].input), comp_id, "watchdog.input-%d", n);
+      retval=hal_pin_new_bool(comp_id, HAL_IN, &(inputs[n].input), 0, "watchdog.input-%d", n);
       if (retval != 0) {
 	  rtapi_print_msg(RTAPI_MSG_ERR,
 	      "WATCHDOG: ERROR: couldn't create input pin watchdog.input-%d\n", n);
 	  goto err;
       }
-      retval=hal_param_float_newf(HAL_RW, &(inputs[n].timeout), comp_id, "watchdog.timeout-%d", n);
+      retval=hal_param_new_real(comp_id, HAL_RW, &(inputs[n].timeout), 0.0, "watchdog.timeout-%d", n);
       if (retval != 0) {
 	  rtapi_print_msg(RTAPI_MSG_ERR,
 	      "WATCHDOG: ERROR: couldn't create input parameter watchdog.timeout-%d\n", n);
 	  goto err;
       }
       
-      inputs[n].timeout=0;
       inputs[n].oldtimeout=-1;
       inputs[n].c_secs = inputs[n].t_secs = 0;
       inputs[n].c_nsecs = inputs[n].t_nsecs = 0;
-      inputs[n].last = *(inputs[n].input);
+      inputs[n].last = hal_get_bool(inputs[n].input);
     }
 
     /* export "global" pins */
-    retval=hal_pin_bit_newf(HAL_OUT, &(data->output), comp_id, "watchdog.ok-out");
+    retval=hal_pin_new_bool(comp_id, HAL_OUT, &(data->output), 0, "watchdog.ok-out");
     if (retval != 0) {
 	rtapi_print_msg(RTAPI_MSG_ERR,
 	    "WATCHDOG: ERROR: couldn't create output pin watchdog.ok-out\n");
 	goto err;
     }
-    retval=hal_pin_bit_newf(HAL_IN, &(data->enable), comp_id, "watchdog.enable-in");
+    retval=hal_pin_new_bool(comp_id, HAL_IN, &(data->enable), 0, "watchdog.enable-in");
     if (retval != 0) {
 	rtapi_print_msg(RTAPI_MSG_ERR,
 	    "WATCHDOG: ERROR: couldn't create input pin watchdog.enable-in\n");
@@ -194,9 +193,9 @@ static void process(void *arg, long period)
     int i, fault=0;
     // set_timeouts has to turn on the output when it detects a valid
     // transition on enable
-    if (!(*data->enable) || (!(*data->output))) return;
+    if (!hal_get_bool(data->enable) || (!hal_get_bool(data->output))) return;
     for (i=0;i<num_inputs;i++) {
-      if (*(inputs[i].input) != inputs[i].last) {
+      if (hal_get_bool(inputs[i].input) != inputs[i].last) {
 	inputs[i].c_secs = inputs[i].t_secs;
 	inputs[i].c_nsecs = inputs[i].t_nsecs;
       } else {
@@ -211,9 +210,9 @@ static void process(void *arg, long period)
 	  }
 	}
       }
-      inputs[i].last=*(inputs[i].input);
+      inputs[i].last=hal_get_bool(inputs[i].input);
     }
-    if (fault) *(data->output)=0;
+    if (fault) hal_set_bool(data->output, 0);
 }
 
 static void set_timeouts(void *arg, long period)
@@ -221,10 +220,10 @@ static void set_timeouts(void *arg, long period)
     (void)arg;
     (void)period;
     int i;
-    hal_float_t temp;
+    rtapi_real temp;
     
     for (i=0;i<num_inputs;i++) {
-      temp=inputs[i].timeout;
+      temp = hal_get_real(inputs[i].timeout);
       if (temp<0) temp=0;	// no negative timeout periods
       if (temp != inputs[i].oldtimeout) {
 	// new timeout, convert to secs/ns
@@ -234,17 +233,17 @@ static void set_timeouts(void *arg, long period)
 	inputs[i].t_nsecs=(1e9*temp);
       }
     }
-    if (!*(data->output)) {
-	if (*(data->enable) && !old_enable) {
+    if (!hal_get_bool(data->output)) {
+	if (hal_get_bool(data->enable) && !old_enable) {
 	  // rising edge on enable, so we can restart
 	  for (i=0;i<num_inputs;i++) {
 	    inputs[i].c_secs = inputs[i].t_secs;
 	    inputs[i].c_nsecs = inputs[i].t_nsecs;
 	  }
-	  *(data->output) = 1;
+	  hal_set_bool(data->output, 1);
 	}
     }
-    old_enable=*(data->enable);
+    old_enable=hal_get_bool(data->enable);
 }
 /***********************************************************************
 *                   LOCAL FUNCTION DEFINITIONS                         *


### PR DESCRIPTION
These are the first batch of components converted to getter/setter that are partly or in whole written C. There is nothing really wild in the conversion.

Several places have had old hal types replaced with the proper rtapi types. The hal types were being abused as normal variable types, making things unnecessarily slow.

There are several places that could have been optimized or streamlined. Some places it was improved, other places it was not. A future sweep across all components should review them anyway and then can be improved.

The debounce.c component has a possible define to export the state variable as a parameter. It was opted to use the preprocessor to select a hal type or a normal type and add access-functions to wrap read/write to the state. Normally, the EXPORT_STATE is undefined and using a normal variable is faster. Otherwise it would have been unnecessarily slower going though the volatility of hal types.
