### PR TITLE
hal: Update the remaining user component VFDs to getter/setter

### DIFF
--- a/src/hal/user_comps/gs2_vfd.c
+++ b/src/hal/user_comps/gs2_vfd.c
@@ -89,38 +89,39 @@ typedef struct {
 
 /* HAL data struct */
 typedef struct {
-  hal_s32_t	*stat1;		// status words from the VFD.  Maybe split these out sometime
-  hal_s32_t	*stat2;
-  hal_float_t	*freq_cmd;	// frequency command
-  hal_float_t	*freq_out;	// actual output frequency
-  hal_float_t	*curr_out;	// output current
-  hal_float_t	*DCBusV;	//
-  hal_float_t	*outV;
-  hal_float_t	*RPM;
-  hal_float_t	*scale_freq;
-  hal_float_t	*power_factor;
-  hal_float_t	*load_pct;
-  hal_s32_t	*FW_Rev;
-  hal_s32_t	errorcount;
-  hal_float_t	looptime;
-  hal_float_t	speed_tolerance;
-  hal_s32_t	retval;
-  hal_bit_t		*at_speed;		// when drive freq_cmd == freq_out and running
-  hal_bit_t		*is_stopped;	// when drive freq out is 0
-  hal_float_t	*speed_command;		// speed command input
-  hal_float_t	motor_hz;		// speeds are scaled in Hz, not RPM
-  hal_float_t	motor_RPM;		// nameplate RPM at default Hz
-  hal_bit_t	*spindle_on;		// spindle 1=on, 0=off
-  hal_bit_t	*spindle_fwd;		// direction, 0=fwd, 1=rev
-  hal_bit_t *spindle_rev;		// on when in rev and running
-  hal_bit_t	*err_reset;		// reset errors when 1
-  hal_s32_t ack_delay;		// number of read/writes before checking at-speed
+    hal_sint_t stat1;           // (pin) status words from the VFD.  Maybe split these out sometime
+    hal_sint_t stat2;           // (pin)
+    hal_real_t freq_cmd;        // (pin) frequency command
+    hal_real_t freq_out;        // (pin) actual output frequency
+    hal_real_t curr_out;        // (pin) output current
+    hal_real_t DCBusV;          // (pin)
+    hal_real_t outV;            // (pin)
+    hal_real_t RPM;             // (pin)
+    hal_real_t scale_freq;      // (pin)
+    hal_real_t power_factor;    // (pin)
+    hal_real_t load_pct;        // (pin)
+    hal_sint_t FW_Rev;          // (pin)
+    hal_sint_t errorcount;      // (param)
+    hal_real_t looptime;        // (param)
+    hal_real_t speed_tolerance; // (param)
+    hal_sint_t retval;          // (param)
+    hal_bool_t at_speed;        // (pin) when drive freq_cmd == freq_out and running
+    hal_bool_t is_stopped;      // (pin) when drive freq out is 0
+    hal_real_t speed_command;   // (pin) speed command input
+    hal_real_t motor_hz;        // (param) speeds are scaled in Hz, not RPM
+    hal_real_t motor_RPM;       // (param) nameplate RPM at default Hz
+    hal_bool_t spindle_on;      // (pin) spindle 1=on, 0=off
+    hal_bool_t spindle_fwd;     // (pin) direction, 0=fwd, 1=rev
+    hal_bool_t spindle_rev;     // (pin) on when in rev and running
+    hal_bool_t err_reset;       // (pin) reset errors when 1
+    hal_sint_t ack_delay;       // (param) number of read/writes before checking at-speed
 
-  hal_bit_t	old_run;		// so we can detect changes in the run state
-  hal_bit_t	old_dir;
-  hal_bit_t	old_err_reset;
-  hal_bit_t    *ena_gs2comp;    // gs2 component enable pin
-  hal_bit_t    *isInitialized;    // initialized status pin
+    hal_bool_t ena_gs2comp;     // (pin) gs2 component enable pin
+    hal_bool_t isInitialized;   // (pin) initialized status pin
+
+    rtapi_bool old_run;         // so we can detect changes in the run state
+    rtapi_bool old_dir;
+    rtapi_bool old_err_reset;
 } haldata_t;
 
 static int done;
@@ -347,58 +348,63 @@ void gs2_show_config(modbus_t *mb_ctx) {
 int write_data(modbus_t *mb_ctx, slavedata_t *slavedata, haldata_t *haldata) {
 //  int write_data[MAX_WRITE_REGS];
     int retval;
-    hal_float_t hzcalc;
+    rtapi_real hzcalc;
 
-    if (haldata->motor_hz<10)
-        haldata->motor_hz = 60;
-    if ((haldata->motor_RPM < 600) || (haldata->motor_RPM > 5000))
-        haldata->motor_RPM = 1800;
-    hzcalc = haldata->motor_hz/haldata->motor_RPM;
+    rtapi_real motor_hz  = hal_get_real(haldata->motor_hz);
+    rtapi_real motor_RPM = hal_get_real(haldata->motor_RPM);
+    if (motor_hz < 10)
+        motor_hz = hal_set_real(haldata->motor_hz, 60);
+    if (motor_RPM < 600 || motor_RPM > 5000)
+        motor_RPM = hal_set_real(haldata->motor_RPM, 1800);
+    hzcalc = motor_hz / motor_RPM;
 
     retval = modbus_write_register(
         mb_ctx,
         slavedata->write_reg_start,
-        abs((int)(*(haldata->speed_command)*hzcalc*10))
+        abs((int)(hal_get_real(haldata->speed_command)*hzcalc*10))
     );
 
-    if (*(haldata->spindle_on) != haldata->old_run) {
-        if (*haldata->spindle_on){
+    rtapi_bool spindle_on = hal_get_bool(haldata->spindle_on);
+    if (spindle_on != haldata->old_run) {
+        if (spindle_on){
             modbus_write_register(mb_ctx, slavedata->write_reg_start+1, 1);
             comm_delay=0;
         }
         else
             modbus_write_register(mb_ctx, slavedata->write_reg_start+1, 0);
-        haldata->old_run = *(haldata->spindle_on);
+        haldata->old_run = spindle_on;
     }
-    if (*(haldata->spindle_fwd) != haldata->old_dir) {
-        if (*haldata->spindle_fwd)
+    rtapi_bool spindle_fwd = hal_get_bool(haldata->spindle_fwd);
+    if (spindle_fwd != haldata->old_dir) {
+        if (spindle_fwd)
             modbus_write_register(mb_ctx, slavedata->write_reg_start+2, 0);
         else
             modbus_write_register(mb_ctx, slavedata->write_reg_start+2, 1);
-        haldata->old_dir = *(haldata->spindle_fwd);
+        haldata->old_dir = spindle_fwd;
     }
-    if (*(haldata->spindle_fwd) || !(*(haldata->spindle_on)))  // JET turn on and off rev based on the status of fwd
-        *(haldata->spindle_rev) = 0;
-    if (!(*haldata->spindle_fwd) && *(haldata->spindle_on))
-        *(haldata->spindle_rev) = 1;
-    if (*(haldata->err_reset) != haldata->old_err_reset) {
-        if (*(haldata->err_reset))
+    if (spindle_fwd || !spindle_on)  // JET turn on and off rev based on the status of fwd
+        hal_set_bool(haldata->spindle_rev, 0);
+    if (!spindle_fwd && spindle_on)
+        hal_set_bool(haldata->spindle_rev, 1);
+    rtapi_bool err_reset = hal_get_bool(haldata->err_reset);
+    if (err_reset != haldata->old_err_reset) {
+        if (err_reset)
             modbus_write_register(mb_ctx, slavedata->write_reg_start+4, 1);
         else
             modbus_write_register(mb_ctx, slavedata->write_reg_start+4, 0);
-        haldata->old_err_reset = *(haldata->err_reset);
+        haldata->old_err_reset = err_reset;
     }
-    if (comm_delay < haldata->ack_delay){ // JET allow time for communications between drive and EMC
+    if (comm_delay < hal_get_si32(haldata->ack_delay)){ // JET allow time for communications between drive and EMC
         comm_delay++;
     }
-    if ((*haldata->spindle_on) && comm_delay == haldata->ack_delay){ // JET test for up to speed
-        if ((*(haldata->freq_cmd))==(*(haldata->freq_out)))
-            *(haldata->at_speed) = 1;
+    if (spindle_on && comm_delay == hal_get_si32(haldata->ack_delay)){ // JET test for up to speed
+        if (hal_get_real(haldata->freq_cmd) == hal_get_real(haldata->freq_out))
+            hal_set_bool(haldata->at_speed, 1);
     }
-    if (*(haldata->spindle_on)==0){ // JET reset at-speed
-        *(haldata->at_speed) = 0;
+    if (!spindle_on){ // JET reset at-speed
+        hal_set_bool(haldata->at_speed, 0);
     }
-    haldata->retval = retval;
+    hal_set_si32(haldata->retval, retval);
     return retval;
 }
 
@@ -458,34 +464,34 @@ int read_data(modbus_t *mb_ctx, slavedata_t *slavedata, haldata_t *hal_data_bloc
         return -1;
     /* but we can signal an error if the other params are null */
     if ((mb_ctx==NULL) || (slavedata == NULL)) {
-        hal_data_block->errorcount++;
+        hal_set_si32(hal_data_block->errorcount, hal_get_si32(hal_data_block->errorcount) + 1);
         return -1;
     }
     retval = modbus_read_registers(mb_ctx, slavedata->read_reg_start,
                                 slavedata->read_reg_count, receive_data);
     if (retval==slavedata->read_reg_count) {
         retval = 0;
-        hal_data_block->retval = retval;
-        *(hal_data_block->stat1) = receive_data[0];
-        *(hal_data_block->stat2) = receive_data[1];
-        *(hal_data_block->freq_cmd) = receive_data[2] * 0.1;
-        *(hal_data_block->freq_out) = receive_data[3] * 0.1;
+        hal_set_si32(hal_data_block->retval, retval);
+        hal_set_si32(hal_data_block->stat1, receive_data[0]);
+        hal_set_si32(hal_data_block->stat2, receive_data[1]);
+        hal_set_real(hal_data_block->freq_cmd, receive_data[2] * 0.1);
+        hal_set_real(hal_data_block->freq_out, receive_data[3] * 0.1);
         if (receive_data[3]==0) {	// JET if freq out is 0 then the drive is stopped
-            *(hal_data_block->is_stopped) = 1;
+            hal_set_bool(hal_data_block->is_stopped, 1);
         } else {
-            *(hal_data_block->is_stopped) = 0;
+            hal_set_bool(hal_data_block->is_stopped, 0);
         }
-        *(hal_data_block->curr_out) = receive_data[4] * 0.1;
-        *(hal_data_block->DCBusV) = receive_data[5] * 0.1;
-        *(hal_data_block->outV) = receive_data[6] * 0.1;
-        *(hal_data_block->RPM) = receive_data[7];
-        *(hal_data_block->scale_freq) = (receive_data[8] | (receive_data[9] << 16)) * 0.1;
-        *(hal_data_block->power_factor) = receive_data[10];
-        *(hal_data_block->load_pct) = receive_data[11] * 0.1;
-        *(hal_data_block->FW_Rev) = receive_data[12];
+        hal_set_real(hal_data_block->curr_out, receive_data[4] * 0.1);
+        hal_set_real(hal_data_block->DCBusV, receive_data[5] * 0.1);
+        hal_set_real(hal_data_block->outV, receive_data[6] * 0.1);
+        hal_set_real(hal_data_block->RPM, receive_data[7]);
+        hal_set_real(hal_data_block->scale_freq, (receive_data[8] | (receive_data[9] << 16)) * 0.1);
+        hal_set_real(hal_data_block->power_factor, receive_data[10]);
+        hal_set_real(hal_data_block->load_pct, receive_data[11] * 0.1);
+        hal_set_si32(hal_data_block->FW_Rev, receive_data[12]);
     } else {
-        hal_data_block->retval = retval;
-        hal_data_block->errorcount++;
+        hal_set_si32(hal_data_block->retval, retval);
+        hal_set_si32(hal_data_block->errorcount, hal_get_si32(hal_data_block->errorcount) + 1);
         retval = -1;
     }
     return retval;
@@ -680,92 +686,69 @@ int main(int argc, char **argv)
         goto out_close;
     }
 
-    retval = hal_pin_s32_newf(HAL_OUT, &(haldata->stat1), hal_comp_id, "%s.status-1", modname);
+    retval = hal_pin_new_si32(hal_comp_id, HAL_OUT, &(haldata->stat1), 0, "%s.status-1", modname);
     if (retval!=0) goto out_closeHAL;
-    retval = hal_pin_s32_newf(HAL_OUT, &(haldata->stat2), hal_comp_id, "%s.status-2", modname);
+    retval = hal_pin_new_si32(hal_comp_id, HAL_OUT, &(haldata->stat2), 0, "%s.status-2", modname);
     if (retval!=0) goto out_closeHAL;
-    retval = hal_pin_float_newf(HAL_OUT, &(haldata->freq_cmd), hal_comp_id, "%s.frequency-command", modname);
+    retval = hal_pin_new_real(hal_comp_id, HAL_OUT, &(haldata->freq_cmd), 0.0, "%s.frequency-command", modname);
     if (retval!=0) goto out_closeHAL;
-    retval = hal_pin_float_newf(HAL_OUT, &(haldata->freq_out), hal_comp_id, "%s.frequency-out", modname);
+    retval = hal_pin_new_real(hal_comp_id, HAL_OUT, &(haldata->freq_out), 0.0, "%s.frequency-out", modname);
     if (retval!=0) goto out_closeHAL;
-    retval = hal_pin_float_newf(HAL_OUT, &(haldata->curr_out), hal_comp_id, "%s.output-current", modname);
+    retval = hal_pin_new_real(hal_comp_id, HAL_OUT, &(haldata->curr_out), 0.0, "%s.output-current", modname);
     if (retval!=0) goto out_closeHAL;
-    retval = hal_pin_float_newf(HAL_OUT, &(haldata->DCBusV), hal_comp_id, "%s.DC-bus-volts", modname);
+    retval = hal_pin_new_real(hal_comp_id, HAL_OUT, &(haldata->DCBusV), 0.0, "%s.DC-bus-volts", modname);
     if (retval!=0) goto out_closeHAL;
-    retval = hal_pin_float_newf(HAL_OUT, &(haldata->outV), hal_comp_id, "%s.output-voltage", modname);
+    retval = hal_pin_new_real(hal_comp_id, HAL_OUT, &(haldata->outV), 0.0, "%s.output-voltage", modname);
     if (retval!=0) goto out_closeHAL;
-    retval = hal_pin_float_newf(HAL_OUT, &(haldata->RPM), hal_comp_id, "%s.motor-RPM", modname);
+    retval = hal_pin_new_real(hal_comp_id, HAL_OUT, &(haldata->RPM), 0.0, "%s.motor-RPM", modname);
     if (retval!=0) goto out_closeHAL;
-    retval = hal_pin_float_newf(HAL_OUT, &(haldata->scale_freq), hal_comp_id, "%s.scale-frequency", modname);
+    retval = hal_pin_new_real(hal_comp_id, HAL_OUT, &(haldata->scale_freq), 0.0, "%s.scale-frequency", modname);
     if (retval!=0) goto out_closeHAL;
-    retval = hal_pin_float_newf(HAL_OUT, &(haldata->power_factor), hal_comp_id, "%s.power-factor", modname);
+    retval = hal_pin_new_real(hal_comp_id, HAL_OUT, &(haldata->power_factor), 0.0, "%s.power-factor", modname);
     if (retval!=0) goto out_closeHAL;
-    retval = hal_pin_float_newf(HAL_OUT, &(haldata->load_pct), hal_comp_id, "%s.load-percentage", modname);
+    retval = hal_pin_new_real(hal_comp_id, HAL_OUT, &(haldata->load_pct), 0.0, "%s.load-percentage", modname);
     if (retval!=0) goto out_closeHAL;
-    retval = hal_pin_s32_newf(HAL_OUT, &(haldata->FW_Rev), hal_comp_id, "%s.firmware-revision", modname);
+    retval = hal_pin_new_si32(hal_comp_id, HAL_OUT, &(haldata->FW_Rev), 0, "%s.firmware-revision", modname);
     if (retval!=0) goto out_closeHAL;
-    retval = hal_param_s32_newf(HAL_RW, &(haldata->errorcount), hal_comp_id, "%s.error-count", modname);
+    retval = hal_param_new_si32(hal_comp_id, HAL_RW, &(haldata->errorcount), 0, "%s.error-count", modname);
     if (retval!=0) goto out_closeHAL;
-    retval = hal_param_float_newf(HAL_RW, &(haldata->looptime), hal_comp_id, "%s.loop-time", modname);
+    retval = hal_param_new_real(hal_comp_id, HAL_RW, &(haldata->looptime), 0.1, "%s.loop-time", modname);
     if (retval!=0) goto out_closeHAL;
-    retval = hal_param_s32_newf(HAL_RW, &(haldata->retval), hal_comp_id, "%s.retval", modname);
+    retval = hal_param_new_si32(hal_comp_id, HAL_RW, &(haldata->retval), 0, "%s.retval", modname);
     if (retval!=0) goto out_closeHAL;
-    retval = hal_pin_bit_newf(HAL_OUT, &(haldata->at_speed), hal_comp_id, "%s.at-speed", modname);
+    retval = hal_pin_new_bool(hal_comp_id, HAL_OUT, &(haldata->at_speed), 0, "%s.at-speed", modname);
     if (retval!=0) goto out_closeHAL;
-    retval = hal_pin_bit_newf(HAL_OUT, &(haldata->is_stopped), hal_comp_id, "%s.is-stopped", modname); // JET
+    retval = hal_pin_new_bool(hal_comp_id, HAL_OUT, &(haldata->is_stopped), 0, "%s.is-stopped", modname); // JET
     if (retval!=0) goto out_closeHAL;
-    retval = hal_pin_float_newf(HAL_IN, &(haldata->speed_command), hal_comp_id, "%s.speed-command", modname);
+    retval = hal_pin_new_real(hal_comp_id, HAL_IN, &(haldata->speed_command), 0.0, "%s.speed-command", modname);
     if (retval!=0) goto out_closeHAL;
-    retval = hal_pin_bit_newf(HAL_IN, &(haldata->spindle_on), hal_comp_id, "%s.spindle-on", modname);
+    retval = hal_pin_new_bool(hal_comp_id, HAL_IN, &(haldata->spindle_on), 0, "%s.spindle-on", modname);
     if (retval!=0) goto out_closeHAL;
-    retval = hal_pin_bit_newf(HAL_IN, &(haldata->spindle_fwd), hal_comp_id, "%s.spindle-fwd", modname);
+    retval = hal_pin_new_bool(hal_comp_id, HAL_IN, &(haldata->spindle_fwd), 1, "%s.spindle-fwd", modname);
     if (retval!=0) goto out_closeHAL;
-    retval = hal_pin_bit_newf(HAL_IN, &(haldata->spindle_rev), hal_comp_id, "%s.spindle-rev", modname); //JET
+    retval = hal_pin_new_bool(hal_comp_id, HAL_IN, &(haldata->spindle_rev), 0, "%s.spindle-rev", modname); //JET
     if (retval!=0) goto out_closeHAL;
-    retval = hal_pin_bit_newf(HAL_IN, &(haldata->err_reset), hal_comp_id, "%s.err-reset", modname);
+    retval = hal_pin_new_bool(hal_comp_id, HAL_IN, &(haldata->err_reset), 0, "%s.err-reset", modname);
     if (retval!=0) goto out_closeHAL;
-    retval = hal_param_float_newf(HAL_RW, &(haldata->speed_tolerance), hal_comp_id, "%s.tolerance", modname);
+    retval = hal_param_new_real(hal_comp_id, HAL_RW, &(haldata->speed_tolerance), 0.01, "%s.tolerance", modname);
     if (retval!=0) goto out_closeHAL;
-    retval = hal_param_float_newf(HAL_RW, &(haldata->motor_hz), hal_comp_id, "%s.nameplate-HZ", modname);
+    retval = hal_param_new_real(hal_comp_id, HAL_RW, &(haldata->motor_hz), 60, "%s.nameplate-HZ", modname);
     if (retval!=0) goto out_closeHAL;
-    retval = hal_param_float_newf(HAL_RW, &(haldata->motor_RPM), hal_comp_id, "%s.nameplate-RPM", modname);
+    retval = hal_param_new_real(hal_comp_id, HAL_RW, &(haldata->motor_RPM), 1730, "%s.nameplate-RPM", modname);
     if (retval!=0) goto out_closeHAL;
-    retval = hal_param_s32_newf(HAL_RW, &(haldata->ack_delay), hal_comp_id, "%s.ack-delay", modname);
+    retval = hal_param_new_si32(hal_comp_id, HAL_RW, &(haldata->ack_delay), 2, "%s.ack-delay", modname);
     if (retval!=0) goto out_closeHAL;
     /* define run (enable) pin and isInitialized */
-    retval = hal_pin_bit_newf(HAL_IN, &(haldata->ena_gs2comp), hal_comp_id, "%s.enable", modname);
+    retval = hal_pin_new_bool(hal_comp_id, HAL_IN, &(haldata->ena_gs2comp), enabled, "%s.enable", modname);
     if (retval!=0) goto out_closeHAL;
-    retval = hal_pin_bit_newf(HAL_OUT, &(haldata->isInitialized), hal_comp_id, "%s.initialized", modname);
+    retval = hal_pin_new_bool(hal_comp_id, HAL_OUT, &(haldata->isInitialized), 0, "%s.initialized", modname);
     if (retval!=0) goto out_closeHAL;
 
-    /* make default data match what we expect to use */
-    *(haldata->stat1) = 0;
-    *(haldata->stat2) = 0;
-    *(haldata->freq_cmd) = 0;
-    *(haldata->freq_out) = 0;
-    *(haldata->curr_out) = 0;
-    *(haldata->DCBusV) = 0;
-    *(haldata->outV) = 0;
-    *(haldata->RPM) = 0;
-    *(haldata->scale_freq) = 0;
-    *(haldata->power_factor) = 0;
-    *(haldata->load_pct) = 0;
-    *(haldata->FW_Rev) = 0;
-    haldata->errorcount = 0;
-    haldata->looptime = 0.1;
-    haldata->motor_RPM = 1730;
-    haldata->motor_hz = 60;
-    haldata->speed_tolerance = 0.01;
-    haldata->ack_delay = 2;
-    *(haldata->err_reset) = 0;
-    *(haldata->spindle_on) = 0;
-    *(haldata->spindle_fwd) = 1;
-    *(haldata->spindle_rev) = 0;
-    haldata->old_run = -1;		// make sure the initial value gets output
-    haldata->old_dir = -1;
-    haldata->old_err_reset = -1;
-    *(haldata->ena_gs2comp) = enabled;  // command line override, defaults to "enabled" for compatibility
-    *(haldata->isInitialized) = 0;
+    // Set stored 'previous' to inverse of initialized to
+    // make sure the initial value gets output
+    haldata->old_run = !hal_get_bool(haldata->spindle_on);
+    haldata->old_dir = !hal_get_bool(haldata->spindle_fwd);
+    haldata->old_err_reset = !hal_get_bool(haldata->err_reset);
 
     // Activate HAL component
     hal_ready(hal_comp_id);
@@ -774,23 +757,24 @@ int main(int argc, char **argv)
     while (done==0) {
 
         /* don't want to scan too fast, and shouldn't delay more than a few seconds */
-        if (haldata->looptime < 0.001) haldata->looptime = 0.001;
-        if (haldata->looptime > 2.0) haldata->looptime = 2.0;
-        loop_timespec.tv_sec = (time_t)(haldata->looptime);
-        loop_timespec.tv_nsec = (long)((haldata->looptime - loop_timespec.tv_sec) * 1000000000l);
+        rtapi_real looptime = hal_get_real(haldata->looptime);
+        if (looptime < 0.001) looptime = hal_set_real(haldata->looptime, 0.001);
+        if (looptime > 2.0)   looptime = hal_set_real(haldata->looptime, 2.0);
+        loop_timespec.tv_sec = (time_t)looptime;
+        loop_timespec.tv_nsec = (long)((looptime - loop_timespec.tv_sec) * 1000000000l);
         nanosleep(&loop_timespec, &remaining);
 
-        if(*(haldata->ena_gs2comp) == 0) {
+        if(!hal_get_bool(haldata->ena_gs2comp)) {
              // Component not enabled, so do nothing and force uninitialized state
-             if (*(haldata->isInitialized)) {
-                *(haldata->spindle_on) = 0;
+             if (hal_get_bool(haldata->isInitialized)) {
+                hal_set_bool(haldata->spindle_on, 0);
                 // need to write to vfd in case we are here when it is being disabled
                 write_data(mb_ctx, &slavedata, haldata);
                 // debug printf below
                 // printf("GS2: Disabling\n");
             }
-            *(haldata->isInitialized) = 0;
-        } else if (!*(haldata->isInitialized)) {
+            hal_set_bool(haldata->isInitialized,  0);
+        } else if (!hal_get_bool(haldata->isInitialized)) {
             // Initialize: configure the gs2 vfd based on command-line arguments
             if (gs2_set_accel_time(mb_ctx, accel_time) != 0) {
                 continue;
@@ -803,7 +787,7 @@ int main(int argc, char **argv)
             }
             // debug printf below
             // printf("GS2: Initialized\n");
-            *(haldata->isInitialized) = 1;
+            hal_set_bool(haldata->isInitialized, 1);
         } else {
             // Enabled and initialized, so do read/write of Modbus
             read_data(mb_ctx, &slavedata, haldata);

--- a/src/hal/user_comps/huanyang-vfd/hy_vfd.c
+++ b/src/hal/user_comps/huanyang-vfd/hy_vfd.c
@@ -74,71 +74,59 @@ int slave = 1;
 
 /* HAL data struct */
 typedef struct {
-	// The HAL comp name will be set to <string>, and all pin and parameter
-	// names will begin with <string>.  
+    // The HAL comp name will be set to <string>, and all pin and parameter
+    // names will begin with <string>.
 
-	hal_bit_t	*enable;				// bit to enable this component
-	
-	hal_float_t	*Set_F;					// frequency command
-	hal_float_t	*Out_F;					// actual output frequency
-	hal_float_t	*Out_A;					// actual output amps
-	hal_float_t	*RoTT;					// actual motor rmp (based on VFD parameters) 
-	hal_float_t	*DCV;					// DC Volts (to be confirmed)
-	hal_float_t	*ACV;					// AC Volts (to be confirmed)
-	hal_float_t	*Cont;
-	hal_float_t *Tmp;					// Temperature (to be confirmed)
-	
-	hal_bit_t *spindle_forward;			// spindle forward input
-	hal_bit_t *spindle_reverse;			// spindle reverse input
-	hal_bit_t *spindle_on;				// spinlde on input
-	hal_float_t *CNTR;					// stores the status of the control request
-	hal_float_t *CNST;					// stores the response of the control request
-	
-	hal_bit_t *CNST_Run;				// CNST Run bit
-	hal_bit_t *CNST_Jog;				// CNST Jog bit	
-	hal_bit_t *CNST_Command_rf;			// CNST Run reverse / forward bit	
-	hal_bit_t *CNST_Running;			// CNST Running bit	
-	hal_bit_t *CNST_Jogging;			// CNST Jogging bit	
-	hal_bit_t *CNST_Running_rf;				// CNST Jog reverse / forward bit	
-	hal_bit_t *CNST_Bracking;			// CNST bracking bit	
-	hal_bit_t *CNST_Track_Start;		// CNST track start bit	
+    hal_bool_t enable;              // bit to enable this component
 
-	hal_float_t *speed_command;			// spindle speed command from EMC
-	hal_float_t	*freq_cmd;				// calculated frequency command
+    hal_real_t Set_F;               // frequency command
+    hal_real_t Out_F;               // actual output frequency
+    hal_real_t Out_A;               // actual output amps
+    hal_real_t RoTT;                // actual motor rmp (based on VFD parameters)
+    hal_real_t DCV;                 // DC Volts (to be confirmed)
+    hal_real_t ACV;                 // AC Volts (to be confirmed)
+    hal_real_t Cont;
+    hal_real_t Tmp;                 // Temperature (to be confirmed)
 
-	hal_float_t *max_freq;				// PD005 Max Operating Frequency
-	hal_float_t *base_freq;				// PD004 Base Frequency
-	hal_float_t *freq_lower_limit;		// PD011 Frequency Lower Limit
-	hal_float_t *rated_motor_voltage; 	// PD141 Rated Motor Voltage - as per motor name plate
-	hal_float_t *rated_motor_current;	// PD142 Rated Motor Current - as per motor name plate
-	hal_u32_t *motor_poles;                 // PD143 Number of motor poles - from motor name plate
-	hal_float_t *rated_motor_rev;		// max motor speed (at max_freq).  PD144 gets set to value corresponding to RPM at 50Hz
-	
-	hal_bit_t	*hycomm_ok;				// the last HYCOMM_OK transactions returned successfully
-	
-	hal_float_t *max_rpm;				// calculated based on VFD max frequency setup parameter
+    hal_bool_t spindle_forward;     // spindle forward input
+    hal_bool_t spindle_reverse;     // spindle reverse input
+    hal_bool_t spindle_on;          // spinlde on input
+    hal_real_t CNTR;                // stores the status of the control request
+    hal_real_t CNST;                // stores the response of the control request
 
-	hal_float_t     *spindle_speed_fb;   // (out) reports current spindle speed (rpm)
-	hal_float_t     *spindle_speed_fb_rps;   // (out) reports current spindle speed (rps)
-	hal_bit_t       *spindle_at_speed;   // (out) True when spindle is on and at commanded speed
-	hal_float_t     *spindle_at_speed_tolerance;  // (in)
+    hal_bool_t CNST_Run;            // CNST Run bit
+    hal_bool_t CNST_Jog;            // CNST Jog bit
+    hal_bool_t CNST_Command_rf;     // CNST Run reverse / forward bit
+    hal_bool_t CNST_Running;        // CNST Running bit
+    hal_bool_t CNST_Jogging;        // CNST Jogging bit
+    hal_bool_t CNST_Running_rf;     // CNST Jog reverse / forward bit
+    hal_bool_t CNST_Bracking;       // CNST bracking bit
+    hal_bool_t CNST_Track_Start;    // CNST track start bit
 
-	hal_u32_t	*retval;
-	hal_s32_t	*errorcount;
-	hal_float_t	looptime;
-	
-	//hal_float_t	motor_nameplate_hz;		// speeds are scaled in Hz, not RPM
-	//hal_float_t	motor_nameplate_RPM;	// nameplate RPM at default Hz
-	//hal_float_t	rpm_limit;				// do-not-exceed output frequency
-	//hal_bit_t	*acc_dec_pattern;		// if set: choose ramp times as defined in F500+F501
-										// if zero (default): choose ramp times as defined in ACC and DEC
-	//hal_float_t	upper_limit_hz;		    // VFD setup parameter - maximum output frequency in HZ
+    hal_real_t speed_command;       // spindle speed command from EMC
+    hal_real_t freq_cmd;            // calculated frequency command
 
-	//hal_bit_t	old_run;				// so we can detect changes in the run state
-	//hal_bit_t	old_dir;
-	//hal_bit_t	old_err_reset;
-	//hal_u32_t	old_cmd1_reg;				// copy of last write to FA00
-	//hal_u32_t	failed_reg;				// remember register for failed hycomm transaction - aids debugging
+    hal_real_t max_freq;            // PD005 Max Operating Frequency
+    hal_real_t base_freq;           // PD004 Base Frequency
+    hal_real_t freq_lower_limit;    // PD011 Frequency Lower Limit
+    hal_real_t rated_motor_voltage; // PD141 Rated Motor Voltage - as per motor name plate
+    hal_real_t rated_motor_current; // PD142 Rated Motor Current - as per motor name plate
+    hal_uint_t motor_poles;         // PD143 Number of motor poles - from motor name plate
+    hal_real_t rated_motor_rev;     // max motor speed (at max_freq).  PD144 gets set to value corresponding to RPM at 50Hz
+
+    hal_bool_t hycomm_ok;           // the last HYCOMM_OK transactions returned successfully
+
+    hal_real_t max_rpm;             // calculated based on VFD max frequency setup parameter
+
+    hal_real_t spindle_speed_fb;            // (out) reports current spindle speed (rpm)
+    hal_real_t spindle_speed_fb_rps;        // (out) reports current spindle speed (rps)
+    hal_bool_t spindle_at_speed;            // (out) True when spindle is on and at commanded speed
+    hal_real_t spindle_at_speed_tolerance;  // (in)
+
+    hal_uint_t retval;
+    hal_sint_t errorcount;
+
+    rtapi_real looptime;
 } haldata_t;
 
 static int done;
@@ -259,7 +247,7 @@ int write_data(hycomm_param_t *hc_param, hycomm_data_t *hc_data, haldata_t *hald
 	int retval;
 	int CNTR, old_CNTR;
 	int CNST;
-	hal_float_t hz_per_rpm;
+	rtapi_real hz_per_rpm;
 	int freq_comp;
 	int freq, old_freq;
 	
@@ -267,31 +255,31 @@ int write_data(hycomm_param_t *hc_param, hycomm_data_t *hc_data, haldata_t *hald
 	hc_data->function = WRITE_FREQ_DATA;
 	hc_data->parameter = 0x00;
 	
-	if ((*(haldata->spindle_forward) && !*(haldata->spindle_reverse)) && *(haldata->spindle_on)) {
+	if ((hal_get_bool(haldata->spindle_forward) && !hal_get_bool(haldata->spindle_reverse)) && hal_get_bool(haldata->spindle_on)) {
 		freq_comp = 1;
-	} else if ((*(haldata->spindle_reverse) && !*(haldata->spindle_forward)) && *(haldata->spindle_on)) {
+	} else if ((hal_get_bool(haldata->spindle_reverse) && !hal_get_bool(haldata->spindle_forward)) && hal_get_bool(haldata->spindle_on)) {
 		freq_comp = -1;
 	} else {
 		freq_comp = 0;	
 	}
 
-	hz_per_rpm = *haldata->max_freq / *(haldata->rated_motor_rev);
-	freq =  abs((int)((*(haldata->speed_command)+freq_comp)*hz_per_rpm*100));
+	hz_per_rpm = hal_get_real(haldata->max_freq) / hal_get_real(haldata->rated_motor_rev);
+	freq =  abs((int)((hal_get_real(haldata->speed_command)+freq_comp)*hz_per_rpm*100));
 	
 	// limit the frequency to the max and min as setup in the VFD
-	if (freq > *(haldata->max_freq)*100)
-		freq = *(haldata->max_freq)*100;
-	if (freq < *(haldata->freq_lower_limit)*100)
-		freq = *(haldata->freq_lower_limit)*100;
+	if (freq > hal_get_real(haldata->max_freq)*100)
+		freq = hal_get_real(haldata->max_freq)*100;
+	if (freq < hal_get_real(haldata->freq_lower_limit)*100)
+		freq = hal_get_real(haldata->freq_lower_limit)*100;
 	
-	old_freq = *(haldata->freq_cmd);
+	old_freq = hal_get_real(haldata->freq_cmd);
 	
 	if (freq != old_freq) {
 		// commanded frequency has changed
 		hc_data->data = freq;
 		if ((retval = hy_comm(hc_param, hc_data)) != 0)
 			goto failed;
-		*(haldata->freq_cmd)  =  freq; 
+		hal_set_real(haldata->freq_cmd, freq);
 	}
 	
 	
@@ -300,87 +288,47 @@ int write_data(hycomm_param_t *hc_param, hycomm_data_t *hc_data, haldata_t *hald
 	hc_data->function = WRITE_CONTROL_DATA;
 	hc_data->parameter = 0x00;
 	
-	if ((*(haldata->spindle_forward) && !*(haldata->spindle_reverse)) && *(haldata->spindle_on)) {
+	if ((hal_get_bool(haldata->spindle_forward) && !hal_get_bool(haldata->spindle_reverse)) && hal_get_bool(haldata->spindle_on)) {
 		CNTR = CONTROL_Run_Fwd;
-	} else if ((*(haldata->spindle_reverse) && !*(haldata->spindle_forward)) && (*haldata->spindle_on)) {
+	} else if ((hal_get_bool(haldata->spindle_reverse) && !hal_get_bool(haldata->spindle_forward)) && hal_get_bool(haldata->spindle_on)) {
 		CNTR = CONTROL_Run_Rev;
 	} else {
 		CNTR = CONTROL_Stop;	
 	}
 	
-	old_CNTR = *(haldata->CNTR);
+	old_CNTR = hal_get_real(haldata->CNTR);
 	hc_data->data = old_CNTR;
 	if ((retval = hy_comm(hc_param, hc_data)) != 0)
 		goto failed;
 	if (CNTR != old_CNTR) {
 		// CNTR register needs to be updated
 		hc_data->data = CNTR;
-		*(haldata->CNTR) = CNTR;
+		hal_set_real(haldata->CNTR, CNTR);
 	}
 
 	
 	CNST = hc_data->ret_data;
-	*(haldata->CNST) = CNST;
+	hal_set_real(haldata->CNST, CNST);
 	
-	if ((CNST & CONTROL_Run) != 0) {
-		*(haldata->CNST_Run) = TRUE;
-	} else {
-		*(haldata->CNST_Run) = FALSE;
-	}
-	
-	if ((CNST & CONTROL_Jog) != 0) {
-		*(haldata->CNST_Jog) = TRUE;
-	} else {
-		*(haldata->CNST_Jog) = FALSE;
-	}
-	
-	if ((CNST & CONTROL_Command_rf) != 0) {
-		*(haldata->CNST_Command_rf) = TRUE;
-	} else {
-		*(haldata->CNST_Command_rf) = FALSE;
-	}
-	
-	if ((CNST & CONTROL_Running) != 0) {
-		*(haldata->CNST_Running) = TRUE;
-	} else {
-		*(haldata->CNST_Running) = FALSE;
-	}
-	
-	if ((CNST & CONTROL_Jogging) != 0) {
-		*(haldata->CNST_Jogging) = TRUE;
-	} else {
-		*(haldata->CNST_Jogging) = FALSE;
-	}
-	
-	if ((CNST & CONTROL_Running_rf) != 0) {
-		*(haldata->CNST_Running_rf) = TRUE;
-	} else {
-		*(haldata->CNST_Running_rf) = FALSE;	
-	}
-	
-	
-	if ((CNST & CONTROL_Bracking) != 0) {
-		*(haldata->CNST_Bracking) = TRUE;
-	} else {
-		*(haldata->CNST_Bracking) = FALSE;
-	}
-	
-	if ((CNST & CONTROL_Track_Start) != 0) {
-		*(haldata->CNST_Track_Start) = TRUE;
-	} else {
-		*(haldata->CNST_Track_Start) = FALSE;	
-	}
+	hal_set_bool(haldata->CNST_Run, (CNST & CONTROL_Run) != 0);
+	hal_set_bool(haldata->CNST_Jog, (CNST & CONTROL_Jog) != 0);
+	hal_set_bool(haldata->CNST_Command_rf, (CNST & CONTROL_Command_rf) != 0);
+	hal_set_bool(haldata->CNST_Running, (CNST & CONTROL_Running) != 0);
+	hal_set_bool(haldata->CNST_Jogging, (CNST & CONTROL_Jogging) != 0);
+	hal_set_bool(haldata->CNST_Running_rf, (CNST & CONTROL_Running_rf) != 0);
+	hal_set_bool(haldata->CNST_Bracking, (CNST & CONTROL_Bracking) != 0);
+	hal_set_bool(haldata->CNST_Track_Start, (CNST & CONTROL_Track_Start) != 0);
 
 	retval = 0;
-	*(haldata->retval) = retval;
+	hal_set_ui32(haldata->retval, retval);
 	return retval;
 
 	failed:
 	if (hc_param->debug) {
 		printf("write_data: FAILED\n");
 	}
-	*(haldata->retval) = retval;
-	(*(haldata->errorcount))++;
+	hal_set_ui32(haldata->retval, retval);
+	hal_set_si32(haldata->errorcount, hal_get_si32(haldata->errorcount) + 1);
 
 	retval = -1;
 	return retval;	
@@ -396,7 +344,7 @@ int read_setup(hycomm_param_t *hc_param, hycomm_data_t *hc_data, haldata_t *hald
 		return -1;
 	/* but we can signal an error if the other params are null */
 	if (hc_param==NULL) {
-		(*(haldata->errorcount))++;
+		hal_set_si32(haldata->errorcount, hal_get_si32(haldata->errorcount) + 1);
 		return -1;
 	}
 
@@ -423,10 +371,10 @@ int read_setup(hycomm_param_t *hc_param, hycomm_data_t *hc_data, haldata_t *hald
 	hc_data->data = 0x0000;
 
 	hc_data->parameter = 5; // PD005 Max Operating Frequency
-        if (*haldata->max_freq != 0) {
+        if (hal_get_real(haldata->max_freq) != 0) {
             // user passed in motor max freq, send to VFD
             hc_data->function = FUNCTION_WRITE;
-            hc_data->data = (uint16_t)(*haldata->max_freq * 100);
+            hc_data->data = (uint16_t)(hal_get_real(haldata->max_freq) * 100);
             if ((retval = hy_comm(hc_param, hc_data)) != 0) {
                 goto failed;
             }
@@ -434,13 +382,13 @@ int read_setup(hycomm_param_t *hc_param, hycomm_data_t *hc_data, haldata_t *hald
         }
 	if ((retval = hy_comm(hc_param, hc_data)) != 0)
 		goto failed;		
-	*(haldata->max_freq) = hc_data->ret_data * 0.01;
+	hal_set_real(haldata->max_freq, hc_data->ret_data * 0.01);
 
 	hc_data->parameter = 4; // PD004 Base Frequency
-        if (*haldata->base_freq != 0) {
+        if (hal_get_real(haldata->base_freq) != 0) {
             // user passed in base freq, send to VFD
             hc_data->function = FUNCTION_WRITE;
-            hc_data->data = (uint16_t)(*haldata->base_freq * 100);
+            hc_data->data = (uint16_t)(hal_get_real(haldata->base_freq) * 100);
             if ((retval = hy_comm(hc_param, hc_data)) != 0) {
                 goto failed;
             }
@@ -448,13 +396,13 @@ int read_setup(hycomm_param_t *hc_param, hycomm_data_t *hc_data, haldata_t *hald
         }
 	if ((retval = hy_comm(hc_param, hc_data)) != 0)
 		goto failed;		
-	*(haldata->base_freq) = hc_data->ret_data * 0.01;
+	hal_set_real(haldata->base_freq, hc_data->ret_data * 0.01);
 
 	hc_data->parameter = 11; // PD011 Frequency Lower Limit
-        if (*haldata->freq_lower_limit != 0) {
+        if (hal_get_real(haldata->freq_lower_limit) != 0) {
             // user passed in motor min freq, send to VFD
             hc_data->function = FUNCTION_WRITE;
-            hc_data->data = (uint16_t)(*haldata->freq_lower_limit * 100);
+            hc_data->data = (uint16_t)(hal_get_real(haldata->freq_lower_limit) * 100);
             if ((retval = hy_comm(hc_param, hc_data)) != 0) {
                 goto failed;
             }
@@ -462,13 +410,13 @@ int read_setup(hycomm_param_t *hc_param, hycomm_data_t *hc_data, haldata_t *hald
         }
 	if ((retval = hy_comm(hc_param, hc_data)) != 0)
 		goto failed;		
-	*(haldata->freq_lower_limit) = hc_data->ret_data * 0.01;
+	hal_set_real(haldata->freq_lower_limit, hc_data->ret_data * 0.01);
 
 	hc_data->parameter = 141; // PD141 Rated Motor Voltage
-        if (*haldata->rated_motor_voltage != 0) {
+        if (hal_get_real(haldata->rated_motor_voltage) != 0) {
             // user passed in motor max voltage, send to VFD
             hc_data->function = FUNCTION_WRITE;
-            hc_data->data = (uint16_t)(*haldata->rated_motor_voltage * 10);
+            hc_data->data = (uint16_t)(hal_get_real(haldata->rated_motor_voltage) * 10);
             if ((retval = hy_comm(hc_param, hc_data)) != 0) {
                 goto failed;
             }
@@ -476,13 +424,13 @@ int read_setup(hycomm_param_t *hc_param, hycomm_data_t *hc_data, haldata_t *hald
         }
 	if ((retval = hy_comm(hc_param, hc_data)) != 0)
 		goto failed;		
-	*(haldata->rated_motor_voltage) = hc_data->ret_data * 0.1;
+	hal_set_real(haldata->rated_motor_voltage, hc_data->ret_data * 0.1);
 
 	hc_data->parameter = 142; // PD142 Rated Motor Current
-        if (*haldata->rated_motor_current != 0) {
+        if (hal_get_real(haldata->rated_motor_current) != 0) {
             // user passed in motor max current, send to VFD
             hc_data->function = FUNCTION_WRITE;
-            hc_data->data = (uint16_t)(*haldata->rated_motor_current * 10);
+            hc_data->data = (uint16_t)(hal_get_real(haldata->rated_motor_current) * 10);
             if ((retval = hy_comm(hc_param, hc_data)) != 0) {
                 goto failed;
             }
@@ -490,13 +438,13 @@ int read_setup(hycomm_param_t *hc_param, hycomm_data_t *hc_data, haldata_t *hald
         }
 	if ((retval = hy_comm(hc_param, hc_data)) != 0)
 		goto failed;		
-	*(haldata->rated_motor_current) = hc_data->ret_data * 0.1;
+	hal_set_real(haldata->rated_motor_current, hc_data->ret_data * 0.1);
 
 	hc_data->parameter = 143; // PD143 Number of Motor Poles
-        if (*haldata->motor_poles != 0) {
+        if (hal_get_ui32(haldata->motor_poles) != 0) {
             // user passed in motor poles, send to VFD
             hc_data->function = FUNCTION_WRITE;
-            hc_data->data = (uint16_t)(*haldata->motor_poles);
+            hc_data->data = (uint16_t)hal_get_ui32(haldata->motor_poles);
             if ((retval = hy_comm(hc_param, hc_data)) != 0) {
                 goto failed;
             }
@@ -504,14 +452,14 @@ int read_setup(hycomm_param_t *hc_param, hycomm_data_t *hc_data, haldata_t *hald
         }
 	if ((retval = hy_comm(hc_param, hc_data)) != 0)
 		goto failed;		
-	*haldata->motor_poles = hc_data->ret_data;
+	hal_set_ui32(haldata->motor_poles, hc_data->ret_data);
 
         hc_data->parameter = 144; // PD144 Rated Motor Rev (at 50 Hz)
-        if (*haldata->rated_motor_rev != 0) {
+        if (hal_get_real(haldata->rated_motor_rev) != 0) {
             // user passed in motor max speed
             // we know motor max freq
             // write the VFD's P144 with "motor speed at 50 Hz"
-            rpm_at_50hz = (*haldata->rated_motor_rev / *haldata->max_freq) * 50.0;
+            rpm_at_50hz = (hal_get_real(haldata->rated_motor_rev) / hal_get_real(haldata->max_freq)) * 50.0;
             hc_data->function = FUNCTION_WRITE;
             hc_data->data = (uint16_t)rpm_at_50hz;
             if ((retval = hy_comm(hc_param, hc_data)) != 0) {
@@ -523,7 +471,7 @@ int read_setup(hycomm_param_t *hc_param, hycomm_data_t *hc_data, haldata_t *hald
 	if ((retval = hy_comm(hc_param, hc_data)) != 0)
 		goto failed;		
         rpm_at_50hz = hc_data->ret_data;
-        *(haldata->rated_motor_rev) = (rpm_at_50hz / 50.0) * *haldata->max_freq;
+        hal_set_real(haldata->rated_motor_rev, (rpm_at_50hz / 50.0) * hal_get_real(haldata->max_freq));
 
 	// Handle explicitly set registers
 	for (int i = 0;hc_param->extra_reg[i] != 0; i++){
@@ -547,15 +495,15 @@ int read_setup(hycomm_param_t *hc_param, hycomm_data_t *hc_data, haldata_t *hald
         fflush(NULL);
 
 	retval = 0;
-	*(haldata->retval) = retval;
+	hal_set_ui32(haldata->retval, retval);
 	return retval;
 
 	failed:
 	if (hc_param->debug) {
 		printf("read_setup: FAILED\n");
 	}
-	*(haldata->retval) = retval;
-	(*(haldata->errorcount))++;
+	hal_set_ui32(haldata->retval, retval);
+	hal_set_si32(haldata->errorcount, hal_get_si32(haldata->errorcount) + 1);
 
 	retval = -1;
 	return retval;	
@@ -574,7 +522,7 @@ int read_data(hycomm_param_t *hc_param, hycomm_data_t *hc_data, haldata_t *halda
 	hc_data->data = STATUS_SetF;
 	if ((retval = hy_comm(hc_param, hc_data)) != 0)
 		goto failed;		
-	*(haldata->Set_F) = hc_data->ret_data * 0.01;
+	hal_set_real(haldata->Set_F, hc_data->ret_data * 0.01);
 	if (hc_param->debug) {
 		printf("Set_F = [%.2X]", hc_data->ret_data);
 		printf("\n");
@@ -583,33 +531,33 @@ int read_data(hycomm_param_t *hc_param, hycomm_data_t *hc_data, haldata_t *halda
 	hc_data->data = STATUS_OutF;
 	if ((retval = hy_comm(hc_param, hc_data)) != 0)
 		goto failed;		
-	*(haldata->Out_F) = hc_data->ret_data * 0.01;
+	hal_set_real(haldata->Out_F, hc_data->ret_data * 0.01);
 	if (hc_param->debug) {
 		printf("Out_F = [%.2X]", hc_data->ret_data);
 		printf("\n");
 	}
 
         if (
-            *haldata->spindle_on
-            && (fabs(*haldata->speed_command) > 0.0)
-            && (*haldata->Set_F > 0.0)
+            hal_get_bool(haldata->spindle_on)
+            && (fabs(hal_get_real(haldata->speed_command)) > 0.0)
+            && (hal_get_real(haldata->Set_F) > 0.0)
         ) {
-            *haldata->spindle_speed_fb = (*haldata->Out_F / *haldata->max_freq) * *haldata->rated_motor_rev;
-            *haldata->spindle_speed_fb_rps = *haldata->spindle_speed_fb / 60.0;
-            if (fabs(1 - (*haldata->spindle_speed_fb / fabs(*haldata->speed_command))) < *haldata->spindle_at_speed_tolerance) {
-                *haldata->spindle_at_speed = 1;
+            hal_set_real(haldata->spindle_speed_fb, (hal_get_real(haldata->Out_F) / hal_get_real(haldata->max_freq)) * hal_get_real(haldata->rated_motor_rev));
+            hal_set_real(haldata->spindle_speed_fb_rps, hal_get_real(haldata->spindle_speed_fb) / 60.0);
+            if (fabs(1 - (hal_get_real(haldata->spindle_speed_fb) / fabs(hal_get_real(haldata->speed_command)))) < hal_get_real(haldata->spindle_at_speed_tolerance)) {
+                hal_set_bool(haldata->spindle_at_speed, 1);
             } else {
-                *haldata->spindle_at_speed = 0;
+                hal_set_bool(haldata->spindle_at_speed, 0);
             }
         } else {
-            *haldata->spindle_speed_fb = 0.0;
-            *haldata->spindle_at_speed = 0;
+            hal_set_real(haldata->spindle_speed_fb, 0.0);
+            hal_set_bool(haldata->spindle_at_speed, 0);
         }
 
 	hc_data->data = STATUS_OutA;
 	if ((retval = hy_comm(hc_param, hc_data)) != 0)
 		goto failed;		
-	*(haldata->Out_A) = hc_data->ret_data * 0.1;
+	hal_set_real(haldata->Out_A, hc_data->ret_data * 0.1);
 	if (hc_param->debug) {
 		printf("Out_A = [%.2X]", hc_data->ret_data);
 		printf("\n");
@@ -618,7 +566,7 @@ int read_data(hycomm_param_t *hc_param, hycomm_data_t *hc_data, haldata_t *halda
 	hc_data->data = STATUS_RoTT;
 	if ((retval = hy_comm(hc_param, hc_data)) != 0)
 		goto failed;		
-	*(haldata->RoTT) = hc_data->ret_data;
+	hal_set_real(haldata->RoTT, hc_data->ret_data);
 	if (hc_param->debug) {
 		printf("RoTT = [%.2X]", hc_data->ret_data);
 		printf("\n");
@@ -627,7 +575,7 @@ int read_data(hycomm_param_t *hc_param, hycomm_data_t *hc_data, haldata_t *halda
 	hc_data->data = STATUS_DCV;
 	if ((retval = hy_comm(hc_param, hc_data)) != 0)
 		goto failed;		
-	*(haldata->DCV) = hc_data->ret_data;
+	hal_set_real(haldata->DCV, hc_data->ret_data);
 	if (hc_param->debug) {
 		printf("DCV = [%.2X]", hc_data->ret_data);
 		printf("\n");
@@ -636,7 +584,7 @@ int read_data(hycomm_param_t *hc_param, hycomm_data_t *hc_data, haldata_t *halda
 	hc_data->data = STATUS_ACV;
 	if ((retval = hy_comm(hc_param, hc_data)) != 0)
 		goto failed;		
-	*(haldata->ACV) = hc_data->ret_data;
+	hal_set_real(haldata->ACV, hc_data->ret_data);
 	if (hc_param->debug) {
 		printf("ACV = [%.2X]", hc_data->ret_data);
 		printf("\n");
@@ -645,7 +593,7 @@ int read_data(hycomm_param_t *hc_param, hycomm_data_t *hc_data, haldata_t *halda
 	hc_data->data = STATUS_Cont;
 	if ((retval = hy_comm(hc_param, hc_data)) != 0)
 		goto failed;		
-	*(haldata->Cont) = hc_data->ret_data;
+	hal_set_real(haldata->Cont, hc_data->ret_data);
 	if (hc_param->debug) {
 		printf("Cont = [%.2X]", hc_data->ret_data);
 		printf("\n");
@@ -654,7 +602,7 @@ int read_data(hycomm_param_t *hc_param, hycomm_data_t *hc_data, haldata_t *halda
 	hc_data->data = STATUS_Tmp;
 	if ((retval = hy_comm(hc_param, hc_data)) != 0)
 		goto failed;		
-	*(haldata->Tmp) = hc_data->ret_data;
+	hal_set_real(haldata->Tmp, hc_data->ret_data);
 	if (hc_param->debug) {
 		printf("Tmp = [%.2X]", hc_data->ret_data);
 		printf("\n");
@@ -662,15 +610,15 @@ int read_data(hycomm_param_t *hc_param, hycomm_data_t *hc_data, haldata_t *halda
 	
 
 	retval = 0;
-	*(haldata->retval) = retval;
+	hal_set_ui32(haldata->retval, retval);
 	return retval;
 
 	failed:
 	if (hc_param->debug) {
 		printf("read_data: FAILED\n");
 	}
-	*(haldata->retval) = retval;
-	(*(haldata->errorcount))++;
+	hal_set_ui32(haldata->retval, retval);
+	hal_set_si32(haldata->errorcount, hal_get_si32(haldata->errorcount) + 1);
 
 	retval = -1;
 	return retval;
@@ -697,7 +645,7 @@ int main(int argc, char **argv)
 	float motor_v = 0;
 	float motor_i = 0;
 	float motor_speed = 0;
-	hal_u32_t motor_poles = 0;
+	rtapi_u32 motor_poles = 0;
 
 	done = 0;
 
@@ -902,150 +850,106 @@ int main(int argc, char **argv)
 		goto out_close;
 	} 
 
-	retval = hal_pin_bit_newf(HAL_IN, &(haldata->enable), hal_comp_id, "%s.enable", modname);
+	retval = hal_pin_new_bool(hal_comp_id, HAL_IN, &(haldata->enable), 0, "%s.enable", modname);
 	if (retval!=0) goto out_closeHAL;
 	
-	retval = hal_pin_float_newf(HAL_OUT, &(haldata->Set_F), hal_comp_id, "%s.SetF", modname);
+	retval = hal_pin_new_real(hal_comp_id, HAL_OUT, &(haldata->Set_F), 0.0, "%s.SetF", modname);
 	if (retval!=0) goto out_closeHAL;
-	retval = hal_pin_float_newf(HAL_OUT, &(haldata->Out_F), hal_comp_id, "%s.OutF", modname);
+	retval = hal_pin_new_real(hal_comp_id, HAL_OUT, &(haldata->Out_F), 0.0, "%s.OutF", modname);
 	if (retval!=0) goto out_closeHAL;
-	retval = hal_pin_float_newf(HAL_OUT, &(haldata->Out_A), hal_comp_id, "%s.OutA", modname);
+	retval = hal_pin_new_real(hal_comp_id, HAL_OUT, &(haldata->Out_A), 0.0, "%s.OutA", modname);
 	if (retval!=0) goto out_closeHAL;
-	retval = hal_pin_float_newf(HAL_OUT, &(haldata->RoTT), hal_comp_id, "%s.Rott", modname);
+	retval = hal_pin_new_real(hal_comp_id, HAL_OUT, &(haldata->RoTT), 0.0, "%s.Rott", modname);
 	if (retval!=0) goto out_closeHAL;
-	retval = hal_pin_float_newf(HAL_OUT, &(haldata->DCV), hal_comp_id, "%s.DCV", modname);
+	retval = hal_pin_new_real(hal_comp_id, HAL_OUT, &(haldata->DCV), 0.0, "%s.DCV", modname);
 	if (retval!=0) goto out_closeHAL;
-	retval = hal_pin_float_newf(HAL_OUT, &(haldata->ACV), hal_comp_id, "%s.ACV", modname);
+	retval = hal_pin_new_real(hal_comp_id, HAL_OUT, &(haldata->ACV), 0.0, "%s.ACV", modname);
 	if (retval!=0) goto out_closeHAL;
-	retval = hal_pin_float_newf(HAL_OUT, &(haldata->Cont), hal_comp_id, "%s.Cont", modname);
+	retval = hal_pin_new_real(hal_comp_id, HAL_OUT, &(haldata->Cont), 0.0, "%s.Cont", modname);
 	if (retval!=0) goto out_closeHAL;
-	retval = hal_pin_float_newf(HAL_OUT, &(haldata->Tmp), hal_comp_id, "%s.Tmp", modname);
-	if (retval!=0) goto out_closeHAL;
-	
-	retval = hal_pin_bit_newf(HAL_IN, &(haldata->spindle_forward), hal_comp_id, "%s.spindle-forward", modname);
-	if (retval!=0) goto out_closeHAL;
-	retval = hal_pin_bit_newf(HAL_IN, &(haldata->spindle_reverse), hal_comp_id, "%s.spindle-reverse", modname);
-	if (retval!=0) goto out_closeHAL;
-	retval = hal_pin_bit_newf(HAL_IN, &(haldata->spindle_on), hal_comp_id, "%s.spindle-on", modname);
-	if (retval!=0) goto out_closeHAL;
-	retval = hal_pin_float_newf(HAL_OUT, &(haldata->CNTR), hal_comp_id, "%s.CNTR", modname);
-	if (retval!=0) goto out_closeHAL;
-	retval = hal_pin_float_newf(HAL_OUT, &(haldata->CNST), hal_comp_id, "%s.CNST", modname);
+	retval = hal_pin_new_real(hal_comp_id, HAL_OUT, &(haldata->Tmp), 0.0, "%s.Tmp", modname);
 	if (retval!=0) goto out_closeHAL;
 	
-	retval = hal_pin_bit_newf(HAL_OUT, &(haldata->CNST_Run), hal_comp_id, "%s.CNST-run", modname); 
+	retval = hal_pin_new_bool(hal_comp_id, HAL_IN, &(haldata->spindle_forward), 0, "%s.spindle-forward", modname);
 	if (retval!=0) goto out_closeHAL;
-	retval = hal_pin_bit_newf(HAL_OUT, &(haldata->CNST_Jog), hal_comp_id, "%s.CNST-jog", modname); 
+	retval = hal_pin_new_bool(hal_comp_id, HAL_IN, &(haldata->spindle_reverse), 0, "%s.spindle-reverse", modname);
 	if (retval!=0) goto out_closeHAL;
-	retval = hal_pin_bit_newf(HAL_OUT, &(haldata->CNST_Command_rf), hal_comp_id, "%s.CNST-command-rf", modname); 
+	retval = hal_pin_new_bool(hal_comp_id, HAL_IN, &(haldata->spindle_on), 0, "%s.spindle-on", modname);
 	if (retval!=0) goto out_closeHAL;
-	retval = hal_pin_bit_newf(HAL_OUT, &(haldata->CNST_Running), hal_comp_id, "%s.CNST-running", modname); 
+	retval = hal_pin_new_real(hal_comp_id, HAL_OUT, &(haldata->CNTR), 0.0, "%s.CNTR", modname);
 	if (retval!=0) goto out_closeHAL;
-	retval = hal_pin_bit_newf(HAL_OUT, &(haldata->CNST_Jogging), hal_comp_id, "%s.CNST-jogging", modname); 
-	if (retval!=0) goto out_closeHAL;
-	retval = hal_pin_bit_newf(HAL_OUT, &(haldata->CNST_Running_rf), hal_comp_id, "%s.CNST-running-rf", modname); 
-	if (retval!=0) goto out_closeHAL;
-	retval = hal_pin_bit_newf(HAL_OUT, &(haldata->CNST_Bracking), hal_comp_id, "%s.CNST-bracking", modname); 
-	if (retval!=0) goto out_closeHAL;
-	retval = hal_pin_bit_newf(HAL_OUT, &(haldata->CNST_Track_Start), hal_comp_id, "%s.CNST-track-start", modname); 
+	retval = hal_pin_new_real(hal_comp_id, HAL_OUT, &(haldata->CNST), 0.0, "%s.CNST", modname);
 	if (retval!=0) goto out_closeHAL;
 	
-	retval = hal_pin_float_newf(HAL_IN, &(haldata->speed_command), hal_comp_id, "%s.speed-command", modname);
+	retval = hal_pin_new_bool(hal_comp_id, HAL_OUT, &(haldata->CNST_Run), 0, "%s.CNST-run", modname);
 	if (retval!=0) goto out_closeHAL;
-	retval = hal_pin_float_newf(HAL_OUT, &(haldata->freq_cmd), hal_comp_id, "%s.frequency-command", modname);
+	retval = hal_pin_new_bool(hal_comp_id, HAL_OUT, &(haldata->CNST_Jog), 0, "%s.CNST-jog", modname);
 	if (retval!=0) goto out_closeHAL;
-	
-	retval = hal_pin_float_newf(HAL_OUT, &(haldata->max_freq), hal_comp_id, "%s.max-freq", modname);
+	retval = hal_pin_new_bool(hal_comp_id, HAL_OUT, &(haldata->CNST_Command_rf), 0, "%s.CNST-command-rf", modname);
 	if (retval!=0) goto out_closeHAL;
-	retval = hal_pin_float_newf(HAL_OUT, &(haldata->base_freq), hal_comp_id, "%s.base-freq", modname);
+	retval = hal_pin_new_bool(hal_comp_id, HAL_OUT, &(haldata->CNST_Running), 0, "%s.CNST-running", modname);
 	if (retval!=0) goto out_closeHAL;
-	retval = hal_pin_float_newf(HAL_OUT, &(haldata->freq_lower_limit), hal_comp_id, "%s.freq-lower-limit", modname);
+	retval = hal_pin_new_bool(hal_comp_id, HAL_OUT, &(haldata->CNST_Jogging), 0, "%s.CNST-jogging", modname);
 	if (retval!=0) goto out_closeHAL;
-	retval = hal_pin_float_newf(HAL_OUT, &(haldata->rated_motor_voltage), hal_comp_id, "%s.rated-motor-voltage", modname);
+	retval = hal_pin_new_bool(hal_comp_id, HAL_OUT, &(haldata->CNST_Running_rf), 0, "%s.CNST-running-rf", modname);
 	if (retval!=0) goto out_closeHAL;
-	retval = hal_pin_float_newf(HAL_OUT, &(haldata->rated_motor_current), hal_comp_id, "%s.rated-motor-current", modname);
+	retval = hal_pin_new_bool(hal_comp_id, HAL_OUT, &(haldata->CNST_Bracking), 0, "%s.CNST-bracking", modname);
 	if (retval!=0) goto out_closeHAL;
-	retval = hal_pin_float_newf(HAL_OUT, &(haldata->rated_motor_rev), hal_comp_id, "%s.rated-motor-rev", modname);
-	if (retval!=0) goto out_closeHAL;
-	retval = hal_pin_u32_newf(HAL_OUT, &(haldata->motor_poles), hal_comp_id, "%s.motor-poles", modname);
-	if (retval!=0) goto out_closeHAL;
-
-	retval = hal_pin_bit_newf(HAL_OUT, &(haldata->hycomm_ok), hal_comp_id, "%s.hycomm-ok", modname); 
+	retval = hal_pin_new_bool(hal_comp_id, HAL_OUT, &(haldata->CNST_Track_Start), 0, "%s.CNST-track-start", modname);
 	if (retval!=0) goto out_closeHAL;
 	
-	retval = hal_pin_s32_newf(HAL_OUT, &(haldata->errorcount), hal_comp_id, "%s.error-count", modname);
+	retval = hal_pin_new_real(hal_comp_id, HAL_IN, &(haldata->speed_command), 0.0, "%s.speed-command", modname);
+	if (retval!=0) goto out_closeHAL;
+	retval = hal_pin_new_real(hal_comp_id, HAL_OUT, &(haldata->freq_cmd), 0.0, "%s.frequency-command", modname);
+	if (retval!=0) goto out_closeHAL;
+	
+	retval = hal_pin_new_real(hal_comp_id, HAL_OUT, &(haldata->max_freq), max_freq, "%s.max-freq", modname);
+	if (retval!=0) goto out_closeHAL;
+	retval = hal_pin_new_real(hal_comp_id, HAL_OUT, &(haldata->base_freq), base_freq, "%s.base-freq", modname);
+	if (retval!=0) goto out_closeHAL;
+	retval = hal_pin_new_real(hal_comp_id, HAL_OUT, &(haldata->freq_lower_limit), min_freq, "%s.freq-lower-limit", modname);
+	if (retval!=0) goto out_closeHAL;
+	retval = hal_pin_new_real(hal_comp_id, HAL_OUT, &(haldata->rated_motor_voltage), motor_v, "%s.rated-motor-voltage", modname);
+	if (retval!=0) goto out_closeHAL;
+	retval = hal_pin_new_real(hal_comp_id, HAL_OUT, &(haldata->rated_motor_current), motor_i, "%s.rated-motor-current", modname);
+	if (retval!=0) goto out_closeHAL;
+	retval = hal_pin_new_real(hal_comp_id, HAL_OUT, &(haldata->rated_motor_rev), motor_speed, "%s.rated-motor-rev", modname);
+	if (retval!=0) goto out_closeHAL;
+	retval = hal_pin_new_ui32(hal_comp_id, HAL_OUT, &(haldata->motor_poles), motor_poles, "%s.motor-poles", modname);
 	if (retval!=0) goto out_closeHAL;
 
-	retval = hal_pin_u32_newf(HAL_OUT, &(haldata->retval), hal_comp_id, "%s.retval", modname);
+	retval = hal_pin_new_bool(hal_comp_id, HAL_OUT, &(haldata->hycomm_ok), 0, "%s.hycomm-ok", modname);
+	if (retval!=0) goto out_closeHAL;
+	
+	retval = hal_pin_new_si32(hal_comp_id, HAL_OUT, &(haldata->errorcount), 0, "%s.error-count", modname);
 	if (retval!=0) goto out_closeHAL;
 
-	retval = hal_pin_float_newf(HAL_OUT, &(haldata->spindle_speed_fb), hal_comp_id, "%s.spindle-speed-fb", modname);
+	retval = hal_pin_new_ui32(hal_comp_id, HAL_OUT, &(haldata->retval), 0, "%s.retval", modname);
 	if (retval!=0) goto out_closeHAL;
 
-	retval = hal_pin_bit_newf(HAL_OUT, &(haldata->spindle_at_speed), hal_comp_id, "%s.spindle-at-speed", modname);
+	retval = hal_pin_new_real(hal_comp_id, HAL_OUT, &(haldata->spindle_speed_fb), 0.0, "%s.spindle-speed-fb", modname);
 	if (retval!=0) goto out_closeHAL;
 
-	retval = hal_pin_float_newf(HAL_IN, &(haldata->spindle_at_speed_tolerance), hal_comp_id, "%s.spindle-at-speed-tolerance", modname);
+	retval = hal_pin_new_bool(hal_comp_id, HAL_OUT, &(haldata->spindle_at_speed), 0, "%s.spindle-at-speed", modname);
 	if (retval!=0) goto out_closeHAL;
 
-	retval = hal_pin_float_newf(HAL_OUT, &(haldata->spindle_speed_fb_rps), hal_comp_id, "%s.spindle-speed-fb-rps", modname);
+	retval = hal_pin_new_real(hal_comp_id, HAL_IN, &(haldata->spindle_at_speed_tolerance), 0.02, "%s.spindle-at-speed-tolerance", modname);
+	if (retval!=0) goto out_closeHAL;
+
+	retval = hal_pin_new_real(hal_comp_id, HAL_OUT, &(haldata->spindle_speed_fb_rps), 0.0, "%s.spindle-speed-fb-rps", modname);
 	if (retval!=0) goto out_closeHAL;
 
 
 	/* make default data match what we expect to use */
 
-	*(haldata->enable) = 0;
-	
-	*(haldata->Set_F) = 0;
-	*(haldata->Out_F) = 0;
-	*(haldata->Out_A) = 0;
-	*(haldata->RoTT) = 0;
-	*(haldata->DCV) = 0;
-	*(haldata->ACV) = 0;
-	*(haldata->Cont) = 0;
-	*(haldata->Tmp) = 0;
-	
-	*(haldata->spindle_forward) = 0;
-	*(haldata->spindle_reverse) = 0;
-	*(haldata->spindle_on) = 0;
-	*(haldata->freq_cmd) = 0;
-	*(haldata->CNTR) = 0;
-	*(haldata->CNST) = 0;
-	
-	*(haldata->max_freq) = max_freq;
-	*(haldata->base_freq) = base_freq;
-	*(haldata->freq_lower_limit) = min_freq;
-	*(haldata->rated_motor_voltage) = motor_v;
-	*(haldata->rated_motor_current) = motor_i;
-	*(haldata->rated_motor_rev) = motor_speed;
-	*(haldata->motor_poles) = motor_poles;
-
-	*(haldata->hycomm_ok) = 0;
-
-	*haldata->spindle_speed_fb = 0.0;
-	*haldata->spindle_at_speed = 0;
-	*haldata->spindle_at_speed_tolerance = 0.02;
-
 	hc_data.slave = slave;
-	*(haldata->errorcount) = 0;
 	haldata->looptime = 0.1;
-
-	
-	//haldata->motor_nameplate_hz = 50;	// folks in The Colonies typically would use 60Hz and 1730 rpm
-	//haldata->motor_nameplate_RPM = 1410;
-	//haldata->rpm_limit = MAX_RPM;
-	//haldata->acc_dec_pattern = 0;
-
-	//haldata->old_run = -1;		// make sure the initial value gets output
-	//haldata->old_dir = -1;
-	//haldata->old_err_reset = -1;
-	//haldata->failed_reg = 0;
 
 	hal_ready(hal_comp_id);
 	hc_data.slave = slave;
 	
 	// wait until EMC and AXIS is ready, ie enable bit is set
-	while (!*(haldata->enable)){
+	while (!hal_get_bool(haldata->enable)){
 		// do nothing until enabled
                 usleep(10*1000);
                 if (done) {
@@ -1074,7 +978,7 @@ int main(int argc, char **argv)
 	// here's the meat of the program.  loop until done (which may be never)
 	while (done==0) {
 		
-		if (*(haldata->enable)) {	
+		if (hal_get_bool(haldata->enable)) {
 			// Read inputs
 			if (read_data(&hc_param, &hc_data, haldata) < 0) {
 				hycomm_ok = 0;
@@ -1090,14 +994,7 @@ int main(int argc, char **argv)
 			}
 		}
 		
-
-		
-		if (hycomm_ok > HYCOMM_MIN_OK) {
-			*(haldata->hycomm_ok) = 1;
-		} else {
-			*(haldata->hycomm_ok) = 0;
-		}
-
+		hal_set_bool(haldata->hycomm_ok, hycomm_ok > HYCOMM_MIN_OK);
 	    
 		// don't want to scan too fast, and shouldn't delay more than a few seconds
 		if (haldata->looptime < 0.001) haldata->looptime = 0.001;

--- a/src/hal/user_comps/vfdb_vfd/vfdb_vfd.c
+++ b/src/hal/user_comps/vfdb_vfd/vfdb_vfd.c
@@ -112,37 +112,37 @@
 
 /* HAL data struct */
 typedef struct {
-    hal_s32_t   *error_code;
-    hal_s32_t 	*status;
-    hal_float_t	*freq_cmd;	// frequency command
-    hal_float_t	*freq_out;	// actual output frequency
-    hal_float_t	*output_volt;	// output voltage
-    hal_float_t	*RPM;
-    hal_float_t *RPS;
-    hal_float_t	*torque_ratio;
-    hal_float_t	*output_current;
-    hal_float_t *max_rpm;	// calculated based on VFD max frequency setup parameter
-    hal_bit_t	*at_speed;	// when drive freq_cmd == freq_out and running
-    hal_bit_t	*is_stopped;	// when drive freq out is 0
-    hal_bit_t	*is_e_stopped;	// true if emergency stop status set in 0xFD00
-    hal_bit_t	*modbus_ok;	// the last MODBUS_OK transactions returned successfully
-    hal_float_t	*speed_command;	// speed command input
+    hal_sint_t error_code;
+    hal_sint_t status;
+    hal_real_t freq_cmd;        // frequency command
+    hal_real_t freq_out;        // actual output frequency
+    hal_real_t output_volt;     // output voltage
+    hal_real_t RPM;
+    hal_real_t RPS;
+    hal_real_t torque_ratio;
+    hal_real_t output_current;
+    hal_real_t max_rpm;         // calculated based on VFD max frequency setup parameter
+    hal_bool_t at_speed;        // when drive freq_cmd == freq_out and running
+    hal_bool_t is_stopped;      // when drive freq out is 0
+    hal_bool_t is_e_stopped;	// true if emergency stop status set in 0xFD00
+    hal_bool_t modbus_ok;	    // the last MODBUS_OK transactions returned successfully
+    hal_real_t speed_command;   // speed command input
 
-    hal_bit_t	*spindle_on;	// spindle 1=on, 0=off
-    // hal_bit_t	*err_reset;	// reset errors when 1  - set fault reset bit in 0xFA00
-    hal_bit_t	*jog_mode;	// termed 'jog-run' in manual - might be useful for spindle positioning
-    hal_s32_t	*errorcount;    // number of failed Modbus transactions - hints at logical errors
+    hal_bool_t spindle_on;      // spindle 1=on, 0=off
+    // hal_bool_t	err_reset;	// reset errors when 1  - set fault reset bit in 0xFA00
+    hal_bool_t jog_mode;        // termed 'jog-run' in manual - might be useful for spindle positioning
+    hal_sint_t errorcount;      // number of failed Modbus transactions - hints at logical errors
 
-    hal_float_t	looptime;
-    hal_float_t	speed_tolerance; 	
-    hal_float_t	motor_nameplate_hz;	// speeds are scaled in Hz, not RPM
-    hal_float_t	motor_nameplate_RPM;	// nameplate RPM at default Hz
-    hal_float_t	rpm_limit;		// do-not-exceed output frequency
-    hal_bit_t	*enabled;		// if set: control VFD via Modbus commands, panel control disabled
+    hal_real_t looptime;            // (param)
+    hal_real_t speed_tolerance;     // (param)
+    hal_real_t motor_nameplate_hz;  // (param) speeds are scaled in Hz, not RPM
+    hal_real_t motor_nameplate_RPM; // (param) nameplate RPM at default Hz
+    hal_real_t rpm_limit;           // (param) do-not-exceed output frequency
+    hal_bool_t enabled;             // if set: control VFD via Modbus commands, panel control disabled
     // if zero (default): manual control through panel enabled
-    hal_float_t	*upper_limit_hz;		// VFD setup parameter - maximum output frequency in HZ
+    hal_real_t upper_limit_hz;      // VFD setup parameter - maximum output frequency in HZ
 
-    hal_bit_t   *max_speed;             // 1: run as fast as possible, ignore unimportant registers
+    hal_bool_t max_speed;           // 1: run as fast as possible, ignore unimportant registers
     // link this to spindle.orient-enable for better orient PID loop behaviour
 } haldata_t;
 
@@ -225,8 +225,8 @@ static struct option long_options[] = {
 
 void  windup(param_pointer p) 
 {
-    if (p->haldata && *(p->haldata->errorcount)) {
-        fprintf(stderr,"%s: %d modbus errors\n",p->progname, *(p->haldata->errorcount));
+    if (p->haldata && hal_get_si32(p->haldata->errorcount)) {
+        fprintf(stderr,"%s: %d modbus errors\n",p->progname, hal_get_si32(p->haldata->errorcount));
         fprintf(stderr,"%s: last command register: 0x%.4x\n",p->progname, p->failed_reg);
         fprintf(stderr,"%s: last error: %s\n",p->progname, modbus_strerror(p->last_errno));
     }
@@ -360,15 +360,15 @@ void usage(int argc, char **argv) {
 
 int write_data(modbus_t *ctx, haldata_t *haldata, param_pointer p)
 {
-    hal_float_t hzcalc;
+    rtapi_real hzcalc;
     int cmd1_reg;
     int freq_reg, freq_cap;
 
-    if (!*(haldata->enabled)) {
+    if (!hal_get_bool(haldata->enabled)) {
         // send 0 to 0x2000 register - no bus control
         if (modbus_write_register(ctx, REG_COMMAND1, 0) < 0) {
             p->failed_reg = REG_COMMAND1;
-            (*haldata->errorcount)++;
+            hal_set_si32(haldata->errorcount, hal_get_si32(haldata->errorcount) + 1);
             p->last_errno = errno;
             return errno;
         }
@@ -377,25 +377,25 @@ int write_data(modbus_t *ctx, haldata_t *haldata, param_pointer p)
 
 retry:
     // set frequency register
-    hzcalc = haldata->motor_nameplate_hz / haldata->motor_nameplate_RPM;
-    freq_reg =  (int)round(fabs((*(haldata->speed_command) * hzcalc * 100.0)));
-    freq_cap =  (int)round(fabs((haldata->rpm_limit * hzcalc * 100)));
+    hzcalc = hal_get_real(haldata->motor_nameplate_hz) / hal_get_real(haldata->motor_nameplate_RPM);
+    freq_reg =  (int)round(fabs((hal_get_real(haldata->speed_command) * hzcalc * 100.0)));
+    freq_cap =  (int)round(fabs((hal_get_real(haldata->rpm_limit) * hzcalc * 100)));
 
     // limit frequency to frequency set via max-rpm
     if (freq_reg > freq_cap)
         freq_reg = freq_cap;
 
-    *(haldata->freq_cmd)  =  freq_reg / 100.0;
+    hal_set_real(haldata->freq_cmd, freq_reg / 100.0);
 
     // prepare command register
     cmd1_reg = 0;
-    if (*haldata->spindle_on){
-        cmd1_reg |= (*haldata->jog_mode) ? CMD_JOG_RUN : CMD_RUN;
+    if (hal_get_bool(haldata->spindle_on)){
+        cmd1_reg |= hal_get_bool(haldata->jog_mode) ? CMD_JOG_RUN : CMD_RUN;
     } else {
         cmd1_reg |= CMD_STOP;
     }
 
-    if (*(haldata->speed_command) >= 0) {
+    if (hal_get_real(haldata->speed_command) >= 0) {
         cmd1_reg |= CMD_FORWARD;
     } else {
         cmd1_reg |= CMD_REVERSE;
@@ -404,9 +404,9 @@ retry:
 //TODO: implement RESET command for VFD-B
 //    // send CMD_FAULT_RESET and CMD_EMERGENCY_STOP only once so the poor thing comes back
 //    // out of reset/estop status eventually
-//    if (*(haldata->err_reset) && !(p->old_cmd1_reg  & CMD_FAULT_RESET ))	{ // not sent yet
+//    if (hal_get_bool(haldata->err_reset) && !(p->old_cmd1_reg  & CMD_FAULT_RESET ))	{ // not sent yet
 //        cmd1_reg |= CMD_FAULT_RESET;		// fault reset bit = 1 -> clear fault
-//        *(haldata->err_reset) = 0;
+//        hal_set_bool(haldata->err_reset, 0);
 //    } else {
 //        cmd1_reg &= ~CMD_FAULT_RESET;
 //    }
@@ -425,7 +425,7 @@ retry:
             goto retry;
         }
         p->failed_reg = REG_COMMAND1;
-        (*haldata->errorcount)++;
+        hal_set_si32(haldata->errorcount, hal_get_si32(haldata->errorcount) + 1);
         p->last_errno = errno;
         return errno;
     } 
@@ -436,7 +436,7 @@ retry:
 
     if ((modbus_write_register(ctx, REG_FREQUENCY, freq_reg)) < 0) {
         p->failed_reg = REG_FREQUENCY;
-        (*haldata->errorcount)++;
+        hal_set_si32(haldata->errorcount, hal_get_si32(haldata->errorcount) + 1);
         p->last_errno = errno;
         return errno;
     } 
@@ -458,9 +458,9 @@ int read_initial(modbus_t *ctx, haldata_t *haldata, param_pointer p)
     voltage, model, eeprom, max_freq;
 
     GETREG(REG_UPPERLIMIT, &max_freq);
-    *(haldata->upper_limit_hz) = (float)max_freq/100.0;
-    *(haldata->max_rpm) = *(haldata->upper_limit_hz) * 
-            haldata->motor_nameplate_RPM / haldata->motor_nameplate_hz;
+    hal_set_real(haldata->upper_limit_hz, (float)max_freq/100.0);
+    hal_set_real(haldata->max_rpm, hal_get_real(haldata->upper_limit_hz) *
+            hal_get_real(haldata->motor_nameplate_RPM) / hal_get_real(haldata->motor_nameplate_hz));
 
     if (p->report_device) {
         GETREG(SR_RATED_CURRENT, &current);
@@ -480,7 +480,7 @@ int read_initial(modbus_t *ctx, haldata_t *haldata, param_pointer p)
     failed:
     p->failed_reg = curr_reg;
     p->last_errno = errno;
-    (*haldata->errorcount)++;
+    hal_set_si32(haldata->errorcount, hal_get_si32(haldata->errorcount) + 1);
     if (p->debug)
         fprintf(stderr, "%s: read_initial: modbus_read_registers(0x%4.4x): %s\n",
                 p->progname, curr_reg, modbus_strerror(errno));
@@ -501,50 +501,41 @@ int read_data(modbus_t *ctx, haldata_t *haldata, param_pointer p)
     }
 
     GETREG(SR_ERROR_CODE, &curr_reg);
-    *(haldata->error_code) = curr_reg;
+    hal_set_si32(haldata->error_code, curr_reg);
 
     // we always at least read the main status register SR_INV_OPSTATUS
     // and current operating frequency SR_OP_FREQUENCY
     GETREG(SR_INV_OPSTATUS, &status_reg);
-    *(haldata->status) = status_reg;
+    hal_set_si32(haldata->status, status_reg);
 
     GETREG(SR_OUTPUT_FREQ, &freq_reg);
-    *(haldata->freq_out) = freq_reg * 0.01;
+    hal_set_real(haldata->freq_out, freq_reg * 0.01);
 
     DBG("read_data: status_reg=%4.4x freq_reg=%4.4x\n", status_reg, freq_reg);
 
     // JET if freq out is 0 then the drive is stopped
-    *(haldata->is_stopped) = (freq_reg == 0);
+    hal_set_bool(haldata->is_stopped, (freq_reg == 0));
+    hal_set_bool(haldata->is_e_stopped, status_reg == ST_EMERGENCY_STOPPED);
 
-    if (status_reg == ST_EMERGENCY_STOPPED) {	// set e-stop status.
-        *(haldata->is_e_stopped) = 1;
-    } else {
-        *(haldata->is_e_stopped) = 0;
-    }
-
-    if ((pollcount == 0) && !*(haldata->max_speed)) {
+    if ((pollcount == 0) && !hal_get_bool(haldata->max_speed)) {
         // less urgent registers
         GETREG(SR_MOTOR_SPEED, &val);
-        *(haldata->RPM) = val;
-        *(haldata->RPS) = val/60.0;
+        hal_set_real(haldata->RPM, val);
+        hal_set_real(haldata->RPS, val/60.0);
 
         GETREG(SR_TORQUE_RATIO, &val);
-        *(haldata->torque_ratio) =  val;
+        hal_set_real(haldata->torque_ratio, val);
 
         GETREG(SR_OUTPUT_CURRENT, &val);
-        *(haldata->output_current) =  val * 0.1;
+        hal_set_real(haldata->output_current, val * 0.1);
 
         GETREG(SR_OUTPUT_VOLTAGE, &val);
-        *(haldata->output_volt) =  val * 0.1;
+        hal_set_real(haldata->output_volt, val * 0.1);
 
         {
-            float speed_error;
-            speed_error = (*haldata->RPM / *haldata->speed_command) - 1.0;
-            if (fabs(speed_error) > haldata->speed_tolerance) {
-                *haldata->at_speed = 0;
-            } else {
-                *haldata->at_speed = 1;
-            }
+            rtapi_real speed_error;
+            speed_error = (hal_get_real(haldata->RPM) / hal_get_real(haldata->speed_command)) - 1.0;
+            hal_set_bool(haldata->at_speed, !(fabs(speed_error) > hal_get_real(haldata->speed_tolerance)));
         }
     } else {
         pollcount++;
@@ -559,7 +550,7 @@ int read_data(modbus_t *ctx, haldata_t *haldata, param_pointer p)
     failed:
     p->failed_reg = curr_reg;
     p->last_errno = errno;
-    (*haldata->errorcount)++;
+    hal_set_si32(haldata->errorcount, hal_get_si32(haldata->errorcount) + 1);
     if (p->debug)
         fprintf(stderr, "%s: read_data: modbus_read_registers(0x%4.4x): %s\n",
                 p->progname, curr_reg, modbus_strerror(errno));
@@ -578,34 +569,34 @@ int read_data(modbus_t *ctx, haldata_t *haldata, param_pointer p)
 int hal_setup(int id, haldata_t *h, const char *name)
 {
     int status;
-    PIN(hal_pin_bit_newf(HAL_OUT, &(h->at_speed), id, "%s.at-speed", name));
-    PIN(hal_pin_float_newf(HAL_OUT, &(h->output_current), id, "%s.output-current", name));
-    PIN(hal_pin_bit_newf(HAL_IN, &(h->enabled), id, "%s.enable", name));
-    // PIN(hal_pin_bit_newf(HAL_IN, &(h->err_reset), id, "%s.err-reset", name));
-    PIN(hal_pin_bit_newf(HAL_IN, &(h->jog_mode), id, "%s.jog-mode", name));
-    PIN(hal_pin_float_newf(HAL_OUT, &(h->freq_cmd), id, "%s.frequency-command", name));
-    PIN(hal_pin_float_newf(HAL_OUT, &(h->freq_out), id, "%s.frequency-out", name));
-    PIN(hal_pin_float_newf(HAL_OUT, &(h->torque_ratio), id, "%s.inverter-load-percentage", name));
-    PIN(hal_pin_bit_newf(HAL_OUT, &(h->is_e_stopped), id, "%s.is-e-stopped", name)); // JET
-    PIN(hal_pin_bit_newf(HAL_OUT, &(h->is_stopped), id, "%s.is-stopped", name)); // JET
-    PIN(hal_pin_float_newf(HAL_OUT, &(h->max_rpm), id, "%s.max-rpm", name));
-    PIN(hal_pin_bit_newf(HAL_OUT, &(h->modbus_ok), id, "%s.modbus-ok", name)); // JET
-    PIN(hal_pin_float_newf(HAL_OUT, &(h->RPM), id, "%s.motor-RPM", name));
-    PIN(hal_pin_float_newf(HAL_OUT, &(h->RPS), id, "%s.motor-RPS", name));
-    PIN(hal_pin_float_newf(HAL_OUT, &(h->output_volt), id, "%s.output-voltage", name));
-    PIN(hal_pin_float_newf(HAL_IN, &(h->speed_command), id, "%s.speed-command", name));
-    PIN(hal_pin_bit_newf(HAL_IN, &(h->spindle_on), id, "%s.spindle-on", name));
-    PIN(hal_pin_s32_newf(HAL_OUT, &(h->error_code), id, "%s.error-code", name));
-    PIN(hal_pin_s32_newf(HAL_OUT, &(h->status), id, "%s.status", name));
-    PIN(hal_pin_bit_newf(HAL_IN, &(h->max_speed), id, "%s.max-speed", name));
-    PIN(hal_pin_s32_newf(HAL_OUT, &(h->errorcount), id, "%s.error-count", name));
-    PIN(hal_pin_float_newf(HAL_OUT, &(h->upper_limit_hz), id, "%s.frequency-limit", name));
+    PIN(hal_pin_new_bool(id, HAL_OUT, &(h->at_speed), 0, "%s.at-speed", name));
+    PIN(hal_pin_new_real(id, HAL_OUT, &(h->output_current), 0.0, "%s.output-current", name));
+    PIN(hal_pin_new_bool(id, HAL_IN, &(h->enabled), 0, "%s.enable", name));
+    // PIN(hal_pin_new_bool(id, HAL_IN, &(h->err_reset), 0, "%s.err-reset", name));
+    PIN(hal_pin_new_bool(id, HAL_IN, &(h->jog_mode), 0, "%s.jog-mode", name));
+    PIN(hal_pin_new_real(id, HAL_OUT, &(h->freq_cmd), 0.0, "%s.frequency-command", name));
+    PIN(hal_pin_new_real(id, HAL_OUT, &(h->freq_out), 0.0, "%s.frequency-out", name));
+    PIN(hal_pin_new_real(id, HAL_OUT, &(h->torque_ratio), 0.0, "%s.inverter-load-percentage", name));
+    PIN(hal_pin_new_bool(id, HAL_OUT, &(h->is_e_stopped), 0, "%s.is-e-stopped", name)); // JET
+    PIN(hal_pin_new_bool(id, HAL_OUT, &(h->is_stopped), 0, "%s.is-stopped", name)); // JET
+    PIN(hal_pin_new_real(id, HAL_OUT, &(h->max_rpm), 0.0, "%s.max-rpm", name));
+    PIN(hal_pin_new_bool(id, HAL_OUT, &(h->modbus_ok), 0, "%s.modbus-ok", name)); // JET
+    PIN(hal_pin_new_real(id, HAL_OUT, &(h->RPM), 0.0, "%s.motor-RPM", name));
+    PIN(hal_pin_new_real(id, HAL_OUT, &(h->RPS), 0.0, "%s.motor-RPS", name));
+    PIN(hal_pin_new_real(id, HAL_OUT, &(h->output_volt), 0.0, "%s.output-voltage", name));
+    PIN(hal_pin_new_real(id, HAL_IN, &(h->speed_command), 0.0, "%s.speed-command", name));
+    PIN(hal_pin_new_bool(id, HAL_IN, &(h->spindle_on), 0, "%s.spindle-on", name));
+    PIN(hal_pin_new_si32(id, HAL_OUT, &(h->error_code), 0, "%s.error-code", name));
+    PIN(hal_pin_new_si32(id, HAL_OUT, &(h->status), 0, "%s.status", name));
+    PIN(hal_pin_new_bool(id, HAL_IN, &(h->max_speed), 0, "%s.max-speed", name));
+    PIN(hal_pin_new_si32(id, HAL_OUT, &(h->errorcount), 0, "%s.error-count", name));
+    PIN(hal_pin_new_real(id, HAL_OUT, &(h->upper_limit_hz), 0.0, "%s.frequency-limit", name));
 
-    PIN(hal_param_float_newf(HAL_RW, &(h->looptime), id, "%s.loop-time", name));
-    PIN(hal_param_float_newf(HAL_RW, &(h->motor_nameplate_hz), id, "%s.nameplate-HZ", name));
-    PIN(hal_param_float_newf(HAL_RW, &(h->motor_nameplate_RPM), id, "%s.nameplate-RPM", name));
-    PIN(hal_param_float_newf(HAL_RW, &(h->rpm_limit), id, "%s.rpm-limit", name));
-    PIN(hal_param_float_newf(HAL_RW, &(h->speed_tolerance), id, "%s.tolerance", name));
+    PIN(hal_param_new_real(id, HAL_RW, &(h->looptime), 0.1, "%s.loop-time", name));
+    PIN(hal_param_new_real(id, HAL_RW, &(h->motor_nameplate_hz), 0.0, "%s.nameplate-HZ", name));
+    PIN(hal_param_new_real(id, HAL_RW, &(h->motor_nameplate_RPM), 0.0, "%s.nameplate-RPM", name));
+    PIN(hal_param_new_real(id, HAL_RW, &(h->rpm_limit), 0.0, "%s.rpm-limit", name));
+    PIN(hal_param_new_real(id, HAL_RW, &(h->speed_tolerance), 0.01, "%s.tolerance", name));
 
     return 0;
 }
@@ -615,32 +606,32 @@ int set_defaults(param_pointer p)
 {
     haldata_t *h = p->haldata;
 
-    *(h->status) = 0;
-    *(h->freq_cmd) = 0;
-    *(h->freq_out) = 0;
-    *(h->output_volt) = 0;
-    *(h->RPM) = 0;
-    *(h->torque_ratio) = 0;
-    *(h->output_current) = 0;
-    *(h->upper_limit_hz) = 0;
-    *(h->at_speed) = 0;
-    *(h->is_stopped) = 0;
-    *(h->is_e_stopped) = 0;
-    *(h->speed_command) = 0;
-    *(h->modbus_ok) = 0;
+    hal_set_si32(h->status, 0);
+    hal_set_real(h->freq_cmd, 0);
+    hal_set_real(h->freq_out, 0);
+    hal_set_real(h->output_volt, 0);
+    hal_set_real(h->RPM, 0);
+    hal_set_real(h->torque_ratio, 0);
+    hal_set_real(h->output_current, 0);
+    hal_set_real(h->upper_limit_hz, 0);
+    hal_set_bool(h->at_speed, 0);
+    hal_set_bool(h->is_stopped, 0);
+    hal_set_bool(h->is_e_stopped, 0);
+    hal_set_real(h->speed_command, 0);
+    hal_set_bool(h->modbus_ok, 0);
 
-    *(h->spindle_on) = 0;
-    // *(h->err_reset) = 0;
-    *(h->jog_mode) = 0;
-    *(h->enabled) = 0;
-    *(h->errorcount) = 0;
-    *(h->max_speed) = 0;
+    hal_set_bool(h->spindle_on, 0);
+    // hal_set_bool(h->err_reset, 0);
+    hal_set_bool(h->jog_mode, 0);
+    hal_set_bool(h->enabled, 0);
+    hal_set_si32(h->errorcount, 0);
+    hal_set_bool(h->max_speed, 0);
 
-    h->looptime = 0.1;
-    h->speed_tolerance = 0.01;      // output frequency within 1% of target frequency
-    h->motor_nameplate_hz = p->motor_hz;
-    h->motor_nameplate_RPM = p->motor_rpm;
-    h->rpm_limit = p->motor_rpm;
+    hal_set_real(h->looptime, 0.1);
+    hal_set_real(h->speed_tolerance, 0.01);      // output frequency within 1% of target frequency
+    hal_set_real(h->motor_nameplate_hz, p->motor_hz);
+    hal_set_real(h->motor_nameplate_RPM, p->motor_rpm);
+    hal_set_real(h->rpm_limit, p->motor_rpm);
 
     p->failed_reg = 0;
     return 0;
@@ -755,11 +746,7 @@ int main(int argc, char **argv)
             } else {
                 p->modbus_ok++;
             }
-            if (p->modbus_ok > MODBUS_MIN_OK) {
-                *(p->haldata->modbus_ok) = 1;
-            } else {
-                *(p->haldata->modbus_ok) = 0;
-            }
+            hal_set_bool(p->haldata->modbus_ok, p->modbus_ok > MODBUS_MIN_OK);
             if ((retval = write_data(p->ctx, p->haldata, p))) {
                 p->modbus_ok = 0;
                 if ((retval == EBADF || retval == ECONNRESET || retval == EPIPE)) {
@@ -768,17 +755,14 @@ int main(int argc, char **argv)
             } else {
                 p->modbus_ok++;
             }
-            if (p->modbus_ok > MODBUS_MIN_OK) {
-                *(p->haldata->modbus_ok) = 1;
-            } else {
-                *(p->haldata->modbus_ok) = 0;
-            }
+            hal_set_bool(p->haldata->modbus_ok, p->modbus_ok > MODBUS_MIN_OK);
             /* don't want to scan too fast, and shouldn't delay more than a few seconds */
-            if (p->haldata->looptime < 0.001) p->haldata->looptime = 0.001;
-            if (p->haldata->looptime > 2.0) p->haldata->looptime = 2.0;
-            loop_timespec.tv_sec = (time_t)(p->haldata->looptime);
-            loop_timespec.tv_nsec = (long)((p->haldata->looptime - loop_timespec.tv_sec) * 1000000000l);
-            if (!p->haldata->max_speed)
+            rtapi_real looptime = hal_get_real(p->haldata->looptime);
+            if (looptime < 0.001) looptime = hal_set_real(p->haldata->looptime, 0.001);
+            if (looptime > 2.0)   looptime = hal_set_real(p->haldata->looptime, 2.0);
+            loop_timespec.tv_sec = (time_t)looptime;
+            loop_timespec.tv_nsec = (long)((looptime - loop_timespec.tv_sec) * 1000000000l);
+            if (!hal_get_bool(p->haldata->max_speed))
                 nanosleep(&loop_timespec, &remaining);
         }
 

--- a/src/hal/user_comps/vfs11_vfd/vfs11_vfd.c
+++ b/src/hal/user_comps/vfs11_vfd/vfs11_vfd.c
@@ -211,45 +211,45 @@
 
 /* HAL data struct */
 typedef struct {
-    hal_s32_t 	*status;
-    hal_float_t	*freq_cmd;	// frequency command
-    hal_float_t	*freq_out;	// actual output frequency
-    hal_float_t	*curr_out_pct;	// output current percentage (base unclear)
-    hal_float_t	*outV_pct;	// output voltage percent
-    hal_float_t	*RPM;
-    hal_float_t	*inv_load_pct;
-    hal_float_t	*load_current_pct;
-    hal_float_t *max_rpm;	// calculated based on VFD max frequency setup parameter
-    hal_s32_t	*trip_code;
-    hal_s32_t	*alarm_code;
-    hal_bit_t	*at_speed;	// when drive freq_cmd == freq_out and running
-    hal_bit_t	*is_stopped;	// when drive freq out is 0
-    hal_bit_t	*estop;		// set estop bit in 0xFA00 - causes 'E trip'
-    hal_bit_t	*is_e_stopped;	// true if emergency stop status set in 0xFD00
-    hal_bit_t	*modbus_ok;	// the last MODBUS_OK transactions returned successfully
-    hal_float_t	*speed_command;	// speed command input
+    hal_sint_t status;
+    hal_real_t freq_cmd;        // frequency command
+    hal_real_t freq_out;        // actual output frequency
+    hal_real_t curr_out_pct;        // output current percentage (base unclear)
+    hal_real_t outV_pct;        // output voltage percent
+    hal_real_t RPM;
+    hal_real_t inv_load_pct;
+    hal_real_t load_current_pct;
+    hal_real_t max_rpm;         // calculated based on VFD max frequency setup parameter
+    hal_sint_t trip_code;
+    hal_sint_t alarm_code;
+    hal_bool_t at_speed;        // when drive freq_cmd == freq_out and running
+    hal_bool_t is_stopped;      // when drive freq out is 0
+    hal_bool_t estop;           // set estop bit in 0xFA00 - causes 'E trip'
+    hal_bool_t is_e_stopped;    // true if emergency stop status set in 0xFD00
+    hal_bool_t modbus_ok;       // the last MODBUS_OK transactions returned successfully
+    hal_real_t speed_command;   // speed command input
 
-    hal_bit_t	*spindle_on;	// spindle 1=on, 0=off
-    hal_bit_t 	*DC_brake;	// setting this will turn off the spindle and engage the DC brake
-    hal_bit_t	*spindle_fwd;	// direction, 0=fwd, 1=rev
-    hal_bit_t 	*spindle_rev;	// on when in rev and running
-    hal_bit_t	*err_reset;	// reset errors when 1  - set fault reset bit in 0xFA00
-    hal_bit_t	*jog_mode;	// termed 'jog-run' in manual - might be useful for spindle positioning
-    hal_s32_t	*errorcount;    // number of failed Modbus transactions - hints at logical errors
+    hal_bool_t spindle_on;      // spindle 1=on, 0=off
+    hal_bool_t DC_brake;        // setting this will turn off the spindle and engage the DC brake
+    hal_bool_t spindle_fwd;     // direction, 0=fwd, 1=rev
+    hal_bool_t spindle_rev;     // on when in rev and running
+    hal_bool_t err_reset;       // reset errors when 1  - set fault reset bit in 0xFA00
+    hal_bool_t jog_mode;        // termed 'jog-run' in manual - might be useful for spindle positioning
+    hal_sint_t errorcount;      // number of failed Modbus transactions - hints at logical errors
 
-    hal_float_t	looptime;
-    hal_float_t	speed_tolerance; 	
-    hal_float_t	motor_nameplate_hz;	// speeds are scaled in Hz, not RPM
-    hal_float_t	motor_nameplate_RPM;	// nameplate RPM at default Hz
-    hal_float_t	rpm_limit;		// do-not-exceed output frequency
-    hal_bit_t	*acc_dec_pattern;	// if set: choose ramp times as defined in F500+F501
-                                        // if zero (default): choose ramp times as defined in ACC and DEC
-    hal_bit_t	*enabled;		// if set: control VFD via Modbus commands, panel control disabled
-                                        // if zero (default): manual control through panel enabled
-    hal_float_t	*upper_limit_hz;		// VFD setup parameter - maximum output frequency in HZ
+    hal_real_t looptime;            // (param)
+    hal_real_t speed_tolerance;     // (param)
+    hal_real_t motor_nameplate_hz;  // (param) speeds are scaled in Hz, not RPM
+    hal_real_t motor_nameplate_RPM; // (param) nameplate RPM at default Hz
+    hal_real_t rpm_limit;           // (param) do-not-exceed output frequency
+    hal_bool_t acc_dec_pattern;     // if set: choose ramp times as defined in F500+F501
+                                    // if zero (default): choose ramp times as defined in ACC and DEC
+    hal_bool_t enabled;             // if set: control VFD via Modbus commands, panel control disabled
+                                    // if zero (default): manual control through panel enabled
+    hal_real_t upper_limit_hz;                // VFD setup parameter - maximum output frequency in HZ
      
-    hal_bit_t   *max_speed;             // 1: run as fast as possible, ignore unimportant registers
-                                        // link this to spindle.orient-enable for better orient PID loop behaviour
+    hal_bool_t max_speed;           // 1: run as fast as possible, ignore unimportant registers
+                                    // link this to spindle.orient-enable for better orient PID loop behaviour
 } haldata_t;
 
 // configuration and execution state
@@ -345,8 +345,8 @@ static struct option long_options[] = {
 
 void  windup(param_pointer p) 
 {
-    if (p->haldata && *(p->haldata->errorcount)) {
-	fprintf(stderr,"%s: %d modbus errors\n",p->progname, *(p->haldata->errorcount));
+    if (p->haldata && hal_get_si32(p->haldata->errorcount)) {
+	fprintf(stderr,"%s: %d modbus errors\n",p->progname, hal_get_si32(p->haldata->errorcount));
 	fprintf(stderr,"%s: last command register: 0x%.4x\n",p->progname, p->failed_reg);
 	fprintf(stderr,"%s: last error: %s\n",p->progname, modbus_strerror(p->last_errno));
     }
@@ -521,15 +521,15 @@ void usage(int argc, char **argv) {
 
 int write_data(modbus_t *ctx, haldata_t *haldata, param_pointer p)
 {
-    hal_float_t hzcalc;
+    rtapi_real hzcalc;
     int cmd1_reg;
     int freq_reg, freq_cap;
 
-    if (!*(haldata->enabled)) {
+    if (!hal_get_bool(haldata->enabled)) {
 	// send 0 to FA00 register - no bus control
 	if (modbus_write_register(ctx, REG_COMMAND1, 0) < 0) {
 	    p->failed_reg = REG_COMMAND1;
-	    (*haldata->errorcount)++;
+	    hal_set_si32(haldata->errorcount, hal_get_si32(haldata->errorcount) + 1);
 	    p->last_errno = errno;
 	    return errno;
 	}
@@ -537,69 +537,69 @@ int write_data(modbus_t *ctx, haldata_t *haldata, param_pointer p)
     }
  retry:
     // set frequency register
-    if (haldata->motor_nameplate_hz < 10)
-	haldata->motor_nameplate_hz = 50;
-    if ((haldata->motor_nameplate_RPM < 600) || (haldata->motor_nameplate_RPM > 5000))
-	haldata->motor_nameplate_RPM = 1410;
-    hzcalc = haldata->motor_nameplate_hz/haldata->motor_nameplate_RPM;
+    if (hal_get_real(haldata->motor_nameplate_hz) < 10)
+        hal_set_real(haldata->motor_nameplate_hz, 50);
+    if ((hal_get_real(haldata->motor_nameplate_RPM) < 600) || (hal_get_real(haldata->motor_nameplate_RPM) > 5000))
+        hal_set_real(haldata->motor_nameplate_RPM, 1410);
+    hzcalc = hal_get_real(haldata->motor_nameplate_hz) / hal_get_real(haldata->motor_nameplate_RPM);
 
-    freq_reg =  abs((int)(*(haldata->speed_command) * hzcalc * 100));
-    freq_cap =  abs((int)(haldata->rpm_limit * hzcalc * 100));
+    freq_reg = abs((int)(hal_get_real(haldata->speed_command) * hzcalc * 100));
+    freq_cap = abs((int)(hal_get_real(haldata->rpm_limit) * hzcalc * 100));
 
     // limit frequency to frequency set via max-rpm
     if (freq_reg > freq_cap)
 	freq_reg = freq_cap;
 
-    *(haldata->freq_cmd)  =  freq_reg / 100.0;
+    hal_set_real(haldata->freq_cmd, freq_reg / 100.0);
 
     // prepare command register
     //  force Modbus control - this disables the panel
     cmd1_reg = (CMD_COMMAND_PRIORITY|CMD_FREQUENCY_PRIORITY);	
-    if (*haldata->spindle_on){
-	cmd1_reg|= (*haldata->jog_mode) ? CMD_JOG_RUN : CMD_RUN;
+    if (hal_get_bool(haldata->spindle_on)){
+        cmd1_reg |= hal_get_bool(haldata->jog_mode) ? CMD_JOG_RUN : CMD_RUN;
     }
 
     // if 1, choose ramp times as per F500/F501
     // fix for PID loops where long ramp times cause oscillation
-    if (haldata->acc_dec_pattern){
+    if (hal_get_bool(haldata->acc_dec_pattern)){
 	cmd1_reg|= CMD_ACCEL_PATTERN_2;
     }
 
     // rev follows fwd
     // two bits for one direction is a mess in the first place
-    *(haldata->spindle_rev) = *(haldata->spindle_fwd) ? 0 : 1;
-    *(haldata->spindle_fwd) = *(haldata->spindle_rev) ? 0 : 1;
+    hal_set_bool(haldata->spindle_rev, !hal_get_bool(haldata->spindle_fwd));
+    hal_set_bool(haldata->spindle_fwd, !hal_get_bool(haldata->spindle_rev));
 
-    if (*haldata->spindle_rev) {
+    if (hal_get_bool(haldata->spindle_rev)) {
 	cmd1_reg |= CMD_REVERSE;
     } else {
 	cmd1_reg &= (~CMD_REVERSE);	// direction bit = 0 -> forward
     }
 
     // DC brake - turn spindle_on off as well
-    if  (*(haldata->DC_brake)) {
+    if  (hal_get_bool(haldata->DC_brake)) {
 	cmd1_reg |= CMD_DC_BRAKE;  	// set DC brake bit
 	cmd1_reg &= ~(CMD_RUN | CMD_JOG_RUN); 	
-	*(haldata->spindle_on) = 0;
-	*(haldata->at_speed) = 0;
+	hal_set_bool(haldata->spindle_on, 0);
+	hal_set_bool(haldata->at_speed, 0);
     } else {
 	cmd1_reg &= ~CMD_DC_BRAKE;
     }
 
     // send CMD_FAULT_RESET and CMD_EMERGENCY_STOP only once so the poor thing comes back
     // out of reset/estop status eventually
-    if (*(haldata->err_reset) && !(p->old_cmd1_reg  & CMD_FAULT_RESET ))	{ // not sent yet
+    if (hal_get_bool(haldata->err_reset) && !(p->old_cmd1_reg  & CMD_FAULT_RESET ))	{ // not sent yet
 	cmd1_reg |= CMD_FAULT_RESET;		// fault reset bit = 1 -> clear fault
-	*(haldata->err_reset) = 0;
+	hal_set_bool(haldata->err_reset, 0);
     } else {
 	cmd1_reg &= ~CMD_FAULT_RESET;
     }
 
-    if (*(haldata->estop) && !(p->old_cmd1_reg  & CMD_EMERGENCY_STOP )) {	// not sent yet)
+    if (hal_get_bool(haldata->estop) && !(p->old_cmd1_reg  & CMD_EMERGENCY_STOP )) {	// not sent yet)
 	cmd1_reg |= CMD_EMERGENCY_STOP;		// estop bit -> trip VFD into estop mode
-	*(haldata->estop) = 0;
-	*(haldata->spindle_on) = 0;
-	*(haldata->at_speed) = 0;
+	hal_set_bool(haldata->estop, 0);
+	hal_set_bool(haldata->spindle_on, 0);
+	hal_set_bool(haldata->at_speed, 0);
     } else {
 	cmd1_reg &= ~CMD_EMERGENCY_STOP;
     }
@@ -618,7 +618,7 @@ int write_data(modbus_t *ctx, haldata_t *haldata, param_pointer p)
 	    goto retry;
 	}
 	p->failed_reg = REG_COMMAND1;
-	(*haldata->errorcount)++;
+	hal_set_si32(haldata->errorcount, hal_get_si32(haldata->errorcount) + 1);
 	p->last_errno = errno;
 	return errno;
     } 
@@ -629,19 +629,19 @@ int write_data(modbus_t *ctx, haldata_t *haldata, param_pointer p)
 
     if ((modbus_write_register(ctx, REG_FREQUENCY, freq_reg)) < 0) {
 	p->failed_reg = REG_FREQUENCY;
-	(*haldata->errorcount)++;
+	hal_set_si32(haldata->errorcount, hal_get_si32(haldata->errorcount) + 1);
 	p->last_errno = errno;
 	return errno;
     } 
 
-    if ((*(haldata->freq_cmd) > 0.01) && ((1.0 - *(haldata->freq_out) / *(haldata->freq_cmd))  < haldata->speed_tolerance)){
-	*(haldata->at_speed) = 1;
+    if ((hal_get_real(haldata->freq_cmd) > 0.01) && ((1.0 - hal_get_real(haldata->freq_out) / hal_get_real(haldata->freq_cmd))  < hal_get_real(haldata->speed_tolerance))){
+	hal_set_bool(haldata->at_speed, 1);
     } else {
-	*(haldata->at_speed) = 0;
+	hal_set_bool(haldata->at_speed, 0);
     }
 
-    if (*(haldata->spindle_on) == 0){ // JET reset at-speed
-	*(haldata->at_speed) = 0;
+    if (!hal_get_bool(haldata->spindle_on)){ // JET reset at-speed
+	hal_set_bool(haldata->at_speed, 0);
     }
     return 0;
 }
@@ -660,10 +660,10 @@ int read_initial(modbus_t *ctx, haldata_t *haldata, param_pointer p)
 	voltage, model, cpu1, cpu2, eeprom, max_freq;
 
     GETREG(REG_UPPERLIMIT, &max_freq);
-    *(haldata->upper_limit_hz) = max_freq/100.0;
-    *(haldata->max_rpm) = *(haldata->upper_limit_hz) * 
-	haldata->motor_nameplate_RPM /
-	haldata->motor_nameplate_hz;
+    hal_set_real(haldata->upper_limit_hz, max_freq/100.0);
+    hal_set_real(haldata->max_rpm, hal_get_real(haldata->upper_limit_hz) *
+        hal_get_real(haldata->motor_nameplate_RPM) /
+        hal_get_real(haldata->motor_nameplate_hz));
 
     if (p->report_device) {
 	GETREG(SR_RATED_CURRENT, &current);
@@ -685,7 +685,7 @@ int read_initial(modbus_t *ctx, haldata_t *haldata, param_pointer p)
  failed:
     p->failed_reg = curr_reg;
     p->last_errno = errno;
-    (*haldata->errorcount)++;
+    hal_set_si32(haldata->errorcount, hal_get_si32(haldata->errorcount) + 1);
     if (p->debug)
 	fprintf(stderr, "%s: read_initial: modbus_read_registers(0x%4.4x): %s\n", 
 		p->progname, curr_reg, modbus_strerror(errno));
@@ -708,54 +708,54 @@ int read_data(modbus_t *ctx, haldata_t *haldata, param_pointer p)
     // we always at least read the main status register SR_INV_OPSTATUS
     // and current operating frequency SR_OP_FREQUENCY
     GETREG(SR_INV_OPSTATUS, &status_reg);
-    *(haldata->status) = status_reg;
+    hal_set_si32(haldata->status, status_reg);
 
     GETREG(SR_OP_FREQUENCY, &freq_reg);
-    *(haldata->freq_out) = freq_reg * 0.01;
+    hal_set_real(haldata->freq_out, freq_reg * 0.01);
 
     DBG("read_data: status_reg=%4.4x freq_reg=%4.4x\n", status_reg, freq_reg);
 
     // JET if freq out is 0 then the drive is stopped
-    *(haldata->is_stopped) = (freq_reg == 0);
+    hal_set_bool(haldata->is_stopped, freq_reg == 0);
 
     // determine what to do next.
     if (status_reg & ST_TRIPPED) {		// read and set trip code.
 	GETREG(SR_TRIPCODE, &val);
-	*(haldata->trip_code) = val;
+	hal_set_si32(haldata->trip_code, val);
 	// a sensible addition would be to read and convey SR_INV_OPSTATUS_T, the status just before the trip
     } else {
-	*(haldata->trip_code) = 0;
+	hal_set_si32(haldata->trip_code, 0);
     }
 
     if (status_reg & ST_ALARMED) {		// read and set alarm bit map.
 	GETREG(SR_ALARM_MONITOR, &val);
-	*(haldata->alarm_code) = val;
+	hal_set_si32(haldata->alarm_code, val);
     } else {
-	*(haldata->alarm_code) = 0;
+	hal_set_si32(haldata->alarm_code, 0);
     }
 
     if (status_reg & ST_EMERGENCY_STOPPED) {	// set e-stop status.
-	*(haldata->is_e_stopped) = 1;
+	hal_set_bool(haldata->is_e_stopped, 1);
     } else {
-	*(haldata->is_e_stopped) = 0;
+	hal_set_bool(haldata->is_e_stopped, 0);
 
     }
     // unsure what to do here with ST_FAILURE_FL bit
 
-    if ((pollcount == 0) && !(*haldata->max_speed)) {
+    if ((pollcount == 0) && !hal_get_bool(haldata->max_speed)) {
 
 	// less urgent registers
 	GETREG(SR_ESTIMATED_OPFREQ, &val);
-	*(haldata->RPM) = val * haldata->motor_nameplate_hz / 100.0;
+	hal_set_real(haldata->RPM, val * hal_get_real(haldata->motor_nameplate_hz) / 100.0);
 
 	GETREG(SR_INV_LOADFACTOR, &val);
-	*(haldata->inv_load_pct) =  val;
+	hal_set_real(haldata->inv_load_pct, val);
 
 	GETREG(SR_LOADCURRENT, &val);
-	*(haldata->load_current_pct) =  val * 0.01;
+	hal_set_real(haldata->load_current_pct, val * 0.01);
 
 	GETREG(SR_OUTPUT_VOLTAGE, &val);
-	*(haldata->outV_pct) =  val * 0.01;
+	hal_set_real(haldata->outV_pct, val * 0.01);
     } else 
 	pollcount++;
     if (pollcount >= p->pollcycles)
@@ -766,7 +766,7 @@ int read_data(modbus_t *ctx, haldata_t *haldata, param_pointer p)
  failed:
     p->failed_reg = curr_reg;
     p->last_errno = errno;
-    (*haldata->errorcount)++;
+    hal_set_si32(haldata->errorcount, hal_get_si32(haldata->errorcount) + 1);
     if (p->debug)
 	fprintf(stderr, "%s: read_data: modbus_read_registers(0x%4.4x): %s\n", 
 		p->progname, curr_reg, modbus_strerror(errno));
@@ -785,41 +785,41 @@ int read_data(modbus_t *ctx, haldata_t *haldata, param_pointer p)
 int hal_setup(int id, haldata_t *h, const char *name)
 {
     int status;
-    PIN(hal_pin_bit_newf(HAL_IN, &(h->acc_dec_pattern), id, "%s.acceleration-pattern", name));
-    PIN(hal_pin_s32_newf(HAL_OUT, &(h->alarm_code), id, "%s.alarm-code", name));
-    PIN(hal_pin_bit_newf(HAL_OUT, &(h->at_speed), id, "%s.at-speed", name));
-    PIN(hal_pin_float_newf(HAL_OUT, &(h->load_current_pct), id, "%s.current-load-percentage", name));
-    PIN(hal_pin_bit_newf(HAL_IN, &(h->DC_brake), id, "%s.dc-brake", name));
-    PIN(hal_pin_bit_newf(HAL_IN, &(h->enabled), id, "%s.enable", name));
-    PIN(hal_pin_bit_newf(HAL_IN, &(h->err_reset), id, "%s.err-reset", name));
-    PIN(hal_pin_bit_newf(HAL_IN, &(h->jog_mode), id, "%s.jog-mode", name));
-    PIN(hal_pin_bit_newf(HAL_IN, &(h->estop), id, "%s.estop", name));
-    PIN(hal_pin_float_newf(HAL_OUT, &(h->freq_cmd), id, "%s.frequency-command", name));
-    PIN(hal_pin_float_newf(HAL_OUT, &(h->freq_out), id, "%s.frequency-out", name));
-    PIN(hal_pin_float_newf(HAL_OUT, &(h->inv_load_pct), id, "%s.inverter-load-percentage", name));
-    PIN(hal_pin_bit_newf(HAL_OUT, &(h->is_e_stopped), id, "%s.is-e-stopped", name)); // JET
-    PIN(hal_pin_bit_newf(HAL_OUT, &(h->is_stopped), id, "%s.is-stopped", name)); // JET
-    PIN(hal_pin_float_newf(HAL_OUT, &(h->max_rpm), id, "%s.max-rpm", name));
-    PIN(hal_pin_bit_newf(HAL_OUT, &(h->modbus_ok), id, "%s.modbus-ok", name)); // JET
-    PIN(hal_pin_float_newf(HAL_OUT, &(h->RPM), id, "%s.motor-RPM", name));
-    PIN(hal_pin_float_newf(HAL_OUT, &(h->curr_out_pct), id, "%s.output-current-percentage", name));
-    PIN(hal_pin_float_newf(HAL_OUT, &(h->outV_pct), id, "%s.output-voltage-percentage", name));
-    PIN(hal_pin_float_newf(HAL_IN, &(h->speed_command), id, "%s.speed-command", name));
-    PIN(hal_pin_bit_newf(HAL_IN, &(h->spindle_fwd), id, "%s.spindle-fwd", name));
-    PIN(hal_pin_bit_newf(HAL_IN, &(h->spindle_on), id, "%s.spindle-on", name));
-    PIN(hal_pin_bit_newf(HAL_IN, &(h->spindle_rev), id, "%s.spindle-rev", name)); //JET
-    PIN(hal_pin_s32_newf(HAL_OUT, &(h->status), id, "%s.status", name));
-    PIN(hal_pin_s32_newf(HAL_OUT, &(h->trip_code), id, "%s.trip-code", name));
-    PIN(hal_pin_bit_newf(HAL_IN, &(h->max_speed), id, "%s.max-speed", name));
-    PIN(hal_pin_s32_newf(HAL_OUT, &(h->errorcount), id, "%s.error-count", name));
-    PIN(hal_pin_float_newf(HAL_OUT, &(h->upper_limit_hz), id, "%s.frequency-limit", name));
+    PIN(hal_pin_new_bool(id, HAL_IN, &(h->acc_dec_pattern), 0, "%s.acceleration-pattern", name));
+    PIN(hal_pin_new_si32(id, HAL_OUT, &(h->alarm_code), 0, "%s.alarm-code", name));
+    PIN(hal_pin_new_bool(id, HAL_OUT, &(h->at_speed), 0, "%s.at-speed", name));
+    PIN(hal_pin_new_real(id, HAL_OUT, &(h->load_current_pct), 0.0, "%s.current-load-percentage", name));
+    PIN(hal_pin_new_bool(id, HAL_IN, &(h->DC_brake), 0, "%s.dc-brake", name));
+    PIN(hal_pin_new_bool(id, HAL_IN, &(h->enabled), 0, "%s.enable", name));
+    PIN(hal_pin_new_bool(id, HAL_IN, &(h->err_reset), 0, "%s.err-reset", name));
+    PIN(hal_pin_new_bool(id, HAL_IN, &(h->jog_mode), 0, "%s.jog-mode", name));
+    PIN(hal_pin_new_bool(id, HAL_IN, &(h->estop), 0, "%s.estop", name));
+    PIN(hal_pin_new_real(id, HAL_OUT, &(h->freq_cmd), 0.0, "%s.frequency-command", name));
+    PIN(hal_pin_new_real(id, HAL_OUT, &(h->freq_out), 0.0, "%s.frequency-out", name));
+    PIN(hal_pin_new_real(id, HAL_OUT, &(h->inv_load_pct), 0.0, "%s.inverter-load-percentage", name));
+    PIN(hal_pin_new_bool(id, HAL_OUT, &(h->is_e_stopped), 0, "%s.is-e-stopped", name)); // JET
+    PIN(hal_pin_new_bool(id, HAL_OUT, &(h->is_stopped), 0, "%s.is-stopped", name)); // JET
+    PIN(hal_pin_new_real(id, HAL_OUT, &(h->max_rpm), 0.0, "%s.max-rpm", name));
+    PIN(hal_pin_new_bool(id, HAL_OUT, &(h->modbus_ok), 0, "%s.modbus-ok", name)); // JET
+    PIN(hal_pin_new_real(id, HAL_OUT, &(h->RPM), 0.0, "%s.motor-RPM", name));
+    PIN(hal_pin_new_real(id, HAL_OUT, &(h->curr_out_pct), 0.0, "%s.output-current-percentage", name));
+    PIN(hal_pin_new_real(id, HAL_OUT, &(h->outV_pct), 0.0, "%s.output-voltage-percentage", name));
+    PIN(hal_pin_new_real(id, HAL_IN, &(h->speed_command), 0.0, "%s.speed-command", name));
+    PIN(hal_pin_new_bool(id, HAL_IN, &(h->spindle_fwd), 1, "%s.spindle-fwd", name));
+    PIN(hal_pin_new_bool(id, HAL_IN, &(h->spindle_on), 0, "%s.spindle-on", name));
+    PIN(hal_pin_new_bool(id, HAL_IN, &(h->spindle_rev), 0, "%s.spindle-rev", name)); //JET
+    PIN(hal_pin_new_si32(id, HAL_OUT, &(h->status), 0, "%s.status", name));
+    PIN(hal_pin_new_si32(id, HAL_OUT, &(h->trip_code), 0, "%s.trip-code", name));
+    PIN(hal_pin_new_bool(id, HAL_IN, &(h->max_speed), 0, "%s.max-speed", name));
+    PIN(hal_pin_new_si32(id, HAL_OUT, &(h->errorcount), 0, "%s.error-count", name));
+    PIN(hal_pin_new_real(id, HAL_OUT, &(h->upper_limit_hz), 0.0, "%s.frequency-limit", name));
 
     // the following limit must be set manually from the panel since its in EEPROM
-    PIN(hal_param_float_newf(HAL_RW, &(h->looptime), id, "%s.loop-time", name));
-    PIN(hal_param_float_newf(HAL_RW, &(h->motor_nameplate_hz), id, "%s.nameplate-HZ", name));
-    PIN(hal_param_float_newf(HAL_RW, &(h->motor_nameplate_RPM), id, "%s.nameplate-RPM", name));
-    PIN(hal_param_float_newf(HAL_RW, &(h->rpm_limit), id, "%s.rpm-limit", name));
-    PIN(hal_param_float_newf(HAL_RW, &(h->speed_tolerance), id, "%s.tolerance", name));
+    PIN(hal_param_new_real(id, HAL_RW, &(h->looptime), 0.1, "%s.loop-time", name));
+    PIN(hal_param_new_real(id, HAL_RW, &(h->motor_nameplate_hz), 50.0, "%s.nameplate-HZ", name));
+    PIN(hal_param_new_real(id, HAL_RW, &(h->motor_nameplate_RPM), 1410.0, "%s.nameplate-RPM", name));
+    PIN(hal_param_new_real(id, HAL_RW, &(h->rpm_limit), MAX_RPM, "%s.rpm-limit", name));
+    PIN(hal_param_new_real(id, HAL_RW, &(h->speed_tolerance), 0.01, "%s.tolerance", name));
 
     return 0;
 }
@@ -829,40 +829,40 @@ int set_defaults(param_pointer p)
 {
     haldata_t *h = p->haldata;
 
-    *(h->status) = 0;
-    *(h->freq_cmd) = 0;
-    *(h->freq_out) = 0;
-    *(h->curr_out_pct) = 0;
-    *(h->outV_pct) = 0;
-    *(h->RPM) = 0;
-    *(h->inv_load_pct) = 0;
-    *(h->load_current_pct) = 0;
-    *(h->upper_limit_hz) = 0;
-    *(h->trip_code) = 0;
-    *(h->alarm_code) = 0;
-    *(h->at_speed) = 0;
-    *(h->is_stopped) = 0;
-    *(h->estop) = 0;
-    *(h->is_e_stopped) = 0;
-    *(h->speed_command) = 0;
-    *(h->modbus_ok) = 0;
+    hal_set_si32(h->status, 0);
+    hal_set_real(h->freq_cmd, 0);
+    hal_set_real(h->freq_out, 0);
+    hal_set_real(h->curr_out_pct, 0);
+    hal_set_real(h->outV_pct, 0);
+    hal_set_real(h->RPM, 0);
+    hal_set_real(h->inv_load_pct, 0);
+    hal_set_real(h->load_current_pct, 0);
+    hal_set_real(h->upper_limit_hz, 0);
+    hal_set_si32(h->trip_code, 0);
+    hal_set_si32(h->alarm_code, 0);
+    hal_set_bool(h->at_speed, 0);
+    hal_set_bool(h->is_stopped, 0);
+    hal_set_bool(h->estop, 0);
+    hal_set_bool(h->is_e_stopped, 0);
+    hal_set_real(h->speed_command, 0);
+    hal_set_bool(h->modbus_ok, 0);
 
-    *(h->spindle_on) = 0;
-    *(h->DC_brake) = 0;
-    *(h->spindle_fwd) = 1;
-    *(h->spindle_rev) = 0;
-    *(h->err_reset) = 0;
-    *(h->jog_mode) = 0;
-    *(h->enabled) = 0;
-    *(h->acc_dec_pattern) = 0;
-    *(h->errorcount) = 0;
-    *(h->max_speed) = 0;
+    hal_set_bool(h->spindle_on, 0);
+    hal_set_bool(h->DC_brake, 0);
+    hal_set_bool(h->spindle_fwd, 1);
+    hal_set_bool(h->spindle_rev, 0);
+    hal_set_bool(h->err_reset, 0);
+    hal_set_bool(h->jog_mode, 0);
+    hal_set_bool(h->enabled, 0);
+    hal_set_bool(h->acc_dec_pattern, 0);
+    hal_set_si32(h->errorcount, 0);
+    hal_set_bool(h->max_speed, 0);
 
-    h->looptime = 0.1;
-    h->speed_tolerance = 0.01;      // output frequency within 1% of target frequency
-    h->motor_nameplate_hz = 50;	    // folks in The Colonies typically would use 60Hz and 1730 rpm
-    h->motor_nameplate_RPM = 1410;
-    h->rpm_limit = MAX_RPM;
+    hal_set_real(h->looptime, 0.1);
+    hal_set_real(h->speed_tolerance, 0.01);      // output frequency within 1% of target frequency
+    hal_set_real(h->motor_nameplate_hz, 50);	    // folks in The Colonies typically would use 60Hz and 1730 rpm
+    hal_set_real(h->motor_nameplate_RPM, 1410);
+    hal_set_real(h->rpm_limit, MAX_RPM);
 
     p->failed_reg = 0;
     return 0;
@@ -1034,11 +1034,7 @@ int main(int argc, char **argv)
 	    } else {
 		p->modbus_ok++;
 	    }
-	    if (p->modbus_ok > MODBUS_MIN_OK) {
-		*(p->haldata->modbus_ok) = 1;
-	    } else {
-		*(p->haldata->modbus_ok) = 0;
-	    }
+	    hal_set_bool(p->haldata->modbus_ok, p->modbus_ok > MODBUS_MIN_OK);
 	    if ((retval = write_data(p->ctx, p->haldata, p))) {
 		p->modbus_ok = 0;
                 if ((retval == EBADF || retval == ECONNRESET || retval == EPIPE)) {
@@ -1047,17 +1043,14 @@ int main(int argc, char **argv)
 	    } else {
 		p->modbus_ok++;
 	    }
-	    if (p->modbus_ok > MODBUS_MIN_OK) {
-		*(p->haldata->modbus_ok) = 1;
-	    } else {
-		*(p->haldata->modbus_ok) = 0;
-	    }
+	    hal_set_bool(p->haldata->modbus_ok, p->modbus_ok > MODBUS_MIN_OK);
 	    /* don't want to scan too fast, and shouldn't delay more than a few seconds */
-	    if (p->haldata->looptime < 0.001) p->haldata->looptime = 0.001;
-	    if (p->haldata->looptime > 2.0) p->haldata->looptime = 2.0;
-	    loop_timespec.tv_sec = (time_t)(p->haldata->looptime);
-	    loop_timespec.tv_nsec = (long)((p->haldata->looptime - loop_timespec.tv_sec) * 1000000000l);
-	    if (!p->haldata->max_speed)
+	    rtapi_real looptime = hal_get_real(p->haldata->looptime);
+	    if (looptime < 0.001) looptime = hal_set_real(p->haldata->looptime, 0.001);
+	    if (looptime > 2.0)   looptime = hal_set_real(p->haldata->looptime, 2.0);
+	    loop_timespec.tv_sec = (time_t)looptime;
+	    loop_timespec.tv_nsec = (long)((looptime - loop_timespec.tv_sec) * 1000000000l);
+	    if (!hal_get_bool(p->haldata->max_speed))
 		nanosleep(&loop_timespec, &remaining);
 	}
     


### PR DESCRIPTION
These are the remaining VFD user components. They are not especially complex, but they do have many lines changed.

Unfortunately, you need to have the hardware and modbus setup to test these VFD drivers. Not something many of us have at hand. So, we need to have some eyes on the code to see if anything got missed.

Note, a lot of the content is badly indented. A few places were corrected (like parts of the hal structs), but most of it needs to be done another time. Altering too much will just confuse the blame and make tracking any potential problems hard. So, mostly left as is.