### PR TITLE
hal: Update the smaller user components to getter/setter

### DIFF
--- a/src/hal/user_comps/hy_gt_vfd.c
+++ b/src/hal/user_comps/hy_gt_vfd.c
@@ -41,15 +41,15 @@
 
 
 typedef struct {
-    hal_float_t *period;
+    hal_real_t period;
 
-    hal_float_t *speed_cmd;
-    hal_float_t *freq_cmd;
-    hal_bit_t *at_speed;
+    hal_real_t speed_cmd;
+    hal_real_t freq_cmd;
+    hal_bool_t at_speed;
 
-    hal_bit_t	*spindle_on;
+    hal_bool_t spindle_on;
 
-    hal_u32_t *modbus_errors;
+    hal_uint_t modbus_errors;
 } haldata_t;
 
 haldata_t *haldata;
@@ -66,8 +66,8 @@ typedef struct {
     float multiplier;
     int type;
     union {
-        hal_float_t *hal_pin_float;
-        hal_u32_t *hal_pin_u32;
+        hal_real_t hal_pin_float;
+        hal_uint_t hal_pin_u32;
     };
 } modbus_register_t;
 
@@ -207,7 +207,7 @@ int set_motor_on_forward(modbus_t *mb) {
             return 0;
         }
         fprintf(stderr, "%s: error writing %u to register 0x%04x: %s\n", __func__, val, addr, modbus_strerror(errno));
-        *haldata->modbus_errors = *haldata->modbus_errors + 1;
+        hal_set_ui32(haldata->modbus_errors, hal_get_ui32(haldata->modbus_errors) + 1);
     }
     return -1;
 }
@@ -225,7 +225,7 @@ int set_motor_off(modbus_t *mb) {
             return 0;
         }
         fprintf(stderr, "%s: error writing %u to register 0x%04x: %s\n", __func__, val, addr, modbus_strerror(errno));
-        *haldata->modbus_errors = *haldata->modbus_errors + 1;
+        hal_set_ui32(haldata->modbus_errors, hal_get_ui32(haldata->modbus_errors) + 1);
     }
     return -1;
 }
@@ -244,7 +244,7 @@ int set_motor_frequency(modbus_t *mb, float freq) {
             return 0;
         }
         fprintf(stderr, "%s: error writing %u to register 0x%04x: %s\n", __func__, val, addr, modbus_strerror(errno));
-        *haldata->modbus_errors = *haldata->modbus_errors + 1;
+        hal_set_ui32(haldata->modbus_errors, hal_get_ui32(haldata->modbus_errors) + 1);
     }
     return -1;
 }
@@ -260,16 +260,16 @@ int read_modbus_register(modbus_t *mb, modbus_register_t *reg) {
         if (r == 1) {
             switch (reg->type) {
             case REGISTER_FLOAT:
-                *reg->hal_pin_float = data * reg->multiplier;
+                hal_set_real(reg->hal_pin_float, data * reg->multiplier);
                 break;
             case REGISTER_U32:
-                *reg->hal_pin_u32 = data;
+                hal_set_ui32(reg->hal_pin_u32, data);
                 break;
             }
             return 0;
         }
         fprintf(stderr, "%s: error reading %s (register 0x%04x): %s\n", __func__, reg->name, reg->address, modbus_strerror(errno));
-        *haldata->modbus_errors = *haldata->modbus_errors + 1;
+        hal_set_ui32(haldata->modbus_errors, hal_get_ui32(haldata->modbus_errors) + 1);
     }
     return -1;
 }
@@ -289,7 +289,7 @@ modbus_register_t *add_modbus_register_float(modbus_t *mb, int address, const ch
     reg = &modbus_register[num_modbus_registers];
     reg->type = REGISTER_FLOAT;
 
-    r = hal_pin_float_newf(HAL_OUT, &reg->hal_pin_float, hal_comp_id, "%s.%s", modname, pin_name);
+    r = hal_pin_new_real(hal_comp_id, HAL_OUT, &reg->hal_pin_float, 0.0, "%s.%s", modname, pin_name);
     if (r != 0) {
         return NULL;
     }
@@ -314,7 +314,7 @@ modbus_register_t *add_modbus_register_u32(modbus_t *mb, int address, const char
     reg = &modbus_register[num_modbus_registers];
     reg->type = REGISTER_U32;
 
-    r = hal_pin_u32_newf(HAL_OUT, &reg->hal_pin_u32, hal_comp_id, "%s.%s", modname, pin_name);
+    r = hal_pin_new_ui32(hal_comp_id, HAL_OUT, &reg->hal_pin_u32, 0, "%s.%s", modname, pin_name);
     if (r != 0) {
         return NULL;
     }
@@ -564,39 +564,32 @@ int main(int argc, char **argv) {
         goto out_close;
     }
 
-    haldata = (haldata_t *)hal_malloc(sizeof(haldata_t));
+    haldata = (haldata_t *)hal_malloc(sizeof(*haldata));
     if (haldata == NULL) {
         printf("%s: ERROR: unable to allocate shared memory\n", modname);
         retval = -1;
         goto out_closeHAL;
     }
 
-    retval = hal_pin_float_newf(HAL_IN, &(haldata->period), hal_comp_id, "%s.period-seconds", modname);
+    retval = hal_pin_new_real(hal_comp_id, HAL_IN, &(haldata->period), 0.1, "%s.period-seconds", modname);
     if (retval != 0) goto out_closeHAL;
 
-    retval = hal_pin_float_newf(HAL_IN, &(haldata->speed_cmd), hal_comp_id, "%s.speed-cmd", modname);
+    retval = hal_pin_new_real(hal_comp_id, HAL_IN, &(haldata->speed_cmd), 0.0, "%s.speed-cmd", modname);
     if (retval != 0) goto out_closeHAL;
 
-    retval = hal_pin_float_newf(HAL_OUT, &(haldata->freq_cmd), hal_comp_id, "%s.freq-cmd", modname);
+    retval = hal_pin_new_real(hal_comp_id, HAL_OUT, &(haldata->freq_cmd), 0.0, "%s.freq-cmd", modname);
     if (retval != 0) goto out_closeHAL;
 
-    retval = hal_pin_bit_newf(HAL_OUT, &(haldata->at_speed), hal_comp_id, "%s.at-speed", modname);
+    retval = hal_pin_new_bool(hal_comp_id, HAL_OUT, &(haldata->at_speed), 0, "%s.at-speed", modname);
     if (retval != 0) goto out_closeHAL;
 
-    retval = hal_pin_bit_newf(HAL_IN, &(haldata->spindle_on), hal_comp_id, "%s.spindle-on", modname);
+    retval = hal_pin_new_bool(hal_comp_id, HAL_IN, &(haldata->spindle_on), 0, "%s.spindle-on", modname);
     if (retval != 0) goto out_closeHAL;
 
-    retval = hal_pin_u32_newf(HAL_OUT, &(haldata->modbus_errors), hal_comp_id, "%s.modbus-errors", modname);
+    retval = hal_pin_new_ui32(hal_comp_id, HAL_OUT, &(haldata->modbus_errors), 0, "%s.modbus-errors", modname);
     if (retval != 0) goto out_closeHAL;
 
-    *haldata->period = 0.1;
-
-    *haldata->freq_cmd = 0.0;
-    *haldata->at_speed = 0;
-
-    *haldata->modbus_errors = 0;
-
-    modbus_register = (modbus_register_t *)hal_malloc(20 * sizeof(modbus_register_t));
+    modbus_register = (modbus_register_t *)hal_malloc(20 * sizeof(*modbus_register));
     if (modbus_register == NULL) {
         printf("%s: ERROR: unable to allocate memory\n", modname);
         retval = -1;
@@ -664,28 +657,26 @@ int main(int argc, char **argv) {
     hal_ready(hal_comp_id);
 
     while (done == 0) {
-        if (*haldata->period < 0.001) *haldata->period = 0.001;
-        if (*haldata->period > 2.0) *haldata->period = 2.0;
-        period_timespec.tv_sec = (time_t)(*haldata->period);
-        period_timespec.tv_nsec = (long)((*haldata->period - period_timespec.tv_sec) * 1000000000l);
+        rtapi_real period = hal_get_real(haldata->period);
+        if (period < 0.001) period = hal_set_real(haldata->period, 0.001);
+        if (period > 2.0)   period = hal_set_real(haldata->period, 2.0);
+        period_timespec.tv_sec = (time_t)period;
+        period_timespec.tv_nsec = (long)((period - period_timespec.tv_sec) * 1000000000l);
         nanosleep(&period_timespec, NULL);
 
         read_modbus_registers(mb);
 
-        if (*haldata->spindle_on) {
+        if (hal_get_bool(haldata->spindle_on)) {
             set_motor_on_forward(mb);
-            *haldata->freq_cmd = (*haldata->speed_cmd / motor_max_speed) * max_freq;
-            set_motor_frequency(mb, *haldata->freq_cmd);
+            rtapi_real speed_cmd = hal_get_real(haldata->speed_cmd);
+            hal_set_real(haldata->freq_cmd, (speed_cmd / motor_max_speed) * max_freq);
+            set_motor_frequency(mb, hal_get_real(haldata->freq_cmd));
 
-            if ((fabs(*haldata->speed_cmd - *speed_fb_reg->hal_pin_float) / *haldata->speed_cmd) < 0.02) {
-                *haldata->at_speed = 1;
-            } else {
-                *haldata->at_speed = 0;
-            }
+            hal_set_bool(haldata->at_speed, (fabs(speed_cmd - hal_get_real(speed_fb_reg->hal_pin_float)) / speed_cmd) < 0.02);
         } else {
             set_motor_off(mb);
-            *haldata->at_speed = 0;
-            *haldata->freq_cmd = 0.0;
+            hal_set_bool(haldata->at_speed, 0);
+            hal_set_real(haldata->freq_cmd, 0.0);
         }
 
     }

--- a/src/hal/user_comps/pi500_vfd/pi500_vfd.comp
+++ b/src/hal/user_comps/pi500_vfd/pi500_vfd.comp
@@ -1,15 +1,15 @@
 component pi500_vfd "Powtran PI500 Modbus driver";
-param rw unsigned mbslaveaddr     "Modbus slave address";
-pin in float commanded_frequency  "Frequency of vfd";
-pin in bit run                    "run the vfd";
-pin in bit enable                 "1 to enable the vfd. 0 will remote trip the vfd, thereby disabling it.";
-pin out bit is_running            "1 when running";
-pin out bit is_at_speed           "1 when running at assigned frequency";
-pin out bit is_ready              "1 when vfd is ready to run";
-pin out bit is_alarm              "1 when vfd alarm is set";
-pin out float motor_current       "Output current in amps";
-pin out float heatsink_temp       "Temperature of drive heatsink";
-pin out bit watchdog_out          "Alternates between 1 and 0 after every update cycle. Feed into a watchdog component to ensure vfd driver is communicating with the vfd properly.";
+param rw ui32 mbslaveaddr  "Modbus slave address";
+pin in  real commanded_frequency "Frequency of vfd";
+pin in  bool run           "run the vfd";
+pin in  bool enable        "1 to enable the vfd. 0 will remote trip the vfd, thereby disabling it.";
+pin out bool is_running    "1 when running";
+pin out bool is_at_speed   "1 when running at assigned frequency";
+pin out bool is_ready      "1 when vfd is ready to run";
+pin out bool is_alarm      "1 when vfd alarm is set";
+pin out real motor_current "Output current in amps";
+pin out real heatsink_temp "Temperature of drive heatsink";
+pin out bool watchdog_out  "Alternates between 1 and 0 after every update cycle. Feed into a watchdog component to ensure vfd driver is communicating with the vfd properly.";
 option userspace yes;
 option userinit yes;
 license "GPLv2 or greater";
@@ -289,9 +289,9 @@ void user_mainloop(void) {
 			continue;
 		}
 
-		is_running = status.running;
-		is_ready = status.ready;
-		is_alarm = status.alarm;
+		is_running_set(status.running);
+		is_ready_set(status.ready);
+		is_alarm_set(status.alarm);
 
 		if(!status.alarm && !enable) { //  && !pi500_trip(ctx)
 			print_modbus_error(__comp_inst, "failed to trip");
@@ -304,7 +304,7 @@ void user_mainloop(void) {
 		else {
 			calculated_frequency = (uint16_t)(fabs(commanded_frequency) * 10 * (status.freq_two_digits ? 10 : 1));
 
-			is_at_speed = (commanded_frequency > 0 && calculated_frequency == status.frequency ? 1 : 0);
+			is_at_speed_set(commanded_frequency > 0 && calculated_frequency == status.frequency ? 1 : 0);
 			
 			if(commanded_frequency > 0 
 				&& calculated_frequency != status.frequency 
@@ -319,9 +319,9 @@ void user_mainloop(void) {
 				continue;
 			}
 
-			watchdog_out = !watchdog_out;
-			motor_current = status.output_current / 100;
-			heatsink_temp = status.sink_temp / 10;
+			watchdog_out_set(!watchdog_out);
+			motor_current_set(status.output_current / 100);
+			heatsink_temp_set(status.sink_temp / 10);
 		}
 	}
 	}

--- a/src/hal/user_comps/sendkeys.c
+++ b/src/hal/user_comps/sendkeys.c
@@ -30,11 +30,11 @@
 static int comp_id;
 
 typedef struct{
-    hal_u32_t *keycode;
-    hal_s32_t *current_event;
-    hal_bit_t *init;
-    hal_bit_t **trigger;
-    hal_u32_t *event;
+    hal_uint_t keycode;
+    hal_sint_t current_event;
+    hal_bool_t init;
+    hal_bool_t *trigger;
+    hal_uint_t *event;
 } sendkeys_hal;
 
 typedef struct {
@@ -44,7 +44,7 @@ typedef struct {
     bool inited;
     int fd;
     bool *prev;
-    hal_u32_t oldcode;
+    rtapi_u32 oldcode;
 } sendkeys_param;
 
 typedef struct {
@@ -85,9 +85,9 @@ int init(int argc, char* argv[]){
         return -1;
     }
 
-    me = hal_malloc(sizeof(sendkeys));
-    codes = malloc(sizeof(int));
-    pins = malloc(sizeof(int));
+    me = hal_malloc(sizeof(*me));
+    codes = malloc(sizeof(*codes));
+    pins = malloc(sizeof(*pins));
     // This is all because RTAPI_MP_ARRAY_** macros do not appear to work in userspace
     for (i = 1; i < argc; i++){
         static int index = -1;
@@ -105,8 +105,8 @@ int init(int argc, char* argv[]){
                 case ' ':
                 case ',':
                     index++;
-                    v1 = realloc(codes, (index + 1) * sizeof(int));
-                    v2 = realloc(pins, (index + 1) * sizeof(int));
+                    v1 = realloc(codes, (index + 1) * sizeof(*codes));
+                    v2 = realloc(pins, (index + 1) * sizeof(*pins));
                     if (!v1 || !v2) {
                         free(v1 ? v1 : codes);
                         free(v2 ? v2 : pins);
@@ -156,24 +156,24 @@ int init(int argc, char* argv[]){
             break;
         }
     }
-    me->hal = (sendkeys_hal*)hal_malloc(me->num_insts * sizeof(sendkeys_hal));
-    me->param = malloc(me->num_insts * sizeof(sendkeys_param));
+    me->hal = (sendkeys_hal*)hal_malloc(me->num_insts * sizeof(*me->hal));
+    me->param = malloc(me->num_insts * sizeof(*me->param));
     for (i = 0; i < me->num_insts; i++){
         sendkeys_hal* hal = &(me->hal[i]);
         sendkeys_param* param = &(me->param[i]);
-        if (hal_pin_u32_newf(HAL_IN, &(hal->keycode), comp_id,
+        if (hal_pin_new_ui32(comp_id, HAL_IN, &(hal->keycode), 0,
         "sendkeys.%i.keycode", i) < 0) {
         free(codes);
         free(pins);
         rtapi_print_msg(RTAPI_MSG_ERR, "sendkeys.N.keycode error\n");
         return -ENOMEM;}
-        if (hal_pin_s32_newf(HAL_OUT, &(hal->current_event), comp_id,
+        if (hal_pin_new_si32(comp_id, HAL_OUT, &(hal->current_event), 0,
         "sendkeys.%i.current-event", i) < 0) {
         free(codes);
         free(pins);
         rtapi_print_msg(RTAPI_MSG_ERR, "sendkeys.N.current-event error\n");
         return -ENOMEM;}
-        if (hal_pin_bit_newf(HAL_IN, &(hal->init), comp_id,
+        if (hal_pin_new_bool(comp_id, HAL_IN, &(hal->init), 0,
         "sendkeys.%i.init", i) < 0) {
         free(codes);
         free(pins);
@@ -184,9 +184,9 @@ int init(int argc, char* argv[]){
         param->num_triggers = pins[i];
         param->num_codes = codes[i];
         param->num_events = codes[i] + pins[i];
-        hal->event = hal_malloc(param->num_events  * sizeof(hal_u32_t*));
+        hal->event = hal_malloc(param->num_events * sizeof(*hal->event));
         for (j = 0; j < param->num_codes; j++){
-            if (hal_param_u32_newf(HAL_RW, &(hal->event[j]), comp_id,
+            if (hal_param_new_ui32(comp_id, HAL_RW, &(hal->event[j]), 0,
                     "sendkeys.%i.scan-event-%02i", i, j) < 0) {
                 free(codes);
                 free(pins);
@@ -194,7 +194,7 @@ int init(int argc, char* argv[]){
                 return -ENOMEM;}
         }
         for (j = 0; j < param->num_triggers; j++){
-            if (hal_param_u32_newf(HAL_RW, &(hal->event[j + param->num_codes]), comp_id,
+            if (hal_param_new_ui32(comp_id, HAL_RW, &(hal->event[j + param->num_codes]), 0,
                     "sendkeys.%i.pin-event-%02i", i, j) < 0) {
                 free(codes);
                 free(pins);
@@ -202,10 +202,10 @@ int init(int argc, char* argv[]){
                 return -ENOMEM;}
         }
         // trigger pins
-        hal->trigger = hal_malloc(param->num_triggers * sizeof(hal_bit_t*));
-        param->prev = malloc(param->num_triggers * sizeof(hal_bit_t));
+        hal->trigger = hal_malloc(param->num_triggers * sizeof(*hal->trigger));
+        param->prev = malloc(param->num_triggers * sizeof(*param->prev));
         for (j = 0; j < param->num_triggers; j++){
-            if (hal_pin_bit_newf(HAL_IN, &(hal->trigger[j]), comp_id,
+            if (hal_pin_new_bool(comp_id, HAL_IN, &(hal->trigger[j]), 0,
                     "sendkeys.%i.trigger-%02i", i, j) < 0) {
                 rtapi_print_msg(RTAPI_MSG_ERR, "sendkeys.N.trigger-%02i error\n",j);
                 free(codes);
@@ -234,17 +234,18 @@ int main(int argc, char* argv[]) {
         for (i = 0; i < me->num_insts; i++){
             sendkeys_hal* hal = &(me->hal[i]);
             sendkeys_param* param = &(me->param[i]);
-            if ((*hal->keycode & 0xC0) == 0x80){
-                *hal->current_event = (*hal->keycode & 0x3f);
+            rtapi_u32 kk = hal_get_ui32(hal->keycode);
+            if ((kk & 0xC0) == 0x80){
+                hal_set_si32(hal->current_event, (kk & 0x3f));
             } else {
-                *hal->current_event = -1;
+                hal_set_si32(hal->current_event, -1);
             }
             // The event codes are written to pins in HAL after the 
             // component is loaded.
             // We need to set up the keyboard based on the events selected
             // so there is a secondary init here.
-            if (! *hal->init) continue;
-            if (*hal->init && ! param->inited) {
+            if (!hal_get_bool(hal->init)) continue;
+            if (hal_get_bool(hal->init) && ! param->inited) {
                 param->fd = open("/dev/uinput", O_WRONLY | O_NONBLOCK);
                 if (param->fd < 0) {
                     rtapi_print_msg(RTAPI_MSG_ERR,
@@ -253,9 +254,10 @@ int main(int argc, char* argv[]) {
                 }
                 ioctl(param->fd, UI_SET_EVBIT, EV_KEY);
                 for (j = 0; j < param->num_events; j++){
-                    if (hal->event[j] > 0 && hal->event[j] < KEY_MAX){
-                        ioctl(param->fd, UI_SET_KEYBIT, hal->event[j]);
-                        rtapi_print("SET_EVBIT %i\n", hal->event[j]);
+                    rtapi_u32 evj = hal_get_ui32(hal->event[j]);
+                    if (evj > 0 && evj < KEY_MAX){
+                        ioctl(param->fd, UI_SET_KEYBIT, evj);
+                        rtapi_print("SET_EVBIT %i\n", evj);
                     }
                 }
                 struct uinput_user_dev uidev;
@@ -270,29 +272,31 @@ int main(int argc, char* argv[]) {
                 if (ioctl(param->fd, UI_DEV_CREATE) < 0) { perror("ioctl(UI_DEV_CREATE)"); abort(); }
                 param->inited = 1;
             }
-            if (*hal->keycode != param->oldcode) {
+            rtapi_u32 kc = hal_get_ui32(hal->keycode);
+            if (kc != param->oldcode) {
                 /* Key press, report the event, send key release, and report again*/
-                if ((int)(*hal->keycode & 0x3F) > param->num_events) continue;
-                if (hal->event[*hal->keycode & 0x3F] == 0) continue;
-                if ((*hal->keycode & 0xC0) == 0xC0){ // keydown
-                    emit(param->fd, EV_KEY, hal->event[*hal->keycode & 0x3F], 1);
+                if ((int)(kc & 0x3F) > param->num_events) continue;
+                if (hal_get_ui32(hal->event[kc & 0x3F]) == 0) continue;
+                if ((kc & 0xC0) == 0xC0){ // keydown
+                    emit(param->fd, EV_KEY, hal_get_ui32(hal->event[kc & 0x3F]), 1);
                     emit(param->fd, EV_SYN, SYN_REPORT, 0);
-                } else if ((*hal->keycode & 0xC0) == 0x80){ // keyup
-                    emit(param->fd, EV_KEY, hal->event[*hal->keycode & 0x3F], 0);
+                } else if ((kc & 0xC0) == 0x80){ // keyup
+                    emit(param->fd, EV_KEY, hal_get_ui32(hal->event[kc & 0x3F]), 0);
                     emit(param->fd, EV_SYN, SYN_REPORT, 0);
                 }
-                param->oldcode = *hal->keycode;
+                param->oldcode = kc;
             }
             for (j = 0; j < param->num_triggers; j++){
-                if (param->prev[j] != *hal->trigger[j]){
-                    if (*hal->trigger[j]){ // keydown
-                        emit(param->fd, EV_KEY, hal->event[param->num_codes + j], 1);
+                rtapi_bool trj = hal_get_bool(hal->trigger[j]);
+                if (param->prev[j] != trj){
+                    if (trj){ // keydown
+                        emit(param->fd, EV_KEY, hal_get_ui32(hal->event[param->num_codes + j]), 1);
                         emit(param->fd, EV_SYN, SYN_REPORT, 0);
                     } else { // keyup
-                        emit(param->fd, EV_KEY, hal->event[param->num_codes + j], 0);
+                        emit(param->fd, EV_KEY, hal_get_ui32(hal->event[param->num_codes + j]), 0);
                         emit(param->fd, EV_SYN, SYN_REPORT, 0);
                     }
-                    param->prev[j] = *hal->trigger[j];
+                    param->prev[j] = trj;
                 }
             }
         }

--- a/src/hal/user_comps/shuttle.c
+++ b/src/hal/user_comps/shuttle.c
@@ -100,11 +100,11 @@ int hal_comp_id;
 
 // each Shuttle* device presents this interface to HAL
 struct shuttle_hal {
-    hal_bit_t *button[MAX_BUTTONS];
-    hal_bit_t *button_not[MAX_BUTTONS];
-    hal_s32_t *counts;        // accumulated counts from the jog wheel
-    hal_float_t *spring_wheel_f;  // current position of the springy outer wheel, as a float from -1 to +1 inclusive
-    hal_s32_t *spring_wheel_s32;  // current position of the springy outer wheel, as a s32 from -7 to +7 inclusive
+    hal_bool_t button[MAX_BUTTONS];
+    hal_bool_t button_not[MAX_BUTTONS];
+    hal_sint_t counts;        // accumulated counts from the jog wheel
+    hal_real_t spring_wheel_f;  // current position of the springy outer wheel, as a float from -1 to +1 inclusive
+    hal_sint_t spring_wheel_s32;  // current position of the springy outer wheel, as a s32 from -7 to +7 inclusive
 };
 
 
@@ -155,32 +155,29 @@ int read_update(struct shuttle *s) {
 
     button = ((uint8_t)packet[4] << 8) | (uint8_t)packet[3];
     for (int i = 0; i < s->contour_type->num_buttons; i ++) {
-        if (button & s->contour_type->button_mask[i]) {
-            *s->hal->button[i] = 1;
-        } else {
-            *s->hal->button[i] = 0;
-        }
-        *s->hal->button_not[i] = !*s->hal->button[i];
+        bool b = !!(button & s->contour_type->button_mask[i]);
+        hal_set_bool(s->hal->button[i], b);
+        hal_set_bool(s->hal->button_not[i], !b);
     }
 
     {
         int curr_count = packet[1];
 
         if (s->read_first_event == 0) {
-            *s->hal->counts = 0;
+            hal_set_si32(s->hal->counts, 0);
             s->prev_count = curr_count;
             s->read_first_event = 1;
         } else {
             int diff_count = curr_count - s->prev_count;
             if (diff_count > 128) diff_count -= 256;
             if (diff_count < -128) diff_count += 256;
-            *s->hal->counts += diff_count;
+            hal_set_si32(s->hal->counts, hal_get_si32(s->hal->counts) + diff_count);
             s->prev_count = curr_count;
         }
     }
 
-    *s->hal->spring_wheel_s32 = packet[0];
-    *s->hal->spring_wheel_f = packet[0] / 7.0;
+    hal_set_si32(s->hal->spring_wheel_s32, packet[0]);
+    hal_set_real(s->hal->spring_wheel_f, packet[0] / 7.0);
 
     return 0;
 }
@@ -251,27 +248,21 @@ struct shuttle *check_for_shuttle(char *dev_filename) {
     }
 
     for (int i = 0; i < s->contour_type->num_buttons; i ++) {
-        r = hal_pin_bit_newf(HAL_OUT, &(s->hal->button[i]), hal_comp_id, "%s.%d.button-%d", modname, num_devices, i);
+        r = hal_pin_new_bool(hal_comp_id, HAL_OUT, &(s->hal->button[i]), 0, "%s.%d.button-%d", modname, num_devices, i);
         if (r != 0) goto fail1;
-        *s->hal->button[i] = 0;
 
-        r = hal_pin_bit_newf(HAL_OUT, &(s->hal->button_not[i]), hal_comp_id, "%s.%d.button-%d-not", modname, num_devices, i);
+        r = hal_pin_new_bool(hal_comp_id, HAL_OUT, &(s->hal->button_not[i]), 1, "%s.%d.button-%d-not", modname, num_devices, i);
         if (r != 0) goto fail1;
-        *s->hal->button_not[i] = 1;
     }
 
-    r = hal_pin_s32_newf(HAL_OUT, &(s->hal->counts), hal_comp_id, "%s.%d.counts", modname, num_devices);
+    r = hal_pin_new_si32(hal_comp_id, HAL_OUT, &(s->hal->counts), 0, "%s.%d.counts", modname, num_devices);
     if (r != 0) goto fail1;
 
-    r = hal_pin_float_newf(HAL_OUT, &(s->hal->spring_wheel_f), hal_comp_id, "%s.%d.spring-wheel-f", modname, num_devices);
+    r = hal_pin_new_real(hal_comp_id, HAL_OUT, &(s->hal->spring_wheel_f), 0.0, "%s.%d.spring-wheel-f", modname, num_devices);
     if (r != 0) goto fail1;
 
-    r = hal_pin_s32_newf(HAL_OUT, &(s->hal->spring_wheel_s32), hal_comp_id, "%s.%d.spring-wheel-s32", modname, num_devices);
+    r = hal_pin_new_si32(hal_comp_id, HAL_OUT, &(s->hal->spring_wheel_s32), 0, "%s.%d.spring-wheel-s32", modname, num_devices);
     if (r != 0) goto fail1;
-
-    *s->hal->counts = 0;
-    *s->hal->spring_wheel_f = 0.0;
-    *s->hal->spring_wheel_s32 = 0;
 
     return s;
 

--- a/src/hal/user_comps/svd-ps_vfd.c
+++ b/src/hal/user_comps/svd-ps_vfd.c
@@ -42,15 +42,15 @@
 
 
 typedef struct {
-    hal_float_t *period;
+    hal_real_t period;
 
-    hal_float_t *speed_cmd;
-    hal_float_t *freq_cmd;
-    hal_bit_t *at_speed;
+    hal_real_t speed_cmd;
+    hal_real_t freq_cmd;
+    hal_bool_t at_speed;
 
-    hal_bit_t	*spindle_on;
+    hal_bool_t spindle_on;
 
-    hal_u32_t *modbus_errors;
+    hal_uint_t modbus_errors;
 } haldata_t;
 
 haldata_t *haldata;
@@ -66,7 +66,7 @@ typedef struct {
     // readable value.
     float multiplier;
 
-    hal_float_t *hal_pin;
+    hal_real_t hal_pin;
 } modbus_register_t;
 
 int num_modbus_registers = 0;
@@ -190,7 +190,7 @@ int set_motor_on_forward(modbus_t *mb) {
             return 0;
         }
         fprintf(stderr, "%s: error writing %u to register 0x%04x: %s\n", __func__, val, addr, modbus_strerror(errno));
-        *haldata->modbus_errors = *haldata->modbus_errors + 1;
+        hal_set_ui32(haldata->modbus_errors, hal_get_ui32(haldata->modbus_errors) + 1);
     }
     return -1;
 }
@@ -207,7 +207,7 @@ int set_motor_off(modbus_t *mb) {
             return 0;
         }
         fprintf(stderr, "%s: error writing %u to register 0x%04x: %s\n", __func__, val, addr, modbus_strerror(errno));
-        *haldata->modbus_errors = *haldata->modbus_errors + 1;
+        hal_set_ui32(haldata->modbus_errors, hal_get_ui32(haldata->modbus_errors) + 1);
     }
     return -1;
 }
@@ -226,7 +226,7 @@ int set_motor_frequency(modbus_t *mb, float freq) {
             return 0;
         }
         fprintf(stderr, "%s: error writing %u to register 0x%04x: %s\n", __func__, val, addr, modbus_strerror(errno));
-        *haldata->modbus_errors = *haldata->modbus_errors + 1;
+        hal_set_ui32(haldata->modbus_errors, hal_get_ui32(haldata->modbus_errors) + 1);
     }
     return -1;
 }
@@ -240,11 +240,11 @@ int read_modbus_register(modbus_t *mb, modbus_register_t *reg) {
         svd_modbus_sleep();
         r = modbus_read_registers(mb, reg->address, 1, &data);
         if (r == 1) {
-            *reg->hal_pin = data * reg->multiplier;
+            hal_set_real(reg->hal_pin, data * reg->multiplier);
             return 0;
         }
         fprintf(stderr, "%s: error reading %s (register 0x%04x): %s\n", __func__, reg->name, reg->address, modbus_strerror(errno));
-        *haldata->modbus_errors = *haldata->modbus_errors + 1;
+        hal_set_ui32(haldata->modbus_errors, hal_get_ui32(haldata->modbus_errors) + 1);
     }
     return -1;
 }
@@ -263,7 +263,7 @@ modbus_register_t *add_modbus_register(modbus_t *mb, int address, const char *pi
 
     reg = &modbus_register[num_modbus_registers];
 
-    r = hal_pin_float_newf(HAL_OUT, &reg->hal_pin, hal_comp_id, "%s.%s", modname, pin_name);
+    r = hal_pin_new_real(hal_comp_id, HAL_OUT, &reg->hal_pin, 0.0, "%s.%s", modname, pin_name);
     if (r != 0) {
         return NULL;
     }
@@ -520,30 +520,23 @@ int main(int argc, char **argv) {
         goto out_closeHAL;
     }
 
-    retval = hal_pin_float_newf(HAL_IN, &(haldata->period), hal_comp_id, "%s.period-seconds", modname);
+    retval = hal_pin_new_real(hal_comp_id, HAL_IN, &(haldata->period), 0.1, "%s.period-seconds", modname);
     if (retval != 0) goto out_closeHAL;
 
-    retval = hal_pin_float_newf(HAL_IN, &(haldata->speed_cmd), hal_comp_id, "%s.speed-cmd", modname);
+    retval = hal_pin_new_real(hal_comp_id, HAL_IN, &(haldata->speed_cmd), 0.0, "%s.speed-cmd", modname);
     if (retval != 0) goto out_closeHAL;
 
-    retval = hal_pin_float_newf(HAL_OUT, &(haldata->freq_cmd), hal_comp_id, "%s.freq-cmd", modname);
+    retval = hal_pin_new_real(hal_comp_id, HAL_OUT, &(haldata->freq_cmd), 0.0, "%s.freq-cmd", modname);
     if (retval != 0) goto out_closeHAL;
 
-    retval = hal_pin_bit_newf(HAL_OUT, &(haldata->at_speed), hal_comp_id, "%s.at-speed", modname);
+    retval = hal_pin_new_bool(hal_comp_id, HAL_OUT, &(haldata->at_speed), 0, "%s.at-speed", modname);
     if (retval != 0) goto out_closeHAL;
 
-    retval = hal_pin_bit_newf(HAL_IN, &(haldata->spindle_on), hal_comp_id, "%s.spindle-on", modname);
+    retval = hal_pin_new_bool(hal_comp_id, HAL_IN, &(haldata->spindle_on), 0, "%s.spindle-on", modname);
     if (retval != 0) goto out_closeHAL;
 
-    retval = hal_pin_u32_newf(HAL_OUT, &(haldata->modbus_errors), hal_comp_id, "%s.modbus-errors", modname);
+    retval = hal_pin_new_ui32(hal_comp_id, HAL_OUT, &(haldata->modbus_errors), 0, "%s.modbus-errors", modname);
     if (retval != 0) goto out_closeHAL;
-
-    *haldata->period = 0.1;
-
-    *haldata->freq_cmd = 0.0;
-    *haldata->at_speed = 0;
-
-    *haldata->modbus_errors = 0;
 
     modbus_register = (modbus_register_t *)hal_malloc(20 * sizeof(modbus_register_t));
     if (modbus_register == NULL) {
@@ -584,28 +577,29 @@ int main(int argc, char **argv) {
     hal_ready(hal_comp_id);
 
     while (done == 0) {
-        if (*haldata->period < 0.001) *haldata->period = 0.001;
-        if (*haldata->period > 2.0) *haldata->period = 2.0;
-        period_timespec.tv_sec = (time_t)(*haldata->period);
-        period_timespec.tv_nsec = (long)((*haldata->period - period_timespec.tv_sec) * 1000000000l);
+        rtapi_real period = hal_get_real(haldata->period);
+        if (period < 0.001) period = hal_set_real(haldata->period, 0.001);
+        if (period > 2.0)   period = hal_set_real(haldata->period, 2.0);
+        period_timespec.tv_sec = (time_t)period;
+        period_timespec.tv_nsec = (long)((period - period_timespec.tv_sec) * 1000000000l);
         nanosleep(&period_timespec, NULL);
 
         read_modbus_registers(mb);
 
-        if (*haldata->spindle_on) {
+        if (hal_get_bool(haldata->spindle_on)) {
 	    set_motor_on_forward(mb);
-            *haldata->freq_cmd = (*haldata->speed_cmd / motor_max_speed) * max_freq;
-            set_motor_frequency(mb, *haldata->freq_cmd);
+            hal_set_real(haldata->freq_cmd, (hal_get_real(haldata->speed_cmd) / motor_max_speed) * max_freq);
+            set_motor_frequency(mb, hal_get_real(haldata->freq_cmd));
 
-            if ((fabs(*haldata->speed_cmd - *speed_fb_reg->hal_pin) / *haldata->speed_cmd) < 0.02) {
-                *haldata->at_speed = 1;
+            if ((fabs(hal_get_real(haldata->speed_cmd) - hal_get_real(speed_fb_reg->hal_pin)) / hal_get_real(haldata->speed_cmd)) < 0.02) {
+                hal_set_bool(haldata->at_speed, 1);
             } else {
-                *haldata->at_speed = 0;
+                hal_set_bool(haldata->at_speed, 0);
             }
         } else {
             set_motor_off(mb);
-            *haldata->at_speed = 0;
-            *haldata->freq_cmd = 0.0;
+            hal_set_bool(haldata->at_speed, 0);
+            hal_set_real(haldata->freq_cmd, 0.0);
         }
 
     }

--- a/src/hal/user_comps/thermistor.comp
+++ b/src/hal/user_comps/thermistor.comp
@@ -32,33 +32,33 @@ variant of the Steinhart-Hart equation, described here:
 include <unistd.h>;
 include <rtapi_math.h>;
 
-pin in float t0_c """Reference temperature of the thermistor, in degrees
+pin in real t0_c """Reference temperature of the thermistor, in degrees
 Celsius (typically 25 C).  This must be set before the component can
 compute the thermistor temperature.  The reference temperature information
 is supplied by the thermistor manufacturer.""";
 
-pin in float r0 """Resistance of the thermistor at the reference
+pin in real r0 """Resistance of the thermistor at the reference
 temperature.  This must be set before the component can compute the
 thermistor temperature.  The reference resistance information is supplied
 by the thermistor manufacturer.""";
 
-pin in float beta """Beta parameter of the thermistor (sometimes
+pin in real beta """Beta parameter of the thermistor (sometimes
 just called B).  This must be set before the component can compute the
 thermistor temperature.  The Beta parameter is supplied by the thermistor
 manufacturer.""";
 
-pin in float r_other """Resistance of the other resistor in the
+pin in real r_other """Resistance of the other resistor in the
 voltage-divider ladder.  This must be set before the component can
 compute the thermistor temperature.""";
 
-pin in float v_total "Supply voltage of the voltage-divider ladder.";
-pin in float v_thermistor "Voltage drop across the termistor.";
+pin in real v_total "Supply voltage of the voltage-divider ladder.";
+pin in real v_thermistor "Voltage drop across the termistor.";
 
-pin out float temperature_c "Temperature sensed by the thermistor, in degrees Celsius.";
-pin out float temperature_k "Temperature sensed by the thermistor, in Kelvins.";
-pin out float temperature_f "Temperature sensed by the thermistor, in degrees Fahrenheit.";
+pin out real temperature_c "Temperature sensed by the thermistor, in degrees Celsius.";
+pin out real temperature_k "Temperature sensed by the thermistor, in Kelvins.";
+pin out real temperature_f "Temperature sensed by the thermistor, in degrees Fahrenheit.";
 
-pin out float resistance "Computed resistance of the thermistor.";
+pin out real resistance "Computed resistance of the thermistor.";
 
 ;;
 
@@ -80,9 +80,9 @@ static void userinit(int argc, char **argv) {
 void user_mainloop(void) {
     while (!should_exit) {
         FOR_ALL_INSTS() {
-            hal_float_t t0_k = t0_c + 273.15;
-            hal_float_t r_inf;
-            hal_float_t current;
+            rtapi_real t0_k = t0_c + 273.15;
+            rtapi_real r_inf;
+            rtapi_real current;
 
             if (t0_k <= 0.0) {
                 goto problem;
@@ -102,12 +102,12 @@ void user_mainloop(void) {
                 goto problem;
             }
 
-            resistance = v_thermistor / current;
+            resistance_set(v_thermistor / current);
             if (isnan(resistance) || isinf(resistance) || (resistance <= 0.0)) {
                 goto problem;
             }
 
-            temperature_k = beta / log(resistance/r_inf);
+            temperature_k_set(beta / log(resistance/r_inf));
             if (isnan(temperature_k) || isinf(temperature_k) || (temperature_k < 0.0)) {
                 goto problem;
             }
@@ -117,12 +117,12 @@ void user_mainloop(void) {
 
 problem:
             // override problematic output pins with bogus but not invalid values
-            resistance = 0;
-            temperature_k = 9999;
+            resistance_set(0);
+            temperature_k_set(9999);
 
 ok:
-            temperature_c = temperature_k - 273.15;
-            temperature_f = (temperature_c * 9.0 / 5.0) + 32.0;
+            temperature_c_set(temperature_k - 273.15);
+            temperature_f_set((temperature_c * 9.0 / 5.0) + 32.0);
         }
         usleep(100 * 1000);
     }

--- a/src/hal/user_comps/wj200_vfd/wj200_vfd.comp
+++ b/src/hal/user_comps/wj200_vfd/wj200_vfd.comp
@@ -1,20 +1,20 @@
 component wj200_vfd "Hitachi wj200 modbus driver";
-param rw unsigned mbslaveaddr     "Modbus slave address";
-param rw float frequency_scale = 1 "RPM / frequency, default 1";
-pin in float commanded_frequency  "Frequency of vfd (scaled to RPM)";
-pin out float motor_frequency     "Motor's actual frequency (scaled to RPM)";
-pin out bit motor_reverse         "1 when actually turning in reverse";
-pin in bit reverse                "1 when reverse 0 when forward";
-pin in bit run                    "run the vfd";
-pin in bit enable                 "1 to enable the vfd. 0 will remote trip the vfd, thereby disabling it.";
-pin out bit is_running            "1 when running";
-pin out bit is_at_speed           "1 when running at assigned frequency";
-pin out bit is_stopped            "1 when stopped";
-pin out bit is_ready              "1 when vfd is ready to run";
-pin out bit is_alarm              "1 when vfd alarm is set";
-pin out float motor_current       "Output current in amps";
-pin out float heatsink_temp       "Temperature of drive heatsink";
-pin out bit watchdog_out          "Alternates between 1 and 0 after every update cycle. Feed into a watchdog component to ensure vfd driver is communicating with the vfd properly.";
+param rw ui32 mbslaveaddr         "Modbus slave address";
+param rw real frequency_scale = 1 "RPM / frequency, default 1";
+pin in  real commanded_frequency  "Frequency of vfd (scaled to RPM)";
+pin out real motor_frequency      "Motor's actual frequency (scaled to RPM)";
+pin out bool motor_reverse        "1 when actually turning in reverse";
+pin in  bool reverse              "1 when reverse 0 when forward";
+pin in  bool run                  "run the vfd";
+pin in  bool enable               "1 to enable the vfd. 0 will remote trip the vfd, thereby disabling it.";
+pin out bool is_running           "1 when running";
+pin out bool is_at_speed          "1 when running at assigned frequency";
+pin out bool is_stopped           "1 when stopped";
+pin out bool is_ready             "1 when vfd is ready to run";
+pin out bool is_alarm             "1 when vfd alarm is set";
+pin out real motor_current        "Output current in amps";
+pin out real heatsink_temp        "Temperature of drive heatsink";
+pin out bool watchdog_out         "Alternates between 1 and 0 after every update cycle. Feed into a watchdog component to ensure vfd driver is communicating with the vfd properly.";
 option userspace yes;
 option userinit yes;
 license "GPLv2 or greater";
@@ -339,21 +339,21 @@ void user_mainloop(void) {
             continue;
         }
 
-		is_running = status.running;
-		is_ready = status.ready;
-		is_alarm = status.alarm;
-		is_stopped = status.stopped;
-		motor_frequency = status.actual_frequency * frequency_scale;
-		motor_reverse = status.output_rotation == 2;
+		is_running_set(status.running);
+		is_ready_set(status.ready);
+		is_alarm_set(status.alarm);
+		is_stopped_set(status.stopped);
+		motor_frequency_set(status.actual_frequency * frequency_scale);
+		motor_reverse_set(status.output_rotation == 2);
 
 		/* The WJ200 has a "bug" in that is_at_speed is set
 		even if it's running in the wrong direction, which is
 		not what we want.  Check that here.  */
 		if (reverse == motor_reverse)
-		  is_at_speed = (status.frequency == 0
+		  is_at_speed_set(status.frequency == 0
 		  	      ? status.stopped : status.at_speed);
 		else
-		  is_at_speed = 0;
+		  is_at_speed_set(0);
 
 		if(!status.alarm && !enable && !wj200_trip(ctx)) {
 			print_modbus_error(__comp_inst, "failed to trip");
@@ -382,9 +382,9 @@ void user_mainloop(void) {
 				continue;
 			}
 
-			watchdog_out = !watchdog_out;
-			motor_current = status.output_current / 100;
-			heatsink_temp = status.sink_temp / 10;
+			watchdog_out_set(!watchdog_out);
+			motor_current_set(status.output_current / 100);
+			heatsink_temp_set(status.sink_temp / 10);
 		}
 	}
 	}


### PR DESCRIPTION
These are the smaller user components. They are all straight forward.

Again, several old hal types were abused as variable types, which are corrected.

It should be noted that the bad indenting in sendkeys.c is a structural problem in that file. No attempt has been made to fix that.