### PR TITLE
docs: add standalone pyvcp testing example

### DIFF
--- a/docs/src/gui/pyvcp-examples.adoc
+++ b/docs/src/gui/pyvcp-examples.adoc
@@ -4,6 +4,33 @@
 = PyVCP Examples
 
 
+== Testing a Panel Without HAL
+
+A PyVCP panel can be opened directly with the `pyvcp` command to check the
+layout and widgets before connecting it to HAL.
+Put the following in a file named `hello_world.xml`:
+
+[source,xml]
+----
+<pyvcp>
+  <vbox>
+    <label>
+      <text>"Hello CNC"</text>
+    </label>
+  </vbox>
+</pyvcp>
+----
+
+Then run the command from a terminal:
+
+[source,shell]
+----
+pyvcp hello_world.xml
+----
+
+This opens the panel as a standalone window.
+It makes the edit/test cycle fast because no HAL setup is required.
+
 == AXIS
 
 To create a PyVCP panel to use with the AXIS interface that is


### PR DESCRIPTION
Issue #4300 requested advertising the `pyvcp` utility so users can test a panel without setting up HAL.

Added a "Testing a Panel Without HAL" section at the top of the PyVCP Examples page with a minimal `hello_world.xml` and the command `pyvcp hello_world.xml`.

- `git diff --check` clean.

Fixes LinuxCNC/linuxcnc#4300