### PR TITLE
CI: Retry rtai downloads if they fail (often connection resets)

### DIFF
--- a/.github/scripts/install-rtai.sh
+++ b/.github/scripts/install-rtai.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -eu #Needed so CI fails when anything is wrong
 set -x
@@ -10,13 +10,15 @@ if false; then
     .github/scripts/add-linuxcnc-repository.sh "$DIST"
     sudo apt-get --yes install linux-headers-5.4.279-rtai-amd64 linux-image-5.4.279-rtai-amd64 rtai-modules-5.4.279
 else
+    CURLOPTS=( --no-progress-meter --retry-all-errors --retry 5 --retry-delay 2 -fLO )
+    NTULINUX_DLD="https://github.com/NTULINUX/RTAI/releases/download"
     #To install the RTAI deb's from NTULINUX git
     TMPDIR=$(mktemp -d)
     (
         cd "$TMPDIR"
-        curl --no-progress-meter -fLO https://github.com/NTULINUX/RTAI/releases/download/v5.3.4/linux-headers-5.4.302-rtai-amd64_5.4.302-rtai-amd64-1_amd64.deb
-        curl --no-progress-meter -fLO https://github.com/NTULINUX/RTAI/releases/download/v5.3.4/linux-image-5.4.302-rtai-amd64_5.4.302-rtai-amd64-1_amd64.deb
-        curl --no-progress-meter -fLO https://github.com/NTULINUX/RTAI/releases/download/v5.3.4/rtai-modules-5.4.302_5.3.4-linuxcnc_amd64.deb
+        curl "${CURLOPTS[@]}" "${NTULINUX_DLD}/v5.3.4/linux-headers-5.4.302-rtai-amd64_5.4.302-rtai-amd64-1_amd64.deb"
+        curl "${CURLOPTS[@]}" "${NTULINUX_DLD}/v5.3.4/linux-image-5.4.302-rtai-amd64_5.4.302-rtai-amd64-1_amd64.deb"
+        curl "${CURLOPTS[@]}" "${NTULINUX_DLD}/v5.3.4/rtai-modules-5.4.302_5.3.4-linuxcnc_amd64.deb"
     )
     sudo dpkg -i \
     "$TMPDIR/linux-headers-5.4.302-rtai-amd64_5.4.302-rtai-amd64-1_amd64.deb" \


### PR DESCRIPTION
There are regular "connection reset" errors when downloading the RTAI kernel debs from github's own servers. This interrupts the build and fails CI.

This PR adds retry options to cURL so that transient errors are ignored. It will retry up to 5 times with 2 second delay in between. Errors that are more persistent will still make CI fail and that should be alright.