### PR TITLE
max31855: reject personality above 15 at load time

### DIFF
--- a/docs/src/hal/comp.adoc
+++ b/docs/src/hal/comp.adoc
@@ -515,6 +515,34 @@ If the requested number of instances exceeds the number of allowed personalities
 personalities are assigned by indexing modulo the number of allowed personalities.
 A message is printed denoting such assignments.
 
+[NOTE]
+====
+If a component uses personality, then it should generally check its value.
+The value of personality is zero if the 'personality=N' argument is not provided to loadrt.
+Pins and params whose personality constraint evaluates to zero are not created, and their memory remains NULL.
+Unconditionally accessing such a pin or param dereferences a NULL pointer and crashes the realtime process.
+
+You can use a test in EXTRA_SETUP() to test the acceptable values of personality for your component.
+You should return -EINVAL if your conditions are not met.
+
+Example testing personality:
+
+[source,c]
+----
+EXTRA_SETUP(){
+    // Silence warnings for the unused arguments.
+    (void)prefix;
+    (void)extra_arg;
+    if (personality < 1) {
+        rtapi_print_msg(RTAPI_MSG_ERR,
+            "mycomp: personality must be >= 1 (use personality=N to set the number of channels)\n");
+        return -EINVAL;
+    }
+    return 0;
+}
+----
+====
+
 == Examples
 
 === constant

--- a/src/hal/components/max31855.comp
+++ b/src/hal/components/max31855.comp
@@ -43,6 +43,7 @@ variable unsigned data_frame [15];
 variable unsigned state = 1;
 
 option period no;
+option extra_setup yes;
 function bitbang_spi;
 license "GPL";
 author "Joseph Calderon";
@@ -197,4 +198,19 @@ FUNCTION(bitbang_spi) {
   }
   state = (delay << 7) | (nbit << 1) | cs;
   cs_out = cs;
+}
+
+EXTRA_SETUP(){
+    (void)prefix;
+    (void)extra_arg;
+    // The pins are sized by (personality & 0xf) but the function uses the
+    // raw value capped at 15, so a larger value exports fewer pins than
+    // the function accesses, and dereferencing the unexported pins kills
+    // rtapi_app when the function runs.
+    if (personality > 15) {
+        rtapi_print_msg(RTAPI_MSG_ERR,
+            "max31855: personality must be at most 15 (use personality=N to set the number of sensors)\n");
+        return -EINVAL;
+    }
+    return 0;
 }


### PR DESCRIPTION
Follow-up to the discussion on #4302.

max31855 sizes its sensor pins by `(personality & 0xf)` but indexes them with the raw value capped at 15. `personality=16` exports zero sensor pins while the function accesses 15 of them, dereferencing NULL pin pointers and killing rtapi_app as soon as the function runs in a thread.

Repro (uspace sim, RIP build):

    loadrt threads name1=t period1=100000 fp1=0
    loadrt max31855 personality=16
    addf max31855.0.bitbang-spi t
    start

Before: rtapi_app dies within one thread period of `start`. Silent in POSIX fallback: halrun still exits 0 and halcmd keeps answering from shm; only `pgrep -x rtapi_app` shows it.
After: `loadrt` fails with `max31855: personality must be at most 15 (use personality=N to set the number of sensors)`.

Also adds the agreed comp.adoc note: components with personality-sized pins should validate the value in EXTRA_SETUP and return -EINVAL, with an example.