### PR TITLE
Fix homing bug when trying to home while homing is in progress (2.9 backport)

### DIFF
--- a/src/emc/motion/command.c
+++ b/src/emc/motion/command.c
@@ -1381,7 +1381,10 @@ void emcmotCommandHandler_locked(void *arg, long servo_period)
 	                   joint_num);
                 return;
 	    }
-
+	    if ( get_homing_is_active() ) {
+	        reportError("Homing not possible until current homing process is finished.\n");
+	        return;
+	    }
 	    if (!GET_MOTION_ENABLE_FLAG()) {
 		break;
 	    }

--- a/src/emc/usr_intf/axis/scripts/axis.py
+++ b/src/emc/usr_intf/axis/scripts/axis.py
@@ -1952,6 +1952,11 @@ def all_homed():
     return isHomed
 
 def go_home(num):
+    s.poll()
+    for j in range(s.joints):
+        if s.joint[j]["homing"]:
+            print(_("Homing not possible until current homing process is finished."))
+            return
     set_motion_teleop(0)
     c.home(num)
     c.wait_complete()

--- a/src/emc/usr_intf/gmoccapy/gmoccapy.py
+++ b/src/emc/usr_intf/gmoccapy/gmoccapy.py
@@ -3857,6 +3857,11 @@ class gmoccapy(object):
     def _on_btn_home_clicked(self, widget):
         # home axis or joint?
         LOG.debug("on button home clicked = {0}".format(widget.get_property("name")))
+        self.stat.poll()
+        for j in range(self.stat.joints):
+            if self.stat.joint[j]["homing"]:
+                self._show_error((13, _("Homing not possible until current homing process is finished.")))
+                return
         if "axis" in widget.get_property("name"):
             value = widget.get_property("name")[-1]
             # now get the joint from directory by the value


### PR DESCRIPTION
Backport of 9d5570ca84 (#3664) to 2.9.

Fixes #4316, which is the same bug as #3314: starting to home a second axis while a homing sequence is already in progress breaks the running homing, and the first joint keeps moving past its ref/limit switch into the mechanical limits.

The command.c change rejects EMCMOT_JOINT_HOME while homing is active, which is the machine-safety part. The axis.py and gmoccapy.py changes guard the GUIs so wait_complete() does not freeze the UI on the rejected command.

Cherry-picked cleanly onto 2.9, no conflicts.
