### PR TITLE
hal: Update the last uspace drivers to getter/setter

### DIFF
--- a/src/hal/drivers/gm.h
+++ b/src/hal/drivers/gm.h
@@ -32,53 +32,51 @@
 #define notPresented	0x00000000
 
 typedef struct {
-	hal_u32_t			serialModulesDataOut[16][8]; // 0000 0000
-	hal_u32_t			serialModulesDataIn[16][8];  // 1000 0000
-	
-	hal_u32_t			moduleId[8];		//addr 0 	0000 000 
-	
-	hal_u32_t			card_status_reg;	//addr 1	0001 000        //  ... Estop_2 | Estop_1 | Pwr_fault | Bus_err | Wdt_err  //Card status read resets wdt
-	hal_u32_t			cardID;				//	0001 001
-	hal_u32_t			card_control_reg; 		//	0001 010	//  Wdt_period(16 bit)[us] | ... | EstopEn_2 | EstopEn_1 | power_enable | card_enable
-	hal_u32_t			reserved_0;			//	0001 011
-	hal_u32_t			gpio;				//	0001 100
-	hal_u32_t			gpioDir;			//	0001 101
-	hal_u32_t			StepGen_status;			//	0001 110
-	hal_u32_t			PCI_clk_counter;		//	0001 111
-	
-	hal_u32_t			ENC_control_reg;	//addr 2	0010 000
-	hal_u32_t			CAN_status_reg;
-	hal_u32_t			CAN_control_reg;
-	hal_u32_t			DAC_0; //DAC AXIS 1-0
-	hal_u32_t			DAC_1; //DAC AXIS 3-2
-	hal_u32_t			DAC_2; //DAC AXIS 5-4
-	hal_u32_t			reserved_1[2];
-	
-	hal_u32_t			CAN_RX_buffer[4];	//addr 3     	0011 000
-	hal_u32_t			CAN_TX_buffer[4];	
-	hal_u32_t			reserved_2[8];		//addr 4       	0100 000
-		
-	hal_u32_t			reserved_3[8];		//addr 5       	0101 000
-		
-	hal_u32_t			reserved_4[8];		//addr 6       	0110 000
-	
-	hal_u32_t			reserved_5[8];		//addr 7       	0111 000
-	
-	hal_s32_t			ENC_counter[6];		//addr 8	1000 000
-	hal_u32_t			reserved_6[2];
-	hal_s32_t			ENC_period[6];		//addr 9	1001 000
-	hal_u32_t			reserved_7[2];
-	hal_s32_t			ENC_index_latch[6]; 	//addr 10	1010 000
-	hal_u32_t			reserved_8[2];
-	hal_s32_t			reserved_9[8]; 		//addr 11	1011 000
+    volatile rtapi_u32 serialModulesDataOut[16][8]; // 0000 0000
+    volatile rtapi_u32 serialModulesDataIn[16][8];  // 1000 0000
 
-	hal_s32_t			StepGen_steprate[6];	//addr 12	1100 000
-	hal_u32_t			reserved_10[2];
-	hal_u32_t			StepGen_fb[6];		//addr 13	1101 000
-	hal_u32_t			reserved_11[2];			
-	hal_u32_t			StepGen_time_params[6];	//addr 14	1110 000
-	hal_u32_t			reserved_12[2];		
-	hal_u32_t			reserved_16[8];		//addr 15	1111 000
+    volatile rtapi_u32 moduleId[8];             // addr 0  0000 000
+
+    volatile rtapi_u32 card_status_reg;         // addr 1  0001 000  //  ... Estop_2 | Estop_1 | Pwr_fault | Bus_err | Wdt_err  //Card status read resets wdt
+    volatile rtapi_u32 cardID;                  //  0001 001
+    volatile rtapi_u32 card_control_reg;        //  0001 010 //  Wdt_period(16 bit)[us] | ... | EstopEn_2 | EstopEn_1 | power_enable | card_enable
+    volatile rtapi_u32 reserved_0;              //  0001 011
+    volatile rtapi_u32 gpio;                    //  0001 100
+    volatile rtapi_u32 gpioDir;                 //  0001 101
+    volatile rtapi_u32 StepGen_status;          //  0001 110
+    volatile rtapi_u32 PCI_clk_counter;         //  0001 111
+
+    volatile rtapi_u32 ENC_control_reg;         // addr 2  0010 000
+    volatile rtapi_u32 CAN_status_reg;
+    volatile rtapi_u32 CAN_control_reg;
+    volatile rtapi_u32 DAC_0;                   // DAC AXIS 1-0
+    volatile rtapi_u32 DAC_1;                   // DAC AXIS 3-2
+    volatile rtapi_u32 DAC_2;                   // DAC AXIS 5-4
+    volatile rtapi_u32 reserved_1[2];
+
+    volatile rtapi_u32 CAN_RX_buffer[4];        // addr 3  0011 000
+    volatile rtapi_u32 CAN_TX_buffer[4];
+
+    volatile rtapi_u32 reserved_2[8];           // addr 4  0100 000
+    volatile rtapi_u32 reserved_3[8];           // addr 5  0101 000
+    volatile rtapi_u32 reserved_4[8];           // addr 6  0110 000
+    volatile rtapi_u32 reserved_5[8];           // addr 7  0111 000
+
+    volatile rtapi_s32 ENC_counter[6];          // addr 8  1000 000
+    volatile rtapi_u32 reserved_6[2];
+    volatile rtapi_s32 ENC_period[6];           // addr 9  1001 000
+    volatile rtapi_u32 reserved_7[2];
+    volatile rtapi_s32 ENC_index_latch[6];      // addr 10 1010 000
+    volatile rtapi_u32 reserved_8[2];
+    volatile rtapi_s32 reserved_9[8];           // addr 11 1011 000
+
+    volatile rtapi_s32 StepGen_steprate[6];     // addr 12 1100 000
+    volatile rtapi_u32 reserved_10[2];
+    volatile rtapi_u32 StepGen_fb[6];           // addr 13 1101 000
+    volatile rtapi_u32 reserved_11[2];
+    volatile rtapi_u32 StepGen_time_params[6];  // addr 14 1110 000
+    volatile rtapi_u32 reserved_12[2];
+    volatile rtapi_u32 reserved_16[8];          // addr 15 1111 000
 
 } volatile card;
 

--- a/src/hal/drivers/hal_bb_gpio.c
+++ b/src/hal/drivers/hal_bb_gpio.c
@@ -34,12 +34,12 @@ MODULE_LICENSE("GPL");
 #define PINS_PER_HEADER  46
 
 typedef struct {
-    hal_bit_t* led_pins[4];
-    hal_bit_t* input_pins[1 + PINS_PER_HEADER * HEADERS]; // array of pointers to bivts
-    hal_bit_t* output_pins[1 + PINS_PER_HEADER * HEADERS]; // array of pointers to bits
-    hal_bit_t  *led_inv[4];
-    hal_bit_t  *input_inv[1 + PINS_PER_HEADER * HEADERS];
-    hal_bit_t  *output_inv[1 + PINS_PER_HEADER * HEADERS];
+    hal_bool_t led_pins[4];
+    hal_bool_t input_pins[1 + PINS_PER_HEADER * HEADERS]; // array of pointers to bivts
+    hal_bool_t output_pins[1 + PINS_PER_HEADER * HEADERS]; // array of pointers to bits
+    hal_bool_t led_inv[4];
+    hal_bool_t input_inv[1 + PINS_PER_HEADER * HEADERS];
+    hal_bool_t output_inv[1 + PINS_PER_HEADER * HEADERS];
 } port_data_t;
 
 static port_data_t *port_data;
@@ -169,7 +169,7 @@ int rtapi_app_main(void) {
             }
 
             // Add HAL pin
-            retval = hal_pin_bit_newf(HAL_IN, &(port_data->led_pins[led]), comp_id, "bb_gpio.userled%d", led);
+            retval = hal_pin_new_bool(comp_id, HAL_IN, &(port_data->led_pins[led]), 0, "bb_gpio.userled%d", led);
 
             if(retval < 0) {
                 rtapi_print_msg(RTAPI_MSG_ERR, "%s: ERROR: userled %d could not export pin, err: %d\n", modname, led, retval);
@@ -178,16 +178,13 @@ int rtapi_app_main(void) {
             }
 
             // Add HAL pin
-            retval = hal_pin_bit_newf(HAL_IN, &(port_data->led_inv[led]), comp_id, "bb_gpio.userled%d-invert", led);
+            retval = hal_pin_new_bool(comp_id, HAL_IN, &(port_data->led_inv[led]), 0, "bb_gpio.userled%d-invert", led);
 
             if(retval < 0) {
                 rtapi_print_msg(RTAPI_MSG_ERR, "%s: ERROR: userled %d could not export pin, err: %d\n", modname, led, retval);
                 hal_exit(comp_id);
                 return -1;
             }
-
-            // Initialize HAL pin
-            *(port_data->led_inv[led]) = 0;
 
             int gpio_num = user_led_gpio_pins[led].port_num;
             // configure gpio port if necessary
@@ -241,7 +238,7 @@ int rtapi_app_main(void) {
             data = NULL; // after the first call, subsequent calls to strtok need to be on NULL
 
             // Add HAL pin
-            retval = hal_pin_bit_newf(HAL_OUT, &(port_data->input_pins[pin + (header - 8)*PINS_PER_HEADER]), comp_id, "bb_gpio.p%d.in-%02d", header, pin);
+            retval = hal_pin_new_bool(comp_id, HAL_OUT, &(port_data->input_pins[pin + (header - 8)*PINS_PER_HEADER]), 0, "bb_gpio.p%d.in-%02d", header, pin);
 
             if(retval < 0) {
                 rtapi_print_msg(RTAPI_MSG_ERR, "%s: ERROR: pin p%d.%02d could not export pin, err: %d\n", modname, header, pin, retval);
@@ -250,16 +247,13 @@ int rtapi_app_main(void) {
             }
 
             // Add HAL pin
-            retval = hal_pin_bit_newf(HAL_IN, &(port_data->input_inv[pin + (header - 8)*PINS_PER_HEADER]), comp_id, "bb_gpio.p%d.in-%02d-invert", header, pin);
+            retval = hal_pin_new_bool(comp_id, HAL_IN, &(port_data->input_inv[pin + (header - 8)*PINS_PER_HEADER]), 0, "bb_gpio.p%d.in-%02d-invert", header, pin);
 
             if(retval < 0) {
                 rtapi_print_msg(RTAPI_MSG_ERR, "%s: ERROR: pin p%d.%02d could not export pin, err: %d\n", modname, header, pin, retval);
                 hal_exit(comp_id);
                 return -1;
             }
-
-            // Initialize HAL pin
-            *(port_data->input_inv[pin + (header - 8)*PINS_PER_HEADER]) = 0;
 
             int gpio_num = bbpin->port_num;
 
@@ -315,7 +309,7 @@ int rtapi_app_main(void) {
             data = NULL; // after the first call, subsequent calls to strtok need to be on NULL
 
             // Add HAL pin
-            retval = hal_pin_bit_newf(HAL_IN, &(port_data->output_pins[pin + (header - 8)*PINS_PER_HEADER]), comp_id, "bb_gpio.p%d.out-%02d", header, pin);
+            retval = hal_pin_new_bool(comp_id, HAL_IN, &(port_data->output_pins[pin + (header - 8)*PINS_PER_HEADER]), 0, "bb_gpio.p%d.out-%02d", header, pin);
 
             if(retval < 0) {
                 rtapi_print_msg(RTAPI_MSG_ERR, "%s: ERROR: pin p%d.%02d could not export pin, err: %d\n", modname, header, pin, retval);
@@ -324,16 +318,13 @@ int rtapi_app_main(void) {
             }
 
             // Add HAL pin
-            retval = hal_pin_bit_newf(HAL_IN, &(port_data->output_inv[pin + (header - 8)*PINS_PER_HEADER]), comp_id, "bb_gpio.p%d.out-%02d-invert", header, pin);
+            retval = hal_pin_new_bool(comp_id, HAL_IN, &(port_data->output_inv[pin + (header - 8)*PINS_PER_HEADER]), 0, "bb_gpio.p%d.out-%02d-invert", header, pin);
 
             if(retval < 0) {
                 rtapi_print_msg(RTAPI_MSG_ERR, "%s: ERROR: pin p%d.%02d could not export pin, err: %d\n", modname, header, pin, retval);
                 hal_exit(comp_id);
                 return -1;
             }
-
-            // Initialize HAL pin
-            *(port_data->output_inv[pin + (header - 8)*PINS_PER_HEADER]) = 0;
 
             int gpio_num = bbpin->port_num;
 
@@ -393,7 +384,7 @@ static void write_port(void *arg, long period) {
 
         if(pin.claimed != 'O') continue; // if we somehow get here but the pin isn't claimed as output, short circuit
 
-        if((*port->led_pins[i] ^ *(port->led_inv[i])) == 0)
+        if((hal_get_bool(port->led_pins[i]) ^ hal_get_bool(port->led_inv[i])) == 0)
             *(pin.port->clrdataout_reg) = (1 << pin.pin_num);
         else
             *(pin.port->setdataout_reg) = (1 << pin.pin_num);
@@ -412,7 +403,7 @@ static void write_port(void *arg, long period) {
 
         if(pin.claimed != 'O') continue; // if we somehow get here but the pin isn't claimed as output, short circuit
 
-        if((*port->output_pins[i] ^ *(port->output_inv[i])) == 0)
+        if((hal_get_bool(port->output_pins[i]) ^ hal_get_bool(port->output_inv[i])) == 0)
             *(pin.port->clrdataout_reg) = (1 << pin.pin_num);
         else
             *(pin.port->setdataout_reg) = (1 << pin.pin_num);
@@ -440,7 +431,7 @@ static void read_port(void *arg, long period) {
 
         if(!(pin.claimed == 'I' || pin.claimed == 'U' || pin.claimed == 'D')) continue; // if we get here but the pin isn't claimed as input, short circuit
 
-        *port->input_pins[i] = ((*(pin.port->datain_reg) & (1 << pin.pin_num))  >> pin.pin_num) ^ *(port->input_inv[i]);
+        hal_set_bool(port->input_pins[i], ((*(pin.port->datain_reg) & (1 << pin.pin_num))  >> pin.pin_num) ^ hal_get_bool(port->input_inv[i]));
     }
 }
 

--- a/src/hal/drivers/hal_evoreg.c
+++ b/src/hal/drivers/hal_evoreg.c
@@ -86,14 +86,14 @@ RTAPI_MP_STRING(cfg, "config string"); */
 */
 
 typedef struct {
-	void *io_base;
-        hal_float_t *dac_out[3];  /* ptrs for dac output */
-	hal_float_t *position[3];	   /* ptrs for encoder input */
-	hal_bit_t *digital_in[47];    /* ptrs for digital input pins 0 - 45 */
-        hal_bit_t *digital_out[25];    /* ptrs for digital output pins 0 - 20 */
-        __u16 raw_counts_old[3];
-        __s32 counts[3];
-        hal_float_t pos_scale;         /*! \todo scale for position command FIXME should be one per axis */
+    void *io_base;
+    hal_real_t dac_out[3];      /* ptrs for dac output */
+    hal_real_t position[3];     /* ptrs for encoder input */
+    hal_bool_t digital_in[47];  /* ptrs for digital input pins 0 - 45 */
+    hal_bool_t digital_out[25]; /* ptrs for digital output pins 0 - 20 */
+    rtapi_u16 raw_counts_old[3];
+    rtapi_s32 counts[3];
+    hal_real_t pos_scale;       /*! \todo scale for position command FIXME should be one per axis */
 } evoreg_t;
 
 /* pointer to array of evoreg_t structs in shared memory, 1 per port */
@@ -172,8 +172,8 @@ int rtapi_app_main(void)
 
     /* Export DAC pin's */
     for ( num_dac=1; num_dac<=MAX_DAC; num_dac++) {
-      retval = hal_pin_float_newf(HAL_IN, &(port_data_array->dac_out[num_dac-1]),
-				  comp_id, "evoreg.%d.dac-%02d-out", 1, num_dac);
+      retval = hal_pin_new_real(comp_id, HAL_IN, &(port_data_array->dac_out[num_dac-1]),
+				  0.0, "evoreg.%d.dac-%02d-out", 1, num_dac);
       if (retval < 0) {
 	  rtapi_print_msg(RTAPI_MSG_ERR,
 	    "EVOREG: ERROR: port %d var export failed with err=%i\n", n + 1,
@@ -185,8 +185,8 @@ int rtapi_app_main(void)
 
     /* Export Encoder pin's */
     for ( num_enc=1; num_enc<=MAX_ENC; num_enc++) {
-      retval = hal_pin_float_newf(HAL_OUT, &(port_data_array->position[num_enc - 1]),
-				  comp_id, "evoreg.%d.position-%02d-in", 1, num_enc);
+      retval = hal_pin_new_real(comp_id, HAL_OUT, &(port_data_array->position[num_enc - 1]),
+				  0.0, "evoreg.%d.position-%02d-in", 1, num_enc);
       if (retval < 0) {
 	  rtapi_print_msg(RTAPI_MSG_ERR,
 	      "EVOREG: ERROR: port %d var export failed with err=%i\n", n + 1,
@@ -200,8 +200,8 @@ int rtapi_app_main(void)
 
     /* export write only HAL pin's for the input bit */
     for ( i=0; i<=45;i++) {
-      retval += hal_pin_bit_newf(HAL_OUT, &(port_data_array->digital_in[i]),
-				 comp_id, "evoreg.%d.pin-%02d-in", 1, i);
+      retval += hal_pin_new_bool(comp_id, HAL_OUT, &(port_data_array->digital_in[i]),
+				 0, "evoreg.%d.pin-%02d-in", 1, i);
 
       /* export another write only HAL pin for the same bit inverted */
       /*
@@ -218,8 +218,8 @@ int rtapi_app_main(void)
 
     /* export read only HAL pin's for the output bit */
     for ( i=0; i<=23;i++) {
-      retval += hal_pin_bit_newf(HAL_IN, &(port_data_array->digital_out[i]),
-				 comp_id, "evoreg.%d.pin-%02d-out", 1, i);
+      retval += hal_pin_new_bool(comp_id, HAL_IN, &(port_data_array->digital_out[i]),
+				 0, "evoreg.%d.pin-%02d-out", 1, i);
 
       /* export another read only HAL pin for the same bit inverted */
       /*
@@ -235,8 +235,8 @@ int rtapi_app_main(void)
     }
 
     /* export parameter for scaling */
-    retval = hal_param_float_newf(HAL_RW, &(port_data_array->pos_scale),
-				  comp_id, "evoreg.%d.position-scale", 1);
+    retval = hal_param_new_real(comp_id, HAL_RW, &(port_data_array->pos_scale),
+				  0.0, "evoreg.%d.position-scale", 1);
     if (retval != 0) {
 	return retval;
     }
@@ -278,9 +278,9 @@ static void update_port(void *arg, long period)
     port = arg;
 
 /* write DAC's */
-    writew((*(port->dac_out[0])/10 * 0x7fff), (char *)port->io_base + 0x60);
-    writew((*(port->dac_out[1])/10 * 0x7fff), (char *)port->io_base + 0x80);
-    writew((*(port->dac_out[2])/10 * 0x7fff), (char *)port->io_base + 0xa0);
+    writew((hal_get_real(port->dac_out[0])/10 * 0x7fff), (char *)port->io_base + 0x60);
+    writew((hal_get_real(port->dac_out[1])/10 * 0x7fff), (char *)port->io_base + 0x80);
+    writew((hal_get_real(port->dac_out[2])/10 * 0x7fff), (char *)port->io_base + 0xa0);
 
 /* Read Encoders, improve the 16bit hardware counters to 32bit and scale the values */
     raw_counts[0] = (__u16) readw(port->io_base);
@@ -296,29 +296,30 @@ static void update_port(void *arg, long period)
     port->counts[2] += (__s16) (raw_counts[2] - port->raw_counts_old[2]);
     port->raw_counts_old[2] = raw_counts[2];
 
-    *port->position[0] = port->counts[0] * port->pos_scale;
-    *port->position[1] = port->counts[1] * port->pos_scale;
-    *port->position[2] = port->counts[2] * port->pos_scale;
+    rtapi_real pos_scale = hal_get_real(port->pos_scale);
+    hal_set_real(port->position[0], port->counts[0] * pos_scale);
+    hal_set_real(port->position[1], port->counts[1] * pos_scale);
+    hal_set_real(port->position[2], port->counts[2] * pos_scale);
 
 
 /* read digital inputs */
      tmp = readw((char *)port->io_base + 0x20);       /* digital input 0-15 */
       mask = 0x01;
 	for (pin=0 ; pin < 16 ; pin++) {
-	*port->digital_in[pin] = (tmp & mask) ? 1:0 ;
+	hal_set_bool(port->digital_in[pin], (tmp & mask) ? 1:0);
 	mask <<= 1;
 	}
      tmp = readw((char *)port->io_base + 0x40);       /* digital input 16-31 */
       mask = 0x01;
 	for (pin=16 ; pin < 32 ; pin++) {
-	*port->digital_in[pin] = (tmp & mask) ? 1:0 ;
+	hal_set_bool(port->digital_in[pin], (tmp & mask) ? 1:0);
 	mask <<= 1;
 	}
 
      tmp = readw((char *)port->io_base + 0x60);       /* digital input 32-45 */
       mask = 0x01;
 	for (pin=32 ; pin < 46 ; pin++) {
-	*port->digital_in[pin] = (tmp & mask) ? 1:0 ;
+	hal_set_bool(port->digital_in[pin], (tmp & mask) ? 1:0);
 	mask <<= 1;
 	}
 
@@ -327,10 +328,10 @@ static void update_port(void *arg, long period)
      tmp = 0x0;
      mask = 0x01;
      for (pin=0; pin < 16; pin++) {
-        if (port->digital_out[pin]) {
+        if (hal_get_bool(port->digital_out[pin])) {
         tmp |= mask;
-        mask <<= 1;
         }
+        mask <<= 1;
      }
      writew( tmp, (char *)port->io_base + 0x20);  /* digital output 0-15 */
 
@@ -338,10 +339,10 @@ static void update_port(void *arg, long period)
      tmp = 0x0;
      mask = 0x01;
      for (pin=16; pin < 24; pin++) {
-        if (port->digital_out[pin]) {
+        if (hal_get_bool(port->digital_out[pin])) {
         tmp |= mask;
-        mask <<= 1;
         }
+        mask <<= 1;
      }
      writew( tmp, (char *)port->io_base + 0x40);  /* digital output 16-23 */
 

--- a/src/hal/drivers/hal_gm.c
+++ b/src/hal/drivers/hal_gm.c
@@ -14,336 +14,345 @@ MODULE_LICENSE("GPL");
 
 typedef struct { //encoder_t
     // Pins
-	hal_bit_t			*reset;
-	hal_s32_t			*counts;
-	hal_float_t			*position;
-	hal_float_t			*velocity;
-	hal_s32_t			*rawcounts;
-	hal_bit_t			*index_enable;
-    
+    hal_bool_t reset;
+    hal_sint_t counts;
+    hal_real_t position;
+    hal_real_t velocity;
+    hal_sint_t rawcounts;
+    hal_bool_t index_enable;
+
     // Parameters
-	hal_bit_t			counter_mode;
-	hal_bit_t			index_mode;
-	hal_bit_t			index_invert;
-	hal_u32_t			counts_per_rev;
-	hal_float_t			position_scale;
-	hal_float_t			min_speed_estimate;
+    hal_bool_t counter_mode;
+    hal_bool_t index_mode;
+    hal_bool_t index_invert;
+    hal_uint_t counts_per_rev;
+    hal_real_t position_scale;
+    hal_real_t min_speed_estimate;
 
     // Private data
-	hal_s32_t			raw_offset;
-	hal_s32_t			index_offset;
-	hal_s32_t			last_index_latch;
-	hal_bit_t			first_index;
-	hal_bit_t			module_exist;
+    rtapi_s32  raw_offset;
+    rtapi_s32  index_offset;
+    rtapi_s32  last_index_latch;
+    rtapi_bool first_index;
+    rtapi_bool module_exist;
 } encoder_t;
 
 typedef struct { //switches_t
     // Pins.
-	hal_bit_t			*home;
-	hal_bit_t			*homeNot;
+    hal_bool_t home;
+    hal_bool_t homeNot;
 
-	hal_bit_t			*posLimSwIn;
-	hal_bit_t			*posLimSwInNot;
-	hal_bit_t			*negLimSwIn;
-	hal_bit_t			*negLimSwInNot;    
+    hal_bool_t posLimSwIn;
+    hal_bool_t posLimSwInNot;
+    hal_bool_t negLimSwIn;
+    hal_bool_t negLimSwInNot;
 } switches_t;
 
 typedef struct { //estop_t
     // Pins.
-	hal_bit_t			*in;
-	hal_bit_t			*inNot;  
+    hal_bool_t in;
+    hal_bool_t inNot;
 } estop_t;
 
 typedef struct { //gpio_t
     // Pins.
-	hal_bit_t			*in;
-	hal_bit_t			*inNot;
-	hal_bit_t			*out;
-	hal_bit_t			isOut;
-	hal_bit_t			invertOut;
+    hal_bool_t in;
+    hal_bool_t inNot;
+    hal_bool_t out;
+    // Parameters
+    hal_bool_t isOut;
+    hal_bool_t invertOut;
 } gpio_t;
 
 typedef struct { //RS485_8output_t
     // Pins.
-	hal_bit_t			*out_0;
-	hal_bit_t			*out_1;
-	hal_bit_t			*out_2;
-	hal_bit_t			*out_3;
-	hal_bit_t			*out_4;
-	hal_bit_t			*out_5;
-	hal_bit_t			*out_6;
-	hal_bit_t			*out_7;
+    hal_bool_t out_0;
+    hal_bool_t out_1;
+    hal_bool_t out_2;
+    hal_bool_t out_3;
+    hal_bool_t out_4;
+    hal_bool_t out_5;
+    hal_bool_t out_6;
+    hal_bool_t out_7;
     // Parameters
-	hal_bit_t			invertOut_0;
-	hal_bit_t			invertOut_1;
-	hal_bit_t			invertOut_2;
-	hal_bit_t			invertOut_3;
-	hal_bit_t			invertOut_4;
-	hal_bit_t			invertOut_5;
-	hal_bit_t			invertOut_6;
-	hal_bit_t			invertOut_7;
+    hal_bool_t invertOut_0;
+    hal_bool_t invertOut_1;
+    hal_bool_t invertOut_2;
+    hal_bool_t invertOut_3;
+    hal_bool_t invertOut_4;
+    hal_bool_t invertOut_5;
+    hal_bool_t invertOut_6;
+    hal_bool_t invertOut_7;
 } RS485_8output_t;
 
 typedef struct { //RS485_8input_t
     // Pins.
-	hal_bit_t			*in_0;
-	hal_bit_t			*inNot_0;
-	hal_bit_t			*in_1;
-	hal_bit_t			*inNot_1;
-	hal_bit_t			*in_2;
-	hal_bit_t			*inNot_2;
-	hal_bit_t			*in_3;
-	hal_bit_t			*inNot_3;
-	hal_bit_t			*in_4;
-	hal_bit_t			*inNot_4;
-	hal_bit_t			*in_5;
-	hal_bit_t			*inNot_5;
-	hal_bit_t			*in_6;
-	hal_bit_t			*inNot_6;
-	hal_bit_t			*in_7;
-	hal_bit_t			*inNot_7;
+    hal_bool_t in_0;
+    hal_bool_t inNot_0;
+    hal_bool_t in_1;
+    hal_bool_t inNot_1;
+    hal_bool_t in_2;
+    hal_bool_t inNot_2;
+    hal_bool_t in_3;
+    hal_bool_t inNot_3;
+    hal_bool_t in_4;
+    hal_bool_t inNot_4;
+    hal_bool_t in_5;
+    hal_bool_t inNot_5;
+    hal_bool_t in_6;
+    hal_bool_t inNot_6;
+    hal_bool_t in_7;
+    hal_bool_t inNot_7;
 } RS485_8input_t;
 
 typedef struct { //RS485_DacAdc_t
     // Pins.
-	hal_float_t			*DAC_0;
-	hal_float_t			*DAC_1;
-	hal_float_t			*DAC_2;
-	hal_float_t			*DAC_3;
+    hal_real_t DAC_0;
+    hal_real_t DAC_1;
+    hal_real_t DAC_2;
+    hal_real_t DAC_3;
 
-	hal_bit_t			*dac_0_enable;
-	hal_bit_t			*dac_1_enable;
-	hal_bit_t			*dac_2_enable;
-	hal_bit_t			*dac_3_enable;
+    hal_bool_t dac_0_enable;
+    hal_bool_t dac_1_enable;
+    hal_bool_t dac_2_enable;
+    hal_bool_t dac_3_enable;
 
-	hal_float_t			*ADC_0;
-	hal_float_t			*ADC_1;
-	hal_float_t			*ADC_2;
-	hal_float_t			*ADC_3;
-	hal_float_t			*ADC_4;
-	hal_float_t			*ADC_5;
-	hal_float_t			*ADC_6;
-	hal_float_t			*ADC_7;
+    hal_real_t ADC_0;
+    hal_real_t ADC_1;
+    hal_real_t ADC_2;
+    hal_real_t ADC_3;
+    hal_real_t ADC_4;
+    hal_real_t ADC_5;
+    hal_real_t ADC_6;
+    hal_real_t ADC_7;
 
     // Parameters.
-	hal_float_t			DAC_0_offset;
-	hal_float_t			DAC_1_offset;
-	hal_float_t			DAC_2_offset;
-	hal_float_t			DAC_3_offset;
-    
-	hal_float_t			DAC_0_min;
-	hal_float_t			DAC_1_min;
-	hal_float_t			DAC_2_min;
-	hal_float_t			DAC_3_min;
-    
-	hal_float_t			DAC_0_max;
-	hal_float_t			DAC_1_max;
-	hal_float_t			DAC_2_max;
-	hal_float_t			DAC_3_max;
-	
-	hal_float_t			ADC_0_offset;
-	hal_float_t			ADC_1_offset;
-	hal_float_t			ADC_2_offset;
-	hal_float_t			ADC_3_offset;
-	hal_float_t			ADC_4_offset;
-	hal_float_t			ADC_5_offset;
-	hal_float_t			ADC_6_offset;
-	hal_float_t			ADC_7_offset;
-    
-	hal_float_t			ADC_0_scale;
-	hal_float_t			ADC_1_scale;
-	hal_float_t			ADC_2_scale;
-	hal_float_t			ADC_3_scale;
-	hal_float_t			ADC_4_scale;
-	hal_float_t			ADC_5_scale;
-	hal_float_t			ADC_6_scale;
-	hal_float_t			ADC_7_scale;
+    hal_real_t DAC_0_offset;
+    hal_real_t DAC_1_offset;
+    hal_real_t DAC_2_offset;
+    hal_real_t DAC_3_offset;
+
+    hal_real_t DAC_0_min;
+    hal_real_t DAC_1_min;
+    hal_real_t DAC_2_min;
+    hal_real_t DAC_3_min;
+
+    hal_real_t DAC_0_max;
+    hal_real_t DAC_1_max;
+    hal_real_t DAC_2_max;
+    hal_real_t DAC_3_max;
+
+    hal_real_t ADC_0_offset;
+    hal_real_t ADC_1_offset;
+    hal_real_t ADC_2_offset;
+    hal_real_t ADC_3_offset;
+    hal_real_t ADC_4_offset;
+    hal_real_t ADC_5_offset;
+    hal_real_t ADC_6_offset;
+    hal_real_t ADC_7_offset;
+
+    hal_real_t ADC_0_scale;
+    hal_real_t ADC_1_scale;
+    hal_real_t ADC_2_scale;
+    hal_real_t ADC_3_scale;
+    hal_real_t ADC_4_scale;
+    hal_real_t ADC_5_scale;
+    hal_real_t ADC_6_scale;
+    hal_real_t ADC_7_scale;
 } RS485_DacAdc_t;
 
 typedef struct { //RS485_TeachPad_t
     // Pins.
-	//6 ADC channel
-	hal_float_t			*ADC_0;
-	hal_float_t			*ADC_1;
-	hal_float_t			*ADC_2;
-	hal_float_t			*ADC_3;
-	hal_float_t			*ADC_4;
-	hal_float_t			*ADC_5;
-	//8 digital input
-	hal_bit_t			*in_0;
-	hal_bit_t			*inNot_0;
-	hal_bit_t			*in_1;
-	hal_bit_t			*inNot_1;
-	hal_bit_t			*in_2;
-	hal_bit_t			*inNot_2;
-	hal_bit_t			*in_3;
-	hal_bit_t			*inNot_3;
-	hal_bit_t			*in_4;
-	hal_bit_t			*inNot_4;
-	hal_bit_t			*in_5;
-	hal_bit_t			*inNot_5;
-	hal_bit_t			*in_6;
-	hal_bit_t			*inNot_6;
-	hal_bit_t			*in_7;
-	hal_bit_t			*inNot_7;	
-	//encoder
-	hal_bit_t			*enc_reset;
-	hal_s32_t			*enc_counts;
-	hal_float_t			*enc_position;
-	hal_s32_t			*enc_rawcounts;
+    //6 ADC channel
+    hal_real_t ADC_0;
+    hal_real_t ADC_1;
+    hal_real_t ADC_2;
+    hal_real_t ADC_3;
+    hal_real_t ADC_4;
+    hal_real_t ADC_5;
+    //8 digital input
+    hal_bool_t in_0;
+    hal_bool_t inNot_0;
+    hal_bool_t in_1;
+    hal_bool_t inNot_1;
+    hal_bool_t in_2;
+    hal_bool_t inNot_2;
+    hal_bool_t in_3;
+    hal_bool_t inNot_3;
+    hal_bool_t in_4;
+    hal_bool_t inNot_4;
+    hal_bool_t in_5;
+    hal_bool_t inNot_5;
+    hal_bool_t in_6;
+    hal_bool_t inNot_6;
+    hal_bool_t in_7;
+    hal_bool_t inNot_7;
+    //encoder
+    hal_bool_t enc_reset;
+    hal_sint_t enc_counts;
+    hal_real_t enc_position;
+    hal_sint_t enc_rawcounts;
 
     // Parameters
-	//6 ADC channels
-	hal_float_t			ADC_0_offset;
-	hal_float_t			ADC_1_offset;
-	hal_float_t			ADC_2_offset;
-	hal_float_t			ADC_3_offset;
-	hal_float_t			ADC_4_offset;
-	hal_float_t			ADC_5_offset;
-	hal_float_t			ADC_0_scale;
-	hal_float_t			ADC_1_scale;
-	hal_float_t			ADC_2_scale;
-	hal_float_t			ADC_3_scale;
-	hal_float_t			ADC_4_scale;
-	hal_float_t			ADC_5_scale;
-	//encoder
-	hal_float_t			enc_position_scale;
-	
-    // Private data
-       //encoder
-       hal_s32_t			enc_raw_offset;
+    //6 ADC channels
+    hal_real_t ADC_0_offset;
+    hal_real_t ADC_1_offset;
+    hal_real_t ADC_2_offset;
+    hal_real_t ADC_3_offset;
+    hal_real_t ADC_4_offset;
+    hal_real_t ADC_5_offset;
+    hal_real_t ADC_0_scale;
+    hal_real_t ADC_1_scale;
+    hal_real_t ADC_2_scale;
+    hal_real_t ADC_3_scale;
+    hal_real_t ADC_4_scale;
+    hal_real_t ADC_5_scale;
+    //encoder
+    hal_real_t enc_position_scale;
+
+   // Private data
+   //encoder
+   rtapi_s32  enc_raw_offset;
 
 } RS485_TeachPad_t;
 
 typedef struct { //RS485_mgr_t
-	hal_u32_t			ID[16];
-	hal_u32_t			BYTES_TO_WRITE[16];
-	hal_u32_t			BYTES_TO_READ[16];
+    rtapi_u32 ID[16];
+    rtapi_u32 BYTES_TO_WRITE[16];
+    rtapi_u32 BYTES_TO_READ[16];
 } RS485_mgr_t;
 
 typedef struct { //axisdac_t
     // Pins.
-	hal_float_t				*value;
-	hal_bit_t				*enable;
- 
+    hal_real_t value;
+    hal_bool_t enable;
+
     // Parameters.
-	hal_float_t				min;
-	hal_float_t				max;
-	hal_float_t				offset;
-	
-	hal_bit_t				invert_serial;
+    hal_real_t min;
+    hal_real_t max;
+    hal_real_t offset;
+
+    hal_bool_t invert_serial;
 } axisdac_t;
 
 typedef struct { //stepgen_t
     // Pins.
-	hal_float_t		*position_cmd;
-	hal_float_t		*velocity_cmd;
-	hal_float_t		*position_fb;
-	hal_s32_t		*count_fb;	
-	hal_bit_t		*enable;
-	
+    hal_real_t position_cmd;
+    hal_real_t velocity_cmd;
+    hal_real_t position_fb;
+    hal_sint_t count_fb;
+    hal_bool_t enable;
+
     // Parameters
-	hal_u32_t		step_type; //0: StepDir, 1: UpDown, 2: Quadrature
-	hal_bit_t		control_type; //0: position, 1: velocity	
-	hal_u32_t		steplen;
-	hal_u32_t		stepspace;
-	hal_u32_t		dirdelay;
-	hal_float_t		maxaccel;
-	hal_float_t		maxvel;
-	hal_bit_t		polarity_A;
-	hal_bit_t		polarity_B;	
-	hal_float_t		position_scale;
-	
+    hal_uint_t step_type; //0: StepDir, 1: UpDown, 2: Quadrature
+    hal_bool_t control_type; //0: position, 1: velocity
+    hal_uint_t steplen;
+    hal_uint_t stepspace;
+    hal_uint_t dirdelay;
+    hal_real_t maxaccel;
+    hal_real_t maxvel;
+    hal_bool_t polarity_A;
+    hal_bool_t polarity_B;
+    hal_real_t position_scale;
+
     //Saved Parameters
-	hal_u32_t		curr_steplen;
-	hal_u32_t		curr_stepspace;
-	hal_u32_t		curr_dirdelay;
-	hal_float_t		curr_maxaccel;
-	hal_float_t		curr_maxvel;	
-	hal_float_t		curr_position_scale;
-	
+    rtapi_u32  curr_steplen;
+    rtapi_u32  curr_stepspace;
+    rtapi_u32  curr_dirdelay;
+    rtapi_real curr_maxaccel;
+    rtapi_real curr_maxvel;
+    rtapi_real curr_position_scale;
+
     // Private data
-	hal_u32_t		stepgen_fb_offset;
-	hal_float_t		old_pos_cmd;
-	hal_float_t		max_dv;
-	hal_float_t		old_vel;
-	hal_float_t		steprate_scale;
+    rtapi_u32  stepgen_fb_offset;
+    union {
+        rtapi_real old_pos_cmd;
+        // This is here to guarantee that the pointer hack works.
+        rtapi_uint __old_pos_cmd_field_size_match_r;
+    };
+    rtapi_real max_dv;
+    rtapi_real old_vel;
+    rtapi_real steprate_scale;
 } stepgen_t;
 
 typedef struct { //CardMgr_t
     // Pins.
-	hal_bit_t		*cardEnable;
-	hal_bit_t		*power_enable;
-	hal_bit_t		*power_fault;
-	hal_bit_t		*watchdog_expired;
-	
-    // Parameters	
-	hal_bit_t		watchdog_enable;
-	hal_u32_t		watchdog_timeout_ns;
-    
+    hal_bool_t cardEnable;
+    hal_bool_t power_enable;
+    hal_bool_t power_fault;
+    hal_bool_t watchdog_expired;
+
+    // Parameters
+    hal_bool_t watchdog_enable;
+    hal_uint_t watchdog_timeout_ns;
+
     // Private data
-	hal_u32_t		card_control_reg;
-	hal_bit_t		disable;
-	hal_u32_t		dbg_PCI_counter_last;
-	hal_u32_t		cntr;
+    rtapi_u32  card_control_reg;
+    union {
+        rtapi_bool disable;
+        // These are here to guarantee that the pointer hack works.
+        rtapi_uint __disable_field_size_match_u;
+        rtapi_real __disable_field_size_match_r;
+    };
+    rtapi_u32  dbg_PCI_counter_last;
+    rtapi_u32  cntr;
 } cardMgr_t;
 
 typedef struct { //CAN_GM_t
-      //Pins
-	hal_bit_t		*enable;
-	hal_float_t		*position_cmd;
-	hal_float_t		*position_fb;
-	
-      //Parameters
-	hal_float_t		position_scale;
+    //Pins
+    hal_bool_t enable;
+    hal_real_t position_cmd;
+    hal_real_t position_fb;
 
+    //Parameters
+    hal_real_t position_scale;
 } CAN_GM_t;
 
 typedef struct { //CANmsg_t
-	hal_bit_t		Ext; //0: Standrad ID, 1: Extended ID
-	hal_u32_t		ID;
-	hal_u32_t		data[8];
-	hal_u32_t		DLC;
-	hal_bit_t		RTR;
+    rtapi_bool Ext; //0: Standrad ID, 1: Extended ID
+    rtapi_u32  ID;
+    rtapi_u32  data[8];
+    rtapi_u32  DLC;
+    rtapi_bool RTR;
 }CANmsg_t;
 
 typedef struct { //gm_device_t
     // Card relatad data
-	card			*pCard;
-	int			boardID;  //Sequential nr of cards,  0  -  MAX_GM_DEVICES-1
-	int 			cardID;   //Version of the card and its modules
+    card *pCard;
+    int   boardID;  //Sequential nr of cards,  0  -  MAX_GM_DEVICES-1
+    int   cardID;   //Version of the card and its modules
 
     // Driver related data
-	switches_t		switches[6];
-	gpio_t			gpio[32];
-	estop_t			estop[2];
-	
-	RS485_mgr_t		RS485_mgr;
-	RS485_8input_t		RS485_8input[16];
-	RS485_8output_t		RS485_8output[16];
-	RS485_DacAdc_t		RS485_DacAdc[16];
-	RS485_TeachPad_t	RS485_TeachPad[16];
-	
-	CAN_GM_t		CAN_GM[6];
-	
-	stepgen_t		stepgen[6];
-	hal_u32_t		stepgen_status;
-	axisdac_t		axisdac[6];
-	encoder_t		encoder[6];
-	
-	cardMgr_t		cardMgr;
-		
-	hal_u32_t		period_ns;
-	hal_float_t		period_s;
-	hal_float_t		rec_period_s;
+    switches_t switches[6];
+    gpio_t     gpio[32];
+    estop_t    estop[2];
+
+    RS485_mgr_t      RS485_mgr;
+    RS485_8input_t   RS485_8input[16];
+    RS485_8output_t  RS485_8output[16];
+    RS485_DacAdc_t   RS485_DacAdc[16];
+    RS485_TeachPad_t RS485_TeachPad[16];
+
+    CAN_GM_t   CAN_GM[6];
+
+    stepgen_t  stepgen[6];
+    rtapi_u32  stepgen_status;
+    axisdac_t  axisdac[6];
+    encoder_t  encoder[6];
+
+    cardMgr_t  cardMgr;
+
+    rtapi_u32  period_ns;
+    rtapi_real period_s;
+    rtapi_real rec_period_s;
 } gm_device_t;
-   
+
 typedef struct { //gm_driver_t
-    int					comp_id;
-    gm_device_t				*device[MAX_GM_DEVICES];
+    int comp_id;
+    gm_device_t *device[MAX_GM_DEVICES];
 } gm_driver_t;
 
-static gm_driver_t				driver;
+static gm_driver_t driver;
 
 static int                      num_boards = 0;
 static int                      failed_errno = 0; // errno of last failed registration
@@ -357,7 +366,7 @@ rtapi_pci_device_id gm_pci_tbl[] = {
         .subvendor = PLX_VENDOR_ID,
         .subdevice = GM_SUBDEVICE_ID_1,
     },
- 
+
     {
         .vendor = PLX_VENDOR_ID,
         .device = GM_DEVICE_ID,
@@ -396,10 +405,10 @@ rtapi_pci_device_id gm_pci_tbl[] = {
   static void stepgenControl(void *arg, long period, unsigned int i);
   static void stepgenCheckParameters(void *arg, long period, unsigned int channel);
   //RS485
-  static unsigned int RS485_CheckChecksum(hal_u32_t* data, hal_u32_t length);
-  static unsigned int RS485_CalcChecksum(hal_u32_t* data, hal_u32_t length);
-  static void RS485_OrderDataRead(hal_u32_t* dataIn32, hal_u32_t* dataOut8, hal_u32_t length);
-  static void RS485_OrderDataWrite(hal_u32_t* dataIn8, hal_u32_t* dataOut32, hal_u32_t length);
+  static unsigned int RS485_CheckChecksum(rtapi_u32* data, rtapi_u32 length);
+  static unsigned int RS485_CalcChecksum(rtapi_u32* data, rtapi_u32 length);
+  static void RS485_OrderDataRead(rtapi_u32* dataIn32, rtapi_u32* dataOut8, rtapi_u32 length);
+  static void RS485_OrderDataWrite(rtapi_u32* dataIn8, rtapi_u32* dataOut32, rtapi_u32 length);
   //Encoders
   static void encoder(void *arg, long period); 
   //CAN
@@ -408,9 +417,9 @@ rtapi_pci_device_id gm_pci_tbl[] = {
   static void CAN_ReceiveDataFrame(void *arg, CANmsg_t *Msg);
 #ifdef CANOPEN
   static void CAN_Reset(void *arg);
-  static void CAN_SetBaud(void *arg, hal_u32_t Baud);
+  static void CAN_SetBaud(void *arg, rtapi_u32 Baud);
 #endif
-  static int CAN_ReadStatus(void *arg, hal_u32_t *RxCnt, hal_u32_t *TxCnt);
+  static int CAN_ReadStatus(void *arg, rtapi_u32 *RxCnt, rtapi_u32 *TxCnt);
   //Card management
   static void card_mgr(void *arg, long period);
 
@@ -508,7 +517,7 @@ gm_pci_remove(struct rtapi_pci_dev *dev)
         if((pDevice = driver.device[i]) != NULL)
         {
           // turn off all
-          pDevice->pCard->card_control_reg = (hal_s32_t) 0;
+          pDevice->pCard->card_control_reg = 0;
 				
           // Unmap card
           rtapi_iounmap((void *)(pDevice->pCard));
@@ -621,20 +630,20 @@ ExportEncoder(void *arg, int comp_id, int version)
 	      for(i=0;i<6;i++)
 	      {
 	      //Export Pins
-		if(error == 0) error = hal_pin_bit_newf(HAL_IN, &(device->encoder[i].reset), comp_id, "gm.%1d.encoder.%1d.reset", boardId, i);
-		if(error == 0) error = hal_pin_s32_newf(HAL_OUT, &(device->encoder[i].counts), comp_id, "gm.%1d.encoder.%1d.counts", boardId, i);
-		if(error == 0) error = hal_pin_float_newf(HAL_OUT, &(device->encoder[i].position), comp_id, "gm.%1d.encoder.%1d.position", boardId, i);
-		if(error == 0) error = hal_pin_float_newf(HAL_OUT, &(device->encoder[i].velocity), comp_id, "gm.%1d.encoder.%1d.velocity", boardId, i);
-		if(error == 0) error = hal_pin_s32_newf(HAL_OUT, &(device->encoder[i].rawcounts), comp_id, "gm.%1d.encoder.%1d.rawcounts", boardId, i);
-		if(error == 0) error = hal_pin_bit_newf(HAL_IO, &(device->encoder[i].index_enable), comp_id, "gm.%1d.encoder.%1d.index-enable", boardId, i);
+		if(error == 0) error = hal_pin_new_bool(comp_id, HAL_IN, &(device->encoder[i].reset), 0, "gm.%1d.encoder.%1d.reset", boardId, i);
+		if(error == 0) error = hal_pin_new_si32(comp_id, HAL_OUT, &(device->encoder[i].counts), 0, "gm.%1d.encoder.%1d.counts", boardId, i);
+		if(error == 0) error = hal_pin_new_real(comp_id, HAL_OUT, &(device->encoder[i].position), 0.0, "gm.%1d.encoder.%1d.position", boardId, i);
+		if(error == 0) error = hal_pin_new_real(comp_id, HAL_OUT, &(device->encoder[i].velocity), 0.0, "gm.%1d.encoder.%1d.velocity", boardId, i);
+		if(error == 0) error = hal_pin_new_si32(comp_id, HAL_OUT, &(device->encoder[i].rawcounts), 0, "gm.%1d.encoder.%1d.rawcounts", boardId, i);
+		if(error == 0) error = hal_pin_new_bool(comp_id, HAL_IO, &(device->encoder[i].index_enable), 0, "gm.%1d.encoder.%1d.index-enable", boardId, i);
 			
 	      //Export Parameters
-		if(error == 0) error = hal_param_bit_newf(HAL_RW, &(device->encoder[i].counter_mode), comp_id, "gm.%1d.encoder.%1d.counter-mode", boardId, i);
-		if(error == 0) error = hal_param_bit_newf(HAL_RW, &(device->encoder[i].index_mode), comp_id, "gm.%1d.encoder.%1d.index-mode", boardId, i);
-		if(error == 0) error = hal_param_bit_newf(HAL_RW, &(device->encoder[i].index_invert), comp_id, "gm.%1d.encoder.%1d.index-invert", boardId, i);
-		if(error == 0) error = hal_param_u32_newf(HAL_RW, &(device->encoder[i].counts_per_rev), comp_id, "gm.%1d.encoder.%1d.counts-per-rev", boardId, i);
-		if(error == 0) error = hal_param_float_newf(HAL_RW, &(device->encoder[i].position_scale), comp_id, "gm.%1d.encoder.%1d.position-scale", boardId, i);
-		if(error == 0) error = hal_param_float_newf(HAL_RW, &(device->encoder[i].min_speed_estimate), comp_id, "gm.%1d.encoder.%1d.min-speed-estimate", boardId, i);
+		if(error == 0) error = hal_param_new_bool(comp_id, HAL_RW, &(device->encoder[i].counter_mode), 0, "gm.%1d.encoder.%1d.counter-mode", boardId, i);
+		if(error == 0) error = hal_param_new_bool(comp_id, HAL_RW, &(device->encoder[i].index_mode), 0, "gm.%1d.encoder.%1d.index-mode", boardId, i);
+		if(error == 0) error = hal_param_new_bool(comp_id, HAL_RW, &(device->encoder[i].index_invert), 0, "gm.%1d.encoder.%1d.index-invert", boardId, i);
+		if(error == 0) error = hal_param_new_ui32(comp_id, HAL_RW, &(device->encoder[i].counts_per_rev), 0, "gm.%1d.encoder.%1d.counts-per-rev", boardId, i);
+		if(error == 0) error = hal_param_new_real(comp_id, HAL_RW, &(device->encoder[i].position_scale), 0.0, "gm.%1d.encoder.%1d.position-scale", boardId, i);
+		if(error == 0) error = hal_param_new_real(comp_id, HAL_RW, &(device->encoder[i].min_speed_estimate), 0.0, "gm.%1d.encoder.%1d.min-speed-estimate", boardId, i);
 		
 	      //Init parameters
 		device->encoder[i].raw_offset = pCard->ENC_counter[i];
@@ -664,8 +673,10 @@ ExportStepgen(void *arg, int comp_id, int version)
 	  case notPresented:
 	    for(i=0;i<6;i++)
 	      {
-		device->stepgen[i].enable = &(device->cardMgr.disable); //Set enable pointers to a 0 value variable
-		device->stepgen[i].position_cmd = &(device->stepgen[i].old_pos_cmd);
+		// FIXME: This is a hack. We shouldn't reference local variables as if
+		// they were pins or params. That can only end very badly...
+		device->stepgen[i].enable = (hal_bool_t)&(device->cardMgr.disable); //Set enable pointers to a 0 value variable
+		device->stepgen[i].position_cmd = (hal_real_t)&(device->stepgen[i].old_pos_cmd);
 	      }
 	      rtapi_print_msg(RTAPI_MSG_WARN, "General Mechatronics: No stepgen module available in this version of the Card.\n");
 	  break;
@@ -676,23 +687,23 @@ ExportStepgen(void *arg, int comp_id, int version)
 	   for(i = 0; i < 6; i++)
 	    {	
 		//Export Pins
-		if(error == 0) error = hal_pin_float_newf(HAL_IN, &(device->stepgen[i].position_cmd), comp_id, "gm.%1d.stepgen.%1d.position-cmd", boardId, i);
-		if(error == 0) error = hal_pin_float_newf(HAL_OUT, &(device->stepgen[i].position_fb), comp_id, "gm.%1d.stepgen.%1d.position-fb", boardId, i);
-		if(error == 0) error = hal_pin_float_newf(HAL_IN, &(device->stepgen[i].velocity_cmd), comp_id, "gm.%1d.stepgen.%1d.velocity-cmd", boardId, i);
-		if(error == 0) error = hal_pin_s32_newf(HAL_OUT, &(device->stepgen[i].count_fb), comp_id, "gm.%1d.stepgen.%1d.count-fb", boardId, i);		
-		if(error == 0) error = hal_pin_bit_newf(HAL_IN, &(device->stepgen[i].enable), comp_id, "gm.%1d.stepgen.%1d.enable", boardId, i);
+		if(error == 0) error = hal_pin_new_real(comp_id, HAL_IN, &(device->stepgen[i].position_cmd), 0.0, "gm.%1d.stepgen.%1d.position-cmd", boardId, i);
+		if(error == 0) error = hal_pin_new_real(comp_id, HAL_OUT, &(device->stepgen[i].position_fb), 0.0, "gm.%1d.stepgen.%1d.position-fb", boardId, i);
+		if(error == 0) error = hal_pin_new_real(comp_id, HAL_IN, &(device->stepgen[i].velocity_cmd), 0.0, "gm.%1d.stepgen.%1d.velocity-cmd", boardId, i);
+		if(error == 0) error = hal_pin_new_si32(comp_id, HAL_OUT, &(device->stepgen[i].count_fb), 0, "gm.%1d.stepgen.%1d.count-fb", boardId, i);		
+		if(error == 0) error = hal_pin_new_bool(comp_id, HAL_IN, &(device->stepgen[i].enable), 0, "gm.%1d.stepgen.%1d.enable", boardId, i);
 
 		//Export Parameters.
-		if(error == 0) error = hal_param_bit_newf(HAL_RW, &(device->stepgen[i].control_type), comp_id, "gm.%1d.stepgen.%1d.control-type", boardId, i); //0: StepDir, 1: UpDown, 2: Quadrature
-		if(error == 0) error = hal_param_u32_newf(HAL_RW, &(device->stepgen[i].step_type), comp_id, "gm.%1d.stepgen.%1d.step-type", boardId, i); //0: position, 1: velocity		
-		if(error == 0) error = hal_param_u32_newf(HAL_RW, &(device->stepgen[i].steplen), comp_id, "gm.%1d.stepgen.%1d.steplen", boardId, i);
-		if(error == 0) error = hal_param_u32_newf(HAL_RW, &(device->stepgen[i].stepspace), comp_id, "gm.%1d.stepgen.%1d.stepspace", boardId, i);
-		if(error == 0) error = hal_param_u32_newf(HAL_RW, &(device->stepgen[i].dirdelay), comp_id, "gm.%1d.stepgen.%1d.dirdelay", boardId, i);	
-		if(error == 0) error = hal_param_float_newf(HAL_RW, &(device->stepgen[i].maxaccel), comp_id, "gm.%1d.stepgen.%1d.maxaccel", boardId, i);
-		if(error == 0) error = hal_param_float_newf(HAL_RW, &(device->stepgen[i].maxvel), comp_id, "gm.%1d.stepgen.%1d.maxvel", boardId, i);
-		if(error == 0) error = hal_param_bit_newf(HAL_RW, &(device->stepgen[i].polarity_A), comp_id, "gm.%1d.stepgen.%1d.invert-step1", boardId, i);
-		if(error == 0) error = hal_param_bit_newf(HAL_RW, &(device->stepgen[i].polarity_B), comp_id, "gm.%1d.stepgen.%1d.invert-step2", boardId, i);
-		if(error == 0) error = hal_param_float_newf(HAL_RW, &(device->stepgen[i].position_scale), comp_id, "gm.%1d.stepgen.%1d.position-scale", boardId, i);
+		if(error == 0) error = hal_param_new_bool(comp_id, HAL_RW, &(device->stepgen[i].control_type), 0, "gm.%1d.stepgen.%1d.control-type", boardId, i); //0: position, 1: velocity
+		if(error == 0) error = hal_param_new_ui32(comp_id, HAL_RW, &(device->stepgen[i].step_type), 0, "gm.%1d.stepgen.%1d.step-type", boardId, i); //0: StepDir, 1: UpDown, 2: Quadrature
+		if(error == 0) error = hal_param_new_ui32(comp_id, HAL_RW, &(device->stepgen[i].steplen), 0, "gm.%1d.stepgen.%1d.steplen", boardId, i);
+		if(error == 0) error = hal_param_new_ui32(comp_id, HAL_RW, &(device->stepgen[i].stepspace), 0, "gm.%1d.stepgen.%1d.stepspace", boardId, i);
+		if(error == 0) error = hal_param_new_ui32(comp_id, HAL_RW, &(device->stepgen[i].dirdelay), 0, "gm.%1d.stepgen.%1d.dirdelay", boardId, i);	
+		if(error == 0) error = hal_param_new_real(comp_id, HAL_RW, &(device->stepgen[i].maxaccel), 0.0, "gm.%1d.stepgen.%1d.maxaccel", boardId, i);
+		if(error == 0) error = hal_param_new_real(comp_id, HAL_RW, &(device->stepgen[i].maxvel), 0.0, "gm.%1d.stepgen.%1d.maxvel", boardId, i);
+		if(error == 0) error = hal_param_new_bool(comp_id, HAL_RW, &(device->stepgen[i].polarity_A), 0, "gm.%1d.stepgen.%1d.invert-step1", boardId, i);
+		if(error == 0) error = hal_param_new_bool(comp_id, HAL_RW, &(device->stepgen[i].polarity_B), 0, "gm.%1d.stepgen.%1d.invert-step2", boardId, i);
+		if(error == 0) error = hal_param_new_real(comp_id, HAL_RW, &(device->stepgen[i].position_scale), 0.0, "gm.%1d.stepgen.%1d.position-scale", boardId, i);
                 if(error != 0) break;
 
 		//Init parameters
@@ -731,14 +742,14 @@ ExportDAC(void *arg, int comp_id, int version)
 	  case notPresented:
 	    for(i=0;i<6;i++)
 	      {
-		device->axisdac[i].enable = &(device->cardMgr.disable); //Set enable pointers to a 0 value variable
+		device->axisdac[i].enable = (hal_bool_t)&(device->cardMgr.disable); //Set enable pointers to a 0 value variable
 	      }
 	      rtapi_print_msg(RTAPI_MSG_WARN, "General Mechatronics: No DAC module available in this version of the Card.\n");
 	    break;
 	  case dacVersion1:
 	    for(i=0;i<6;i++)
 	      {
-		device->axisdac[i].enable = &(device->cardMgr.disable); //Set enable pointers to a 0 value variable
+		device->axisdac[i].enable = (hal_bool_t)&(device->cardMgr.disable); //Set enable pointers to a 0 value variable
 	      }
               rtapi_print_msg(RTAPI_MSG_WARN, "General Mechatronics: This card supports DAC ver.1 only, which is no longer produced. No DAC pins will be exported to HAL. If you need DAC, contact to bence.kovacs@generalmechatronics.com for firmware upgrade.\n");
 	    break;
@@ -746,20 +757,14 @@ ExportDAC(void *arg, int comp_id, int version)
 	      for(i=0;i<6;i++)
 	      {
 		//Export Pins
-		if(error == 0) error = hal_pin_bit_newf(HAL_IN, &(device->axisdac[i].enable), comp_id, "gm.%1d.dac.%1d.enable", boardId, i);
-		if(error == 0) error = hal_pin_float_newf(HAL_IN, &(device->axisdac[i].value), comp_id, "gm.%1d.dac.%1d.value", boardId, i);
+		if(error == 0) error = hal_pin_new_bool(comp_id, HAL_IN, &(device->axisdac[i].enable), 0, "gm.%1d.dac.%1d.enable", boardId, i);
+		if(error == 0) error = hal_pin_new_real(comp_id, HAL_IN, &(device->axisdac[i].value), 0.0, "gm.%1d.dac.%1d.value", boardId, i);
 
 		//Export Parameters.
-		if(error == 0) error = hal_param_float_newf(HAL_RW, &(device->axisdac[i].min), comp_id, "gm.%1d.dac.%1d.low-limit", boardId, i);
-		if(error == 0) error = hal_param_float_newf(HAL_RW, &(device->axisdac[i].max), comp_id, "gm.%1d.dac.%1d.high-limit", boardId, i);
-		if(error == 0) error = hal_param_float_newf(HAL_RW, &(device->axisdac[i].offset), comp_id, "gm.%1d.dac.%1d.offset", boardId, i);
-		if(error == 0) error = hal_param_bit_newf(HAL_RW, &(device->axisdac[i].invert_serial), comp_id, "gm.%1d.dac.%1d.invert-serial", boardId, i);
-		
-		//Init Parameters
-		device->axisdac[i].max = 10;
-		device->axisdac[i].min = -10;
-		device->axisdac[i].offset = 0;
-		device->axisdac[i].invert_serial = 0;
+		if(error == 0) error = hal_param_new_real(comp_id, HAL_RW, &(device->axisdac[i].min), -10.0, "gm.%1d.dac.%1d.low-limit", boardId, i);
+		if(error == 0) error = hal_param_new_real(comp_id, HAL_RW, &(device->axisdac[i].max), 10.0, "gm.%1d.dac.%1d.high-limit", boardId, i);
+		if(error == 0) error = hal_param_new_real(comp_id, HAL_RW, &(device->axisdac[i].offset), 0.0, "gm.%1d.dac.%1d.offset", boardId, i);
+		if(error == 0) error = hal_param_new_bool(comp_id, HAL_RW, &(device->axisdac[i].invert_serial), 0, "gm.%1d.dac.%1d.invert-serial", boardId, i);
 		
 		//Init FPGA regs
 		pCard->DAC_0 = 0x1FFF1FFF;
@@ -793,7 +798,7 @@ ExportRS485(void *arg, int comp_id, int version)
 	    //READ IDs of connected modules
 	    for(i=0; i<8; i++)
 	    {
-		temp=(hal_u32_t)pCard->moduleId[i];
+		temp = pCard->moduleId[i];
 		 
 		if(((temp & 0xff)^0xaa) == ((temp & 0xff00)>>8)) 
 		 {
@@ -818,181 +823,149 @@ ExportRS485(void *arg, int comp_id, int version)
 			device-> RS485_mgr.BYTES_TO_WRITE[i]=0;
 			device-> RS485_mgr.BYTES_TO_READ[i]=2;	//1 data byte + 1 Checksum
 			
-			if(error == 0) error = hal_pin_bit_newf(HAL_OUT, &(device->RS485_8input[i].in_0), comp_id, "gm.%1d.rs485.%02d.in-0", boardId, i);
-			if(error == 0) error = hal_pin_bit_newf(HAL_OUT, &(device->RS485_8input[i].inNot_0), comp_id, "gm.%1d.rs485.%02d.in-not-0", boardId, i);
-			if(error == 0) error = hal_pin_bit_newf(HAL_OUT, &(device->RS485_8input[i].in_1), comp_id, "gm.%1d.rs485.%02d.in-1", boardId, i);
-			if(error == 0) error = hal_pin_bit_newf(HAL_OUT, &(device->RS485_8input[i].inNot_1), comp_id, "gm.%1d.rs485.%02d.in-not-1", boardId, i);
-			if(error == 0) error = hal_pin_bit_newf(HAL_OUT, &(device->RS485_8input[i].in_2), comp_id, "gm.%1d.rs485.%02d.in-2", boardId, i);
-			if(error == 0) error = hal_pin_bit_newf(HAL_OUT, &(device->RS485_8input[i].inNot_2), comp_id, "gm.%1d.rs485.%02d.in-not-2", boardId, i);
-			if(error == 0) error = hal_pin_bit_newf(HAL_OUT, &(device->RS485_8input[i].in_3), comp_id, "gm.%1d.rs485.%02d.in-3", boardId, i);
-			if(error == 0) error = hal_pin_bit_newf(HAL_OUT, &(device->RS485_8input[i].inNot_3), comp_id, "gm.%1d.rs485.%02d.in-not-3", boardId, i);
-			if(error == 0) error = hal_pin_bit_newf(HAL_OUT, &(device->RS485_8input[i].in_4), comp_id, "gm.%1d.rs485.%02d.in-4", boardId, i);
-			if(error == 0) error = hal_pin_bit_newf(HAL_OUT, &(device->RS485_8input[i].inNot_4), comp_id, "gm.%1d.rs485.%02d.in-not-4", boardId, i);
-			if(error == 0) error = hal_pin_bit_newf(HAL_OUT, &(device->RS485_8input[i].in_5), comp_id, "gm.%1d.rs485.%02d.in-5", boardId, i);
-			if(error == 0) error = hal_pin_bit_newf(HAL_OUT, &(device->RS485_8input[i].inNot_5), comp_id, "gm.%1d.rs485.%02d.in-not-5", boardId, i);
-			if(error == 0) error = hal_pin_bit_newf(HAL_OUT, &(device->RS485_8input[i].in_6), comp_id, "gm.%1d.rs485.%02d.in-6", boardId, i);
-			if(error == 0) error = hal_pin_bit_newf(HAL_OUT, &(device->RS485_8input[i].inNot_6), comp_id, "gm.%1d.rs485.%02d.in-not-6", boardId, i);
-			if(error == 0) error = hal_pin_bit_newf(HAL_OUT, &(device->RS485_8input[i].in_7), comp_id, "gm.%1d.rs485.%02d.in-7", boardId, i);
-			if(error == 0) error = hal_pin_bit_newf(HAL_OUT, &(device->RS485_8input[i].inNot_7), comp_id, "gm.%1d.rs485.%02d.in-not-7", boardId, i);	
+			if(error == 0) error = hal_pin_new_bool(comp_id, HAL_OUT, &(device->RS485_8input[i].in_0), 0, "gm.%1d.rs485.%02d.in-0", boardId, i);
+			if(error == 0) error = hal_pin_new_bool(comp_id, HAL_OUT, &(device->RS485_8input[i].inNot_0), 1, "gm.%1d.rs485.%02d.in-not-0", boardId, i);
+			if(error == 0) error = hal_pin_new_bool(comp_id, HAL_OUT, &(device->RS485_8input[i].in_1), 0, "gm.%1d.rs485.%02d.in-1", boardId, i);
+			if(error == 0) error = hal_pin_new_bool(comp_id, HAL_OUT, &(device->RS485_8input[i].inNot_1), 1, "gm.%1d.rs485.%02d.in-not-1", boardId, i);
+			if(error == 0) error = hal_pin_new_bool(comp_id, HAL_OUT, &(device->RS485_8input[i].in_2), 0, "gm.%1d.rs485.%02d.in-2", boardId, i);
+			if(error == 0) error = hal_pin_new_bool(comp_id, HAL_OUT, &(device->RS485_8input[i].inNot_2), 1, "gm.%1d.rs485.%02d.in-not-2", boardId, i);
+			if(error == 0) error = hal_pin_new_bool(comp_id, HAL_OUT, &(device->RS485_8input[i].in_3), 0, "gm.%1d.rs485.%02d.in-3", boardId, i);
+			if(error == 0) error = hal_pin_new_bool(comp_id, HAL_OUT, &(device->RS485_8input[i].inNot_3), 1, "gm.%1d.rs485.%02d.in-not-3", boardId, i);
+			if(error == 0) error = hal_pin_new_bool(comp_id, HAL_OUT, &(device->RS485_8input[i].in_4), 0, "gm.%1d.rs485.%02d.in-4", boardId, i);
+			if(error == 0) error = hal_pin_new_bool(comp_id, HAL_OUT, &(device->RS485_8input[i].inNot_4), 1, "gm.%1d.rs485.%02d.in-not-4", boardId, i);
+			if(error == 0) error = hal_pin_new_bool(comp_id, HAL_OUT, &(device->RS485_8input[i].in_5), 0, "gm.%1d.rs485.%02d.in-5", boardId, i);
+			if(error == 0) error = hal_pin_new_bool(comp_id, HAL_OUT, &(device->RS485_8input[i].inNot_5), 1, "gm.%1d.rs485.%02d.in-not-5", boardId, i);
+			if(error == 0) error = hal_pin_new_bool(comp_id, HAL_OUT, &(device->RS485_8input[i].in_6), 0, "gm.%1d.rs485.%02d.in-6", boardId, i);
+			if(error == 0) error = hal_pin_new_bool(comp_id, HAL_OUT, &(device->RS485_8input[i].inNot_6), 1, "gm.%1d.rs485.%02d.in-not-6", boardId, i);
+			if(error == 0) error = hal_pin_new_bool(comp_id, HAL_OUT, &(device->RS485_8input[i].in_7), 0, "gm.%1d.rs485.%02d.in-7", boardId, i);
+			if(error == 0) error = hal_pin_new_bool(comp_id, HAL_OUT, &(device->RS485_8input[i].inNot_7), 1, "gm.%1d.rs485.%02d.in-not-7", boardId, i);	
 		  break;		  
 		  case RS485MODUL_ID_8OUTPUT:
 			device-> RS485_mgr.BYTES_TO_WRITE[i]=2; // 1 data byte + 1 Checksum
 			device-> RS485_mgr.BYTES_TO_READ[i]=0;
 			
-		    	if(error == 0) error = hal_pin_bit_newf(HAL_IN, &(device->RS485_8output[i].out_0), comp_id, "gm.%1d.rs485.%02d.relay-0", boardId, i);
-			if(error == 0) error = hal_pin_bit_newf(HAL_IN, &(device->RS485_8output[i].out_1), comp_id, "gm.%1d.rs485.%02d.relay-1", boardId, i);
-			if(error == 0) error = hal_pin_bit_newf(HAL_IN, &(device->RS485_8output[i].out_2), comp_id, "gm.%1d.rs485.%02d.relay-2", boardId, i);
-			if(error == 0) error = hal_pin_bit_newf(HAL_IN, &(device->RS485_8output[i].out_3), comp_id, "gm.%1d.rs485.%02d.relay-3", boardId, i);
-			if(error == 0) error = hal_pin_bit_newf(HAL_IN, &(device->RS485_8output[i].out_4), comp_id, "gm.%1d.rs485.%02d.relay-4", boardId, i);
-			if(error == 0) error = hal_pin_bit_newf(HAL_IN, &(device->RS485_8output[i].out_5), comp_id, "gm.%1d.rs485.%02d.relay-5", boardId, i);
-			if(error == 0) error = hal_pin_bit_newf(HAL_IN, &(device->RS485_8output[i].out_6), comp_id, "gm.%1d.rs485.%02d.relay-6", boardId, i);
-			if(error == 0) error = hal_pin_bit_newf(HAL_IN, &(device->RS485_8output[i].out_7), comp_id, "gm.%1d.rs485.%02d.relay-7", boardId, i);
+			if(error == 0) error = hal_pin_new_bool(comp_id, HAL_IN, &(device->RS485_8output[i].out_0), 0, "gm.%1d.rs485.%02d.relay-0", boardId, i);
+			if(error == 0) error = hal_pin_new_bool(comp_id, HAL_IN, &(device->RS485_8output[i].out_1), 0, "gm.%1d.rs485.%02d.relay-1", boardId, i);
+			if(error == 0) error = hal_pin_new_bool(comp_id, HAL_IN, &(device->RS485_8output[i].out_2), 0, "gm.%1d.rs485.%02d.relay-2", boardId, i);
+			if(error == 0) error = hal_pin_new_bool(comp_id, HAL_IN, &(device->RS485_8output[i].out_3), 0, "gm.%1d.rs485.%02d.relay-3", boardId, i);
+			if(error == 0) error = hal_pin_new_bool(comp_id, HAL_IN, &(device->RS485_8output[i].out_4), 0, "gm.%1d.rs485.%02d.relay-4", boardId, i);
+			if(error == 0) error = hal_pin_new_bool(comp_id, HAL_IN, &(device->RS485_8output[i].out_5), 0, "gm.%1d.rs485.%02d.relay-5", boardId, i);
+			if(error == 0) error = hal_pin_new_bool(comp_id, HAL_IN, &(device->RS485_8output[i].out_6), 0, "gm.%1d.rs485.%02d.relay-6", boardId, i);
+			if(error == 0) error = hal_pin_new_bool(comp_id, HAL_IN, &(device->RS485_8output[i].out_7), 0, "gm.%1d.rs485.%02d.relay-7", boardId, i);
 			
-		    	if(error == 0) error = hal_param_bit_newf(HAL_RW, &(device->RS485_8output[i].invertOut_0), comp_id, "gm.%1d.rs485.%02d.invert-relay-0", boardId, i);
-			if(error == 0) error = hal_param_bit_newf(HAL_RW, &(device->RS485_8output[i].invertOut_1), comp_id, "gm.%1d.rs485.%02d.invert-relay-1", boardId, i);
-			if(error == 0) error = hal_param_bit_newf(HAL_RW, &(device->RS485_8output[i].invertOut_2), comp_id, "gm.%1d.rs485.%02d.invert-relay-2", boardId, i);
-			if(error == 0) error = hal_param_bit_newf(HAL_RW, &(device->RS485_8output[i].invertOut_3), comp_id, "gm.%1d.rs485.%02d.invert-relay-3", boardId, i);
-			if(error == 0) error = hal_param_bit_newf(HAL_RW, &(device->RS485_8output[i].invertOut_4), comp_id, "gm.%1d.rs485.%02d.invert-relay-4", boardId, i);
-			if(error == 0) error = hal_param_bit_newf(HAL_RW, &(device->RS485_8output[i].invertOut_5), comp_id, "gm.%1d.rs485.%02d.invert-relay-5", boardId, i);
-			if(error == 0) error = hal_param_bit_newf(HAL_RW, &(device->RS485_8output[i].invertOut_6), comp_id, "gm.%1d.rs485.%02d.invert-relay-6", boardId, i);
-			if(error == 0) error = hal_param_bit_newf(HAL_RW, &(device->RS485_8output[i].invertOut_7), comp_id, "gm.%1d.rs485.%02d.invert-relay-7", boardId, i);
+			if(error == 0) error = hal_param_new_bool(comp_id, HAL_RW, &(device->RS485_8output[i].invertOut_0), 0, "gm.%1d.rs485.%02d.invert-relay-0", boardId, i);
+			if(error == 0) error = hal_param_new_bool(comp_id, HAL_RW, &(device->RS485_8output[i].invertOut_1), 0, "gm.%1d.rs485.%02d.invert-relay-1", boardId, i);
+			if(error == 0) error = hal_param_new_bool(comp_id, HAL_RW, &(device->RS485_8output[i].invertOut_2), 0, "gm.%1d.rs485.%02d.invert-relay-2", boardId, i);
+			if(error == 0) error = hal_param_new_bool(comp_id, HAL_RW, &(device->RS485_8output[i].invertOut_3), 0, "gm.%1d.rs485.%02d.invert-relay-3", boardId, i);
+			if(error == 0) error = hal_param_new_bool(comp_id, HAL_RW, &(device->RS485_8output[i].invertOut_4), 0, "gm.%1d.rs485.%02d.invert-relay-4", boardId, i);
+			if(error == 0) error = hal_param_new_bool(comp_id, HAL_RW, &(device->RS485_8output[i].invertOut_5), 0, "gm.%1d.rs485.%02d.invert-relay-5", boardId, i);
+			if(error == 0) error = hal_param_new_bool(comp_id, HAL_RW, &(device->RS485_8output[i].invertOut_6), 0, "gm.%1d.rs485.%02d.invert-relay-6", boardId, i);
+			if(error == 0) error = hal_param_new_bool(comp_id, HAL_RW, &(device->RS485_8output[i].invertOut_7), 0, "gm.%1d.rs485.%02d.invert-relay-7", boardId, i);
 
 		  break;
 		  case RS485MODUL_ID_DACADC:
 			device-> RS485_mgr.BYTES_TO_WRITE[i]=5; // 8 data byte + 1 Checksum
 			device-> RS485_mgr.BYTES_TO_READ[i]=9; 
 		      
-			if(error == 0) error = hal_pin_float_newf(HAL_IN, &(device->RS485_DacAdc[i].DAC_0), comp_id, "gm.%1d.rs485.%02d.dac-0", boardId, i);
-			if(error == 0) error = hal_pin_float_newf(HAL_IN, &(device->RS485_DacAdc[i].DAC_1), comp_id, "gm.%1d.rs485.%02d.dac-1", boardId, i);
-			if(error == 0) error = hal_pin_float_newf(HAL_IN, &(device->RS485_DacAdc[i].DAC_2), comp_id, "gm.%1d.rs485.%02d.dac-2", boardId, i);
-			if(error == 0) error = hal_pin_float_newf(HAL_IN, &(device->RS485_DacAdc[i].DAC_3), comp_id, "gm.%1d.rs485.%02d.dac-3", boardId, i);
-			if(error == 0) error = hal_pin_bit_newf(HAL_IN, &(device->RS485_DacAdc[i].dac_0_enable), comp_id, "gm.%1d.rs485.%02d.dac-enable-0", boardId, i);
-			if(error == 0) error = hal_pin_bit_newf(HAL_IN, &(device->RS485_DacAdc[i].dac_1_enable), comp_id, "gm.%1d.rs485.%02d.dac-enable-1", boardId, i);
-			if(error == 0) error = hal_pin_bit_newf(HAL_IN, &(device->RS485_DacAdc[i].dac_2_enable), comp_id, "gm.%1d.rs485.%02d.dac-enable-2", boardId, i);
-			if(error == 0) error = hal_pin_bit_newf(HAL_IN, &(device->RS485_DacAdc[i].dac_3_enable), comp_id, "gm.%1d.rs485.%02d.dac-enable-3", boardId, i);
-			if(error == 0) error = hal_pin_float_newf(HAL_OUT, &(device->RS485_DacAdc[i].ADC_0), comp_id, "gm.%1d.rs485.%02d.adc-0", boardId, i);
-			if(error == 0) error = hal_pin_float_newf(HAL_OUT, &(device->RS485_DacAdc[i].ADC_1), comp_id, "gm.%1d.rs485.%02d.adc-1", boardId, i);      
-			if(error == 0) error = hal_pin_float_newf(HAL_OUT, &(device->RS485_DacAdc[i].ADC_2), comp_id, "gm.%1d.rs485.%02d.adc-2", boardId, i);      
-			if(error == 0) error = hal_pin_float_newf(HAL_OUT, &(device->RS485_DacAdc[i].ADC_3), comp_id, "gm.%1d.rs485.%02d.adc-3", boardId, i);        
-			if(error == 0) error = hal_pin_float_newf(HAL_OUT, &(device->RS485_DacAdc[i].ADC_4), comp_id, "gm.%1d.rs485.%02d.adc-4", boardId, i);
-			if(error == 0) error = hal_pin_float_newf(HAL_OUT, &(device->RS485_DacAdc[i].ADC_5), comp_id, "gm.%1d.rs485.%02d.adc-5", boardId, i);      
-			if(error == 0) error = hal_pin_float_newf(HAL_OUT, &(device->RS485_DacAdc[i].ADC_6), comp_id, "gm.%1d.rs485.%02d.adc-6", boardId, i);      
-			if(error == 0) error = hal_pin_float_newf(HAL_OUT, &(device->RS485_DacAdc[i].ADC_7), comp_id, "gm.%1d.rs485.%02d.adc-7", boardId, i);      
-			if(error == 0) error = hal_param_float_newf(HAL_RW, &(device->RS485_DacAdc[i].DAC_0_offset), comp_id, "gm.%1d.rs485.%02d.dac-offset-0", boardId, i);
-			if(error == 0) error = hal_param_float_newf(HAL_RW, &(device->RS485_DacAdc[i].DAC_1_offset), comp_id, "gm.%1d.rs485.%02d.dac-offset-1", boardId, i);
-			if(error == 0) error = hal_param_float_newf(HAL_RW, &(device->RS485_DacAdc[i].DAC_2_offset), comp_id, "gm.%1d.rs485.%02d.dac-offset-2", boardId, i);
-			if(error == 0) error = hal_param_float_newf(HAL_RW, &(device->RS485_DacAdc[i].DAC_3_offset), comp_id, "gm.%1d.rs485.%02d.dac-offset-3", boardId, i);	      
-			if(error == 0) error = hal_param_float_newf(HAL_RW, &(device->RS485_DacAdc[i].DAC_0_max), comp_id, "gm.%1d.rs485.%02d.dac-high-limit-0", boardId, i);
-			if(error == 0) error = hal_param_float_newf(HAL_RW, &(device->RS485_DacAdc[i].DAC_1_max), comp_id, "gm.%1d.rs485.%02d.dac-high-limit-1", boardId, i);
-			if(error == 0) error = hal_param_float_newf(HAL_RW, &(device->RS485_DacAdc[i].DAC_2_max), comp_id, "gm.%1d.rs485.%02d.dac-high-limit-2", boardId, i);
-			if(error == 0) error = hal_param_float_newf(HAL_RW, &(device->RS485_DacAdc[i].DAC_3_max), comp_id, "gm.%1d.rs485.%02d.dac-high-limit-3", boardId, i);
-			if(error == 0) error = hal_param_float_newf(HAL_RW, &(device->RS485_DacAdc[i].DAC_0_min), comp_id, "gm.%1d.rs485.%02d.dac-low-limit-0", boardId, i);
-			if(error == 0) error = hal_param_float_newf(HAL_RW, &(device->RS485_DacAdc[i].DAC_1_min), comp_id, "gm.%1d.rs485.%02d.dac-low-limit-1", boardId, i);
-			if(error == 0) error = hal_param_float_newf(HAL_RW, &(device->RS485_DacAdc[i].DAC_2_min), comp_id, "gm.%1d.rs485.%02d.dac-low-limit-2", boardId, i);
-			if(error == 0) error = hal_param_float_newf(HAL_RW, &(device->RS485_DacAdc[i].DAC_3_min), comp_id, "gm.%1d.rs485.%02d.dac-low-limit-3", boardId, i);
-			if(error == 0) error = hal_param_float_newf(HAL_RW, &(device->RS485_DacAdc[i].ADC_0_offset), comp_id, "gm.%1d.rs485.%02d.adc-offset-0", boardId, i);
-			if(error == 0) error = hal_param_float_newf(HAL_RW, &(device->RS485_DacAdc[i].ADC_1_offset), comp_id, "gm.%1d.rs485.%02d.adc-offset-1", boardId, i);
-			if(error == 0) error = hal_param_float_newf(HAL_RW, &(device->RS485_DacAdc[i].ADC_2_offset), comp_id, "gm.%1d.rs485.%02d.adc-offset-2", boardId, i);
-			if(error == 0) error = hal_param_float_newf(HAL_RW, &(device->RS485_DacAdc[i].ADC_3_offset), comp_id, "gm.%1d.rs485.%02d.adc-offset-3", boardId, i);
-			if(error == 0) error = hal_param_float_newf(HAL_RW, &(device->RS485_DacAdc[i].ADC_4_offset), comp_id, "gm.%1d.rs485.%02d.adc-offset-4", boardId, i);
-			if(error == 0) error = hal_param_float_newf(HAL_RW, &(device->RS485_DacAdc[i].ADC_5_offset), comp_id, "gm.%1d.rs485.%02d.adc-offset-5", boardId, i);
-			if(error == 0) error = hal_param_float_newf(HAL_RW, &(device->RS485_DacAdc[i].ADC_6_offset), comp_id, "gm.%1d.rs485.%02d.adc-offset-6", boardId, i);
-			if(error == 0) error = hal_param_float_newf(HAL_RW, &(device->RS485_DacAdc[i].ADC_7_offset), comp_id, "gm.%1d.rs485.%02d.adc-offset-7", boardId, i);
-			if(error == 0) error = hal_param_float_newf(HAL_RW, &(device->RS485_DacAdc[i].ADC_0_scale), comp_id, "gm.%1d.rs485.%02d.adc-scale-0", boardId, i);
-			if(error == 0) error = hal_param_float_newf(HAL_RW, &(device->RS485_DacAdc[i].ADC_1_scale), comp_id, "gm.%1d.rs485.%02d.adc-scale-1", boardId, i);
-			if(error == 0) error = hal_param_float_newf(HAL_RW, &(device->RS485_DacAdc[i].ADC_2_scale), comp_id, "gm.%1d.rs485.%02d.adc-scale-2", boardId, i);
-			if(error == 0) error = hal_param_float_newf(HAL_RW, &(device->RS485_DacAdc[i].ADC_3_scale), comp_id, "gm.%1d.rs485.%02d.adc-scale-3", boardId, i);
-			if(error == 0) error = hal_param_float_newf(HAL_RW, &(device->RS485_DacAdc[i].ADC_4_scale), comp_id, "gm.%1d.rs485.%02d.adc-scale-4", boardId, i);
-			if(error == 0) error = hal_param_float_newf(HAL_RW, &(device->RS485_DacAdc[i].ADC_5_scale), comp_id, "gm.%1d.rs485.%02d.adc-scale-5", boardId, i);
-			if(error == 0) error = hal_param_float_newf(HAL_RW, &(device->RS485_DacAdc[i].ADC_6_scale), comp_id, "gm.%1d.rs485.%02d.adc-scale-6", boardId, i);
-			if(error == 0) error = hal_param_float_newf(HAL_RW, &(device->RS485_DacAdc[i].ADC_7_scale), comp_id, "gm.%1d.rs485.%02d.adc-scale-7", boardId, i);	
-			
-			device->RS485_DacAdc[i].DAC_0_max = 10;
-			device->RS485_DacAdc[i].DAC_0_min = -10;
-			device->RS485_DacAdc[i].DAC_1_max = 10;
-			device->RS485_DacAdc[i].DAC_1_min = -10;
-			device->RS485_DacAdc[i].DAC_2_max = 10;
-			device->RS485_DacAdc[i].DAC_2_min = -10;
-			device->RS485_DacAdc[i].DAC_3_max = 10;
-			device->RS485_DacAdc[i].DAC_3_min = -10;
-			device->RS485_DacAdc[i].ADC_0_scale = 1;
-			device->RS485_DacAdc[i].ADC_1_scale = 1;
-			device->RS485_DacAdc[i].ADC_2_scale = 1;
-			device->RS485_DacAdc[i].ADC_3_scale = 1;
-			device->RS485_DacAdc[i].ADC_4_scale = 1;
-			device->RS485_DacAdc[i].ADC_5_scale = 1;
-			device->RS485_DacAdc[i].ADC_6_scale = 1;
-			device->RS485_DacAdc[i].ADC_7_scale = 1;
-		    break;		    
+			if(error == 0) error = hal_pin_new_real(comp_id, HAL_IN, &(device->RS485_DacAdc[i].DAC_0), 0.0, "gm.%1d.rs485.%02d.dac-0", boardId, i);
+			if(error == 0) error = hal_pin_new_real(comp_id, HAL_IN, &(device->RS485_DacAdc[i].DAC_1), 0.0, "gm.%1d.rs485.%02d.dac-1", boardId, i);
+			if(error == 0) error = hal_pin_new_real(comp_id, HAL_IN, &(device->RS485_DacAdc[i].DAC_2), 0.0, "gm.%1d.rs485.%02d.dac-2", boardId, i);
+			if(error == 0) error = hal_pin_new_real(comp_id, HAL_IN, &(device->RS485_DacAdc[i].DAC_3), 0.0, "gm.%1d.rs485.%02d.dac-3", boardId, i);
+			if(error == 0) error = hal_pin_new_bool(comp_id, HAL_IN, &(device->RS485_DacAdc[i].dac_0_enable), 0, "gm.%1d.rs485.%02d.dac-enable-0", boardId, i);
+			if(error == 0) error = hal_pin_new_bool(comp_id, HAL_IN, &(device->RS485_DacAdc[i].dac_1_enable), 0, "gm.%1d.rs485.%02d.dac-enable-1", boardId, i);
+			if(error == 0) error = hal_pin_new_bool(comp_id, HAL_IN, &(device->RS485_DacAdc[i].dac_2_enable), 0, "gm.%1d.rs485.%02d.dac-enable-2", boardId, i);
+			if(error == 0) error = hal_pin_new_bool(comp_id, HAL_IN, &(device->RS485_DacAdc[i].dac_3_enable), 0, "gm.%1d.rs485.%02d.dac-enable-3", boardId, i);
+			if(error == 0) error = hal_pin_new_real(comp_id, HAL_OUT, &(device->RS485_DacAdc[i].ADC_0), 0.0, "gm.%1d.rs485.%02d.adc-0", boardId, i);
+			if(error == 0) error = hal_pin_new_real(comp_id, HAL_OUT, &(device->RS485_DacAdc[i].ADC_1), 0.0, "gm.%1d.rs485.%02d.adc-1", boardId, i);
+			if(error == 0) error = hal_pin_new_real(comp_id, HAL_OUT, &(device->RS485_DacAdc[i].ADC_2), 0.0, "gm.%1d.rs485.%02d.adc-2", boardId, i);
+			if(error == 0) error = hal_pin_new_real(comp_id, HAL_OUT, &(device->RS485_DacAdc[i].ADC_3), 0.0, "gm.%1d.rs485.%02d.adc-3", boardId, i);
+			if(error == 0) error = hal_pin_new_real(comp_id, HAL_OUT, &(device->RS485_DacAdc[i].ADC_4), 0.0, "gm.%1d.rs485.%02d.adc-4", boardId, i);
+			if(error == 0) error = hal_pin_new_real(comp_id, HAL_OUT, &(device->RS485_DacAdc[i].ADC_5), 0.0, "gm.%1d.rs485.%02d.adc-5", boardId, i);
+			if(error == 0) error = hal_pin_new_real(comp_id, HAL_OUT, &(device->RS485_DacAdc[i].ADC_6), 0.0, "gm.%1d.rs485.%02d.adc-6", boardId, i);
+			if(error == 0) error = hal_pin_new_real(comp_id, HAL_OUT, &(device->RS485_DacAdc[i].ADC_7), 0.0, "gm.%1d.rs485.%02d.adc-7", boardId, i);
+			if(error == 0) error = hal_param_new_real(comp_id, HAL_RW, &(device->RS485_DacAdc[i].DAC_0_offset), 0.0, "gm.%1d.rs485.%02d.dac-offset-0", boardId, i);
+			if(error == 0) error = hal_param_new_real(comp_id, HAL_RW, &(device->RS485_DacAdc[i].DAC_1_offset), 0.0, "gm.%1d.rs485.%02d.dac-offset-1", boardId, i);
+			if(error == 0) error = hal_param_new_real(comp_id, HAL_RW, &(device->RS485_DacAdc[i].DAC_2_offset), 0.0, "gm.%1d.rs485.%02d.dac-offset-2", boardId, i);
+			if(error == 0) error = hal_param_new_real(comp_id, HAL_RW, &(device->RS485_DacAdc[i].DAC_3_offset), 0.0, "gm.%1d.rs485.%02d.dac-offset-3", boardId, i);
+			if(error == 0) error = hal_param_new_real(comp_id, HAL_RW, &(device->RS485_DacAdc[i].DAC_0_max), 10.0, "gm.%1d.rs485.%02d.dac-high-limit-0", boardId, i);
+			if(error == 0) error = hal_param_new_real(comp_id, HAL_RW, &(device->RS485_DacAdc[i].DAC_1_max), 10.0, "gm.%1d.rs485.%02d.dac-high-limit-1", boardId, i);
+			if(error == 0) error = hal_param_new_real(comp_id, HAL_RW, &(device->RS485_DacAdc[i].DAC_2_max), 10.0, "gm.%1d.rs485.%02d.dac-high-limit-2", boardId, i);
+			if(error == 0) error = hal_param_new_real(comp_id, HAL_RW, &(device->RS485_DacAdc[i].DAC_3_max), 10.0, "gm.%1d.rs485.%02d.dac-high-limit-3", boardId, i);
+			if(error == 0) error = hal_param_new_real(comp_id, HAL_RW, &(device->RS485_DacAdc[i].DAC_0_min), -10.0, "gm.%1d.rs485.%02d.dac-low-limit-0", boardId, i);
+			if(error == 0) error = hal_param_new_real(comp_id, HAL_RW, &(device->RS485_DacAdc[i].DAC_1_min), -10.0, "gm.%1d.rs485.%02d.dac-low-limit-1", boardId, i);
+			if(error == 0) error = hal_param_new_real(comp_id, HAL_RW, &(device->RS485_DacAdc[i].DAC_2_min), -10.0, "gm.%1d.rs485.%02d.dac-low-limit-2", boardId, i);
+			if(error == 0) error = hal_param_new_real(comp_id, HAL_RW, &(device->RS485_DacAdc[i].DAC_3_min), -10.0, "gm.%1d.rs485.%02d.dac-low-limit-3", boardId, i);
+			if(error == 0) error = hal_param_new_real(comp_id, HAL_RW, &(device->RS485_DacAdc[i].ADC_0_offset), 0.0, "gm.%1d.rs485.%02d.adc-offset-0", boardId, i);
+			if(error == 0) error = hal_param_new_real(comp_id, HAL_RW, &(device->RS485_DacAdc[i].ADC_1_offset), 0.0, "gm.%1d.rs485.%02d.adc-offset-1", boardId, i);
+			if(error == 0) error = hal_param_new_real(comp_id, HAL_RW, &(device->RS485_DacAdc[i].ADC_2_offset), 0.0, "gm.%1d.rs485.%02d.adc-offset-2", boardId, i);
+			if(error == 0) error = hal_param_new_real(comp_id, HAL_RW, &(device->RS485_DacAdc[i].ADC_3_offset), 0.0, "gm.%1d.rs485.%02d.adc-offset-3", boardId, i);
+			if(error == 0) error = hal_param_new_real(comp_id, HAL_RW, &(device->RS485_DacAdc[i].ADC_4_offset), 0.0, "gm.%1d.rs485.%02d.adc-offset-4", boardId, i);
+			if(error == 0) error = hal_param_new_real(comp_id, HAL_RW, &(device->RS485_DacAdc[i].ADC_5_offset), 0.0, "gm.%1d.rs485.%02d.adc-offset-5", boardId, i);
+			if(error == 0) error = hal_param_new_real(comp_id, HAL_RW, &(device->RS485_DacAdc[i].ADC_6_offset), 0.0, "gm.%1d.rs485.%02d.adc-offset-6", boardId, i);
+			if(error == 0) error = hal_param_new_real(comp_id, HAL_RW, &(device->RS485_DacAdc[i].ADC_7_offset), 0.0, "gm.%1d.rs485.%02d.adc-offset-7", boardId, i);
+			if(error == 0) error = hal_param_new_real(comp_id, HAL_RW, &(device->RS485_DacAdc[i].ADC_0_scale), 1.0, "gm.%1d.rs485.%02d.adc-scale-0", boardId, i);
+			if(error == 0) error = hal_param_new_real(comp_id, HAL_RW, &(device->RS485_DacAdc[i].ADC_1_scale), 1.0, "gm.%1d.rs485.%02d.adc-scale-1", boardId, i);
+			if(error == 0) error = hal_param_new_real(comp_id, HAL_RW, &(device->RS485_DacAdc[i].ADC_2_scale), 1.0, "gm.%1d.rs485.%02d.adc-scale-2", boardId, i);
+			if(error == 0) error = hal_param_new_real(comp_id, HAL_RW, &(device->RS485_DacAdc[i].ADC_3_scale), 1.0, "gm.%1d.rs485.%02d.adc-scale-3", boardId, i);
+			if(error == 0) error = hal_param_new_real(comp_id, HAL_RW, &(device->RS485_DacAdc[i].ADC_4_scale), 1.0, "gm.%1d.rs485.%02d.adc-scale-4", boardId, i);
+			if(error == 0) error = hal_param_new_real(comp_id, HAL_RW, &(device->RS485_DacAdc[i].ADC_5_scale), 1.0, "gm.%1d.rs485.%02d.adc-scale-5", boardId, i);
+			if(error == 0) error = hal_param_new_real(comp_id, HAL_RW, &(device->RS485_DacAdc[i].ADC_6_scale), 1.0, "gm.%1d.rs485.%02d.adc-scale-6", boardId, i);
+			if(error == 0) error = hal_param_new_real(comp_id, HAL_RW, &(device->RS485_DacAdc[i].ADC_7_scale), 1.0, "gm.%1d.rs485.%02d.adc-scale-7", boardId, i);
+		    break;
 		    case RS485MODUL_ID_TEACHPAD:
 			device-> RS485_mgr.BYTES_TO_WRITE[i]=0;
-			device-> RS485_mgr.BYTES_TO_READ[i]=12;	//1 for 8 digit input, 6 for adc, 4 for encoder + 1 Checksum		
-			
-			if(error == 0) error = hal_pin_bit_newf(HAL_OUT, &(device->RS485_TeachPad[i].in_0), comp_id, "gm.%1d.rs485.%02d.in-0", boardId, i);
-			if(error == 0) error = hal_pin_bit_newf(HAL_OUT, &(device->RS485_TeachPad[i].inNot_0), comp_id, "gm.%1d.rs485.%02d.in-not-0", boardId, i);
-			if(error == 0) error = hal_pin_bit_newf(HAL_OUT, &(device->RS485_TeachPad[i].in_1), comp_id, "gm.%1d.rs485.%02d.in-1", boardId, i);
-			if(error == 0) error = hal_pin_bit_newf(HAL_OUT, &(device->RS485_TeachPad[i].inNot_1), comp_id, "gm.%1d.rs485.%02d.in-not-1", boardId, i);
-			if(error == 0) error = hal_pin_bit_newf(HAL_OUT, &(device->RS485_TeachPad[i].in_2), comp_id, "gm.%1d.rs485.%02d.in-2", boardId, i);
-			if(error == 0) error = hal_pin_bit_newf(HAL_OUT, &(device->RS485_TeachPad[i].inNot_2), comp_id, "gm.%1d.rs485.%02d.in-not-2", boardId, i);
-			if(error == 0) error = hal_pin_bit_newf(HAL_OUT, &(device->RS485_TeachPad[i].in_3), comp_id, "gm.%1d.rs485.%02d.in-3", boardId, i);
-			if(error == 0) error = hal_pin_bit_newf(HAL_OUT, &(device->RS485_TeachPad[i].inNot_3), comp_id, "gm.%1d.rs485.%02d.in-not-3", boardId, i);
-			if(error == 0) error = hal_pin_bit_newf(HAL_OUT, &(device->RS485_TeachPad[i].in_4), comp_id, "gm.%1d.rs485.%02d.in-4", boardId, i);
-			if(error == 0) error = hal_pin_bit_newf(HAL_OUT, &(device->RS485_TeachPad[i].inNot_4), comp_id, "gm.%1d.rs485.%02d.in-not-4", boardId, i);
-			if(error == 0) error = hal_pin_bit_newf(HAL_OUT, &(device->RS485_TeachPad[i].in_5), comp_id, "gm.%1d.rs485.%02d.in-5", boardId, i);
-			if(error == 0) error = hal_pin_bit_newf(HAL_OUT, &(device->RS485_TeachPad[i].inNot_5), comp_id, "gm.%1d.rs485.%02d.in-not-5", boardId, i);
-			if(error == 0) error = hal_pin_bit_newf(HAL_OUT, &(device->RS485_TeachPad[i].in_6), comp_id, "gm.%1d.rs485.%02d.in-6", boardId, i);
-			if(error == 0) error = hal_pin_bit_newf(HAL_OUT, &(device->RS485_TeachPad[i].inNot_6), comp_id, "gm.%1d.rs485.%02d.in-not-6", boardId, i);
-			if(error == 0) error = hal_pin_bit_newf(HAL_OUT, &(device->RS485_TeachPad[i].in_7), comp_id, "gm.%1d.rs485.%02d.in-7", boardId, i);
-			if(error == 0) error = hal_pin_bit_newf(HAL_OUT, &(device->RS485_TeachPad[i].inNot_7), comp_id, "gm.%1d.rs485.%02d.in-not-7", boardId, i);	
+			device-> RS485_mgr.BYTES_TO_READ[i]=12;	//1 for 8 digit input, 6 for adc, 4 for encoder + 1 Checksum
 
-			if(error == 0) error = hal_pin_float_newf(HAL_OUT, &(device->RS485_TeachPad[i].ADC_0), comp_id, "gm.%1d.rs485.%02d.adc-0", boardId, i);
-			if(error == 0) error = hal_pin_float_newf(HAL_OUT, &(device->RS485_TeachPad[i].ADC_1), comp_id, "gm.%1d.rs485.%02d.adc-1", boardId, i);      
-			if(error == 0) error = hal_pin_float_newf(HAL_OUT, &(device->RS485_TeachPad[i].ADC_2), comp_id, "gm.%1d.rs485.%02d.adc-2", boardId, i);      
-			if(error == 0) error = hal_pin_float_newf(HAL_OUT, &(device->RS485_TeachPad[i].ADC_3), comp_id, "gm.%1d.rs485.%02d.adc-3", boardId, i);        
-			if(error == 0) error = hal_pin_float_newf(HAL_OUT, &(device->RS485_TeachPad[i].ADC_4), comp_id, "gm.%1d.rs485.%02d.adc-4", boardId, i);
-			if(error == 0) error = hal_pin_float_newf(HAL_OUT, &(device->RS485_TeachPad[i].ADC_5), comp_id, "gm.%1d.rs485.%02d.adc-5", boardId, i);  
-			
-			if(error == 0) error = hal_param_float_newf(HAL_RW, &(device->RS485_TeachPad[i].ADC_0_offset), comp_id, "gm.%1d.rs485.%02d.adc-offset-0", boardId, i);
-			if(error == 0) error = hal_param_float_newf(HAL_RW, &(device->RS485_TeachPad[i].ADC_1_offset), comp_id, "gm.%1d.rs485.%02d.adc-offset-1", boardId, i);
-			if(error == 0) error = hal_param_float_newf(HAL_RW, &(device->RS485_TeachPad[i].ADC_2_offset), comp_id, "gm.%1d.rs485.%02d.adc-offset-2", boardId, i);
-			if(error == 0) error = hal_param_float_newf(HAL_RW, &(device->RS485_TeachPad[i].ADC_3_offset), comp_id, "gm.%1d.rs485.%02d.adc-offset-3", boardId, i);
-			if(error == 0) error = hal_param_float_newf(HAL_RW, &(device->RS485_TeachPad[i].ADC_4_offset), comp_id, "gm.%1d.rs485.%02d.adc-offset-4", boardId, i);
-			if(error == 0) error = hal_param_float_newf(HAL_RW, &(device->RS485_TeachPad[i].ADC_5_offset), comp_id, "gm.%1d.rs485.%02d.adc-offset-5", boardId, i);
-			
-			if(error == 0) error = hal_param_float_newf(HAL_RW, &(device->RS485_TeachPad[i].ADC_0_scale), comp_id, "gm.%1d.rs485.%02d.adc-scale-0", boardId, i);
-			if(error == 0) error = hal_param_float_newf(HAL_RW, &(device->RS485_TeachPad[i].ADC_1_scale), comp_id, "gm.%1d.rs485.%02d.adc-scale-1", boardId, i);
-			if(error == 0) error = hal_param_float_newf(HAL_RW, &(device->RS485_TeachPad[i].ADC_2_scale), comp_id, "gm.%1d.rs485.%02d.adc-scale-2", boardId, i);
-			if(error == 0) error = hal_param_float_newf(HAL_RW, &(device->RS485_TeachPad[i].ADC_3_scale), comp_id, "gm.%1d.rs485.%02d.adc-scale-3", boardId, i);
-			if(error == 0) error = hal_param_float_newf(HAL_RW, &(device->RS485_TeachPad[i].ADC_4_scale), comp_id, "gm.%1d.rs485.%02d.adc-scale-4", boardId, i);
-			if(error == 0) error = hal_param_float_newf(HAL_RW, &(device->RS485_TeachPad[i].ADC_5_scale), comp_id, "gm.%1d.rs485.%02d.adc-scale-5", boardId, i);
-			
-			if(error == 0) error = hal_pin_bit_newf(HAL_IN, &(device->RS485_TeachPad[i].enc_reset), comp_id, "gm.%1d.rs485.%02d.enc-reset", boardId, i);
-			if(error == 0) error = hal_pin_s32_newf(HAL_OUT, &(device->RS485_TeachPad[i].enc_counts), comp_id, "gm.%1d.rs485.%02d.enc-counts", boardId, i);
-			if(error == 0) error = hal_pin_float_newf(HAL_OUT, &(device->RS485_TeachPad[i].enc_position), comp_id, "gm.%1d.rs485.%02d.enc-position", boardId, i);
-			if(error == 0) error = hal_pin_s32_newf(HAL_OUT, &(device->RS485_TeachPad[i].enc_rawcounts), comp_id, "gm.%1d.rs485.%02d.enc-rawcounts", boardId, i);
-			if(error == 0) error = hal_param_float_newf(HAL_RW, &(device->RS485_TeachPad[i].enc_position_scale), comp_id, "gm.%1d.rs485.%02d.enc-position-scale", boardId, i);
-			
-			device->RS485_TeachPad[i].ADC_0_scale = 1;
-			device->RS485_TeachPad[i].ADC_1_scale = 1;
-			device->RS485_TeachPad[i].ADC_2_scale = 1;
-			device->RS485_TeachPad[i].ADC_3_scale = 1;
-			device->RS485_TeachPad[i].ADC_4_scale = 1;
-			device->RS485_TeachPad[i].ADC_5_scale = 1;
-			
-			device->RS485_TeachPad[i].ADC_0_offset = 0;
-			device->RS485_TeachPad[i].ADC_1_offset = 0;
-			device->RS485_TeachPad[i].ADC_2_offset = 0;
-			device->RS485_TeachPad[i].ADC_3_offset = 0;
-			device->RS485_TeachPad[i].ADC_4_offset = 0;
-			device->RS485_TeachPad[i].ADC_5_offset = 0;
-			
+			if(error == 0) error = hal_pin_new_bool(comp_id, HAL_OUT, &(device->RS485_TeachPad[i].in_0), 0, "gm.%1d.rs485.%02d.in-0", boardId, i);
+			if(error == 0) error = hal_pin_new_bool(comp_id, HAL_OUT, &(device->RS485_TeachPad[i].inNot_0), 1, "gm.%1d.rs485.%02d.in-not-0", boardId, i);
+			if(error == 0) error = hal_pin_new_bool(comp_id, HAL_OUT, &(device->RS485_TeachPad[i].in_1), 0, "gm.%1d.rs485.%02d.in-1", boardId, i);
+			if(error == 0) error = hal_pin_new_bool(comp_id, HAL_OUT, &(device->RS485_TeachPad[i].inNot_1), 1, "gm.%1d.rs485.%02d.in-not-1", boardId, i);
+			if(error == 0) error = hal_pin_new_bool(comp_id, HAL_OUT, &(device->RS485_TeachPad[i].in_2), 0, "gm.%1d.rs485.%02d.in-2", boardId, i);
+			if(error == 0) error = hal_pin_new_bool(comp_id, HAL_OUT, &(device->RS485_TeachPad[i].inNot_2), 1, "gm.%1d.rs485.%02d.in-not-2", boardId, i);
+			if(error == 0) error = hal_pin_new_bool(comp_id, HAL_OUT, &(device->RS485_TeachPad[i].in_3), 0, "gm.%1d.rs485.%02d.in-3", boardId, i);
+			if(error == 0) error = hal_pin_new_bool(comp_id, HAL_OUT, &(device->RS485_TeachPad[i].inNot_3), 1, "gm.%1d.rs485.%02d.in-not-3", boardId, i);
+			if(error == 0) error = hal_pin_new_bool(comp_id, HAL_OUT, &(device->RS485_TeachPad[i].in_4), 0, "gm.%1d.rs485.%02d.in-4", boardId, i);
+			if(error == 0) error = hal_pin_new_bool(comp_id, HAL_OUT, &(device->RS485_TeachPad[i].inNot_4), 1, "gm.%1d.rs485.%02d.in-not-4", boardId, i);
+			if(error == 0) error = hal_pin_new_bool(comp_id, HAL_OUT, &(device->RS485_TeachPad[i].in_5), 0, "gm.%1d.rs485.%02d.in-5", boardId, i);
+			if(error == 0) error = hal_pin_new_bool(comp_id, HAL_OUT, &(device->RS485_TeachPad[i].inNot_5), 1, "gm.%1d.rs485.%02d.in-not-5", boardId, i);
+			if(error == 0) error = hal_pin_new_bool(comp_id, HAL_OUT, &(device->RS485_TeachPad[i].in_6), 0, "gm.%1d.rs485.%02d.in-6", boardId, i);
+			if(error == 0) error = hal_pin_new_bool(comp_id, HAL_OUT, &(device->RS485_TeachPad[i].inNot_6), 1, "gm.%1d.rs485.%02d.in-not-6", boardId, i);
+			if(error == 0) error = hal_pin_new_bool(comp_id, HAL_OUT, &(device->RS485_TeachPad[i].in_7), 0, "gm.%1d.rs485.%02d.in-7", boardId, i);
+			if(error == 0) error = hal_pin_new_bool(comp_id, HAL_OUT, &(device->RS485_TeachPad[i].inNot_7), 1, "gm.%1d.rs485.%02d.in-not-7", boardId, i);
+
+			if(error == 0) error = hal_pin_new_real(comp_id, HAL_OUT, &(device->RS485_TeachPad[i].ADC_0), 0.0, "gm.%1d.rs485.%02d.adc-0", boardId, i);
+			if(error == 0) error = hal_pin_new_real(comp_id, HAL_OUT, &(device->RS485_TeachPad[i].ADC_1), 0.0, "gm.%1d.rs485.%02d.adc-1", boardId, i);
+			if(error == 0) error = hal_pin_new_real(comp_id, HAL_OUT, &(device->RS485_TeachPad[i].ADC_2), 0.0, "gm.%1d.rs485.%02d.adc-2", boardId, i);
+			if(error == 0) error = hal_pin_new_real(comp_id, HAL_OUT, &(device->RS485_TeachPad[i].ADC_3), 0.0, "gm.%1d.rs485.%02d.adc-3", boardId, i);
+			if(error == 0) error = hal_pin_new_real(comp_id, HAL_OUT, &(device->RS485_TeachPad[i].ADC_4), 0.0, "gm.%1d.rs485.%02d.adc-4", boardId, i);
+			if(error == 0) error = hal_pin_new_real(comp_id, HAL_OUT, &(device->RS485_TeachPad[i].ADC_5), 0.0, "gm.%1d.rs485.%02d.adc-5", boardId, i);
+
+			if(error == 0) error = hal_param_new_real(comp_id, HAL_RW, &(device->RS485_TeachPad[i].ADC_0_offset), 0.0, "gm.%1d.rs485.%02d.adc-offset-0", boardId, i);
+			if(error == 0) error = hal_param_new_real(comp_id, HAL_RW, &(device->RS485_TeachPad[i].ADC_1_offset), 0.0, "gm.%1d.rs485.%02d.adc-offset-1", boardId, i);
+			if(error == 0) error = hal_param_new_real(comp_id, HAL_RW, &(device->RS485_TeachPad[i].ADC_2_offset), 0.0, "gm.%1d.rs485.%02d.adc-offset-2", boardId, i);
+			if(error == 0) error = hal_param_new_real(comp_id, HAL_RW, &(device->RS485_TeachPad[i].ADC_3_offset), 0.0, "gm.%1d.rs485.%02d.adc-offset-3", boardId, i);
+			if(error == 0) error = hal_param_new_real(comp_id, HAL_RW, &(device->RS485_TeachPad[i].ADC_4_offset), 0.0, "gm.%1d.rs485.%02d.adc-offset-4", boardId, i);
+			if(error == 0) error = hal_param_new_real(comp_id, HAL_RW, &(device->RS485_TeachPad[i].ADC_5_offset), 0.0, "gm.%1d.rs485.%02d.adc-offset-5", boardId, i);
+
+			if(error == 0) error = hal_param_new_real(comp_id, HAL_RW, &(device->RS485_TeachPad[i].ADC_0_scale), 1.0, "gm.%1d.rs485.%02d.adc-scale-0", boardId, i);
+			if(error == 0) error = hal_param_new_real(comp_id, HAL_RW, &(device->RS485_TeachPad[i].ADC_1_scale), 1.0, "gm.%1d.rs485.%02d.adc-scale-1", boardId, i);
+			if(error == 0) error = hal_param_new_real(comp_id, HAL_RW, &(device->RS485_TeachPad[i].ADC_2_scale), 1.0, "gm.%1d.rs485.%02d.adc-scale-2", boardId, i);
+			if(error == 0) error = hal_param_new_real(comp_id, HAL_RW, &(device->RS485_TeachPad[i].ADC_3_scale), 1.0, "gm.%1d.rs485.%02d.adc-scale-3", boardId, i);
+			if(error == 0) error = hal_param_new_real(comp_id, HAL_RW, &(device->RS485_TeachPad[i].ADC_4_scale), 1.0, "gm.%1d.rs485.%02d.adc-scale-4", boardId, i);
+			if(error == 0) error = hal_param_new_real(comp_id, HAL_RW, &(device->RS485_TeachPad[i].ADC_5_scale), 1.0, "gm.%1d.rs485.%02d.adc-scale-5", boardId, i);
+
+			if(error == 0) error = hal_pin_new_bool(comp_id, HAL_IN, &(device->RS485_TeachPad[i].enc_reset), 0, "gm.%1d.rs485.%02d.enc-reset", boardId, i);
+			if(error == 0) error = hal_pin_new_si32(comp_id, HAL_OUT, &(device->RS485_TeachPad[i].enc_counts), 0, "gm.%1d.rs485.%02d.enc-counts", boardId, i);
+			if(error == 0) error = hal_pin_new_real(comp_id, HAL_OUT, &(device->RS485_TeachPad[i].enc_position), 0.0, "gm.%1d.rs485.%02d.enc-position", boardId, i);
+			if(error == 0) error = hal_pin_new_si32(comp_id, HAL_OUT, &(device->RS485_TeachPad[i].enc_rawcounts), 0, "gm.%1d.rs485.%02d.enc-rawcounts", boardId, i);
+			if(error == 0) error = hal_param_new_real(comp_id, HAL_RW, &(device->RS485_TeachPad[i].enc_position_scale), 1.0, "gm.%1d.rs485.%02d.enc-position-scale", boardId, i);
+
 			device->RS485_TeachPad[i].enc_raw_offset = 0;
-			device->RS485_TeachPad[i].enc_position_scale=1;
 		    break;
 		    default:
 			rtapi_print_msg(RTAPI_MSG_ERR, "General Mechatronics: ERROR, unknown rs485 module type.\nPlease, download the latest driver.\n");
 		}
-	    } 
+	    }
 	    break;
 	  default:
 	    rtapi_print_msg(RTAPI_MSG_ERR, "General Mechatronics: ERROR, unknown rs485 version.\nPlease, download the latest driver.\n");
@@ -1013,7 +986,7 @@ ExportCAN(void *arg, int comp_id, int version)
 	  case notPresented:
 	    for(i=0;i<6;i++)
 	      {
-		device->CAN_GM[i].enable = &(device->cardMgr.disable); //Set enable pointers to a 0 value variable
+		device->CAN_GM[i].enable = (hal_bool_t)&(device->cardMgr.disable); //Set enable pointers to a 0 value variable
 	      }	 
 	    rtapi_print_msg(RTAPI_MSG_WARN, "General Mechatronics: No CAN module available in this version of the Card.\n");
 	    break;
@@ -1023,12 +996,12 @@ ExportCAN(void *arg, int comp_id, int version)
 	    for(i=0;i<6;i++)
 	    {
 	       //Export Pins
-		  if(error == 0) error = hal_pin_bit_newf(HAL_IN, &(device->CAN_GM[i].enable), comp_id, "gm.%1d.can-gm.%1d.enable", boardId, i);
-		  if(error == 0) error = hal_pin_float_newf(HAL_IN, &(device->CAN_GM[i].position_cmd), comp_id, "gm.%1d.can-gm.%1d.position-cmd", boardId, i);
-		  if(error == 0) error = hal_pin_float_newf(HAL_OUT, &(device->CAN_GM[i].position_fb), comp_id, "gm.%1d.can-gm.%1d.position-fb", boardId, i);
+		  if(error == 0) error = hal_pin_new_bool(comp_id, HAL_IN, &(device->CAN_GM[i].enable), 0, "gm.%1d.can-gm.%1d.enable", boardId, i);
+		  if(error == 0) error = hal_pin_new_real(comp_id, HAL_IN, &(device->CAN_GM[i].position_cmd), 0.0, "gm.%1d.can-gm.%1d.position-cmd", boardId, i);
+		  if(error == 0) error = hal_pin_new_real(comp_id, HAL_OUT, &(device->CAN_GM[i].position_fb), 0.0, "gm.%1d.can-gm.%1d.position-fb", boardId, i);
 		  
 	       //Export Parameters
-		  if(error == 0) error = hal_param_float_newf(HAL_RW, &(device->CAN_GM[i].position_scale), comp_id, "gm.%1d.can-gm.%1d.position-scale", boardId, i);
+		  if(error == 0) error = hal_param_new_real(comp_id, HAL_RW, &(device->CAN_GM[i].position_scale), 0.0, "gm.%1d.can-gm.%1d.position-scale", boardId, i);
 	    }
 	    
 	    //Export Pins and Parameters for CANopen Servo Controllers
@@ -1052,41 +1025,41 @@ ExportMixed(void *arg, int comp_id)
 	for(i = 0; i < 6; i++)
 	{	
 		// Pins
-		if(error == 0) error = hal_pin_bit_newf(HAL_OUT, &(device->switches[i].home), comp_id, "gm.%1d.axis.%1d.home-sw-in", boardId, i);
-		if(error == 0) error = hal_pin_bit_newf(HAL_OUT, &(device->switches[i].homeNot), comp_id, "gm.%1d.axis.%1d.home-sw-in-not", boardId, i);
-		if(error == 0) error = hal_pin_bit_newf(HAL_OUT, &(device->switches[i].posLimSwIn), comp_id, "gm.%1d.axis.%1d.pos-lim-sw-in", boardId, i);
-		if(error == 0) error = hal_pin_bit_newf(HAL_OUT, &(device->switches[i].posLimSwInNot), comp_id, "gm.%1d.axis.%1d.pos-lim-sw-in-not", boardId, i);
-		if(error == 0) error = hal_pin_bit_newf(HAL_OUT, &(device->switches[i].negLimSwIn), comp_id, "gm.%1d.axis.%1d.neg-lim-sw-in", boardId, i);
-		if(error == 0) error = hal_pin_bit_newf(HAL_OUT, &(device->switches[i].negLimSwInNot), comp_id, "gm.%1d.axis.%1d.neg-lim-sw-in-not", boardId, i);
+		if(error == 0) error = hal_pin_new_bool(comp_id, HAL_OUT, &(device->switches[i].home), 0, "gm.%1d.axis.%1d.home-sw-in", boardId, i);
+		if(error == 0) error = hal_pin_new_bool(comp_id, HAL_OUT, &(device->switches[i].homeNot), 0, "gm.%1d.axis.%1d.home-sw-in-not", boardId, i);
+		if(error == 0) error = hal_pin_new_bool(comp_id, HAL_OUT, &(device->switches[i].posLimSwIn), 0, "gm.%1d.axis.%1d.pos-lim-sw-in", boardId, i);
+		if(error == 0) error = hal_pin_new_bool(comp_id, HAL_OUT, &(device->switches[i].posLimSwInNot), 0, "gm.%1d.axis.%1d.pos-lim-sw-in-not", boardId, i);
+		if(error == 0) error = hal_pin_new_bool(comp_id, HAL_OUT, &(device->switches[i].negLimSwIn), 0, "gm.%1d.axis.%1d.neg-lim-sw-in", boardId, i);
+		if(error == 0) error = hal_pin_new_bool(comp_id, HAL_OUT, &(device->switches[i].negLimSwInNot), 0, "gm.%1d.axis.%1d.neg-lim-sw-in-not", boardId, i);
 	}
 
 	//Power bridge Fault and Error pins
-	if(error == 0) error = hal_pin_bit_newf(HAL_IN, &(device->cardMgr.power_enable), comp_id, "gm.%1d.power-enable", boardId);
-	if(error == 0) error = hal_pin_bit_newf(HAL_OUT, &(device->cardMgr.power_fault), comp_id, "gm.%1d.power-fault", boardId);
+	if(error == 0) error = hal_pin_new_bool(comp_id, HAL_IN, &(device->cardMgr.power_enable), 0, "gm.%1d.power-enable", boardId);
+	if(error == 0) error = hal_pin_new_bool(comp_id, HAL_OUT, &(device->cardMgr.power_fault), 0, "gm.%1d.power-fault", boardId);
 	
 	//Watchdog pins and parameters
-	if(error == 0) error = hal_param_bit_newf(HAL_RW, &(device->cardMgr.watchdog_enable), comp_id, "gm.%1d.watchdog-enable", boardId);
-	if(error == 0) error = hal_param_u32_newf(HAL_RW, &(device->cardMgr.watchdog_timeout_ns), comp_id, "gm.%1d.watchdog-timeout-ns", boardId);
-	if(error == 0) error = hal_pin_bit_newf(HAL_OUT, &(device->cardMgr.watchdog_expired), comp_id, "gm.%1d.watchdog-expired", boardId);
+	if(error == 0) error = hal_param_new_bool(comp_id, HAL_RW, &(device->cardMgr.watchdog_enable), 0, "gm.%1d.watchdog-enable", boardId);
+	if(error == 0) error = hal_param_new_ui32(comp_id, HAL_RW, &(device->cardMgr.watchdog_timeout_ns), 0, "gm.%1d.watchdog-timeout-ns", boardId);
+	if(error == 0) error = hal_pin_new_bool(comp_id, HAL_OUT, &(device->cardMgr.watchdog_expired), 0, "gm.%1d.watchdog-expired", boardId);
 		      
 	//Export pins and parameters for parallel IOs
 	for(i=0;i<4;i++)
 	{
 		for(j=0;j<8;j++)
 		{
-			if(error == 0) error = hal_pin_bit_newf(HAL_OUT, &(device->gpio[i*8+j].in), comp_id, "gm.%1d.gpio.%1d.in-%1d", boardId, i, j);	
-			if(error == 0) error = hal_pin_bit_newf(HAL_OUT, &(device->gpio[i*8+j].inNot), comp_id, "gm.%1d.gpio.%1d.in-not-%1d", boardId, i, j);		
-			if(error == 0) error = hal_pin_bit_newf(HAL_IN, &(device->gpio[i*8+j].out), comp_id, "gm.%1d.gpio.%1d.out-%1d", boardId, i, j);
-			if(error == 0) error = hal_param_bit_newf(HAL_RW, &(device->gpio[i*8+j].isOut), comp_id, "gm.%1d.gpio.%1d.is-out-%1d", boardId, i, j);
-			if(error == 0) error = hal_param_bit_newf(HAL_RW, &(device->gpio[i*8+j].invertOut), comp_id, "gm.%1d.gpio.%1d.invert-out-%1d", boardId, i, j);
+			if(error == 0) error = hal_pin_new_bool(comp_id, HAL_OUT, &(device->gpio[i*8+j].in), 0, "gm.%1d.gpio.%1d.in-%1d", boardId, i, j);	
+			if(error == 0) error = hal_pin_new_bool(comp_id, HAL_OUT, &(device->gpio[i*8+j].inNot), 1, "gm.%1d.gpio.%1d.in-not-%1d", boardId, i, j);		
+			if(error == 0) error = hal_pin_new_bool(comp_id, HAL_IN, &(device->gpio[i*8+j].out), 0, "gm.%1d.gpio.%1d.out-%1d", boardId, i, j);
+			if(error == 0) error = hal_param_new_bool(comp_id, HAL_RW, &(device->gpio[i*8+j].isOut), 0, "gm.%1d.gpio.%1d.is-out-%1d", boardId, i, j);
+			if(error == 0) error = hal_param_new_bool(comp_id, HAL_RW, &(device->gpio[i*8+j].invertOut), 0, "gm.%1d.gpio.%1d.invert-out-%1d", boardId, i, j);
 		}
 	}
 
 	//Export pins and parameters for estops
 	for(i=0;i<2;i++)
 	{
-		if(error == 0) error = hal_pin_bit_newf(HAL_OUT, &(device->estop[i].in), comp_id, "gm.%1d.estop.%1d.in", boardId, i);			
-		if(error == 0) error = hal_pin_bit_newf(HAL_OUT, &(device->estop[i].inNot), comp_id, "gm.%1d.estop.%1d.in-not", boardId, i);
+		if(error == 0) error = hal_pin_new_bool(comp_id, HAL_OUT, &(device->estop[i].in), 0, "gm.%1d.estop.%1d.in", boardId, i);			
+		if(error == 0) error = hal_pin_new_bool(comp_id, HAL_OUT, &(device->estop[i].inNot), 1, "gm.%1d.estop.%1d.in-not", boardId, i);
 	}
 	
 	device->cardMgr.cntr = 0; //Counter of executing card_mgr() function
@@ -1124,7 +1097,7 @@ read(void *arg, long period)
     	gm_device_t	*device = (gm_device_t *)arg;
     	card	*pCard = device->pCard;
 	unsigned int i;
-	hal_u32_t temp;
+	rtapi_u32 temp;
 
       //basic card functionality: watchdog, switches, estop
 	card_mgr(arg, period);
@@ -1133,8 +1106,8 @@ read(void *arg, long period)
 	temp=pCard->gpio;
     	for(i = 0; i < 32; i++)
 	{
-		*(device->gpio[i].in) = (hal_bit_t)((temp & ((unsigned int) 1 << i)) == 0 ? 0 : 1);
-		*(device->gpio[i].inNot) = (hal_bit_t)((temp & ((unsigned int) 1 << i)) == 0 ? 1 : 0);
+		hal_set_bool(device->gpio[i].in,    (temp & ((unsigned int) 1 << i)) == 0 ? 0 : 1);
+		hal_set_bool(device->gpio[i].inNot, (temp & ((unsigned int) 1 << i)) == 0 ? 1 : 0);
 	}
 
       //Read Encoders
@@ -1148,25 +1121,25 @@ write(void *arg, long period)
 	card	*pCard = device->pCard;
 
 	int		i, temp1=0, temp2=0;
-	hal_float_t	DAC[6];
-	hal_u32_t	DAC_INTEGER[6];
+	rtapi_real	DAC[6];
+	rtapi_u32	DAC_INTEGER[6];
 
 	//Refresh DAC values
 	  for(i=0;i<6;i++)
 	  {
-		if(*(device->axisdac[i].enable))
+		if(hal_get_bool(device->axisdac[i].enable))
 		{
-			if( (*(device->axisdac[i].value) + device->axisdac[i].offset) > device->axisdac[i].max)
+			if( (hal_get_real(device->axisdac[i].value) + hal_get_real(device->axisdac[i].offset)) > hal_get_real(device->axisdac[i].max))
 			{
-				DAC[i] = device->axisdac[i].max;
+				DAC[i] = hal_get_real(device->axisdac[i].max);
 			}
-			else if (  (*(device->axisdac[i].value) + device->axisdac[i].offset) < device->axisdac[i].min)
+			else if (  (hal_get_real(device->axisdac[i].value) + hal_get_real(device->axisdac[i].offset)) < hal_get_real(device->axisdac[i].min))
 			{
-				DAC[i] = device->axisdac[i].min;
+				DAC[i] = hal_get_real(device->axisdac[i].min);
 			}
 			else
 			{
-				DAC[i] =   (*(device->axisdac[i].value) + device->axisdac[i].offset);
+				DAC[i] =   (hal_get_real(device->axisdac[i].value) + hal_get_real(device->axisdac[i].offset));
 			}
 		}
 		else
@@ -1178,9 +1151,9 @@ write(void *arg, long period)
 		if(DAC[i] < 0) DAC[i] = 0;
 		else if (DAC[i] > 16383) DAC[i] = 16383;
 
-		DAC_INTEGER[i] = (hal_u32_t)(DAC[i]);
+		DAC_INTEGER[i] = (rtapi_u32)(DAC[i]);
 		
-		if(device->axisdac[i].invert_serial) DAC_INTEGER[i] |= 0x8000;
+		if(hal_get_bool(device->axisdac[i].invert_serial)) DAC_INTEGER[i] |= 0x8000;
 	  }
 	  pCard->DAC_0 = ((DAC_INTEGER[1] & 0xFFFF) << 16) | (DAC_INTEGER[0] & 0xFFFF);
 	  pCard->DAC_1 = ((DAC_INTEGER[3] & 0xFFFF) << 16) | (DAC_INTEGER[2] & 0xFFFF);
@@ -1196,8 +1169,8 @@ write(void *arg, long period)
 	  temp1 = 0;
 	  for(i = 0; i < 32; i++)
 	  {
-		if(device->gpio[i].isOut) temp1 |= 0x0001 << i;			//write gpio mask: 1=output, 0=input
-		if((*(device->gpio[i].out)) ^ (device->gpio[i].invertOut)) temp2 |= 0x0001 << i;	//write outputs
+		if(hal_get_bool(device->gpio[i].isOut)) temp1 |= 0x0001 << i;			//write gpio mask: 1=output, 0=input
+		if((hal_get_bool(device->gpio[i].out)) ^ hal_get_bool(device->gpio[i].invertOut)) temp2 |= 0x0001 << i;	//write outputs
 	  }
 	  pCard->gpioDir=temp1;
 	  pCard->gpio=temp2;
@@ -1214,9 +1187,9 @@ GM_CAN_SERVO(void *arg)
 {
 	gm_device_t	*device = (gm_device_t *)arg;
 
-	hal_u32_t	Rx_buf_cntr, Tx_buf_cntr;
-	hal_u32_t	i, temp=0;
-	hal_s32_t	posFb;
+	rtapi_u32	Rx_buf_cntr, Tx_buf_cntr;
+	rtapi_u32	i, temp=0;
+	rtapi_s32	posFb;
 	CANmsg_t	CAN_msg;
 
 	//Position references: ID 0x10 - 0x15
@@ -1224,7 +1197,7 @@ GM_CAN_SERVO(void *arg)
 
       //Do not run, if none of the GM CAN channels are enabled
 	for(i=0;i<6;i++){
-	  if(*(device->CAN_GM[i].enable) == 1) temp++;
+	  if(hal_get_bool(device->CAN_GM[i].enable)) temp++;
 	}
 	if(temp == 0) return;
 
@@ -1238,30 +1211,30 @@ GM_CAN_SERVO(void *arg)
 	  
 	  if((CAN_msg.ID >= 0x20) && (CAN_msg.ID <= 0x25))
 	  {
-	    if((device->CAN_GM[CAN_msg.ID - 0x20].position_scale<10e-6) && (device->CAN_GM[CAN_msg.ID - 0x20].position_scale>-10e-6))
+	    if((hal_get_real(device->CAN_GM[CAN_msg.ID - 0x20].position_scale)<10e-6) && (hal_get_real(device->CAN_GM[CAN_msg.ID - 0x20].position_scale)>-10e-6))
 	    {
-	      device->CAN_GM[CAN_msg.ID - 0x20].position_scale = 1;
+	      hal_set_real(device->CAN_GM[CAN_msg.ID - 0x20].position_scale, 1);
 	    }
 	     posFb = (CAN_msg.data[3] << 24) | (CAN_msg.data[2] << 16) | (CAN_msg.data[1] << 8) | CAN_msg.data[0];
-	     *(device->CAN_GM[CAN_msg.ID - 0x20].position_fb) = (hal_float_t)posFb / device->CAN_GM[CAN_msg.ID - 0x20].position_scale;
+	     hal_set_real(device->CAN_GM[CAN_msg.ID - 0x20].position_fb, (rtapi_real)posFb / hal_get_real(device->CAN_GM[CAN_msg.ID - 0x20].position_scale));
 	  }
 	}
 
       //Send reference
 	for(i=0;i<6;i++)
 	{
-	  if(*(device->CAN_GM[i].enable) == 1)
+	  if(hal_get_bool(device->CAN_GM[i].enable))
 	  {
 	    CAN_msg.RTR = 0; //Not a request frame
 	    CAN_msg.Ext = 0; //Standard ID
 	    CAN_msg.DLC = 4; //4 byte data
 	    CAN_msg.ID = 0x10 + i;
 
-	    if((device->CAN_GM[i].position_scale<10e-6) && (device->CAN_GM[i].position_scale>-10e-6))
+	    if((hal_get_real(device->CAN_GM[i].position_scale)<10e-6) && (hal_get_real(device->CAN_GM[i].position_scale)>-10e-6))
 	    {
-	      device->CAN_GM[i].position_scale = 1;
+	      hal_set_real(device->CAN_GM[i].position_scale, 1);
 	    }
-	    temp = (hal_u32_t)(*(device->CAN_GM[i].position_cmd) * device->CAN_GM[i].position_scale);
+	    temp = (rtapi_u32)(hal_get_real(device->CAN_GM[i].position_cmd) * hal_get_real(device->CAN_GM[i].position_scale));
 	    CAN_msg.data[0] = temp & 0xFF;
 	    CAN_msg.data[1] = (temp >> 8) & 0xFF;
 	    CAN_msg.data[2] = (temp >> 16) & 0xFF;
@@ -1276,12 +1249,12 @@ GM_CAN_SERVO(void *arg)
 	}  
 }
 static int
-CAN_ReadStatus(void *arg, hal_u32_t *RxCnt, hal_u32_t *TxCnt)
+CAN_ReadStatus(void *arg, rtapi_u32 *RxCnt, rtapi_u32 *TxCnt)
 {
 	gm_device_t	*device = (gm_device_t *)arg;
 	card	*pCard = device->pCard;
 	
-	hal_u32_t temp;  
+	rtapi_u32 temp;
 	
 	temp = pCard->CAN_status_reg;
 	*TxCnt = temp & 0x3FF;
@@ -1296,7 +1269,7 @@ CAN_ReceiveDataFrame(void *arg, CANmsg_t *Msg)
 	gm_device_t	*device = (gm_device_t *)arg;
 	card		*pCard = device->pCard;
 	
-	hal_u32_t	temp;
+	rtapi_u32	temp;
 	
 	temp = pCard->CAN_RX_buffer[0];
 	if(temp & 0x80000000)
@@ -1334,7 +1307,7 @@ CAN_SendDataFrame(void *arg, CANmsg_t *Msg)
 	gm_device_t	*device = (gm_device_t *)arg;
 	card		*pCard = device->pCard;
 	
-	hal_u32_t ID;
+	rtapi_u32 ID;
 	
 	ID = Msg->ID;//MsgID;
 	if(Msg->Ext) ID |= 0x80000000;
@@ -1359,7 +1332,7 @@ CAN_Reset(void *arg)
 }
 
 static void
-CAN_SetBaud(void *arg, hal_u32_t Baud)
+CAN_SetBaud(void *arg, rtapi_u32 Baud)
 {
   	gm_device_t		*device = (gm_device_t *)arg;
 	card	*pCard = device->pCard;
@@ -1401,42 +1374,42 @@ card_mgr(void *arg, long period)
 	gm_device_t		*device = (gm_device_t *)arg;
     	card	*pCard = device->pCard;
 	
-	hal_u32_t	temp=0, i, j;
+	rtapi_u32	temp=0, i, j;
 	
       //Read card status reg and process data
 	temp = pCard->card_status_reg; //This resets watch dog timer
 	
-	*(device->cardMgr.watchdog_expired) = 	(hal_bit_t)((temp & (0x0001 << 0)) == 0 ? 0 : 1);
-	*(device->cardMgr.power_fault) = 	(hal_bit_t)((temp & (0x0001 << 2)) == 0 ? 0 : 1);
-	*(device->estop[0].in) = 		(hal_bit_t)((temp & (0x0001 << 3)) == 0 ? 0 : 1);
-	*(device->estop[0].inNot) = 		(hal_bit_t)((temp & (0x0001 << 3)) == 0 ? 1 : 0);
-	*(device->estop[1].in) = 		(hal_bit_t)((temp & (0x0001 << 4)) == 0 ? 0 : 1);
-	*(device->estop[1].inNot) = 		(hal_bit_t)((temp & (0x0001 << 4)) == 0 ? 1 : 0);
+	hal_set_bool(device->cardMgr.watchdog_expired, 	(temp & (0x0001 << 0)) == 0 ? 0 : 1);
+	hal_set_bool(device->cardMgr.power_fault, 		(temp & (0x0001 << 2)) == 0 ? 0 : 1);
+	hal_set_bool(device->estop[0].in, 		(temp & (0x0001 << 3)) == 0 ? 0 : 1);
+	hal_set_bool(device->estop[0].inNot,	(temp & (0x0001 << 3)) == 0 ? 1 : 0);
+	hal_set_bool(device->estop[1].in, 		(temp & (0x0001 << 4)) == 0 ? 0 : 1);
+	hal_set_bool(device->estop[1].inNot,	(temp & (0x0001 << 4)) == 0 ? 1 : 0);
 	
     	for(i=5, j=0; i<11; i++,j++)
 	{
-		*(device->switches[j].home) = 		(hal_bit_t)((temp & (0x0001 << i)) == 0 ? 0 : 1);
-		*(device->switches[j].homeNot) = 	(hal_bit_t)((temp & (0x0001 << i)) == 0 ? 1 : 0);
+		hal_set_bool(device->switches[j].home, 		(temp & (0x0001 << i)) == 0 ? 0 : 1);
+		hal_set_bool(device->switches[j].homeNot, 	(temp & (0x0001 << i)) == 0 ? 1 : 0);
 	}
 	for(j=0;i<17;i++,j++){
-		*(device->switches[j].posLimSwIn) = 	(hal_bit_t)((temp & (0x0001 << i)) == 0 ? 0 : 1);
-		*(device->switches[j].posLimSwInNot) = 	(hal_bit_t)((temp & (0x0001 << i)) == 0 ? 1 : 0);
+		hal_set_bool(device->switches[j].posLimSwIn, 	(temp & (0x0001 << i)) == 0 ? 0 : 1);
+		hal_set_bool(device->switches[j].posLimSwInNot,	(temp & (0x0001 << i)) == 0 ? 1 : 0);
 	}
 	for(j=0;i<23;i++,j++){
-		*(device->switches[j].negLimSwIn) = 	(hal_bit_t)((temp & (0x0001 << i)) == 0 ? 0 : 1);
-		*(device->switches[j].negLimSwInNot) = 	(hal_bit_t)((temp & (0x0001 << i)) == 0 ? 1 : 0);
+		hal_set_bool(device->switches[j].negLimSwIn, 	(temp & (0x0001 << i)) == 0 ? 0 : 1);
+		hal_set_bool(device->switches[j].negLimSwInNot,	(temp & (0x0001 << i)) == 0 ? 1 : 0);
 	}
 	
 	
       //Check if change happened in control reg and write control reg if well
 	 //  ... Estop_1 | Estop_0 | Pwr_fault | Bus_err | Wdt_err  //Card status read resets wdt
 	temp = 1; //EMC run
-	if(*(device->cardMgr.power_enable)) temp |= (0x0001 << 1); //power enable
+	if(hal_get_bool(device->cardMgr.power_enable)) temp |= (0x0001 << 1); //power enable
 	
-	if(device->cardMgr.watchdog_enable) //watchdog timeout in ns*256 unit. 0 if watchdog is disabled
+	if(hal_get_bool(device->cardMgr.watchdog_enable)) //watchdog timeout in ns*256 unit. 0 if watchdog is disabled
 	{
-	  if(device->cardMgr.watchdog_timeout_ns < 256) temp |= 0x100;
-	  else temp |= (device->cardMgr.watchdog_timeout_ns & 0xFFFFFF00);
+	  if(hal_get_ui32(device->cardMgr.watchdog_timeout_ns) < 256) temp |= 0x100;
+	  else temp |= (hal_get_ui32(device->cardMgr.watchdog_timeout_ns) & 0xFFFFFF00);
 	}
 	
 	if(temp != device->cardMgr.card_control_reg)
@@ -1454,7 +1427,7 @@ card_mgr(void *arg, long period)
 	      temp = rtapi_get_msg_level();
 	      rtapi_set_msg_level(RTAPI_MSG_ALL);
 	      rtapi_print_msg(RTAPI_MSG_INFO, "General Mechatronics: PCI clk frequency is %d khz.\n",
-		      (int)((hal_float_t)(pCard->PCI_clk_counter - device->cardMgr.dbg_PCI_counter_last)/period*62500));	//Calculate frequency
+		      (int)((rtapi_real)(pCard->PCI_clk_counter - device->cardMgr.dbg_PCI_counter_last)/period*62500));	//Calculate frequency
 	      rtapi_set_msg_level(temp);
 	  }
 	  device->cardMgr.cntr++;
@@ -1472,14 +1445,14 @@ encoder(void *arg, long period)
     card	*pCard = device->pCard;
 
     int		i;
-	hal_s32_t	temp1 = 0, temp2;
-	hal_float_t	vel;
+	rtapi_s32	temp1 = 0, temp2;
+	rtapi_real	vel;
 
 	//Update parameters
 	for(i=0; i<6; i++)
 	{
-	   if(device->encoder[i].index_invert == 1) temp1 |= (0x1 << i);
-	   if(device->encoder[i].counter_mode == 1) temp1 |= (0x1 << (i+6));
+	   if(hal_get_bool(device->encoder[i].index_invert)) temp1 |= (0x1 << i);
+	   if(hal_get_bool(device->encoder[i].counter_mode)) temp1 |= (0x1 << (i+6));
 	}
 	pCard->ENC_control_reg = temp1;
 	
@@ -1491,18 +1464,18 @@ encoder(void *arg, long period)
 		temp1 = pCard->ENC_counter[i];
 		temp2 = pCard->ENC_index_latch[i];
 		
-		if(*(device->encoder[i].reset) == 1) //If encoder in reset state
+		if(hal_get_bool(device->encoder[i].reset)) //If encoder in reset state
 		{
 		  device->encoder[i].index_offset = temp1;
 		}
-		else if(*(device->encoder[i].index_enable) == 1) //If not in reset and index is enabled
+		else if(hal_get_bool(device->encoder[i].index_enable)) //If not in reset and index is enabled
 		{
 		  if (temp2 != device->encoder[i].last_index_latch) //If index pulse come
 		  {
-		    if(device->encoder[i].index_mode == 0)  //reset counter at index
+		    if(!hal_get_bool(device->encoder[i].index_mode))  //reset counter at index
 		    {
 		      device->encoder[i].index_offset = temp2;  
-		      *(device->encoder[i].index_enable) = 0; //disable index
+		      hal_set_bool(device->encoder[i].index_enable, 0); //disable index
 		    }
 		    else	//round counter at index
 		    {
@@ -1512,13 +1485,13 @@ encoder(void *arg, long period)
 		      }
 		      else
 		      {
-			if(temp2 > (device->encoder[i].last_index_latch + (hal_s32_t)(device->encoder[i].counts_per_rev/4)))
+			if(temp2 > (device->encoder[i].last_index_latch + (rtapi_sint)(hal_get_ui32(device->encoder[i].counts_per_rev)/4)))
 			{
-			  device->encoder[i].index_offset -=  device->encoder[i].last_index_latch + device->encoder[i].counts_per_rev - temp2;
+			  device->encoder[i].index_offset -=  device->encoder[i].last_index_latch + hal_get_ui32(device->encoder[i].counts_per_rev) - temp2;
 			}
-			else if(temp2 < (device->encoder[i].last_index_latch - (hal_s32_t)(device->encoder[i].counts_per_rev/4)))
+			else if(temp2 < (device->encoder[i].last_index_latch - (rtapi_sint)(hal_get_ui32(device->encoder[i].counts_per_rev)/4)))
 			{
-			  device->encoder[i].index_offset -=  device->encoder[i].last_index_latch - device->encoder[i].counts_per_rev - temp2;
+			  device->encoder[i].index_offset -=  device->encoder[i].last_index_latch - hal_get_ui32(device->encoder[i].counts_per_rev) - temp2;
 			}
 			else
 			{
@@ -1530,23 +1503,23 @@ encoder(void *arg, long period)
 		}
 		device->encoder[i].last_index_latch = temp2;
 		
-		*(device->encoder[i].rawcounts) =  temp1 - device->encoder[i].raw_offset;
-		*(device->encoder[i].counts) = *(device->encoder[i].rawcounts) - device->encoder[i].index_offset;
+		hal_set_si32(device->encoder[i].rawcounts, temp1 - device->encoder[i].raw_offset);
+		hal_set_si32(device->encoder[i].counts, hal_get_si32(device->encoder[i].rawcounts) - device->encoder[i].index_offset);
 		
-		if((device->encoder[i].position_scale < 0.000001) && (device->encoder[i].position_scale > -0.000001))  device->encoder[i].position_scale = 1; //Don't like to divide by 0
-		*(device->encoder[i].position) = (hal_float_t) *(device->encoder[i].counts) / device->encoder[i].position_scale;
+		if((hal_get_real(device->encoder[i].position_scale) < 0.000001) && (hal_get_real(device->encoder[i].position_scale) > -0.000001))  hal_set_real(device->encoder[i].position_scale, 1); //Don't like to divide by 0
+		hal_set_real(device->encoder[i].position, (rtapi_real) hal_get_si32(device->encoder[i].counts) / hal_get_real(device->encoder[i].position_scale));
 		
-		vel = (hal_float_t) pCard->ENC_period[i];
+		vel = (rtapi_real) pCard->ENC_period[i];
 		if(vel == 0) vel = 1;
-		vel = 33333333 / ( vel * device->encoder[i].position_scale); //velocity in position units / s
+		vel = 33333333 / ( vel * hal_get_real(device->encoder[i].position_scale)); //velocity in position units / s
 		
-		if(fabs(vel) > device->encoder[i].min_speed_estimate)
+		if(fabs(vel) > hal_get_real(device->encoder[i].min_speed_estimate))
 		{
-		  *(device->encoder[i].velocity) =  vel;
+		  hal_set_real(device->encoder[i].velocity, vel);
 		}
 		else
 		{
-		  *(device->encoder[i].velocity) = 0;
+		  hal_set_real(device->encoder[i].velocity, 0);
 		}
 	  }
 }
@@ -1565,7 +1538,7 @@ stepgen(void *arg, long period)
       //Update stepgen status with enable bits
 	for(i=0;i<6;i++)
 	{
-	  if(*(device->stepgen[i].enable) == 1) device->stepgen_status |= (0x1 << i);	//six stepgens share one status reg, 5 bits for each.
+	  if(hal_get_bool(device->stepgen[i].enable)) device->stepgen_status |= (0x1 << i);	//six stepgens share one status reg, 5 bits for each.
 	  else
           {
             device->stepgen_status &= ~(0x1 << i);			//LS bits of 5 bits are the enable bits
@@ -1576,7 +1549,7 @@ stepgen(void *arg, long period)
       //Check parameter changes, if enabled
 	for(i=0;i<6;i++)
 	{
-	  if(*(device->stepgen[i].enable) == 1)
+	  if(hal_get_bool(device->stepgen[i].enable))
 	  {
 	    stepgenCheckParameters(arg, period, i);
 	  }
@@ -1588,7 +1561,7 @@ stepgen(void *arg, long period)
       //Run steppers, if enabled
 	for(i=0;i<6;i++)
 	{
-	  if(*(device->stepgen[i].enable) == 1)
+	  if(hal_get_bool(device->stepgen[i].enable))
 	  {
 	    stepgenControl(arg, period, i);
 	  }
@@ -1597,7 +1570,7 @@ stepgen(void *arg, long period)
       //update old pos_cmd
 	for(i=0;i<6;i++)
 	{
-	  device->stepgen[i].old_pos_cmd = *(device->stepgen[i].position_cmd);
+	  device->stepgen[i].old_pos_cmd = hal_get_real(device->stepgen[i].position_cmd);
 	}
 }
 
@@ -1607,8 +1580,8 @@ stepgenCheckParameters(void *arg, long period, unsigned int channel)
       gm_device_t		*device = (gm_device_t *)arg;
       card	*pCard = device->pCard;
       
-      hal_u32_t 	temp1, temp2;
-      hal_float_t 	min_period, max_vel;
+      rtapi_u32 	temp1, temp2;
+      rtapi_real 	min_period, max_vel;
       
       //If period changed : recalc period related parameters
       if(device->period_ns != period)
@@ -1618,41 +1591,41 @@ stepgenCheckParameters(void *arg, long period, unsigned int channel)
       }
       
       //If position scale changed : update steprate_scale
-      if(device->stepgen[channel].curr_position_scale != device->stepgen[channel].position_scale)
+      if(device->stepgen[channel].curr_position_scale != hal_get_real(device->stepgen[channel].position_scale))
       {	
 	//30 ns is circley time of CLK, 1/10e9 is ns -sec conversion, 42.. is 2^32 because steprate is 32 bit
-	device->stepgen[channel].steprate_scale = device->stepgen[channel].position_scale * 30.0 / 1000000000.0 * 4294967296.0;
+	device->stepgen[channel].steprate_scale = hal_get_real(device->stepgen[channel].position_scale) * 30.0 / 1000000000.0 * 4294967296.0;
       }
             
       //If steplen, stepspace, position_scale or max_vel changed  :  update max_vel
-      if((device->stepgen[channel].steplen != device->stepgen[channel].curr_steplen) || (device->stepgen[channel].stepspace != device->stepgen[channel].curr_stepspace) || 
-	  (device->stepgen[channel].maxvel != device->stepgen[channel].curr_maxvel) || (device->stepgen[channel].curr_position_scale != device->stepgen[channel].position_scale))
+      if((hal_get_ui32(device->stepgen[channel].steplen) != device->stepgen[channel].curr_steplen) || (hal_get_ui32(device->stepgen[channel].stepspace) != device->stepgen[channel].curr_stepspace) ||
+	  (hal_get_real(device->stepgen[channel].maxvel) != device->stepgen[channel].curr_maxvel) || (device->stepgen[channel].curr_position_scale != hal_get_real(device->stepgen[channel].position_scale)))
       {
-	min_period = (device->stepgen[channel].steplen + device->stepgen[channel].stepspace) * 0.000000001;
-	max_vel = 1/((hal_float_t)min_period * fabs(device->stepgen[channel].position_scale));
+	min_period = (hal_get_ui32(device->stepgen[channel].steplen) + hal_get_ui32(device->stepgen[channel].stepspace)) * 0.000000001;
+	max_vel = 1.0/((rtapi_real)min_period * fabs(hal_get_real(device->stepgen[channel].position_scale)));
 	
-	if(device->stepgen[channel].maxvel <= 0)
+	if(hal_get_real(device->stepgen[channel].maxvel) <= 0)
 	{
-	  device->stepgen[channel].maxvel = max_vel;
+	  hal_set_real(device->stepgen[channel].maxvel, max_vel);
 	}
 	else
 	{
-	  if(max_vel < device->stepgen[channel].maxvel) //if stepgen given velocity is higher, then what is possible with step timing parameters
+	  if(max_vel < hal_get_real(device->stepgen[channel].maxvel)) //if stepgen given velocity is higher, then what is possible with step timing parameters
 	  {
-	    device->stepgen[channel].maxvel = max_vel;
+	    hal_set_real(device->stepgen[channel].maxvel, max_vel);
 	    rtapi_print_msg(RTAPI_MSG_ERR, "GM: stepgen.%d.maxvel can not be reached with given 'steplen' and 'stepspace' parameters.\n", channel);
 	  }
 	}
       }
       
       //If steplen or dirdelay changed : update FPGA time parameter regs
-      if((device->stepgen[channel].steplen != device->stepgen[channel].curr_steplen) || (device->stepgen[channel].dirdelay != device->stepgen[channel].curr_dirdelay))
+      if((hal_get_ui32(device->stepgen[channel].steplen) != device->stepgen[channel].curr_steplen) || (hal_get_ui32(device->stepgen[channel].dirdelay) != device->stepgen[channel].curr_dirdelay))
       {	
 	//Init time constants, send them to PCI 
-	temp1= (device->stepgen[channel].steplen <= 1900000) ? (device->stepgen[channel].steplen/30) : 63333;
-	temp2= (device->stepgen[channel].dirdelay <= 1900000) ? (device->stepgen[channel].dirdelay/30) : 63333;
+	temp1= (hal_get_ui32(device->stepgen[channel].steplen) <= 1900000) ? (hal_get_ui32(device->stepgen[channel].steplen)/30) : 63333;
+	temp2= (hal_get_ui32(device->stepgen[channel].dirdelay) <= 1900000) ? (hal_get_ui32(device->stepgen[channel].dirdelay)/30) : 63333;
 	
-	if((device->stepgen[channel].steplen > 1900000) || (device->stepgen[channel].dirdelay > 1900000))
+	if((hal_get_ui32(device->stepgen[channel].steplen) > 1900000) || (hal_get_ui32(device->stepgen[channel].dirdelay) > 1900000))
 	{
 	  rtapi_print_msg(RTAPI_MSG_ERR, "GM: stepgen: 'steplen' and 'dirdelay' must be lower than 1 900 000 ns.\n");
 	}
@@ -1660,30 +1633,30 @@ stepgenCheckParameters(void *arg, long period, unsigned int channel)
       }
       
       //If enable, step_type or polarity bits changed : update fpga status reg
-      if (*(device->stepgen[channel].enable) == 1) device->stepgen_status |= (0x1 << channel);	//Bit 0-5 is the enable bit
+      if (hal_get_bool(device->stepgen[channel].enable)) device->stepgen_status |= (0x1 << channel);	//Bit 0-5 is the enable bit
 	else device->stepgen_status &= ~(0x1 << channel);
-      if (device->stepgen[channel].step_type == 1) device->stepgen_status |= (0x1 << (channel + 6));	//Bits 6-17 are the step_mode bits
+      if (hal_get_ui32(device->stepgen[channel].step_type) == 1) device->stepgen_status |= (0x1 << (channel + 6));	//Bits 6-17 are the step_mode bits
 	else device->stepgen_status &= ~(0x1 << (channel + 6));
-      if (device->stepgen[channel].step_type == 2) device->stepgen_status |= (0x1 << (channel + 12));	
+      if (hal_get_ui32(device->stepgen[channel].step_type) == 2) device->stepgen_status |= (0x1 << (channel + 12));
 	else device->stepgen_status &= ~(0x1 << (channel + 12));
-      if (device->stepgen[channel].polarity_A == 1) device->stepgen_status |= (0x1 << (channel + 18));	//18-23. bit is polarity of channel A
+      if (hal_get_bool(device->stepgen[channel].polarity_A)) device->stepgen_status |= (0x1 << (channel + 18));	//18-23. bit is polarity of channel A
 	else device->stepgen_status &= ~(0x1 << (channel + 18));
-      if (device->stepgen[channel].polarity_B == 1) device->stepgen_status |= (0x1 << (channel + 24));	//24-29. bit is polarity of channel B
+      if (hal_get_bool(device->stepgen[channel].polarity_B)) device->stepgen_status |= (0x1 << (channel + 24));	//24-29. bit is polarity of channel B
 	else device->stepgen_status &= ~(0x1 << (channel + 24));
 	
       pCard->StepGen_status = device->stepgen_status;
       
       //If max_vel, max_accel or period changed : calc max_dv
-      if((device->stepgen[channel].maxvel != device->stepgen[channel].curr_maxvel) || (device->stepgen[channel].maxaccel != device->stepgen[channel].curr_maxaccel) || (device->period_ns != period))
+      if((hal_get_real(device->stepgen[channel].maxvel) != device->stepgen[channel].curr_maxvel) || (hal_get_real(device->stepgen[channel].maxaccel) != device->stepgen[channel].curr_maxaccel) || (device->period_ns != period))
       {
-	if(device->stepgen[channel].maxaccel <= 1e-20)
+	if(hal_get_real(device->stepgen[channel].maxaccel) <= 1e-20)
 	{
-	  device->stepgen[channel].maxaccel = device->stepgen[channel].maxvel * device->rec_period_s;
-	  device->stepgen[channel].max_dv = device->stepgen[channel].maxvel;
+	  hal_set_real(device->stepgen[channel].maxaccel, hal_get_real(device->stepgen[channel].maxvel) * device->rec_period_s);
+	  device->stepgen[channel].max_dv = hal_get_real(device->stepgen[channel].maxvel);
 	}
 	else
 	{
-	  device->stepgen[channel].max_dv =  device->stepgen[channel].maxaccel * device->period_s; //max velocity change in position_unit/period^2
+	  device->stepgen[channel].max_dv =  hal_get_real(device->stepgen[channel].maxaccel) * device->period_s; //max velocity change in position_unit/period^2
 	}
 	//vel = freq/pos_scale
 	//pos=counts/pos_scale
@@ -1691,12 +1664,12 @@ stepgenCheckParameters(void *arg, long period, unsigned int channel)
       
       //Update current values
       device->period_ns = period;
-      device->stepgen[channel].curr_position_scale = device->stepgen[channel].position_scale;
-      device->stepgen[channel].curr_stepspace = device->stepgen[channel].stepspace;
-      device->stepgen[channel].curr_maxvel = device->stepgen[channel].maxvel;
-      device->stepgen[channel].curr_maxaccel = device->stepgen[channel].maxaccel;
-      device->stepgen[channel].curr_steplen = device->stepgen[channel].steplen;
-      device->stepgen[channel].curr_dirdelay= device->stepgen[channel].dirdelay;
+      device->stepgen[channel].curr_position_scale = hal_get_real(device->stepgen[channel].position_scale);
+      device->stepgen[channel].curr_stepspace = hal_get_ui32(device->stepgen[channel].stepspace);
+      device->stepgen[channel].curr_maxvel = hal_get_real(device->stepgen[channel].maxvel);
+      device->stepgen[channel].curr_maxaccel = hal_get_real(device->stepgen[channel].maxaccel);
+      device->stepgen[channel].curr_steplen = hal_get_ui32(device->stepgen[channel].steplen);
+      device->stepgen[channel].curr_dirdelay= hal_get_ui32(device->stepgen[channel].dirdelay);
       
 }
 
@@ -1707,63 +1680,63 @@ stepgenControl(void *arg, long period, unsigned int channel)
     gm_device_t		*device = (gm_device_t *)arg;
     card	*pCard = device->pCard;
 	
-	hal_s32_t stepgen_fb, stepgen_fb_int, last_count_fb_LS16_bits, last_count_fb_MS16_bits, last_count_fb;	
-	hal_float_t	ref_vel = 0, match_acc, match_time, avg_v, est_out, est_cmd, est_err, dp;
+	rtapi_s32 stepgen_fb, stepgen_fb_int, last_count_fb_LS16_bits, last_count_fb_MS16_bits, last_count_fb;
+	rtapi_real	ref_vel = 0, match_acc, match_time, avg_v, est_out, est_cmd, est_err, dp;
 	
      //read and count feedbacks
 	stepgen_fb = pCard->StepGen_fb[channel];	//pCard->StepGen_Fb[channel] is 16.16 bit fixed point feedback in [step] unit
 	stepgen_fb -= device->stepgen[channel].stepgen_fb_offset;
 	stepgen_fb_int= stepgen_fb >> 16;		//get integer part of step feedback
 	
-	last_count_fb = *(device->stepgen[channel].count_fb);
+	last_count_fb = hal_get_si32(device->stepgen[channel].count_fb);
 	last_count_fb_LS16_bits = last_count_fb & 0xFFFF;
 	last_count_fb_MS16_bits = last_count_fb & 0xFFFF0000;
 	
       //Check for 16 bit overflow of stepgen_fb
 	if(stepgen_fb_int > last_count_fb_LS16_bits + 32768) //16 bit step counter down overflow  
 	{
-	  *(device->stepgen[channel].count_fb) = (last_count_fb_MS16_bits + stepgen_fb_int - 65536);
+	  hal_set_si32(device->stepgen[channel].count_fb, (last_count_fb_MS16_bits + stepgen_fb_int - 65536));
 	}
 	else if (stepgen_fb_int + 32768 < last_count_fb_LS16_bits) //16 bit step counter up overflow
 	{
-	   *(device->stepgen[channel].count_fb) = (last_count_fb_MS16_bits + stepgen_fb_int + 65536);
+	   hal_set_si32(device->stepgen[channel].count_fb, (last_count_fb_MS16_bits + stepgen_fb_int + 65536));
 	}
 	else //no overflow
 	{
-	  *(device->stepgen[channel].count_fb) =   (last_count_fb_MS16_bits + stepgen_fb_int);
+	  hal_set_si32(device->stepgen[channel].count_fb, (last_count_fb_MS16_bits + stepgen_fb_int));
 	}
 
       //save old position and get new one
-	*(device->stepgen[channel].position_fb) = (*(device->stepgen[channel].count_fb) + ((hal_float_t)(stepgen_fb & 0xFFFF))/65536)/device->stepgen[channel].position_scale;	//[pos_unit]
+	hal_set_real(device->stepgen[channel].position_fb, (hal_get_si32(device->stepgen[channel].count_fb) + ((rtapi_real)(stepgen_fb & 0xFFFF))/65536)/hal_get_real(device->stepgen[channel].position_scale));	//[pos_unit]
 	
       //velocity control is easy
-	if(device->stepgen[channel].control_type == 1)
+	if(hal_get_bool(device->stepgen[channel].control_type))
 	{
-	  ref_vel = *(device->stepgen[channel].velocity_cmd); 
+	  ref_vel = hal_get_real(device->stepgen[channel].velocity_cmd);
 	}
 	
       //Position control is more difficult
 	/*Position control based on John Kasunich's stepgen hal component.*/
-	else if(device->stepgen[channel].control_type == 0)
+	else if(!hal_get_bool(device->stepgen[channel].control_type))
 	{
 	//Reference velocity:
-	  ref_vel =  (*(device->stepgen[channel].position_cmd) - device->stepgen[channel].old_pos_cmd) * device->rec_period_s;
+	  ref_vel =  (hal_get_real(device->stepgen[channel].position_cmd) - device->stepgen[channel].old_pos_cmd) * device->rec_period_s;
 	  
 	  if(ref_vel > device->stepgen[channel].old_vel)
 	  {
-	    match_acc = device->stepgen[channel].maxaccel;
+	    match_acc = hal_get_real(device->stepgen[channel].maxaccel);
 	  }
 	  else
 	  {
-	   match_acc =  -device->stepgen[channel].maxaccel;
+	   match_acc =  -hal_get_real(device->stepgen[channel].maxaccel);
 	  }
 	  
 	  match_time = (ref_vel - device->stepgen[channel].old_vel) / match_acc;
 	  
 	  avg_v = (ref_vel + device->stepgen[channel].old_vel) * 0.5;
 	  
-	  est_out = *(device->stepgen[channel].position_fb) + avg_v * match_time;;
-	  est_cmd =  *(device->stepgen[channel].position_cmd) + ref_vel * (match_time - 1.5 * device->period_s);	  
+	  est_out = hal_get_real(device->stepgen[channel].position_fb) + avg_v * match_time;;
+	  est_cmd =  hal_get_real(device->stepgen[channel].position_cmd) + ref_vel * (match_time - 1.5 * device->period_s);
 	  
 	  est_err = est_out - est_cmd;
 	  
@@ -1794,8 +1767,8 @@ stepgenControl(void *arg, long period, unsigned int channel)
       //Check max velocity, max acceleration and output baudrate
       
 	//Check max velocity
-	if(ref_vel > device->stepgen[channel].maxvel) ref_vel = device->stepgen[channel].maxvel;
-	else if(ref_vel < -device->stepgen[channel].maxvel) ref_vel = -device->stepgen[channel].maxvel;
+	if(ref_vel > hal_get_real(device->stepgen[channel].maxvel)) ref_vel = hal_get_real(device->stepgen[channel].maxvel);
+	else if(ref_vel < -hal_get_real(device->stepgen[channel].maxvel)) ref_vel = -hal_get_real(device->stepgen[channel].maxvel);
 	  
 	//Check max acceleration
 	if((device->stepgen[channel].old_vel-ref_vel) > device->stepgen[channel].max_dv) 
@@ -1809,7 +1782,7 @@ stepgenControl(void *arg, long period, unsigned int channel)
 	//Save old velocity
 	device->stepgen[channel].old_vel=ref_vel; 
 	//Set steprate
-	pCard->StepGen_steprate[channel] = (hal_s32_t)(ref_vel * device->stepgen[channel].steprate_scale);
+	pCard->StepGen_steprate[channel] = (rtapi_s32)(ref_vel * device->stepgen[channel].steprate_scale);
 	
 }
 
@@ -1824,21 +1797,21 @@ RS485(void *arg, long period)
 	card	*pCard = device->pCard;
 	
 	unsigned int i, j;
-	hal_float_t temp;
-        hal_u32_t temp_u32;
+	rtapi_real temp;
+        rtapi_u32 temp_u32;
         bool data_wr = 0;
-        static hal_bit_t failed=0;
+        static rtapi_bool failed=0;
 	
 	//for write function
-	hal_u32_t RS485DataIn8[32], RS485DataOut32[8];
+	rtapi_u32 RS485DataIn8[32], RS485DataOut32[8];
 	//for read function
-	hal_u32_t RS485DataIn32[8], RS485DataOut8[32];
+	rtapi_u32 RS485DataIn32[8], RS485DataOut8[32];
 
        //Check modules if any of it failed:
        //READ IDs of correctly connected modules and compare it with saved ID-s.
 	for(i=0; i<8; i++)
 	{
-	temp_u32=(hal_u32_t)pCard->moduleId[i];
+	temp_u32 = pCard->moduleId[i];
 		 
 	  if(((temp_u32 & 0xff)^0xaa) == ((temp_u32 & 0xff00)>>8)) 
 	  {
@@ -1850,7 +1823,7 @@ RS485(void *arg, long period)
                 failed=1;
                 rtapi_print_msg(RTAPI_MSG_ERR, "GM: ERROR: RS485 module ID:%2d failed.\n", 2*i);
               }
-              *(device->cardMgr.power_fault) = 1;
+              hal_set_bool(device->cardMgr.power_fault, 1);
             }
 	  }
 		 
@@ -1864,7 +1837,7 @@ RS485(void *arg, long period)
                 failed=1; 
                 rtapi_print_msg(RTAPI_MSG_ERR, "GM: ERROR: RS485 module ID:%2d failed.\n", 2*i+1);
               }
-              *(device->cardMgr.power_fault) = 1;
+              hal_set_bool(device->cardMgr.power_fault, 1);
             }
 	  }
         }
@@ -1876,7 +1849,7 @@ RS485(void *arg, long period)
 		if(i != 0) *(&(pCard->serialModulesDataIn[i-1][7])); 
 		else *(&(pCard->serialModulesDataOut[15][7]));
 	      //Read bytes to RS485DataIn32 array
-		for(j=0; j<8; j++) RS485DataIn32[j]= (hal_u32_t)pCard->serialModulesDataIn[i][j];
+		for(j=0; j<8; j++) RS485DataIn32[j]= (rtapi_u32)pCard->serialModulesDataIn[i][j];
 		
 	      //Order data to RS485DataOut8 buffer
 		RS485_OrderDataRead(RS485DataIn32, RS485DataOut8, device-> RS485_mgr.BYTES_TO_READ[i]);
@@ -1886,72 +1859,71 @@ RS485(void *arg, long period)
 		  switch (device-> RS485_mgr.ID[i])
 		  {
 		    case RS485MODUL_ID_8INPUT:
-			*(device->RS485_8input[i].in_0) = ((hal_bit_t)(RS485DataOut8[0] & 0x1) ? 1 : 0);
-			*(device->RS485_8input[i].inNot_0) = (hal_bit_t)(RS485DataOut8[0] & 0x1) ? 0 : 1;
-			*(device->RS485_8input[i].in_1) = (hal_bit_t)((RS485DataOut8[0] >> 1) & 0x1) ? 1 : 0;
-			*(device->RS485_8input[i].inNot_1) = (hal_bit_t)((RS485DataOut8[0] >> 1) & 0x1) ? 0 : 1;
-			*(device->RS485_8input[i].in_2) = (hal_bit_t)((RS485DataOut8[0] >> 2) & 0x1) ? 1 : 0;
-			*(device->RS485_8input[i].inNot_2) = (hal_bit_t)((RS485DataOut8[0] >> 2) & 0x1) ? 0 : 1;
-			*(device->RS485_8input[i].in_3) = (hal_bit_t)((RS485DataOut8[0] >> 3) & 0x1) ? 1 : 0;
-			*(device->RS485_8input[i].inNot_3) = (hal_bit_t)((RS485DataOut8[0] >> 3) & 0x1) ? 0 : 1;
-			*(device->RS485_8input[i].in_4) = (hal_bit_t)((RS485DataOut8[0] >> 4) & 0x1) ? 1 : 0;
-			*(device->RS485_8input[i].inNot_4) = (hal_bit_t)((RS485DataOut8[0] >> 4) & 0x1) ? 0 : 1;
-			*(device->RS485_8input[i].in_5) = (hal_bit_t)((RS485DataOut8[0] >> 5) & 0x1) ? 1 : 0;
-			*(device->RS485_8input[i].inNot_5) = (hal_bit_t)((RS485DataOut8[0] >> 5) & 0x1) ? 0 : 1;
-			*(device->RS485_8input[i].in_6) = (hal_bit_t)((RS485DataOut8[0] >> 6) & 0x1) ? 1 : 0;
-			*(device->RS485_8input[i].inNot_6) = (hal_bit_t)((RS485DataOut8[0] >> 6) & 0x1) ? 0 : 1;
-			*(device->RS485_8input[i].in_7) = (hal_bit_t)((RS485DataOut8[0] >> 7) & 0x1) ? 1 : 0;
-			*(device->RS485_8input[i].inNot_7) = (hal_bit_t)((RS485DataOut8[0] >> 7) & 0x1) ? 0 : 1;
+			hal_set_bool(device->RS485_8input[i].in_0,    (RS485DataOut8[0] & 0x1) ? 1 : 0);
+			hal_set_bool(device->RS485_8input[i].inNot_0, (RS485DataOut8[0] & 0x1) ? 0 : 1);
+			hal_set_bool(device->RS485_8input[i].in_1,    ((RS485DataOut8[0] >> 1) & 0x1) ? 1 : 0);
+			hal_set_bool(device->RS485_8input[i].inNot_1, ((RS485DataOut8[0] >> 1) & 0x1) ? 0 : 1);
+			hal_set_bool(device->RS485_8input[i].in_2,    ((RS485DataOut8[0] >> 2) & 0x1) ? 1 : 0);
+			hal_set_bool(device->RS485_8input[i].inNot_2, ((RS485DataOut8[0] >> 2) & 0x1) ? 0 : 1);
+			hal_set_bool(device->RS485_8input[i].in_3,    ((RS485DataOut8[0] >> 3) & 0x1) ? 1 : 0);
+			hal_set_bool(device->RS485_8input[i].inNot_3, ((RS485DataOut8[0] >> 3) & 0x1) ? 0 : 1);
+			hal_set_bool(device->RS485_8input[i].in_4,    ((RS485DataOut8[0] >> 4) & 0x1) ? 1 : 0);
+			hal_set_bool(device->RS485_8input[i].inNot_4, ((RS485DataOut8[0] >> 4) & 0x1) ? 0 : 1);
+			hal_set_bool(device->RS485_8input[i].in_5,    ((RS485DataOut8[0] >> 5) & 0x1) ? 1 : 0);
+			hal_set_bool(device->RS485_8input[i].inNot_5, ((RS485DataOut8[0] >> 5) & 0x1) ? 0 : 1);
+			hal_set_bool(device->RS485_8input[i].in_6,    ((RS485DataOut8[0] >> 6) & 0x1) ? 1 : 0);
+			hal_set_bool(device->RS485_8input[i].inNot_6, ((RS485DataOut8[0] >> 6) & 0x1) ? 0 : 1);
+			hal_set_bool(device->RS485_8input[i].in_7,    ((RS485DataOut8[0] >> 7) & 0x1) ? 1 : 0);
+			hal_set_bool(device->RS485_8input[i].inNot_7, ((RS485DataOut8[0] >> 7) & 0x1) ? 0 : 1);
 		      break;
 		      
 		   case RS485MODUL_ID_DACADC:
-			*(device->RS485_DacAdc[i].ADC_0) = (((hal_float_t)RS485DataOut8[0])/25.5-5) * device->RS485_DacAdc[i].ADC_0_scale - device->RS485_DacAdc[i].ADC_0_offset;
-			*(device->RS485_DacAdc[i].ADC_1) = (((hal_float_t)RS485DataOut8[1])/25.5-5) * device->RS485_DacAdc[i].ADC_1_scale - device->RS485_DacAdc[i].ADC_1_offset;
-			*(device->RS485_DacAdc[i].ADC_2) = (((hal_float_t)RS485DataOut8[2])/25.5-5) * device->RS485_DacAdc[i].ADC_2_scale - device->RS485_DacAdc[i].ADC_2_offset;
-			*(device->RS485_DacAdc[i].ADC_3) = (((hal_float_t)RS485DataOut8[3])/25.5-5) * device->RS485_DacAdc[i].ADC_3_scale - device->RS485_DacAdc[i].ADC_3_offset;
-			*(device->RS485_DacAdc[i].ADC_4) = (((hal_float_t)RS485DataOut8[4])/25.5-5) * device->RS485_DacAdc[i].ADC_4_scale - device->RS485_DacAdc[i].ADC_4_offset;
-			*(device->RS485_DacAdc[i].ADC_5) = (((hal_float_t)RS485DataOut8[5])/25.5-5) * device->RS485_DacAdc[i].ADC_5_scale - device->RS485_DacAdc[i].ADC_5_offset;
-			*(device->RS485_DacAdc[i].ADC_6) = (((hal_float_t)RS485DataOut8[6])/25.5-5) * device->RS485_DacAdc[i].ADC_6_scale - device->RS485_DacAdc[i].ADC_6_offset;
-			*(device->RS485_DacAdc[i].ADC_7) = (((hal_float_t)RS485DataOut8[7])/25.5-5) * device->RS485_DacAdc[i].ADC_7_scale - device->RS485_DacAdc[i].ADC_7_offset;
-			
+			hal_set_real(device->RS485_DacAdc[i].ADC_0, (((rtapi_real)RS485DataOut8[0])/25.5-5) * hal_get_real(device->RS485_DacAdc[i].ADC_0_scale) - hal_get_real(device->RS485_DacAdc[i].ADC_0_offset));
+			hal_set_real(device->RS485_DacAdc[i].ADC_1, (((rtapi_real)RS485DataOut8[1])/25.5-5) * hal_get_real(device->RS485_DacAdc[i].ADC_1_scale) - hal_get_real(device->RS485_DacAdc[i].ADC_1_offset));
+			hal_set_real(device->RS485_DacAdc[i].ADC_2, (((rtapi_real)RS485DataOut8[2])/25.5-5) * hal_get_real(device->RS485_DacAdc[i].ADC_2_scale) - hal_get_real(device->RS485_DacAdc[i].ADC_2_offset));
+			hal_set_real(device->RS485_DacAdc[i].ADC_3, (((rtapi_real)RS485DataOut8[3])/25.5-5) * hal_get_real(device->RS485_DacAdc[i].ADC_3_scale) - hal_get_real(device->RS485_DacAdc[i].ADC_3_offset));
+			hal_set_real(device->RS485_DacAdc[i].ADC_4, (((rtapi_real)RS485DataOut8[4])/25.5-5) * hal_get_real(device->RS485_DacAdc[i].ADC_4_scale) - hal_get_real(device->RS485_DacAdc[i].ADC_4_offset));
+			hal_set_real(device->RS485_DacAdc[i].ADC_5, (((rtapi_real)RS485DataOut8[5])/25.5-5) * hal_get_real(device->RS485_DacAdc[i].ADC_5_scale) - hal_get_real(device->RS485_DacAdc[i].ADC_5_offset));
+			hal_set_real(device->RS485_DacAdc[i].ADC_6, (((rtapi_real)RS485DataOut8[6])/25.5-5) * hal_get_real(device->RS485_DacAdc[i].ADC_6_scale) - hal_get_real(device->RS485_DacAdc[i].ADC_6_offset));
+			hal_set_real(device->RS485_DacAdc[i].ADC_7, (((rtapi_real)RS485DataOut8[7])/25.5-5) * hal_get_real(device->RS485_DacAdc[i].ADC_7_scale) - hal_get_real(device->RS485_DacAdc[i].ADC_7_offset));
 		      break;
 		      
 		   case RS485MODUL_ID_TEACHPAD:
 
-			*(device->RS485_TeachPad[i].in_0) = ((hal_bit_t)(RS485DataOut8[0] & 0x1) ? 1 : 0);
-			*(device->RS485_TeachPad[i].inNot_0) = (hal_bit_t)(RS485DataOut8[0] & 0x1) ? 0 : 1;
-			*(device->RS485_TeachPad[i].in_1) = (hal_bit_t)((RS485DataOut8[0] >> 1) & 0x1) ? 1 : 0;
-			*(device->RS485_TeachPad[i].inNot_1) = (hal_bit_t)((RS485DataOut8[0] >> 1) & 0x1) ? 0 : 1;
-			*(device->RS485_TeachPad[i].in_2) = (hal_bit_t)((RS485DataOut8[0] >> 2) & 0x1) ? 1 : 0;
-			*(device->RS485_TeachPad[i].inNot_2) = (hal_bit_t)((RS485DataOut8[0] >> 2) & 0x1) ? 0 : 1;
-			*(device->RS485_TeachPad[i].in_3) = (hal_bit_t)((RS485DataOut8[0] >> 3) & 0x1) ? 1 : 0;
-			*(device->RS485_TeachPad[i].inNot_3) = (hal_bit_t)((RS485DataOut8[0] >> 3) & 0x1) ? 0 : 1;
-			*(device->RS485_TeachPad[i].in_4) = (hal_bit_t)((RS485DataOut8[0] >> 4) & 0x1) ? 1 : 0;
-			*(device->RS485_TeachPad[i].inNot_4) = (hal_bit_t)((RS485DataOut8[0] >> 4) & 0x1) ? 0 : 1;
-			*(device->RS485_TeachPad[i].in_5) = (hal_bit_t)((RS485DataOut8[0] >> 5) & 0x1) ? 1 : 0;
-			*(device->RS485_TeachPad[i].inNot_5) = (hal_bit_t)((RS485DataOut8[0] >> 5) & 0x1) ? 0 : 1;
-			*(device->RS485_TeachPad[i].in_6) = (hal_bit_t)((RS485DataOut8[0] >> 6) & 0x1) ? 1 : 0;
-			*(device->RS485_TeachPad[i].inNot_6) = (hal_bit_t)((RS485DataOut8[0] >> 6) & 0x1) ? 0 : 1;
-			*(device->RS485_TeachPad[i].in_7) = (hal_bit_t)((RS485DataOut8[0] >> 7) & 0x1) ? 1 : 0;
-			*(device->RS485_TeachPad[i].inNot_7) = (hal_bit_t)((RS485DataOut8[0] >> 7) & 0x1) ? 0 : 1;
+			hal_set_bool(device->RS485_TeachPad[i].in_0,    (RS485DataOut8[0] & 0x1) ? 1 : 0);
+			hal_set_bool(device->RS485_TeachPad[i].inNot_0, (RS485DataOut8[0] & 0x1) ? 0 : 1);
+			hal_set_bool(device->RS485_TeachPad[i].in_1,    ((RS485DataOut8[0] >> 1) & 0x1) ? 1 : 0);
+			hal_set_bool(device->RS485_TeachPad[i].inNot_1, ((RS485DataOut8[0] >> 1) & 0x1) ? 0 : 1);
+			hal_set_bool(device->RS485_TeachPad[i].in_2,    ((RS485DataOut8[0] >> 2) & 0x1) ? 1 : 0);
+			hal_set_bool(device->RS485_TeachPad[i].inNot_2, ((RS485DataOut8[0] >> 2) & 0x1) ? 0 : 1);
+			hal_set_bool(device->RS485_TeachPad[i].in_3,    ((RS485DataOut8[0] >> 3) & 0x1) ? 1 : 0);
+			hal_set_bool(device->RS485_TeachPad[i].inNot_3, ((RS485DataOut8[0] >> 3) & 0x1) ? 0 : 1);
+			hal_set_bool(device->RS485_TeachPad[i].in_4,    ((RS485DataOut8[0] >> 4) & 0x1) ? 1 : 0);
+			hal_set_bool(device->RS485_TeachPad[i].inNot_4, ((RS485DataOut8[0] >> 4) & 0x1) ? 0 : 1);
+			hal_set_bool(device->RS485_TeachPad[i].in_5,    ((RS485DataOut8[0] >> 5) & 0x1) ? 1 : 0);
+			hal_set_bool(device->RS485_TeachPad[i].inNot_5, ((RS485DataOut8[0] >> 5) & 0x1) ? 0 : 1);
+			hal_set_bool(device->RS485_TeachPad[i].in_6,    ((RS485DataOut8[0] >> 6) & 0x1) ? 1 : 0);
+			hal_set_bool(device->RS485_TeachPad[i].inNot_6, ((RS485DataOut8[0] >> 6) & 0x1) ? 0 : 1);
+			hal_set_bool(device->RS485_TeachPad[i].in_7,    ((RS485DataOut8[0] >> 7) & 0x1) ? 1 : 0);
+			hal_set_bool(device->RS485_TeachPad[i].inNot_7, ((RS485DataOut8[0] >> 7) & 0x1) ? 0 : 1);
 
-			*(device->RS485_TeachPad[i].ADC_0) = (hal_float_t)RS485DataOut8[1]/51.2 * device->RS485_TeachPad[i].ADC_0_scale - device->RS485_TeachPad[i].ADC_0_offset;
-			*(device->RS485_TeachPad[i].ADC_1) = (hal_float_t)RS485DataOut8[2]/51.2 * device->RS485_TeachPad[i].ADC_1_scale - device->RS485_TeachPad[i].ADC_1_offset;
-			*(device->RS485_TeachPad[i].ADC_2) = (hal_float_t)RS485DataOut8[3]/51.2 * device->RS485_TeachPad[i].ADC_2_scale - device->RS485_TeachPad[i].ADC_2_offset;
-			*(device->RS485_TeachPad[i].ADC_3) = (hal_float_t)RS485DataOut8[4]/51.2 * device->RS485_TeachPad[i].ADC_3_scale - device->RS485_TeachPad[i].ADC_3_offset;
-			*(device->RS485_TeachPad[i].ADC_4) = (hal_float_t)RS485DataOut8[5]/51.2 * device->RS485_TeachPad[i].ADC_4_scale - device->RS485_TeachPad[i].ADC_4_offset;
-			*(device->RS485_TeachPad[i].ADC_5) = (hal_float_t)RS485DataOut8[6]/51.2 * device->RS485_TeachPad[i].ADC_5_scale - device->RS485_TeachPad[i].ADC_5_offset;
-			
-			*(device->RS485_TeachPad[i].enc_rawcounts)= (RS485DataOut8[7] & 0xff) | ((RS485DataOut8[8] & 0xff) << 8) | ((RS485DataOut8[9] & 0xff) << 16) | (RS485DataOut8[10] << 24);
-			if(*(device->RS485_TeachPad[i].enc_reset))
+			hal_set_real(device->RS485_TeachPad[i].ADC_0, (rtapi_real)RS485DataOut8[1]/51.2 * hal_get_real(device->RS485_TeachPad[i].ADC_0_scale) - hal_get_real(device->RS485_TeachPad[i].ADC_0_offset));
+			hal_set_real(device->RS485_TeachPad[i].ADC_1, (rtapi_real)RS485DataOut8[2]/51.2 * hal_get_real(device->RS485_TeachPad[i].ADC_1_scale) - hal_get_real(device->RS485_TeachPad[i].ADC_1_offset));
+			hal_set_real(device->RS485_TeachPad[i].ADC_2, (rtapi_real)RS485DataOut8[3]/51.2 * hal_get_real(device->RS485_TeachPad[i].ADC_2_scale) - hal_get_real(device->RS485_TeachPad[i].ADC_2_offset));
+			hal_set_real(device->RS485_TeachPad[i].ADC_3, (rtapi_real)RS485DataOut8[4]/51.2 * hal_get_real(device->RS485_TeachPad[i].ADC_3_scale) - hal_get_real(device->RS485_TeachPad[i].ADC_3_offset));
+			hal_set_real(device->RS485_TeachPad[i].ADC_4, (rtapi_real)RS485DataOut8[5]/51.2 * hal_get_real(device->RS485_TeachPad[i].ADC_4_scale) - hal_get_real(device->RS485_TeachPad[i].ADC_4_offset));
+			hal_set_real(device->RS485_TeachPad[i].ADC_5, (rtapi_real)RS485DataOut8[6]/51.2 * hal_get_real(device->RS485_TeachPad[i].ADC_5_scale) - hal_get_real(device->RS485_TeachPad[i].ADC_5_offset));
+
+			hal_set_si32(device->RS485_TeachPad[i].enc_rawcounts, (RS485DataOut8[7] & 0xff) | ((RS485DataOut8[8] & 0xff) << 8) | ((RS485DataOut8[9] & 0xff) << 16) | (RS485DataOut8[10] << 24));
+			if(hal_get_bool(device->RS485_TeachPad[i].enc_reset))
 			{
-			  device->RS485_TeachPad[i].enc_raw_offset = *(device->RS485_TeachPad[i].enc_rawcounts);
+			  device->RS485_TeachPad[i].enc_raw_offset = hal_get_si32(device->RS485_TeachPad[i].enc_rawcounts);
 			}
-			*(device->RS485_TeachPad[i].enc_counts) = *(device->RS485_TeachPad[i].enc_rawcounts) - device->RS485_TeachPad[i].enc_raw_offset;
+			hal_set_si32(device->RS485_TeachPad[i].enc_counts, hal_get_si32(device->RS485_TeachPad[i].enc_rawcounts) - device->RS485_TeachPad[i].enc_raw_offset);
 			
-			if((device->RS485_TeachPad[i].enc_position_scale < 0.000001) && (device->RS485_TeachPad[i].enc_position_scale > -0.000001)) device->RS485_TeachPad[i].enc_position_scale=1; //don't divide by 0
+			if((hal_get_real(device->RS485_TeachPad[i].enc_position_scale) < 0.000001) && (hal_get_real(device->RS485_TeachPad[i].enc_position_scale) > -0.000001)) hal_set_real(device->RS485_TeachPad[i].enc_position_scale, 1); //don't divide by 0
 			
-			*(device->RS485_TeachPad[i].enc_position) = *(device->RS485_TeachPad[i].enc_counts) / device->RS485_TeachPad[i].enc_position_scale;
+			hal_set_real(device->RS485_TeachPad[i].enc_position, hal_get_si32(device->RS485_TeachPad[i].enc_counts) / hal_get_real(device->RS485_TeachPad[i].enc_position_scale));
 			
 		    default:
 		      break;     
@@ -1967,24 +1939,24 @@ RS485(void *arg, long period)
 		switch (device-> RS485_mgr.ID[i])
 		{
 		    case RS485MODUL_ID_8OUTPUT:
-		      RS485DataIn8[0]=((*(device->RS485_8output[i].out_7) ^ (device->RS485_8output[i].invertOut_7)) << 7) |
-				      ((*(device->RS485_8output[i].out_6) ^ (device->RS485_8output[i].invertOut_6)) << 6) |
-				      ((*(device->RS485_8output[i].out_5) ^ (device->RS485_8output[i].invertOut_5)) << 5) |
-				      ((*(device->RS485_8output[i].out_4) ^ (device->RS485_8output[i].invertOut_4)) << 4) |
-				      ((*(device->RS485_8output[i].out_3) ^ (device->RS485_8output[i].invertOut_3)) << 3) |
-				      ((*(device->RS485_8output[i].out_2) ^ (device->RS485_8output[i].invertOut_2)) << 2) |
-				      ((*(device->RS485_8output[i].out_1) ^ (device->RS485_8output[i].invertOut_1)) << 1) |
-				      ((*(device->RS485_8output[i].out_0) ^ (device->RS485_8output[i].invertOut_0)) << 0);
+		      RS485DataIn8[0]=((hal_get_bool(device->RS485_8output[i].out_7) ^ hal_get_bool(device->RS485_8output[i].invertOut_7)) << 7) |
+				      ((hal_get_bool(device->RS485_8output[i].out_6) ^ hal_get_bool(device->RS485_8output[i].invertOut_6)) << 6) |
+				      ((hal_get_bool(device->RS485_8output[i].out_5) ^ hal_get_bool(device->RS485_8output[i].invertOut_5)) << 5) |
+				      ((hal_get_bool(device->RS485_8output[i].out_4) ^ hal_get_bool(device->RS485_8output[i].invertOut_4)) << 4) |
+				      ((hal_get_bool(device->RS485_8output[i].out_3) ^ hal_get_bool(device->RS485_8output[i].invertOut_3)) << 3) |
+				      ((hal_get_bool(device->RS485_8output[i].out_2) ^ hal_get_bool(device->RS485_8output[i].invertOut_2)) << 2) |
+				      ((hal_get_bool(device->RS485_8output[i].out_1) ^ hal_get_bool(device->RS485_8output[i].invertOut_1)) << 1) |
+				      ((hal_get_bool(device->RS485_8output[i].out_0) ^ hal_get_bool(device->RS485_8output[i].invertOut_0)) << 0);
 		    break;
 
 		    case RS485MODUL_ID_DACADC:
 		     //DAC 0 
-		      if(*(device->RS485_DacAdc[i].dac_0_enable))
+		      if(hal_get_bool(device->RS485_DacAdc[i].dac_0_enable))
 		      {
-			temp = *(device->RS485_DacAdc[i].DAC_0)+ device->RS485_DacAdc[i].DAC_0_offset;
+			temp = hal_get_real(device->RS485_DacAdc[i].DAC_0)+ hal_get_real(device->RS485_DacAdc[i].DAC_0_offset);
 			
-			if(temp > device->RS485_DacAdc[i].DAC_0_max) {  temp = device->RS485_DacAdc[i].DAC_0_max; }
-			else if(temp < device->RS485_DacAdc[i].DAC_0_min) { temp = device->RS485_DacAdc[i].DAC_0_min; }
+			if(temp > hal_get_real(device->RS485_DacAdc[i].DAC_0_max)) {  temp = hal_get_real(device->RS485_DacAdc[i].DAC_0_max); }
+			else if(temp < hal_get_real(device->RS485_DacAdc[i].DAC_0_min)) { temp = hal_get_real(device->RS485_DacAdc[i].DAC_0_min); }
 			
 			temp = (temp + 10)*12.8 + 0.5;
 		      }
@@ -1992,14 +1964,14 @@ RS485(void *arg, long period)
 		      
 		      if(temp>255) temp=255;
 		      else if(temp <0) temp=0;
-		      RS485DataIn8[0]= (hal_u32_t)temp;
+		      RS485DataIn8[0]= (rtapi_u32)temp;
 		    //DAC 1
-		      if(*(device->RS485_DacAdc[i].dac_1_enable))
+		      if(hal_get_bool(device->RS485_DacAdc[i].dac_1_enable))
 		      {
-			temp = *(device->RS485_DacAdc[i].DAC_1)+ device->RS485_DacAdc[i].DAC_1_offset;
+			temp = hal_get_real(device->RS485_DacAdc[i].DAC_1)+ hal_get_real(device->RS485_DacAdc[i].DAC_1_offset);
 			
-			if(temp > device->RS485_DacAdc[i].DAC_1_max) {  temp = device->RS485_DacAdc[i].DAC_1_max; }
-			else if(temp < device->RS485_DacAdc[i].DAC_1_min) { temp = device->RS485_DacAdc[i].DAC_1_min; }
+			if(temp > hal_get_real(device->RS485_DacAdc[i].DAC_1_max)) {  temp = hal_get_real(device->RS485_DacAdc[i].DAC_1_max); }
+			else if(temp < hal_get_real(device->RS485_DacAdc[i].DAC_1_min)) { temp = hal_get_real(device->RS485_DacAdc[i].DAC_1_min); }
 			
 			temp = (temp + 10)*12.8 + 0.5;
                       }
@@ -2007,15 +1979,15 @@ RS485(void *arg, long period)
 
 		      if(temp>255) temp=255;
 		      else if(temp <0) temp=0;
-		      RS485DataIn8[1]= (hal_u32_t)temp;
+		      RS485DataIn8[1]= (rtapi_u32)temp;
 		      
 		    //DAC 2
-		      if(*(device->RS485_DacAdc[i].dac_2_enable))
+		      if(hal_get_bool(device->RS485_DacAdc[i].dac_2_enable))
 		      {
-			temp = *(device->RS485_DacAdc[i].DAC_2)+ device->RS485_DacAdc[i].DAC_2_offset;
+			temp = hal_get_real(device->RS485_DacAdc[i].DAC_2)+ hal_get_real(device->RS485_DacAdc[i].DAC_2_offset);
 			
-			if(temp > device->RS485_DacAdc[i].DAC_2_max) {  temp = device->RS485_DacAdc[i].DAC_2_max; }
-			else if(temp < device->RS485_DacAdc[i].DAC_2_min) { temp = device->RS485_DacAdc[i].DAC_2_min; }
+			if(temp > hal_get_real(device->RS485_DacAdc[i].DAC_2_max)) {  temp = hal_get_real(device->RS485_DacAdc[i].DAC_2_max); }
+			else if(temp < hal_get_real(device->RS485_DacAdc[i].DAC_2_min)) { temp = hal_get_real(device->RS485_DacAdc[i].DAC_2_min); }
 			
 			temp = (temp + 10)*12.8 + 0.5;
                       }
@@ -2023,15 +1995,15 @@ RS485(void *arg, long period)
 
 		      if(temp>255) temp=255;
 		      else if(temp <0) temp=0;
-		      RS485DataIn8[2]= (hal_u32_t)temp;
+		      RS485DataIn8[2]= (rtapi_u32)temp;
 		      
 		    //DAC 3
-		      if(*(device->RS485_DacAdc[i].dac_3_enable))
+		      if(hal_get_bool(device->RS485_DacAdc[i].dac_3_enable))
 		      {
-			temp = *(device->RS485_DacAdc[i].DAC_3)+ device->RS485_DacAdc[i].DAC_3_offset;
+			temp = hal_get_real(device->RS485_DacAdc[i].DAC_3)+ hal_get_real(device->RS485_DacAdc[i].DAC_3_offset);
 			
-			if(temp > device->RS485_DacAdc[i].DAC_3_max) {  temp = device->RS485_DacAdc[i].DAC_3_max; }
-			else if(temp < device->RS485_DacAdc[i].DAC_3_min) { temp = device->RS485_DacAdc[i].DAC_3_min; }
+			if(temp > hal_get_real(device->RS485_DacAdc[i].DAC_3_max)) {  temp = hal_get_real(device->RS485_DacAdc[i].DAC_3_max); }
+			else if(temp < hal_get_real(device->RS485_DacAdc[i].DAC_3_min)) { temp = hal_get_real(device->RS485_DacAdc[i].DAC_3_min); }
 			
 			temp = (temp + 10)*12.8 + 0.5;
                       }
@@ -2039,7 +2011,7 @@ RS485(void *arg, long period)
 
 		      if(temp>255) temp=255;
 		      else if(temp <0) temp=0;
-		      RS485DataIn8[3]= (hal_u32_t)temp;
+		      RS485DataIn8[3]= (rtapi_u32)temp;
 
 		    break;		    
 		    		      
@@ -2064,7 +2036,7 @@ RS485(void *arg, long period)
 
 
 static void
-RS485_OrderDataRead(hal_u32_t* dataIn32, hal_u32_t* dataOut8, hal_u32_t length)
+RS485_OrderDataRead(rtapi_u32* dataIn32, rtapi_u32* dataOut8, rtapi_u32 length)
 {
 	int i, j;
 	//Order data (received to dataIn in reverse order and shifted) to dataOut[0]-dataOut[length-1]
@@ -2077,7 +2049,7 @@ RS485_OrderDataRead(hal_u32_t* dataIn32, hal_u32_t* dataOut8, hal_u32_t length)
  }
  
 static void
-RS485_OrderDataWrite(hal_u32_t* dataIn8, hal_u32_t* dataOut32, hal_u32_t length)
+RS485_OrderDataWrite(rtapi_u32* dataIn8, rtapi_u32* dataOut32, rtapi_u32 length)
 {
 	unsigned i, j;
 	/* Byte order: 
@@ -2100,7 +2072,7 @@ RS485_OrderDataWrite(hal_u32_t* dataIn8, hal_u32_t* dataOut32, hal_u32_t length)
  }
  
 static unsigned int
-RS485_CheckChecksum(hal_u32_t* data, hal_u32_t length)
+RS485_CheckChecksum(rtapi_u32* data, rtapi_u32 length)
 {
       unsigned int i=0, tempChecksum=0;
       
@@ -2116,7 +2088,7 @@ RS485_CheckChecksum(hal_u32_t* data, hal_u32_t length)
 }
 
 static unsigned int
-RS485_CalcChecksum(hal_u32_t* data, hal_u32_t length)
+RS485_CalcChecksum(rtapi_u32* data, rtapi_u32 length)
 {
       unsigned int i, tempChecksum=0;
       

--- a/src/hal/drivers/hal_parport.c
+++ b/src/hal/drivers/hal_parport.c
@@ -124,17 +124,17 @@ typedef struct {
     unsigned short base_addr;	/* base I/O address (0x378, etc.) */
     unsigned char data_dir;	/* non-zero if pins 2-9 are input */
     unsigned char use_control_in; /* non-zero if pins 1, 4, 16, 17 are input */ 
-    hal_bit_t *status_in[10];	/* ptrs for in pins 15, 13, 12, 10, 11 */
-    hal_bit_t *data_in[16];	/* ptrs for input pins 2 - 9 */
-    hal_bit_t *data_out[8];	/* ptrs for output pins 2 - 9 */
-    hal_bit_t data_inv[8];	/* polarity params for output pins 2 - 9 */
-    hal_bit_t data_reset[8];	/* reset flag for output pins 2 - 9 */
-    hal_bit_t *control_in[8];	/* ptrs for in pins 1, 14, 16, 17 */
-    hal_bit_t *control_out[4];	/* ptrs for out pins 1, 14, 16, 17 */
-    hal_bit_t control_inv[4];	/* pol. params for output pins 1, 14, 16, 17 */
-    hal_bit_t control_reset[4];	/* reset flag for output pins 1, 14, 16, 17 */
-    hal_u32_t reset_time;       /* min ns between write and reset */
-    hal_u32_t debug1, debug2;
+    hal_bool_t status_in[10];	/* (pin) ptrs for in pins 15, 13, 12, 10, 11 */
+    hal_bool_t data_in[16];	/* (pin) ptrs for input pins 2 - 9 */
+    hal_bool_t data_out[8];	/* (pin) ptrs for output pins 2 - 9 */
+    hal_bool_t data_inv[8];	/* (param) polarity params for output pins 2 - 9 */
+    hal_bool_t data_reset[8];	/* (param) reset flag for output pins 2 - 9 */
+    hal_bool_t control_in[8];	/* ptrs for in pins 1, 14, 16, 17 */
+    hal_bool_t control_out[4];	/* ptrs for out pins 1, 14, 16, 17 */
+    hal_bool_t control_inv[4];	/* (param) pol. params for output pins 1, 14, 16, 17 */
+    hal_bool_t control_reset[4];/* (param) reset flag for output pins 1, 14, 16, 17 */
+    hal_uint_t reset_time;      /* (param) min ns between write and reset */
+    hal_uint_t debug1, debug2;  /* (param) */
     long long write_time;
     unsigned short outdata;
     unsigned char reset_mask;       /* reset flag for pin 2..9 */
@@ -178,9 +178,9 @@ static int pins_and_params(char *argv[]);
 
 static unsigned short parse_port_addr(char *cp);
 static int export_port(int portnum, parport_t * addr);
-static int export_input_pin(int portnum, int pin, hal_bit_t ** base, int n);
-static int export_output_pin(int portnum, int pin, hal_bit_t ** dbase,
-    hal_bit_t * pbase, hal_bit_t * rbase, int n);
+static int export_input_pin(int portnum, int pin, hal_bool_t * base, int n);
+static int export_output_pin(int portnum, int pin, hal_bool_t * dbase,
+    hal_bool_t * pbase, hal_bool_t * rbase, int n);
 
 /***********************************************************************
 *                       INIT AND EXIT CODE                             *
@@ -316,8 +316,8 @@ static void read_port(void *arg, long period)
     /* split the bits into 10 variables (5 regular, 5 inverted) */
     mask = 0x08;
     for (b = 0; b < 10; b += 2) {
-	*(port->status_in[b]) = indata & mask;
-	*(port->status_in[b + 1]) = !(indata & mask);
+	hal_set_bool(port->status_in[b], indata & mask);
+	hal_set_bool(port->status_in[b + 1], !(indata & mask));
 	mask <<= 1;
     }
     /* are we using the data port for input? */
@@ -327,8 +327,8 @@ static void read_port(void *arg, long period)
 	/* split the bits into 16 variables (8 regular, 8 inverted) */
 	mask = 0x01;
 	for (b = 0; b < 16; b += 2) {
-	    *(port->data_in[b]) = indata & mask;
-	    *(port->data_in[b + 1]) = !(indata & mask);
+	    hal_set_bool(port->data_in[b], indata & mask);
+	    hal_set_bool(port->data_in[b + 1], !(indata & mask));
 	    mask <<= 1;
 	}
     }
@@ -338,8 +338,8 @@ static void read_port(void *arg, long period)
         /* correct for hardware inverters on pins 1, 14, & 17 */
         indata = rtapi_inb(port->base_addr + 2) ^ 0x0B;
         for (b = 0; b < 8; b += 2) {
-            *(port->control_in[b]) = indata & mask;
-            *(port->control_in[b + 1]) = !(indata & mask);
+            hal_set_bool(port->control_in[b], indata & mask);
+            hal_set_bool(port->control_in[b + 1], !(indata & mask));
 	    mask <<= 1;
         }
     }
@@ -350,10 +350,10 @@ static void reset_port(void *arg, long period) {
     long long deadline;
     unsigned char outdata = (unsigned char)((port->outdata&~port->reset_mask) ^ port->reset_val);
    
-    if(port->reset_time > period/4) port->reset_time = period/4;
+    if(hal_get_ui32(port->reset_time) > period/4) hal_set_ui32(port->reset_time, period/4);
 
     if(outdata != port->outdata) {
-        deadline = port->write_time + port->reset_time;
+        deadline = port->write_time + hal_get_ui32(port->reset_time);
         while(rtapi_get_time() < deadline) {}
         rtapi_outb(outdata, port->base_addr);
         port->outdata = outdata;
@@ -362,7 +362,7 @@ static void reset_port(void *arg, long period) {
     outdata = (unsigned char)((port->outdata_ctrl&~port->reset_mask_ctrl)^port->reset_val_ctrl);
 
     if(outdata != port->outdata_ctrl) {
-        deadline = port->write_time_ctrl + port->reset_time;
+        deadline = port->write_time_ctrl + hal_get_ui32(port->reset_time);
         while(rtapi_get_time() < deadline) {}
 	/* correct for hardware inverters on pins 1, 14, & 17 */
         rtapi_outb(outdata ^ 0x0B, port->base_addr + 2);
@@ -387,15 +387,15 @@ static void write_port(void *arg, long period)
 	/* assemble output byte for data port from 8 source variables */
 	for (b = 0; b < 8; b++) {
 	    /* get the data, add to output byte */
-	    if ((*(port->data_out[b])) && (!port->data_inv[b])) {
+	    if ((hal_get_bool(port->data_out[b])) && (!hal_get_bool(port->data_inv[b]))) {
 		outdata |= mask;
 	    }
-	    if ((!*(port->data_out[b])) && (port->data_inv[b])) {
+	    if ((!hal_get_bool(port->data_out[b])) && (hal_get_bool(port->data_inv[b]))) {
 		outdata |= mask;
 	    }
-	    if (port->data_reset[b]) {
+	    if (hal_get_bool(port->data_reset[b])) {
 		reset_mask |= mask;
-		if(port->data_inv[b]) reset_val |= mask;
+		if(hal_get_bool(port->data_inv[b])) reset_val |= mask;
 	    }
 	    mask <<= 1;
 	}
@@ -424,15 +424,15 @@ static void write_port(void *arg, long period)
 	mask = 0x01;
 	for (b = 0; b < 4; b++) {
 	    /* get the data, add to output byte */
-	    if ((*(port->control_out[b])) && (!port->control_inv[b])) {
+	    if ((hal_get_bool(port->control_out[b])) && (!hal_get_bool(port->control_inv[b]))) {
 		outdata |= mask;
 	    }
-	    if ((!*(port->control_out[b])) && (port->control_inv[b])) {
+	    if ((!hal_get_bool(port->control_out[b])) && (hal_get_bool(port->control_inv[b]))) {
 		outdata |= mask;
 	    }
-	    if (port->control_reset[b]) {
+	    if (hal_get_bool(port->control_reset[b])) {
 		reset_mask |= mask;
-		if(port->control_inv[b]) reset_val |= mask;
+		if(hal_get_bool(port->control_inv[b])) reset_val |= mask;
 	    }
 	    mask <<= 1;
 	}
@@ -545,7 +545,7 @@ static int pins_and_params(char *argv[])
 	return -1;
     }
     /* allocate shared memory for parport data */
-    port_data_array = hal_malloc(num_ports * sizeof(parport_t));
+    port_data_array = hal_malloc(num_ports * sizeof(*port_data_array));
     if (port_data_array == 0) {
 	rtapi_print_msg(RTAPI_MSG_ERR,
 	    "PARPORT: ERROR: hal_malloc() failed\n");
@@ -666,6 +666,11 @@ static int export_port(int portnum, parport_t * port)
 	retval += export_input_pin(portnum, 7, port->data_in, 5);
 	retval += export_input_pin(portnum, 8, port->data_in, 6);
 	retval += export_input_pin(portnum, 9, port->data_in, 7);
+        // Allocated in a conditional below. Make sure there is memory for them.
+        retval += hal_param_new_fake(comp_id, (hal_refs_u *)&port->reset_time);
+        // The debug params are apparently not used. Just to be sure.
+        retval += hal_param_new_fake(comp_id, (hal_refs_u *)&port->debug1);
+        retval += hal_param_new_fake(comp_id, (hal_refs_u *)&port->debug2);
     } else {
 	/* declare output pins (data port) */
 	retval += export_output_pin(portnum, 2,
@@ -684,11 +689,11 @@ static int export_port(int portnum, parport_t * port)
 	    port->data_out, port->data_inv, port->data_reset, 6);
 	retval += export_output_pin(portnum, 9,
 	    port->data_out, port->data_inv, port->data_reset, 7);
-	retval += hal_param_u32_newf(HAL_RW, &port->reset_time, comp_id, 
+	retval += hal_param_new_ui32(comp_id, HAL_RW, &port->reset_time, 0,
 			"parport.%d.reset-time", portnum);
-	retval += hal_param_u32_newf(HAL_RW, &port->debug1, comp_id, 
+	retval += hal_param_new_ui32(comp_id, HAL_RW, &port->debug1, 0,
 			"parport.%d.debug1", portnum);
-	retval += hal_param_u32_newf(HAL_RW, &port->debug2, comp_id, 
+	retval += hal_param_new_ui32(comp_id, HAL_RW, &port->debug2, 0,
 			"parport.%d.debug2", portnum);
 	port->write_time = 0;
     }
@@ -715,42 +720,42 @@ static int export_port(int portnum, parport_t * port)
     return retval;
 }
 
-static int export_input_pin(int portnum, int pin, hal_bit_t ** base, int n)
+static int export_input_pin(int portnum, int pin, hal_bool_t * base, int n)
 {
     int retval;
 
     /* export write only HAL pin for the input bit */
-    retval = hal_pin_bit_newf(HAL_OUT, base + (2 * n), comp_id,
+    retval = hal_pin_new_bool(comp_id, HAL_OUT, base + (2 * n), 0,
             "parport.%d.pin-%02d-in", portnum, pin);
     if (retval != 0) {
 	return retval;
     }
     /* export another write only HAL pin for the same bit inverted */
-    retval = hal_pin_bit_newf(HAL_OUT, base + (2 * n) + 1, comp_id,
+    retval = hal_pin_new_bool(comp_id, HAL_OUT, base + (2 * n) + 1, 0,
             "parport.%d.pin-%02d-in-not", portnum, pin);
     return retval;
 }
 
-static int export_output_pin(int portnum, int pin, hal_bit_t ** dbase,
-    hal_bit_t * pbase, hal_bit_t * rbase, int n)
+static int export_output_pin(int portnum, int pin, hal_bool_t * dbase,
+    hal_bool_t * pbase, hal_bool_t * rbase, int n)
 {
     int retval;
 
     /* export read only HAL pin for output data */
-    retval = hal_pin_bit_newf(HAL_IN, dbase + n, comp_id,
+    retval = hal_pin_new_bool(comp_id, HAL_IN, dbase + n, 0,
             "parport.%d.pin-%02d-out", portnum, pin);
     if (retval != 0) {
 	return retval;
     }
     /* export parameter for polarity */
-    retval = hal_param_bit_newf(HAL_RW, pbase + n, comp_id,
+    retval = hal_param_new_bool(comp_id, HAL_RW, pbase + n, 0,
             "parport.%d.pin-%02d-out-invert", portnum, pin);
     if (retval != 0) {
 	return retval;
     }
     /* export parameter for reset */
     if (rbase)
-	retval = hal_param_bit_newf(HAL_RW, rbase + n, comp_id,
+	retval = hal_param_new_bool(comp_id, HAL_RW, rbase + n, 0,
 		"parport.%d.pin-%02d-out-reset", portnum, pin);
     return retval;
 }

--- a/src/hal/drivers/hal_ppmc.c
+++ b/src/hal/drivers/hal_ppmc.c
@@ -219,31 +219,31 @@ an unsafe condition, then the board will immediately return to the ESTOP state.
 
 /* this structure contains the runtime data for a digital output */
 typedef struct {
-    hal_bit_t *data;		/* output pin value */
-    hal_bit_t invert;		/* parameter to invert output pin */
+    hal_bool_t data;		/* output pin value */
+    hal_bool_t invert;		/* parameter: to invert output pin */
 } dout_t;
 
 /* this structure contains the runtime data for a digital input */
 typedef struct {
-    hal_bit_t *data;		/* input pin value */
-    hal_bit_t *data_not;	/* inverted input pin value */
+    hal_bool_t data;		/* input pin value */
+    hal_bool_t data_not;	/* inverted input pin value */
 } din_t;
 
 /* this structure contains the runtime data for a step pulse generator */
 typedef struct {
-    hal_bit_t *enable;		/* enable pin for step generator */
-    hal_float_t *vel;		/* velocity command pin*/
-    hal_float_t scale;		/* parameter: scaling for vel to Hz */
-    hal_float_t max_vel;	/* velocity limit */
-    hal_float_t freq;		/* parameter: velocity cmd scaled to Hz */
+    hal_bool_t enable;		/* enable pin for step generator */
+    hal_real_t vel;		/* velocity command pin*/
+    hal_real_t scale;		/* parameter: scaling for vel to Hz */
+    hal_real_t max_vel;		/* parameter: velocity limit */
+    hal_real_t freq;		/* parameter: velocity cmd scaled to Hz */
 } stepgen_t;
 
 /* runtime data for a set of 4 step pulse generators */
 typedef struct {
     stepgen_t sg[4];		/* per generator data */
-    hal_u32_t setup_time_ns;	/* setup time in nanoseconds */
-    hal_u32_t pulse_width_ns;	/* pulse width in nanoseconds */
-    hal_u32_t pulse_space_ns;	/* min pulse space in nanoseconds */
+    hal_uint_t setup_time_ns;	/* parameter: setup time in nanoseconds */
+    hal_uint_t pulse_width_ns;	/* parameter: pulse width in nanoseconds */
+    hal_uint_t pulse_space_ns;	/* parameter: min pulse space in nanoseconds */
 } stepgens_t;
 
 #define BOOT_NORMAL 0
@@ -252,13 +252,13 @@ typedef struct {
 
 /* this structure contains the runtime data for a PWM generator */
 typedef struct {
-    hal_bit_t *enable;		/* enable pin for PWM generator */
-    hal_float_t *value;		/* value command pin */
-    hal_float_t scale;		/* parameter: scaling */
-    hal_float_t max_dc;		/* maximum duty cycle 0.0-1.0 */
-    hal_float_t min_dc;		/* minimum duty cycle 0.0-1.0 */
-    hal_float_t duty_cycle;	/* actual duty cycle output */
-    hal_bit_t bootstrap;	/* enable bootstrap mode (pulses at startup) */
+    hal_bool_t enable;		/* enable pin for PWM generator */
+    hal_real_t value;		/* value command pin */
+    hal_real_t scale;		/* parameter: scaling */
+    hal_real_t max_dc;		/* parameter: maximum duty cycle 0.0-1.0 */
+    hal_real_t min_dc;		/* parameter: minimum duty cycle 0.0-1.0 */
+    hal_real_t duty_cycle;	/* parameter: actual duty cycle output */
+    hal_bool_t bootstrap;	/* parameter: enable bootstrap mode (pulses at startup) */
     unsigned char boot_state;	/* state for bootstrap state machine */
     unsigned char old_enable;	/* used to detect rising edge, for boot */
 } pwmgen_t;
@@ -266,16 +266,16 @@ typedef struct {
 /* runtime data for a set of 4 PWM generators */
 typedef struct {
     pwmgen_t pg[4];		/* per generator data */
-    hal_float_t freq;		/* PWM frequency */
-    hal_float_t old_freq;	/* previous value, to detect changes */
+    hal_real_t freq;		/* parameter: PWM frequency */
+    rtapi_real old_freq;	/* previous value, to detect changes */
     unsigned short period;	/* period in clock ticks */
     double period_recip;	/* reciprocal of period */
 } pwmgens_t;
 
 /* this structure contains the runtime data for a 16-bit DAC */
 typedef struct {
-    hal_float_t *value;		/* value command pin */
-    hal_float_t scale;		/* parameter: scaling */
+    hal_real_t value;		/* value command pin */
+    hal_real_t scale;		/* parameter: scaling */
 } DAC_t;
 
 /* runtime data for a 4-channel 16-bit DAC */
@@ -291,19 +291,19 @@ typedef union {
 
 /* runtime data for a single encoder */
 typedef struct {
-  hal_float_t *position;      /* output: scaled position pointer */
-  hal_s32_t *count;           /* output: unscaled encoder counts */
-  hal_s32_t *delta;		/* output: delta counts since last read */
-  hal_s32_t prevdir;		/* local: previous direction  */
-  hal_float_t scale;          /* parameter: scale factor */
-  hal_bit_t *index;           /* output: index flag */
-  hal_bit_t *index_enable;    /* enable index pulse to reset encoder count */
-  hal_s32_t oldreading;     /* used to detect overflow / underflow of the counter JE001 */
-  unsigned int indres;        /* copy of reset-on-index register bits (only valid on 1st encoder of board)*/
-  unsigned int indrescnt;    /* counts servo cycles since index reset was turned on */
-  hal_float_t *vel;             /* output: scaled velocity */
-  hal_float_t min_speed;        /* parameter: min speed for velocity estimation */
-  hal_u32_t counts_since_timeout;    /* for velocity estimation */
+  hal_real_t position;      /* output: scaled position pointer */
+  hal_sint_t count;         /* output: unscaled encoder counts */
+  hal_sint_t delta;         /* output: delta counts since last read */
+  rtapi_s32 prevdir;        /* local: previous direction  */
+  hal_real_t scale;         /* parameter: scale factor */
+  hal_bool_t index;         /* output: index flag */
+  hal_bool_t index_enable;  /* enable index pulse to reset encoder count */
+  rtapi_s32 oldreading;     /* used to detect overflow / underflow of the counter JE001 */
+  unsigned int indres;      /* copy of reset-on-index register bits (only valid on 1st encoder of board)*/
+  unsigned int indrescnt;   /* counts servo cycles since index reset was turned on */
+  hal_real_t vel;           /* output: scaled velocity */
+  hal_real_t min_speed;     /* parameter: min speed for velocity estimation */
+  rtapi_u32 counts_since_timeout;    /* for velocity estimation */
   unsigned short old_timestamp;
   unsigned short timestamp;
 } encoder_t;
@@ -957,8 +957,8 @@ static void read_digins(slot_data_t *slot)
     b = 0;
     mask = 0x01;
     while ( b < 8 ) {
-	*(slot->digin[b].data) = indata & mask;
-	*(slot->digin[b].data_not) = !(indata & mask);
+	hal_set_bool(slot->digin[b].data, !!(indata & mask));
+	hal_set_bool(slot->digin[b].data_not, !(indata & mask));
 	mask <<= 1;
 	b++;
     }
@@ -967,8 +967,8 @@ static void read_digins(slot_data_t *slot)
     /* and split them too */
     mask = 0x01;
     while ( b < 16 ) {
-	*(slot->digin[b].data) = indata & mask;
-	*(slot->digin[b].data_not) = !(indata & mask);
+	hal_set_bool(slot->digin[b].data, !!(indata & mask));
+	hal_set_bool(slot->digin[b].data_not, !(indata & mask));
 	mask <<= 1;
 	b++;
     }
@@ -984,10 +984,10 @@ static void write_digouts(slot_data_t *slot)
     /* assemble output byte from 8 source variables */
     for (b = 0; b < 8; b++) {
 	/* get the data, add to output byte */
-	if ((*(slot->digout[b].data)) && (!slot->digout[b].invert)) {
+	if ((hal_get_bool(slot->digout[b].data)) && !hal_get_bool(slot->digout[b].invert)) {
 	    outdata |= mask;
 	}
-	if ((!*(slot->digout[b].data)) && (slot->digout[b].invert)) {
+	if ((!hal_get_bool(slot->digout[b].data)) && hal_get_bool(slot->digout[b].invert)) {
 	    outdata |= mask;
 	}
 	mask <<= 1;
@@ -1008,8 +1008,8 @@ static void read_PPMC_digins(slot_data_t *slot)
     b = 0;
     mask = 0x01;
     while ( b < 8 ) {
-	*(slot->digin[b].data) = indata & mask;
-	*(slot->digin[b].data_not) = !(indata & mask);
+	hal_set_bool(slot->digin[b].data, !!(indata & mask));
+	hal_set_bool(slot->digin[b].data_not, !(indata & mask));
 	mask <<= 1;
 	b++;
     }
@@ -1018,8 +1018,8 @@ static void read_PPMC_digins(slot_data_t *slot)
     /* and split them too */
     mask = 0x01;
     while ( b < 16 ) {
-	*(slot->digin[b].data) = indata & mask;
-	*(slot->digin[b].data_not) = !(indata & mask);
+	hal_set_bool(slot->digin[b].data, !!(indata & mask));
+	hal_set_bool(slot->digin[b].data_not, !(indata & mask));
 	mask <<= 1;
 	b++;
     }
@@ -1029,8 +1029,8 @@ static void read_PPMC_digins(slot_data_t *slot)
       /* and split them too */
       mask = 0x01;
       while ( b < 18 ) {
-	*(slot->digin[b].data) = indata & mask;
-	*(slot->digin[b].data_not) = !(indata & mask);
+	hal_set_bool(slot->digin[b].data, !!(indata & mask));
+	hal_set_bool(slot->digin[b].data_not, !(indata & mask));
 	mask <<= 1;
 	b++;
       }
@@ -1048,10 +1048,10 @@ static void write_PPMC_digouts(slot_data_t *slot)
     /* assemble output byte from 8 source variables */
     for (b = 0; b < 8; b++) {
 	/* get the data, add to output byte */
-	if ((*(slot->digout[b].data)) && (!slot->digout[b].invert)) {
+	if ((hal_get_bool(slot->digout[b].data)) && !hal_get_bool(slot->digout[b].invert)) {
 	    outdata |= mask;
 	}
-	if ((!*(slot->digout[b].data)) && (slot->digout[b].invert)) {
+	if ((!hal_get_bool(slot->digout[b].data)) && hal_get_bool(slot->digout[b].invert)) {
 	    outdata |= mask;
 	}
 	mask <<= 1;
@@ -1060,10 +1060,10 @@ static void write_PPMC_digouts(slot_data_t *slot)
     slot->wr_buf[DIO_DOUTA] = outdata;
     if (slot->digout[8].data != NULL) {  // no estop funct on slave boards - hal pin doesn't exist
       outdata = 0;  // now process estop bit
-      if ((*(slot->digout[8].data)) && (!slot->digout[8].invert)) {
+      if ((hal_get_bool(slot->digout[8].data)) && !hal_get_bool(slot->digout[8].invert)) {
 	outdata =1;
       }
-      if ((!*(slot->digout[8].data)) && (slot->digout[8].invert)) {
+      if ((!hal_get_bool(slot->digout[8].data)) && hal_get_bool(slot->digout[8].invert)) {
 	outdata |= 1;
       }
       slot->wr_buf[DIO_ESTOP_OUT] = outdata;
@@ -1076,7 +1076,7 @@ static void read_encoders(slot_data_t *slot)
   int i, byteindex, byteindx2;
   double vel;                    // local temporary velocity
     union pos_tag {
-      hal_s32_t l;              // JE001
+      rtapi_s32 l;               // JE001
         struct byte_tag {
             signed char b0;
             signed char b1;
@@ -1092,8 +1092,6 @@ static void read_encoders(slot_data_t *slot)
       } byte;
     } timebase, timestamp;
     unsigned short delta_time;
-    //    hal_u32_t timestamp;
-    //    hal_u32_t timebase;
       
     // sample timebase only on boards so equipped
     if (slot->use_timestamp) {
@@ -1116,22 +1114,22 @@ static void read_encoders(slot_data_t *slot)
         else
             if ((oldpos.byte.b2 == 0) && (pos.byte.b2 & 0xc0) == 0xc0)
                 pos.byte.b3--;
-	*(slot->encoder[i].delta) = pos.l - slot->encoder[i].oldreading;
+	hal_set_si32(slot->encoder[i].delta, pos.l - slot->encoder[i].oldreading);
 	vel = (pos.l - slot->encoder[i].oldreading) /
-	           (read_period * 1e-9 * slot->encoder[i].scale);
+	           (read_period * 1e-9 * hal_get_real(slot->encoder[i].scale));
 	/* index processing */
 	if ( (slot->rd_buf[ENCISR] & ( 1 << i )) != 0 ) {
 	  //	  rtapi_print_msg(RTAPI_MSG_INFO, "index seen for axis %d",i);
 	  //	  rtapi_print_msg(RTAPI_MSG_INFO, "indrescnt %d\n",slot->encoder[i].indrescnt);
 	    /* index edge occurred since last time this code ran */
-	    *(slot->encoder[i].index) = 1;
+	    hal_set_bool(slot->encoder[i].index, 1);
 	    /* index-enable only works on version 2 and up */
 	    if (slot->ver >= 2) {
 		/* were we looking for an index edge? */
 		if ( ((slot->encoder[0].indres & ( 1 << i )) != 0) &&
 		     (slot->encoder[i].indrescnt > 3)) {
 		    /* yes, clear index-enable to announce that we found it */
-		    *(slot->encoder[i].index_enable) = 0;
+		    hal_set_bool(slot->encoder[i].index_enable, 0);
 		    /* need to properly set the 24->32 bit extension byte */
 		    if ( pos.byte.b2 < 0 ) {
 		      /* going backwards */
@@ -1144,18 +1142,18 @@ static void read_encoders(slot_data_t *slot)
 	    }
 	} else {
 	  /* no index edge since last check */
-	  *(slot->encoder[i].index) = 0;
+	  hal_set_bool(slot->encoder[i].index, 0);
 	}
 	slot->encoder[i].oldreading = pos.l;
-	*(slot->encoder[i].count) = pos.l;
-	if (slot->encoder[i].scale < 0.0) {
-	  if (slot->encoder[i].scale > -EPSILON)
-	    slot->encoder[i].scale = -1.0;
+	hal_set_si32(slot->encoder[i].count, pos.l);
+	if (hal_get_real(slot->encoder[i].scale) < 0.0) {
+	  if (hal_get_real(slot->encoder[i].scale) > -EPSILON)
+	    hal_set_real(slot->encoder[i].scale, -1.0);
 	} else {
-	  if (slot->encoder[i].scale < EPSILON)
-	    slot->encoder[i].scale = 1.0;
+	  if (hal_get_real(slot->encoder[i].scale) < EPSILON)
+	    hal_set_real(slot->encoder[i].scale, 1.0);
 	}
-	*(slot->encoder[i].position) = pos.l / slot->encoder[i].scale;
+	hal_set_real(slot->encoder[i].position, pos.l / hal_get_real(slot->encoder[i].scale));
 	// perform velocity estimate when hardware provides timestamps
 	if (slot->use_timestamp) {
 	  slot->encoder[i].old_timestamp = slot->encoder[i].timestamp;
@@ -1163,20 +1161,20 @@ static void read_encoders(slot_data_t *slot)
 	  timestamp.byte.b1 = slot->rd_buf[byteindx2++];
 	  slot->encoder[i].timestamp = timestamp.s;
 	  // one or more counts this sample
-	  if (*(slot->encoder[i].delta) != 0.0) {
+	  if (hal_get_si32(slot->encoder[i].delta) != 0.0) {
 	    delta_time = timestamp.s - slot->encoder[i].old_timestamp;
 	    delta_time = delta_time & 0xffff;
 	    if (slot->encoder[i].counts_since_timeout < 2) {
 	      // just keep simple vel calc from above
 	      slot->encoder[i].counts_since_timeout++;
-	      *(slot->encoder[i].vel) = vel;  // cannot make estimate
+	      hal_set_real(slot->encoder[i].vel, vel);  // cannot make estimate
 	    } else {
-	      vel = *(slot->encoder[i].delta) / (delta_time * 1e-6 * slot->encoder[i].scale);
-	      *(slot->encoder[i].vel) = vel;
+	      vel = hal_get_si32(slot->encoder[i].delta) / (delta_time * 1e-6 * hal_get_real(slot->encoder[i].scale));
+	      hal_set_real(slot->encoder[i].vel, vel);
 	    }
-	    if (((slot->encoder[i].prevdir > 0) && (*(slot->encoder[i].delta) < 0)) ||
-		((slot->encoder[i].prevdir < 0) && (*(slot->encoder[i].delta) > 0))) {
-	      *(slot->encoder[i].vel) = 0.0;    /* suppress velocity of dithering encoder at reversal */
+	    if (((slot->encoder[i].prevdir > 0) && (hal_get_si32(slot->encoder[i].delta) < 0)) ||
+		((slot->encoder[i].prevdir < 0) && (hal_get_si32(slot->encoder[i].delta) > 0))) {
+	      hal_set_real(slot->encoder[i].vel, 0.0);    /* suppress velocity of dithering encoder at reversal */
 	    }
 	  } else {
 	    // no counts this sample
@@ -1186,27 +1184,27 @@ static void read_encoders(slot_data_t *slot)
 	      //  if (delta_time < slot->encoder[i].scale * slot->encoder[i].min_speed) {
 	      if (delta_time < 65500) {
 		// 1e-6 is timebase period
-		vel = 1.0 / (slot->encoder[i].scale * delta_time * 1e-6);
+		vel = 1.0 / (hal_get_real(slot->encoder[i].scale) * delta_time * 1e-6);
 		if (vel < 0.0) vel = -vel;
-		if (vel < *(slot->encoder[i].vel)) {
-		  *(slot->encoder[i].vel) = vel;
+		if (vel < hal_get_real(slot->encoder[i].vel)) {
+		  hal_set_real(slot->encoder[i].vel, vel);
 		}
-		if (-vel > *(slot->encoder[i].vel)) {
-		  *(slot->encoder[i].vel) = -vel;
+		if (-vel > hal_get_real(slot->encoder[i].vel)) {
+		  hal_set_real(slot->encoder[i].vel, -vel);
 		}
 	      } else {
 		slot->encoder[i].counts_since_timeout = 0;
-		*(slot->encoder[i].vel) = 0;
+		hal_set_real(slot->encoder[i].vel, 0);
 	      }
 	    } else {
-	      *(slot->encoder[i].vel) = 0;
+	      hal_set_real(slot->encoder[i].vel, 0);
 	    }
 	  }
 	} else {
-	  *(slot->encoder[i].vel) = vel;  // encoder without timestamp
+	  hal_set_real(slot->encoder[i].vel, vel);  // encoder without timestamp
 	}
-	if (*(slot->encoder[i].delta) > 0) slot->encoder[i].prevdir = 1;  // mark last direction moved
-	if (*(slot->encoder[i].delta) < 0) slot->encoder[i].prevdir = -1;
+	if (hal_get_si32(slot->encoder[i].delta) > 0) slot->encoder[i].prevdir = 1;  // mark last direction moved
+	if (hal_get_si32(slot->encoder[i].delta) < 0) slot->encoder[i].prevdir = -1;
     }
 }
 
@@ -1224,7 +1222,7 @@ static void write_encoders(slot_data_t *slot)
 	return;
     }
     for (i = 0; i < 4; i++) {
-	if ( *(slot->encoder[i].index_enable) ) {
+	if ( hal_get_bool(slot->encoder[i].index_enable) ) {
 	    /* all 4 control bits are packed into the same register */
 	  if ((slot->encoder[0].indres & (1 << i)) == 0) {
 	    slot->encoder[i].indrescnt = 0; /* clear counter first time only */
@@ -1244,16 +1242,16 @@ static void write_encoders(slot_data_t *slot)
 /* fetch a time parameter (in nS), make sure it is a multiple
    of 100nS, and is between min_ns and 25.4uS, and return the
    value in 10MHz clock pulses. */
-static unsigned int ns2cp( hal_u32_t *pns, unsigned int min_ns )
+static unsigned int ns2cp( hal_uint_t pns, unsigned int min_ns )
 {
     unsigned ns, cp;
 
-    ns = *pns;
+    ns = hal_get_ui32(pns);
     if ( ns < min_ns ) ns = min_ns;
     if ( ns > 25400 ) ns = 25400;
     cp = ns / 100;
     ns = cp * 100;
-    *pns = ns;
+    hal_set_ui32(pns, ns);
     return cp;
 }
 
@@ -1267,13 +1265,13 @@ static void write_stepgens(slot_data_t *slot)
     unsigned char control_byte;
 
     /* pulse width cannot be less than 200nS (HW limit) */
-    pulse_width = ns2cp(&(slot->stepgen->pulse_width_ns), 200);
+    pulse_width = ns2cp(slot->stepgen->pulse_width_ns, 200);
     /* write pulse width to the cache, inverted */
     slot->wr_buf[RATE_WIDTH_0] = 256 - pulse_width;
     /* pulse space cannot be less than 300nS (HW limitation) */
-    pulse_space = ns2cp(&(slot->stepgen->pulse_space_ns), 300);
+    pulse_space = ns2cp(slot->stepgen->pulse_space_ns, 300);
     /* setup time cannot be less than 2 (HW limit) */
-    setup_time = ns2cp(&(slot->stepgen->setup_time_ns), 200);
+    setup_time = ns2cp(slot->stepgen->setup_time_ns, 200);
     /* write it to the cache, inverted */
     slot->wr_buf[RATE_SETUP_0] = 256 - setup_time;
     /* calculate the max frequency, varies with pulse width and
@@ -1285,37 +1283,37 @@ static void write_stepgens(slot_data_t *slot)
 	/* point to the specific stepgen */
 	sg = &(slot->stepgen->sg[n]);
 	/* validate the scale value */
-	if ( sg->scale < 0.0 ) {
-	    if ( sg->scale > -EPSILON ) {
+	if ( hal_get_real(sg->scale) < 0.0 ) {
+	    if ( hal_get_real(sg->scale) > -EPSILON ) {
 		/* too small, divide by zero is bad */
-		sg->scale = -1.0;
+		hal_set_real(sg->scale, -1.0);
 	    }
-	    abs_scale = -sg->scale;
+	    abs_scale = -hal_get_real(sg->scale);
 	} else {
-	    if ( sg->scale < EPSILON ) {
-		sg->scale = 1.0;
+	    if ( hal_get_real(sg->scale) < EPSILON ) {
+		hal_set_real(sg->scale, 1.0);
 	    }
-	    abs_scale = sg->scale;
+	    abs_scale = hal_get_real(sg->scale);
 	}
 	ch_max_freq = bd_max_freq;
 	/* check for user specified max velocity */
-	if (sg->max_vel <= 0.0) {
+	if (hal_get_real(sg->max_vel) <= 0.0) {
 	    /* set to zero if negative, and ignore if zero */
-	    sg->max_vel = 0.0;
+	    hal_set_real(sg->max_vel, 0.0);
 	} else {
 	    /* parameter is non-zero and positive, compare to max_freq */
-	    if ( (sg->max_vel * abs_scale) > ch_max_freq) {
+	    if ( (hal_get_real(sg->max_vel) * abs_scale) > ch_max_freq) {
 		/* parameter is too high, lower it */
-		sg->max_vel = ch_max_freq / abs_scale;
+		hal_set_real(sg->max_vel, ch_max_freq / abs_scale);
 	    } else {
 		/* lower max_freq to match parameter */
-		ch_max_freq = sg->max_vel * abs_scale;
+		ch_max_freq = hal_get_real(sg->max_vel) * abs_scale;
 	    }
 	}
 	/* calculate desired frequency */
-	freq = *(sg->vel) * sg->scale;
+	freq = hal_get_real(sg->vel) * hal_get_real(sg->scale);
 	/* should we be running? */
-	if ( *(sg->enable) != 0 ) {
+	if ( hal_get_bool(sg->enable) != 0 ) {
 	    run = 1;
 	} else {
 	    run = 0;
@@ -1350,9 +1348,9 @@ static void write_stepgens(slot_data_t *slot)
 	}
 	/* set dir bit in the control byte, and save the frequency */
 	if ( reverse ) {
-	    sg->freq = -freq;
+	    hal_set_real(sg->freq, -freq);
 	} else {
-	    sg->freq = freq;
+	    hal_set_real(sg->freq, freq);
 	    control_byte |= 0x40;
 	}
 	/* correct for an offset of 4 in the hardware */
@@ -1378,17 +1376,17 @@ static void write_pwmgens(slot_data_t *slot)
     unsigned char control_byte;
 
     /* zero frequency is a special case, turn off everything */
-    if ( slot->pwmgen->freq == 0.0 ) {
-	slot->pwmgen->old_freq = slot->pwmgen->freq;
+    if ( hal_get_real(slot->pwmgen->freq) == 0.0 ) {
+	slot->pwmgen->old_freq = hal_get_real(slot->pwmgen->freq);
 	/* write control byte to cache */
 	slot->wr_buf[PWM_CTRL_0] = 0;
 	/* done */
 	return;
     }
     /* check for new frequency setting */
-    if ( slot->pwmgen->freq != slot->pwmgen->old_freq ) {
+    if ( hal_get_real(slot->pwmgen->freq) != slot->pwmgen->old_freq ) {
 	/* process new frequency value */
-	freq = slot->pwmgen->freq;
+	freq = hal_get_real(slot->pwmgen->freq);
 	/* frequency must be between 153Hz and 500KHz */
 	if ( freq < 153.0 ) {
 	    freq = 153.0;
@@ -1404,7 +1402,7 @@ static void write_pwmgens(slot_data_t *slot)
 	/* calculate actual frequency (after rounding, etc) */
 	freq = 10000000.0 / period;
 	/* save values */
-	slot->pwmgen->freq = freq;
+	hal_set_real(slot->pwmgen->freq, freq);
 	slot->pwmgen->old_freq = freq;
 	slot->pwmgen->period = period;
 	slot->pwmgen->period_recip = 1.0 / period;
@@ -1420,31 +1418,31 @@ static void write_pwmgens(slot_data_t *slot)
 	/* point to the specific pwm generator */
 	pg = &(slot->pwmgen->pg[n]);
 	/* validate the scale value */
-	if ( pg->scale < 0.0 ) {
-	    if ( pg->scale > -EPSILON ) {
+	if ( hal_get_real(pg->scale) < 0.0 ) {
+	    if ( hal_get_real(pg->scale) > -EPSILON ) {
 		/* too small, divide by zero is bad */
-		pg->scale = -1.0;
+		hal_set_real(pg->scale, -1.0);
 	    }
 	} else {
-	    if ( pg->scale < EPSILON ) {
-		pg->scale = 1.0;
+	    if ( hal_get_real(pg->scale) < EPSILON ) {
+		hal_set_real(pg->scale, 1.0);
 	    }
 	}
 	/* calculate desired duty cycle */
-	dc = *(pg->value) / pg->scale;
+	dc = hal_get_real(pg->value) / hal_get_real(pg->scale);
 	/* Special code to deal with the requirements of the Pico PWM
 	   amps.  They need at least one PWM pulse in each direction 
 	   every time you enable the amps.  So we override the commanded
 	   duty cycle with +5%, then -5%, for one thread execution time 
 	   each, when we see a rising edge on enable.
 	*/
-	if ( pg->bootstrap != 0 ) {
+	if ( hal_get_bool(pg->bootstrap) != 0 ) {
 	    /* check for rising edge on enable */
-	    if (( *(pg->enable) != 0 ) && ( pg->old_enable == 0 )) {
+	    if (( hal_get_bool(pg->enable) != 0 ) && ( pg->old_enable == 0 )) {
 		/* kick off state machine */
 		pg->boot_state = BOOT_FWD;
 	    }
-	    pg->old_enable = *(pg->enable);
+	    pg->old_enable = hal_get_bool(pg->enable);
 	    /* now execute a state machine */
 	    switch(pg->boot_state) {
 	    case BOOT_NORMAL:
@@ -1471,21 +1469,21 @@ static void write_pwmgens(slot_data_t *slot)
 	    abs_dc = dc;
 	}
 	/* reset any illegal duty cycle limits */
-	if (( pg->min_dc > 1.0 ) || ( pg->min_dc < 0.0 )) {
-	    pg->min_dc = 0.0;
+	if (( hal_get_real(pg->min_dc) > 1.0 ) || ( hal_get_real(pg->min_dc) < 0.0 )) {
+	    hal_set_real(pg->min_dc, 0.0);
 	} 
-	if (( pg->max_dc > 1.0 ) || ( pg->max_dc < 0.0 )) {
-	    pg->max_dc = 1.0;
+	if (( hal_get_real(pg->max_dc) > 1.0 ) || ( hal_get_real(pg->max_dc) < 0.0 )) {
+	    hal_set_real(pg->max_dc, 1.0);
 	} 
-	if ( pg->min_dc >= pg->max_dc ) {
-	    pg->min_dc = 0.0;
-	    pg->max_dc = 1.0;
+	if ( hal_get_real(pg->min_dc) >= hal_get_real(pg->max_dc) ) {
+	    hal_set_real(pg->min_dc, 0.0);
+	    hal_set_real(pg->max_dc, 1.0);
 	}
 	/* apply limits */
-	if ( abs_dc > pg->max_dc ) {
-	    abs_dc = pg->max_dc;
-	} else if ( abs_dc < pg->min_dc ) {
-	    abs_dc = pg->min_dc;
+	if ( abs_dc > hal_get_real(pg->max_dc) ) {
+	    abs_dc = hal_get_real(pg->max_dc);
+	} else if ( abs_dc < hal_get_real(pg->min_dc) ) {
+	    abs_dc = hal_get_real(pg->min_dc);
 	}
 	/* calculate length of PWM pulse in clocks */
 	len = ( abs_dc * slot->pwmgen->period ) + 0.5;
@@ -1493,14 +1491,14 @@ static void write_pwmgens(slot_data_t *slot)
 	abs_dc = len * slot->pwmgen->period_recip;
 	/* set run bit in the control byte */
 	control_byte >>= 2;
-	if ( *(pg->enable) != 0 ) {
+	if ( hal_get_bool(pg->enable) != 0 ) {
 	    control_byte |= 0x80;
 	}
 	/* set dir bit in the control byte, and save the duty cycle */
 	if ( reverse ) {
-	    pg->duty_cycle = -abs_dc;
+	    hal_set_real(pg->duty_cycle, -abs_dc);
 	} else {
-	    pg->duty_cycle = abs_dc;
+	    hal_set_real(pg->duty_cycle, abs_dc);
 	    control_byte |= 0x40;
 	}
 	/* calculate count at which to turn off output */
@@ -1527,18 +1525,18 @@ static void write_DACs(slot_data_t *slot)
       /* point to the specific DAC */
       pg = &(slot->DAC->pg[n]);
       /* validate the scale value */
-      if ( pg->scale < 0.0 ) {
-	if ( pg->scale > -EPSILON ) {
+      if ( hal_get_real(pg->scale) < 0.0 ) {
+	if ( hal_get_real(pg->scale) > -EPSILON ) {
 	  /* too small, divide by zero is bad */
-	  pg->scale = -1.0;
+	  hal_set_real(pg->scale, -1.0);
 	}
       } else {
-	if ( pg->scale < EPSILON ) {
-	  pg->scale = 1.0;
+	if ( hal_get_real(pg->scale) < EPSILON ) {
+	  hal_set_real(pg->scale, 1.0);
 	}
       }
       /* calculate desired output voltage */
-      volts = *(pg->value) / pg->scale;
+      volts = hal_get_real(pg->value) / hal_get_real(pg->scale);
       /* output to DAC word works like:
 	 0xFFFF -> +10 V
 	 0x8000 ->   0 V
@@ -1568,14 +1566,14 @@ static void write_extraDAC(slot_data_t *slot)
     /* point to the DAC */
     pg = &(slot->extra->dac);
     /* validate the scale value */
-    if ( pg->scale < 0.0 ) {
-	if ( pg->scale > -EPSILON ) {
+    if ( hal_get_real(pg->scale) < 0.0 ) {
+	if ( hal_get_real(pg->scale) > -EPSILON ) {
 	    /* too small, divide by zero is bad */
-	    pg->scale = -1.0;
+	    hal_set_real(pg->scale, -1.0);
 	}
     } else {
-	if ( pg->scale < EPSILON ) {
-	    pg->scale = 1.0;
+	if ( hal_get_real(pg->scale) < EPSILON ) {
+	    hal_set_real(pg->scale, 1.0);
 	}
     }
     /* calculate desired output voltage */
@@ -1589,7 +1587,7 @@ static void write_extraDAC(slot_data_t *slot)
        UPC and USC boards sold with the spindle DAC option
        have SSR1 set up for + output, and SSR2 for - output.  */
 
-    volts = *(pg->value) / pg->scale;
+    volts = hal_get_real(pg->value) / hal_get_real(pg->scale);
     if (volts < 0.0 ) volts = -volts;  // no fabs function available!!
     /* output to DAC word works like:
 	0xFF -> +10 V
@@ -1620,10 +1618,10 @@ static void write_extra_dout(slot_data_t *slot)
     for (b = 0; b < 8; b++) {
       pg = &(slot->extra->douts[b]);
 	/* get the data, add to output byte */
-	if ((*(pg->data)) && (!pg->invert)) {
+	if ((hal_get_bool(pg->data)) && !hal_get_bool(pg->invert)) {
 	    outdata |= mask;
 	}
-	if ((!*(pg->data)) && (pg->invert)) {
+	if ((!hal_get_bool(pg->data)) && hal_get_bool(pg->invert)) {
 	    outdata |= mask;
 	}
 	mask <<= 1;
@@ -1704,12 +1702,12 @@ static int export_UxC_digin(slot_data_t *slot, bus_data_t *bus)
     }
     for ( n = 0 ; n < 16 ; n++ ) {
 	/* export pins for input data */
-	retval = hal_pin_bit_newf(HAL_OUT, &(slot->digin[n].data), comp_id,
+	retval = hal_pin_new_bool(comp_id, HAL_OUT, &(slot->digin[n].data), 0,
 				  "ppmc.%d.din.%02d.in", bus->busnum, bus->last_digin);
 	if (retval != 0) {
 	    return retval;
 	}
-	retval = hal_pin_bit_newf(HAL_OUT, &(slot->digin[n].data_not), comp_id,
+	retval = hal_pin_new_bool(comp_id, HAL_OUT, &(slot->digin[n].data_not), 0,
 				  "ppmc.%d.din.%02d.in-not", bus->busnum, bus->last_digin);
 	if (retval != 0) {
 	    return retval;
@@ -1744,18 +1742,17 @@ static int export_UxC_digout(slot_data_t *slot, bus_data_t *bus)
     }
     for ( n = 0 ; n < 8 ; n++ ) {
 	/* export pin for output data */
-	retval = hal_pin_bit_newf(HAL_IN, &(slot->digout[n].data), comp_id,
+	retval = hal_pin_new_bool(comp_id, HAL_IN, &(slot->digout[n].data), 0,
 				  "ppmc.%d.dout.%02d.out", bus->busnum, bus->last_digout);
 	if (retval != 0) {
 	    return retval;
 	}
 	/* export parameter for inversion */
-	retval = hal_param_bit_newf(HAL_RW, &(slot->digout[n].invert), comp_id,
+	retval = hal_param_new_bool(comp_id, HAL_RW, &(slot->digout[n].invert), 0,
 				    "ppmc.%d.dout.%02d-invert", bus->busnum, bus->last_digout);
 	if (retval != 0) {
 	    return retval;
 	}
-	slot->digout[n].invert = 0;
 	/* increment number to prepare for next output */
 	bus->last_digout++;
     }
@@ -1780,12 +1777,12 @@ static int export_PPMC_digin(slot_data_t *slot, bus_data_t *bus)
     }
     for ( n = 0 ; n < 16 ; n++ ) {
 	/* export pins for input data */
-	retval = hal_pin_bit_newf(HAL_OUT, &(slot->digin[n].data), comp_id,
+	retval = hal_pin_new_bool(comp_id, HAL_OUT, &(slot->digin[n].data), 0,
 				  "ppmc.%d.din.%02d.in", bus->busnum, bus->last_digin);
 	if (retval != 0) {
 	    return retval;
 	}
-	retval = hal_pin_bit_newf(HAL_OUT, &(slot->digin[n].data_not), comp_id,
+	retval = hal_pin_new_bool(comp_id, HAL_OUT, &(slot->digin[n].data_not), 0,
 				  "ppmc.%d.din.%02d.in-not", bus->busnum, bus->last_digin);
 	if (retval != 0) {
 	    return retval;
@@ -1794,22 +1791,22 @@ static int export_PPMC_digin(slot_data_t *slot, bus_data_t *bus)
 	bus->last_digin++;
     }
     if (bus->last_digin < 31) {
-	retval = hal_pin_bit_newf(HAL_OUT, &(slot->digin[16].data), comp_id,
+	retval = hal_pin_new_bool(comp_id, HAL_OUT, &(slot->digin[16].data), 0,
 				  "ppmc.%d.din.estop.in", bus->busnum);
 	if (retval != 0) {
 	    return retval;
 	}
-	retval = hal_pin_bit_newf(HAL_OUT, &(slot->digin[16].data_not), comp_id,
+	retval = hal_pin_new_bool(comp_id, HAL_OUT, &(slot->digin[16].data_not), 0,
 				  "ppmc.%d.din.estop.in-not", bus->busnum);
 	if (retval != 0) {
 	    return retval;
 	}
-	retval = hal_pin_bit_newf(HAL_OUT, &(slot->digin[17].data), comp_id,
+	retval = hal_pin_new_bool(comp_id, HAL_OUT, &(slot->digin[17].data), 0,
 				  "ppmc.%d.din.fault.in", bus->busnum);
 	if (retval != 0) {
 	    return retval;
 	}
-	retval = hal_pin_bit_newf(HAL_OUT, &(slot->digin[17].data_not), comp_id,
+	retval = hal_pin_new_bool(comp_id, HAL_OUT, &(slot->digin[17].data_not), 0,
 				  "ppmc.%d.din.fault.in-not", bus->busnum);
 	if (retval != 0) {
 	    return retval;
@@ -1848,36 +1845,34 @@ static int export_PPMC_digout(slot_data_t *slot, bus_data_t *bus)
     }
     for ( n = 0 ; n < 8 ; n++ ) {
 	/* export pin for output data */
-	retval = hal_pin_bit_newf(HAL_IN, &(slot->digout[n].data), comp_id,
+	retval = hal_pin_new_bool(comp_id, HAL_IN, &(slot->digout[n].data), 0,
 				  "ppmc.%d.dout.%02d.out", bus->busnum, bus->last_digout);
 	if (retval != 0) {
 	    return retval;
 	}
 	/* export parameter for inversion */
-	retval = hal_param_bit_newf(HAL_RW, &(slot->digout[n].invert), comp_id,
+	retval = hal_param_new_bool(comp_id, HAL_RW, &(slot->digout[n].invert), 0,
 				    "ppmc.%d.dout.%02d.invert", bus->busnum, bus->last_digout);
 	if (retval != 0) {
 	    return retval;
 	}
-	slot->digout[n].invert = 0;
 	/* increment number to prepare for next output */
 	bus->last_digout++;
     }
 	/* export pin for E-Stop control */
     if (bus->last_digout < 15) {                // only on first DIO board
       rtapi_print_msg(RTAPI_MSG_INFO, "PPMC:  master DIO at # %d\n",bus->last_digout);
-      retval = hal_pin_bit_newf(HAL_IN, &(slot->digout[8].data), comp_id,
+      retval = hal_pin_new_bool(comp_id, HAL_IN, &(slot->digout[8].data), 0,
 				"ppmc.%d.dout.Estop.out", bus->busnum);
       if (retval != 0) {
 	return retval;
       }
       /* export parameter for inversion */
-      retval = hal_param_bit_newf(HAL_RW, &(slot->digout[8].invert), comp_id,
+      retval = hal_param_new_bool(comp_id, HAL_RW, &(slot->digout[8].invert), 0,
 				  "ppmc.%d.dout.Estop.invert", bus->busnum);
       if (retval != 0) {
 	return retval;
       }
-      slot->digout[8].invert = 0;
       add_wr_funct(write_PPMC_digouts, slot, block(DIO_DOUTA, DIO_ESTOP_OUT));
       rtapi_print_msg(RTAPI_MSG_INFO, "PPMC:  exporting as MASTER D Out\n");
     }
@@ -1907,59 +1902,54 @@ static int export_USC_stepgen(slot_data_t *slot, bus_data_t *bus)
 	return -1;
     }
     /* export params that apply to all four stepgens */
-    retval = hal_param_u32_newf(HAL_RW, &(slot->stepgen->setup_time_ns), comp_id,
+    /* 10uS default setup time */
+    retval = hal_param_new_ui32(comp_id, HAL_RW, &(slot->stepgen->setup_time_ns), 10000,
 	"ppmc.%d.stepgen.%02d-%02d.setup-time-ns", bus->busnum, bus->last_stepgen, bus->last_stepgen+3);
     if (retval != 0) {
 	return retval;
     }
-    /* 10uS default setup time */
-    slot->stepgen->setup_time_ns = 10000;
-    retval = hal_param_u32_newf(HAL_RW, &(slot->stepgen->pulse_width_ns), comp_id,
+    /* 4uS default pulse width */
+    retval = hal_param_new_ui32(comp_id, HAL_RW, &(slot->stepgen->pulse_width_ns), 4000,
 	"ppmc.%d.stepgen.%02d-%02d.pulse-width-ns", bus->busnum, bus->last_stepgen, bus->last_stepgen+3);
     if (retval != 0) {
 	return retval;
     }
-    /* 4uS default pulse width */
-    slot->stepgen->pulse_width_ns = 4000;
-    retval = hal_param_u32_newf(HAL_RW, &(slot->stepgen->pulse_space_ns), comp_id,
+    /* 4uS default pulse spacing */
+    retval = hal_param_new_ui32(comp_id, HAL_RW, &(slot->stepgen->pulse_space_ns), 4000,
 	"ppmc.%d.stepgen.%02d-%02d.pulse-space-min-ns", bus->busnum, bus->last_stepgen, bus->last_stepgen+3);
     if (retval != 0) {
 	return retval;
     }
-    /* 4uS default pulse spacing */
-    slot->stepgen->pulse_space_ns = 4000;
     /* export per-stepgen pins and params */
     for ( n = 0 ; n < 4 ; n++ ) {
 	/* pointer to the stepgen struct */
 	sg = &(slot->stepgen->sg[n]);
 	/* enable pin */
-	retval = hal_pin_bit_newf(HAL_IN, &(sg->enable), comp_id,
+	retval = hal_pin_new_bool(comp_id, HAL_IN, &(sg->enable), 0,
 		"ppmc.%d.stepgen.%02d.enable", bus->busnum, bus->last_stepgen);
 	if (retval != 0) {
 	    return retval;
 	}
 	/* velocity command pin */
-	retval = hal_pin_float_newf(HAL_IN, &(sg->vel), comp_id,
+	retval = hal_pin_new_real(comp_id, HAL_IN, &(sg->vel), 0.0,
 		"ppmc.%d.stepgen.%02d.velocity", bus->busnum, bus->last_stepgen);
 	if (retval != 0) {
 	    return retval;
 	}
 	/* velocity scaling parameter */
-	retval = hal_param_float_newf(HAL_RW, &(sg->scale), comp_id,
+	retval = hal_param_new_real(comp_id, HAL_RW, &(sg->scale), 1.0,
 		"ppmc.%d.stepgen.%02d.scale", bus->busnum, bus->last_stepgen);
 	if (retval != 0) {
 	    return retval;
 	}
-	sg->scale = 1.0;
 	/* maximum velocity parameter */
-	retval = hal_param_float_newf(HAL_RW, &(sg->max_vel), comp_id,
+	retval = hal_param_new_real(comp_id, HAL_RW, &(sg->max_vel), 0.0,
 		"ppmc.%d.stepgen.%02d.max-vel", bus->busnum, bus->last_stepgen);
 	if (retval != 0) {
 	    return retval;
 	}
-	sg->max_vel = 0.0;
 	/* actual frequency parameter */
-	retval = hal_param_float_newf(HAL_RO, &(sg->freq), comp_id,
+	retval = hal_param_new_real(comp_id, HAL_RO, &(sg->freq), 0.0,
 		"ppmc.%d.stepgen.%02d.freq", bus->busnum, bus->last_stepgen);
 	if (retval != 0) {
 	    return retval;
@@ -1989,63 +1979,57 @@ static int export_UPC_pwmgen(slot_data_t *slot, bus_data_t *bus)
 	return -1;
     }
     /* export params that apply to all four pwmgens */
-    retval = hal_param_float_newf(HAL_RW, &(slot->pwmgen->freq), comp_id,
+    retval = hal_param_new_real(comp_id, HAL_RW, &(slot->pwmgen->freq), 0.0,
 	"ppmc.%d.pwm.%02d-%02d.freq", bus->busnum, bus->last_pwmgen, bus->last_pwmgen+3);
     if (retval != 0) {
 	return retval;
     }
-    /* set initial value for param */
-    slot->pwmgen->freq = 0.0;
     /* export per-pwmgen pins and params, and set initial values */
     for ( n = 0 ; n < 4 ; n++ ) {
 	/* pointer to the pwmgen struct */
 	pg = &(slot->pwmgen->pg[n]);
 	/* enable pin */
-	retval = hal_pin_bit_newf(HAL_IN, &(pg->enable), comp_id,
+	retval = hal_pin_new_bool(comp_id, HAL_IN, &(pg->enable), 0,
 		"ppmc.%d.pwm.%02d.enable", bus->busnum, bus->last_pwmgen);
 	if (retval != 0) {
 	    return retval;
 	}
 	/* value command pin */
-	retval = hal_pin_float_newf(HAL_IN, &(pg->value), comp_id,
+	retval = hal_pin_new_real(comp_id, HAL_IN, &(pg->value), 0.0,
 		"ppmc.%d.pwm.%02d.value", bus->busnum, bus->last_pwmgen);
 	if (retval != 0) {
 	    return retval;
 	}
 	/* output scaling parameter */
-	retval = hal_param_float_newf(HAL_RW, &(pg->scale), comp_id,
+	retval = hal_param_new_real(comp_id, HAL_RW, &(pg->scale), 1.0,
 		"ppmc.%d.pwm.%02d.scale", bus->busnum, bus->last_pwmgen);
 	if (retval != 0) {
 	    return retval;
 	}
-	pg->scale = 1.0;
 	/* maximum duty cycle parameter */
-	retval = hal_param_float_newf(HAL_RW, &(pg->max_dc), comp_id,
+	retval = hal_param_new_real(comp_id, HAL_RW, &(pg->max_dc), 1.0,
 		"ppmc.%d.pwm.%02d.max-dc", bus->busnum, bus->last_pwmgen);
 	if (retval != 0) {
 	    return retval;
 	}
-	pg->max_dc = 1.0;
 	/* minimum duty cycle parameter */
-	retval = hal_param_float_newf(HAL_RW, &(pg->min_dc), comp_id,
+	retval = hal_param_new_real(comp_id, HAL_RW, &(pg->min_dc), 0.0,
 		"ppmc.%d.pwm.%02d.min-dc", bus->busnum, bus->last_pwmgen);
 	if (retval != 0) {
 	    return retval;
 	}
-	pg->min_dc = 0.0;
 	/* actual duty cycle parameter */
-	retval = hal_param_float_newf(HAL_RO, &(pg->duty_cycle), comp_id,
+	retval = hal_param_new_real(comp_id, HAL_RO, &(pg->duty_cycle), 0.0,
 		"ppmc.%d.pwm.%02d.duty-cycle", bus->busnum, bus->last_pwmgen);
 	if (retval != 0) {
 	    return retval;
 	}
 	/* bootstrap mode parameter */
-	retval = hal_param_bit_newf(HAL_RW, &(pg->bootstrap), comp_id,
+	retval = hal_param_new_bool(comp_id, HAL_RW, &(pg->bootstrap), 0,
 		"ppmc.%d.pwm.%02d.bootstrap", bus->busnum, bus->last_pwmgen);
 	if (retval != 0) {
 	    return retval;
 	}
-	pg->bootstrap = 0;
 	pg->boot_state = 0;
 	pg->old_enable = 0;
 	/* increment number to prepare for next output */
@@ -2076,18 +2060,17 @@ static int export_PPMC_DAC(slot_data_t *slot, bus_data_t *bus)
 	/* pointer to the DAC struct */
 	pg = &(slot->DAC->pg[n]);
 	/* value command pin */
-	retval = hal_pin_float_newf(HAL_IN, &(pg->value), comp_id,
+	retval = hal_pin_new_real(comp_id, HAL_IN, &(pg->value), 0.0,
 		"ppmc.%d.DAC.%02d.value", bus->busnum, bus->last_DAC);
 	if (retval != 0) {
 	    return retval;
 	}
 	/* output scaling parameter */
-	retval = hal_param_float_newf(HAL_RW, &(pg->scale), comp_id,
+	retval = hal_param_new_real(comp_id, HAL_RW, &(pg->scale), 1.0,
 		"ppmc.%d.DAC.%02d.scale", bus->busnum, bus->last_DAC);
 	if (retval != 0) {
 	    return retval;
 	}
-	pg->scale = 1.0;
 	/* increment number to prepare for next output */
 	bus->last_DAC++;
     }
@@ -2184,36 +2167,36 @@ static int export_encoders(slot_data_t *slot, bus_data_t *bus)
     }
     for ( n = 0 ; n < 4 ; n++ ) {
         /* scale input parameter */
-        retval = hal_param_float_newf(HAL_RW, &(slot->encoder[n].scale), comp_id,
+        retval = hal_param_new_real(comp_id, HAL_RW, &(slot->encoder[n].scale), 1.0,
 		"ppmc.%d.encoder.%02d.scale", bus->busnum, bus->last_encoder);
         if (retval != 0) {
             return retval;
         }
         /* scaled encoder position */
-        retval = hal_pin_float_newf(HAL_OUT, &(slot->encoder[n].position), comp_id,
+        retval = hal_pin_new_real(comp_id, HAL_OUT, &(slot->encoder[n].position), 0.0,
 		"ppmc.%d.encoder.%02d.position", bus->busnum, bus->last_encoder);
         if (retval != 0) {
             return retval;
         }
 	/* raw encoder position */
-	retval = hal_pin_s32_newf(HAL_OUT, &(slot->encoder[n].count), comp_id,
+	retval = hal_pin_new_si32(comp_id, HAL_OUT, &(slot->encoder[n].count), 0,
 		"ppmc.%d.encoder.%02d.count", bus->busnum, bus->last_encoder);
 	if (retval != 0) {
 		return retval;
 	}
 	/* raw encoder delta */
-	retval = hal_pin_s32_newf(HAL_OUT, &(slot->encoder[n].delta), comp_id,
+	retval = hal_pin_new_si32(comp_id, HAL_OUT, &(slot->encoder[n].delta), 0,
 		"ppmc.%d.encoder.%02d.delta", bus->busnum, bus->last_encoder);
 	if (retval != 0) {
 		return retval;
 	}
 	/* encoder index bit */
-	retval = hal_pin_bit_newf(HAL_OUT, &(slot->encoder[n].index), comp_id,
+	retval = hal_pin_new_bool(comp_id, HAL_OUT, &(slot->encoder[n].index), 0,
 		"ppmc.%d.encoder.%02d.index", bus->busnum, bus->last_encoder);
 	if (retval != 0) {
 		return retval;
 	}
-	retval = hal_pin_float_newf(HAL_OUT, &(slot->encoder[n].vel), comp_id,
+	retval = hal_pin_new_real(comp_id, HAL_OUT, &(slot->encoder[n].vel), 0.0,
 	    "ppmc.%d.encoder.%02d.velocity",bus->busnum,bus->last_encoder);
 	if (retval != 0) {
 	  return retval;
@@ -2222,7 +2205,7 @@ static int export_encoders(slot_data_t *slot, bus_data_t *bus)
 	  /* encoder index enable bit */
 	  /* if the ver of the board firmware is >= 2 then the board supports
 	     this function, so export the pin */
-	  retval = hal_pin_bit_newf(HAL_IO, &(slot->encoder[n].index_enable), comp_id,
+	  retval = hal_pin_new_bool(comp_id, HAL_IO, &(slot->encoder[n].index_enable), 0,
 		"ppmc.%d.encoder.%02d.index-enable", bus->busnum, bus->last_encoder);
 	  if (retval != 0) {
 	    return retval;
@@ -2230,7 +2213,7 @@ static int export_encoders(slot_data_t *slot, bus_data_t *bus)
 	  if (slot->use_timestamp) {
 	    /* encoder time stamp function / velocity estimation */
 	    /* only implemented on latest UPC right now */
-	    retval = hal_param_float_newf(HAL_RW, &(slot->encoder[n].min_speed), comp_id,
+	    retval = hal_param_new_real(comp_id, HAL_RW, &(slot->encoder[n].min_speed), 0.0,
 		   "ppmc.%d.encoder.%02d.min-speed-estimate", bus->busnum, bus->last_encoder);
 	    if (retval != 0) {
 	      return retval;
@@ -2276,18 +2259,17 @@ static int export_extra_dac(slot_data_t *slot, bus_data_t *bus)
     /* pointer to the DAC struct */
     pg = &(slot->extra->dac);
     /* value command pin */
-    retval = hal_pin_float_newf(HAL_IN, &(pg->value), comp_id,
+    retval = hal_pin_new_real(comp_id, HAL_IN, &(pg->value), 0.0,
 	"ppmc.%d.DAC8.%02d.value", bus->busnum, bus->last_extraDAC);
     if (retval != 0) {
 	return retval;
     }
     /* output scaling parameter */
-    retval = hal_param_float_newf(HAL_RW, &(pg->scale), comp_id,
+    retval = hal_param_new_real(comp_id, HAL_RW, &(pg->scale), 1.0,
 	"ppmc.%d.DAC8.%02d.scale", bus->busnum, bus->last_extraDAC);
     if (retval != 0) {
 	return retval;
     }
-    pg->scale = 1.0;
     /* increment number to prepare for next output */
     bus->last_extraDAC++;
     add_wr_funct(write_extraDAC, slot, block(UxC_EXTRA, UxC_EXTRA));
@@ -2340,18 +2322,17 @@ static int export_extra_dout(slot_data_t *slot, bus_data_t *bus)
     for ( n = 0 ; n < 8 ; n++ ) {
       pg = &(slot->extra->douts[n]);
 	/* export pin for output data */
-	retval = hal_pin_bit_newf(HAL_IN, &(pg->data), comp_id,
+	retval = hal_pin_new_bool(comp_id, HAL_IN, &(pg->data), 0,
 		"ppmc.%d.dout.%02d.out", bus->busnum, bus->last_digout);
 	if (retval != 0) {
 	    return retval;
 	}
 	/* export parameter for inversion */
-	retval = hal_param_bit_newf(HAL_RW, &(pg->invert), comp_id,
+	retval = hal_param_new_bool(comp_id, HAL_RW, &(pg->invert), 0,
 		"ppmc.%d.dout.%02d.invert", bus->busnum, bus->last_digout);
 	if (retval != 0) {
 	    return retval;
 	}
-	pg->invert = 0;
 	/* increment number to prepare for next output */
 	bus->last_digout++;
     }


### PR DESCRIPTION
These are the last drivers (except hostmot2) that are compiled in uspace. The rest is rtai/kernel only afaict,which will come later.

Both hal_bb_gpio.c and hal_evoreg.c drivers are straight forward and not too big a change.
Apart from that, I think that the hard-coded number in the hal_evoreg.c pin-array sizes are off. The comments don't match the numbers and the implementation does neither. Not going to touch this can of worms. Also, there are several kernel-types still in the code. No sure anyone has tried this driver for some time.

The gm.h file has the hardware memory layout structure. All its members are volatile because this is a PCI MMIO. The old hal types cannot be (ab)used anymore, so the normal equivalent is used.
The hal_gm.c driver is a bit special because it abuses hal memory and pin target memory. It originally pointed to local parameters, but these do not work like that anymore. However, an overlay union was created to support taking the address of the target and pretend it to be a new hal type (it is all in HAL memory anyway). This is very ugly and non-portable, but it is the quickest way to fix the problem at hand. Otherwise the driver would need considerable work to be fixed. This hack is used in cardMgr_t and stepgen_t. Furthermore, it is a big driver with a some inefficient code. I really hope we can find anyone who can test this. The driver is "only" 14 years old with the last update 10 years ago...

The hal_parport.c driver uses parameters but does not always allocate them. It depends on the mode of the port. It has been verified that the allocations match the run-time conditions and there should be no crash.

The hal_ppmc.c driver is big and inefficient at times. Fixing that was harder than to let it be. At least it didn't get worse.