### PR TITLE
hal: Update mainly C components to getter/setter.

### DIFF
--- a/src/hal/components/demux_generic.c
+++ b/src/hal/components/demux_generic.c
@@ -19,6 +19,7 @@
 
 #include <rtapi.h>
 #include <rtapi_app.h>
+#include <rtapi_math.h>
 #include <hal.h>
 
 
@@ -30,18 +31,16 @@ MODULE_LICENSE("GPL");
 #define MAX_CHAN 100
 #define MAX_SIZE 1024
 #define EPS 2e-7
-#define MAX_S32 0x7FFFFFFF
-#define MAX_U32 0xFFFFFFFF
 
 typedef struct {
-    hal_data_u *input;
-    hal_data_u **outputs;
-    hal_u32_t *sel_int;
-    hal_bit_t **sel_bit;
-    unsigned int selection;
-    hal_u32_t *debounce;
-    unsigned int timer;
-    hal_bit_t *suppress;
+    hal_refs_u input;
+    hal_refs_u *outputs;
+    hal_uint_t sel_int;
+    hal_bool_t *sel_bit;
+    hal_uint_t selection; // (param)
+    hal_uint_t debounce;
+    hal_uint_t timer;     // (param)
+    hal_bool_t suppress;
     int in_type;
     int out_type;
     int size;
@@ -56,7 +55,6 @@ typedef struct {
 static int comp_id;
 static demux_t *demux;
 static void write_fp(void *arg, long period);
-static void write_nofp(void *arg, long period);
 
 char *config[MAX_CHAN];
 RTAPI_MP_ARRAY_STRING(config, MAX_CHAN, "demux specifiers inNUMout");
@@ -79,7 +77,7 @@ int rtapi_app_main(void){
     }
 
     // allocate shared memory for the base struct
-    demux = hal_malloc(sizeof(demux_t));
+    demux = hal_malloc(sizeof(*demux));
     if (demux == 0) {
         rtapi_print_msg(RTAPI_MSG_ERR,
                 "demux_generic component: Out of Memory\n");
@@ -89,7 +87,7 @@ int rtapi_app_main(void){
 
     // Count the instances.
     for (demux->num_insts = 0; config[demux->num_insts];demux->num_insts++) {}
-    demux->insts = hal_malloc(demux->num_insts * sizeof(demux_inst_t));
+    demux->insts = hal_malloc(demux->num_insts * sizeof(*demux->insts));
     // Parse the config string
     for (i = 0; i < demux->num_insts; i++) {
         char c;
@@ -116,11 +114,11 @@ int rtapi_app_main(void){
                 break;
             case 'b':
             case 'B':
-                type = HAL_BIT;
+                type = HAL_BOOL;
                 break;
             case 'f':
             case 'F':
-                type = HAL_FLOAT;
+                type = HAL_REAL;
                 break;
             case 's':
             case 'S':
@@ -168,22 +166,13 @@ int rtapi_app_main(void){
             inst->out_type = inst->in_type;
         }
 
-        if (inst->in_type == HAL_FLOAT || inst->out_type == HAL_FLOAT) {
-            retval = hal_export_functf(write_fp, inst, 1, 0, comp_id, "demux-gen.%02i", i);
-            if (retval < 0) {
-                rtapi_print_msg(RTAPI_MSG_ERR, "demux_generic: ERROR: function export"
-                        " failed\n");
-                goto fail0;
-            }
-        }
-        else
-        {
-            retval = hal_export_functf(write_nofp, inst, 0, 0, comp_id, "demux-gen.%02i", i);
-            if (retval < 0) {
-                rtapi_print_msg(RTAPI_MSG_ERR, "demux_generic: ERROR: function export"
-                        " failed\n");
-                goto fail0;
-            }
+        // We did away with the no-fp thread.
+        // Always export the float case. It can do any-to-any.
+        retval = hal_export_functf(write_fp, inst, 1, 0, comp_id, "demux-gen.%02i", i);
+        if (retval < 0) {
+            rtapi_print_msg(RTAPI_MSG_ERR, "demux_generic: ERROR: function export"
+                    " failed\n");
+            goto fail0;
         }
         // Input pins
         
@@ -193,9 +182,9 @@ int rtapi_app_main(void){
         if (s !=1){
             inst->num_bits = 0;
         } else { //make the bit pins
-            inst->sel_bit = hal_malloc(inst->num_bits * sizeof(hal_bit_t*));
+            inst->sel_bit = hal_malloc(inst->num_bits * sizeof(*inst->sel_bit));
             for (p = 0; p < inst->num_bits; p++) {
-                retval = hal_pin_bit_newf(HAL_IN, &inst->sel_bit[p], comp_id,
+                retval = hal_pin_new_bool(comp_id, HAL_IN, &inst->sel_bit[p], 0,
                     "demux-gen.%02i.sel-bit-%02i", i, p);
                 if (retval != 0) {
                     goto fail0;
@@ -203,7 +192,7 @@ int rtapi_app_main(void){
             }
         }
 
-        retval = hal_pin_u32_newf(HAL_IN, &(inst->sel_int), comp_id,
+        retval = hal_pin_new_ui32(comp_id, HAL_IN, &(inst->sel_int), 0,
                 "demux-gen.%02i.sel-int", i);
         if (retval != 0) {
             goto fail0;
@@ -214,44 +203,60 @@ int rtapi_app_main(void){
         if (retval >= HAL_NAME_LEN) {
             goto fail0;
         }
-        retval = hal_pin_new(hal_name, inst->in_type, HAL_IN,
-                (void**)&(inst->input), comp_id);
+        switch(inst->in_type) {
+        case HAL_BOOL: retval = hal_pin_new_bool(comp_id, HAL_IN, &inst->input.b, 0, "%s", hal_name); break;
+        case HAL_REAL: retval = hal_pin_new_real(comp_id, HAL_IN, &inst->input.r, 0, "%s", hal_name); break;
+        case HAL_S32:  retval = hal_pin_new_si32(comp_id, HAL_IN, &inst->input.s, 0, "%s", hal_name); break;
+        case HAL_U32:  retval = hal_pin_new_ui32(comp_id, HAL_IN, &inst->input.u, 0, "%s", hal_name); break;
+        // FIXME: Future...when we switch types
+        case HAL_SINT: retval = hal_pin_new_sint(comp_id, HAL_IN, &inst->input.s, 0, "%s", hal_name); break;
+        case HAL_UINT: retval = hal_pin_new_uint(comp_id, HAL_IN, &inst->input.u, 0, "%s", hal_name); break;
+        default: retval = -ENOENT; break;
+        }
         if (retval != 0) {
             goto fail0;
         }
 
         // Behaviour-modifiers
-        retval = hal_pin_bit_newf(HAL_IN, &inst->suppress, comp_id,
+        retval = hal_pin_new_bool(comp_id, HAL_IN, &inst->suppress, 0,
                 "demux-gen.%02i.suppress-no-input", i);
         if (retval != 0) {
             goto fail0;
         }
-        retval = hal_pin_u32_newf(HAL_IN, &inst->debounce, comp_id,
+        retval = hal_pin_new_ui32(comp_id, HAL_IN, &inst->debounce, 0,
                 "demux-gen.%02i.debounce-us", i);
         if (retval != 0) {
             goto fail0;
         }
-        retval = hal_param_u32_newf(HAL_RO, &inst->timer, comp_id,
+        retval = hal_param_new_ui32(comp_id, HAL_RO, &inst->timer, 0,
                 "demux-gen.%02i.elapsed", i);
         if (retval != 0) {
             goto fail0;
         }
-        retval = hal_param_u32_newf(HAL_RO, &inst->selection, comp_id,
+        retval = hal_param_new_ui32(comp_id, HAL_RO, &inst->selection, 0,
                 "demux-gen.%02i.selected", i);
         if (retval != 0) {
             goto fail0;
         }
 
         //output pins
-        inst->outputs = hal_malloc(inst->size * sizeof(hal_data_u*));
+        inst->outputs = hal_malloc(inst->size * sizeof(*inst->outputs));
         for (p = 0; p < inst->size; p++) {
             retval = rtapi_snprintf(hal_name, HAL_NAME_LEN,
                     "demux-gen.%02i.out-%s-%02i", i, types[inst->out_type], p);
             if (retval >= HAL_NAME_LEN) {
                 goto fail0;
             }
-            retval = hal_pin_new(hal_name, inst->out_type, HAL_OUT,
-                    (void**)&(inst->outputs[p]), comp_id);
+            switch(inst->out_type) {
+            case HAL_BOOL: retval = hal_pin_new_bool(comp_id, HAL_OUT, &inst->outputs[p].b, 0, "%s", hal_name); break;
+            case HAL_REAL: retval = hal_pin_new_real(comp_id, HAL_OUT, &inst->outputs[p].r, 0, "%s", hal_name); break;
+            case HAL_S32:  retval = hal_pin_new_si32(comp_id, HAL_OUT, &inst->outputs[p].s, 0, "%s", hal_name); break;
+            case HAL_U32:  retval = hal_pin_new_ui32(comp_id, HAL_OUT, &inst->outputs[p].u, 0, "%s", hal_name); break;
+            // FIXME: Future...when we switch types
+            case HAL_SINT: retval = hal_pin_new_sint(comp_id, HAL_OUT, &inst->outputs[p].s, 0, "%s", hal_name); break;
+            case HAL_UINT: retval = hal_pin_new_uint(comp_id, HAL_OUT, &inst->outputs[p].u, 0, "%s", hal_name); break;
+            default: retval = -ENOENT; break;
+            }
             if (retval != 0) {
                 goto fail0;
             }
@@ -268,124 +273,103 @@ int rtapi_app_main(void){
 
 }
 
+// From 'f' to 't' conversion
+#define FT(f,t) ((((f) & 0x0f) << 4) + ((t) & 0x0f))
+
 void write_fp(void *arg, long period) {
     demux_inst_t *inst = arg;
     int i = 0;
     unsigned s = 0;
     if (inst->num_bits > 0) {
         while (i < inst->num_bits) {
-            s += (*inst->sel_bit[i] != 0) << i;
+            s += (hal_get_bool(inst->sel_bit[i]) != 0) << i;
             i++;
         }
     }
     // if you document it, it's not a bug, it's a feature. Might even be useful
-    s += *inst->sel_int;
+    s += hal_get_ui32(inst->sel_int);
 
-    if (*inst->suppress && s == 0)
+    if (hal_get_bool(inst->suppress) && s == 0)
         return;
-    if (s != inst->selection && inst->timer < *inst->debounce) {
-        inst->timer += period / 1000;
+    rtapi_u32 timer = hal_get_ui32(inst->timer);
+    if (s != hal_get_ui32(inst->selection) && timer < hal_get_ui32(inst->debounce)) {
+        hal_set_ui32(inst->timer, timer + period / 1000);
         return;
     }
 
-    inst->selection = s;
-    inst->timer = 0;
+    hal_set_ui32(inst->selection, s);
+    hal_set_ui32(inst->timer, 0);
 
     if ((int)s >= inst->size)
         s = inst->size - 1;
 
-    switch (inst->in_type * 8 + inst->out_type) {
-    case 012: //HAL_BIT => HAL_FLOAT
-        inst->outputs[s]->f = inst->input->b ? 1.0 : 0.0; //
+    switch (FT(inst->in_type, inst->out_type)) {
+    case FT(HAL_BOOL, HAL_BOOL):
+        hal_set_bool(inst->outputs[s].b, hal_get_bool(inst->input.b));
         break;
-    case 021: //HAL_FLOAT => HAL_BIT
-        inst->outputs[s]->b =
-                (inst->input->f > EPS || inst->input->f < -EPS) ? 1 : 0;
+    case FT(HAL_BOOL, HAL_S32):
+        hal_set_si32(inst->outputs[s].s, hal_get_bool(inst->input.b));
         break;
-    case 022: //HAL_FLOAT => HAL_FLOAT
-        inst->outputs[s]->f = inst->input->f;
+    case FT(HAL_BOOL, HAL_U32):
+        hal_set_ui32(inst->outputs[s].u, hal_get_bool(inst->input.b));
         break;
-    case 023: //HAL_FLOAT => HAL_S32
-        if (inst->input->f > MAX_S32) {
-            inst->outputs[s]->s = MAX_S32;
-        } else if (inst->input->f < -MAX_S32) {
-            inst->outputs[s]->s = -MAX_S32;
+    case FT(HAL_BOOL, HAL_REAL):
+        hal_set_real(inst->outputs[s].r, hal_get_bool(inst->input.b) ? 1.0 : 0.0);
+        break;
+
+    case FT(HAL_REAL, HAL_BOOL):
+        hal_set_bool(inst->outputs[s].b, fabs(hal_get_real(inst->input.r)) > EPS);
+        break;
+    case FT(HAL_REAL, HAL_REAL):
+        hal_set_real(inst->outputs[s].r, hal_get_real(inst->input.r));
+        break;
+    case FT(HAL_REAL, HAL_S32): {
+        rtapi_real v = hal_get_real(inst->input.r);
+        if (v > RTAPI_INT32_MAX) {
+            hal_set_si32(inst->outputs[s].s, RTAPI_INT32_MAX);
+        } else if (v < RTAPI_INT32_MIN) {
+            hal_set_si32(inst->outputs[s].s, RTAPI_INT32_MIN);
         } else {
-            inst->outputs[s]->s = inst->input->f;
+            hal_set_si32(inst->outputs[s].s, v);
         }
-        break;
-    case 024: //HAL_FLOAT => HAL_U32
-        if (inst->input->f > MAX_U32) {
-            inst->outputs[s]->u = MAX_U32;
-        } else if (inst->input->f < 0) {
-            inst->outputs[s]->u = 0;
+        break; }
+    case FT(HAL_REAL, HAL_U32): {
+        rtapi_real v = hal_get_real(inst->input.r);
+        if (v > RTAPI_UINT32_MAX) {
+            hal_set_ui32(inst->outputs[s].u, RTAPI_UINT32_MAX);
+        } else if (v < 0) {
+            hal_set_ui32(inst->outputs[s].u, 0);
         } else {
-            inst->outputs[s]->u = inst->input->f;
+            hal_set_ui32(inst->outputs[s].u, v);
         }
-        break;
-    case 032: //HAL_S32 => HAL_FLOAT
-        inst->outputs[s]->f = inst->input->s;
-        break;
-    case 042: //HAL_U32 => HAL_FLOAT
-        inst->outputs[s]->f = (unsigned int) inst->input->u;
-        break;
-    }
-}
+        break; }
 
-void write_nofp(void *arg, long period) {
-    demux_inst_t *inst = arg;
-    int i = 0;
-    unsigned s = 0;
-    if (inst->num_bits > 0) {
-        while (i < inst->num_bits) {
-            s += (*inst->sel_bit[i] != 0) << i;
-            i++;
-        }
-    }
+    case FT(HAL_S32, HAL_BOOL):
+        hal_set_bool(inst->outputs[s].b, hal_get_si32(inst->input.s) != 0);
+        break;
+    case FT(HAL_S32, HAL_S32):
+        hal_set_si32(inst->outputs[s].s, hal_get_si32(inst->input.s));
+        break;
+    case FT(HAL_S32, HAL_U32): {
+        rtapi_s32 v = hal_get_si32(inst->input.s);
+        hal_set_ui32(inst->outputs[s].u, v > 0 ? v : 0);
+        break; }
+    case FT(HAL_S32, HAL_REAL):
+        hal_set_real(inst->outputs[s].r, hal_get_si32(inst->input.s));
+        break;
 
-    s += *inst->sel_int;
-
-    if (*inst->suppress && s == 0)
-        return;
-    if (s != inst->selection && inst->timer < *inst->debounce) {
-        inst->timer += period / 1000;
-        return;
-    }
-
-    inst->selection = s;
-    inst->timer = 0;
-
-    if ((int)s >= inst->size)
-        s = inst->size - 1;
-    switch (inst->in_type * 8 + inst->out_type) {
-    case 011: //HAL_BIT => HAL_BIT
-        inst->outputs[s]->b = inst->input->b;
+    case FT(HAL_U32, HAL_BIT):
+        hal_set_bool(inst->outputs[s].b, hal_get_ui32(inst->input.u) != 0);
         break;
-    case 013: //HAL_BIT => HAL_S32
-        inst->outputs[s]->s = inst->input->b;
+    case FT(HAL_U32, HAL_S32): {
+        rtapi_u32 v = hal_get_ui32(inst->input.u);
+        hal_set_si32(inst->outputs[s].s, v > (rtapi_u32)RTAPI_INT32_MAX ? RTAPI_INT32_MAX : (rtapi_s32)v);
+        break; }
+    case FT(HAL_U32, HAL_U32):
+        hal_set_ui32(inst->outputs[s].u, hal_get_ui32(inst->input.u));
         break;
-    case 014: //HAL_BIT => HAL_U32
-        inst->outputs[s]->u = inst->input->b;
-        break;
-    case 031: //HAL_S32 => HAL_BIT
-        inst->outputs[s]->b = inst->input->s == 0 ? 0 : 1;
-        break;
-    case 033: //HAL_S32 => HAL_S32
-        inst->outputs[s]->s = inst->input->s;
-        break;
-    case 034: //HAL_S32 => HAL_U32
-        inst->outputs[s]->u = (inst->input->s > 0) ? inst->input->s : 0;
-        break;
-    case 041: //HAL_U32 => HAL_BIT
-        inst->outputs[s]->b = inst->input->u == 0 ? 0 : 1;
-        break;
-    case 043: //HAL_U32 => HAL_S32
-        inst->outputs[s]->s =
-                ((unsigned int) inst->input->u > MAX_S32) ?
-                        MAX_S32 : inst->input->u;
-        break;
-    case 044: //HAL_U32 => HAL_U32
-        inst->outputs[s]->u = inst->input->u;
+    case FT(HAL_U32, HAL_REAL):
+        hal_set_real(inst->outputs[s].r, hal_get_ui32(inst->input.u));
         break;
     }
 }

--- a/src/hal/components/encoder_ratio.c
+++ b/src/hal/components/encoder_ratio.c
@@ -116,22 +116,22 @@ RTAPI_MP_ARRAY_STRING(names,MAX_CHAN,"encoder_ratio names");
 /* this structure contains the runtime data for a single counter */
 
 typedef struct {
-    hal_bit_t *master_A;	/* quadrature input */
-    hal_bit_t *master_B;	/* quadrature input */
-    hal_bit_t *slave_A;		/* quadrature input */
-    hal_bit_t *slave_B;		/* quadrature input */
-    hal_bit_t *enable;		/* enable input */
-    unsigned char master_state;	/* quad decode state machine state */
-    unsigned char slave_state;	/* quad decode state machine state */
+    hal_bool_t master_A;	/* quadrature input */
+    hal_bool_t master_B;	/* quadrature input */
+    hal_bool_t slave_A;		/* quadrature input */
+    hal_bool_t slave_B;		/* quadrature input */
+    hal_bool_t enable;		/* enable input */
+    unsigned master_state;	/* quad decode state machine state */
+    unsigned slave_state;	/* quad decode state machine state */
     int raw_error;		/* internal data */
     int master_increment;	/* internal data */
     int slave_increment;	/* internal data */
     double output_scale;	/* internal data */
-    hal_float_t *error;		/* error output */
-    hal_u32_t *master_ppr;	/* parameter: master encoder PPR */
-    hal_u32_t *slave_ppr;	/* parameter: slave encoder PPR */
-    hal_u32_t *master_teeth;	/* parameter: master "gear" tooth count */
-    hal_u32_t *slave_teeth;	/* parameter: slave "gear" tooth count */
+    hal_real_t error;		/* error output */
+    hal_uint_t master_ppr;	/* parameter: master encoder PPR */
+    hal_uint_t slave_ppr;	/* parameter: slave encoder PPR */
+    hal_uint_t master_teeth;	/* parameter: master "gear" tooth count */
+    hal_uint_t slave_teeth;	/* parameter: slave "gear" tooth count */
 } encoder_pair_t;
 
 /* pointer to array of counter_t structs in shmem, 1 per counter */
@@ -240,7 +240,7 @@ int rtapi_app_main(void)
 	encoder_pair_array[n].slave_increment = 0;
 	encoder_pair_array[n].raw_error = 0;
 	encoder_pair_array[n].output_scale = 1.0;
-	*(encoder_pair_array[n].error) = 0.0;
+	hal_set_real(encoder_pair_array[n].error, 0.0);
     }
     /* export functions */
     retval = hal_export_funct("encoder-ratio.sample", sample,
@@ -279,7 +279,7 @@ static void sample(void *arg, long period)
     (void)period;
     encoder_pair_t *pair;
     int n;
-    unsigned char state;
+    unsigned state;
 
     pair = arg;
     for (n = 0; n < howmany; n++) {
@@ -287,16 +287,16 @@ static void sample(void *arg, long period)
 	/* get state machine current state */
 	state = pair->master_state;
 	/* add input bits to state code */
-	if (*(pair->master_A)) {
+	if (hal_get_bool(pair->master_A)) {
 	    state |= SM_PHASE_A_MASK;
 	}
-	if (*(pair->master_B)) {
+	if (hal_get_bool(pair->master_B)) {
 	    state |= SM_PHASE_B_MASK;
 	}
 	/* look up new state */
 	state = lut[state & SM_LOOKUP_MASK];
 	/* are we enabled? */
-	if ( *(pair->enable) != 0 ) {
+	if ( hal_get_bool(pair->enable) != 0 ) {
 	    /* has an edge been detected? */
 	    if (state & SM_CNT_UP_MASK) {
 		pair->raw_error -= pair->master_increment;
@@ -310,10 +310,10 @@ static void sample(void *arg, long period)
 	/* get state machine current state */
 	state = pair->slave_state;
 	/* add input bits to state code */
-	if (*(pair->slave_A)) {
+	if (hal_get_bool(pair->slave_A)) {
 	    state |= SM_PHASE_A_MASK;
 	}
-	if (*(pair->slave_B)) {
+	if (hal_get_bool(pair->slave_B)) {
 	    state |= SM_PHASE_B_MASK;
 	}
 	/* look up new state */
@@ -342,13 +342,13 @@ static void update(void *arg, long period)
     for (n = 0; n < howmany; n++) {
 	/* scale raw error to output pin */
 	if ( pair->output_scale > 0 ) {
-	    *(pair->error) = pair->raw_error / pair->output_scale;
+	    hal_set_real(pair->error, pair->raw_error / pair->output_scale);
 	}
 	/* update scale factors (only needed if params change, but
 	   it's faster to do it every time than to detect changes.) */
-	pair->master_increment = *(pair->master_teeth) * *(pair->slave_ppr);
-	pair->slave_increment = *(pair->slave_teeth) * *(pair->master_ppr);
-	pair->output_scale = *(pair->master_ppr) * *(pair->slave_ppr) * *(pair->slave_teeth);
+	pair->master_increment = hal_get_ui32(pair->master_teeth) * hal_get_ui32(pair->slave_ppr);
+	pair->slave_increment = hal_get_ui32(pair->slave_teeth) * hal_get_ui32(pair->master_ppr);
+	pair->output_scale = hal_get_ui32(pair->master_ppr) * hal_get_ui32(pair->slave_ppr) * hal_get_ui32(pair->slave_teeth);
 	/* move on to next pair */
 	pair++;
     }
@@ -372,55 +372,55 @@ static int export_encoder_pair(int num, encoder_pair_t * addr, char* prefix)
     rtapi_set_msg_level(RTAPI_MSG_WARN);
 
     /* export pins for the quadrature inputs */
-    retval = hal_pin_bit_newf(HAL_IN, &(addr->master_A), comp_id,
+    retval = hal_pin_new_bool(comp_id, HAL_IN, &(addr->master_A), 0,
 			      "%s.master-A", prefix);
     if (retval != 0) {
 	return retval;
     }
-    retval = hal_pin_bit_newf(HAL_IN, &(addr->master_B), comp_id,
+    retval = hal_pin_new_bool(comp_id, HAL_IN, &(addr->master_B), 0,
 			      "%s.master-B", prefix);
     if (retval != 0) {
 	return retval;
     }
-    retval = hal_pin_bit_newf(HAL_IN, &(addr->slave_A), comp_id,
+    retval = hal_pin_new_bool(comp_id, HAL_IN, &(addr->slave_A), 0,
 			      "%s.slave-A", prefix);
     if (retval != 0) {
 	return retval;
     }
-    retval = hal_pin_bit_newf(HAL_IN, &(addr->slave_B), comp_id,
+    retval = hal_pin_new_bool(comp_id, HAL_IN, &(addr->slave_B), 0,
 			      "%s.slave-B", prefix);
     if (retval != 0) {
 	return retval;
     }
     /* export pin for the enable input */
-    retval = hal_pin_bit_newf(HAL_IN, &(addr->enable), comp_id,
+    retval = hal_pin_new_bool(comp_id, HAL_IN, &(addr->enable), 0,
 			      "%s.enable", prefix);
     if (retval != 0) {
 	return retval;
     }
     /* export pin for output */
-    retval = hal_pin_float_newf(HAL_OUT, &(addr->error), comp_id,
+    retval = hal_pin_new_real(comp_id, HAL_OUT, &(addr->error), 0.0,
 				"%s.error", prefix);
     if (retval != 0) {
 	return retval;
     }
     /* export pins for config info() */
-    retval = hal_pin_u32_newf(HAL_IO, &(addr->master_ppr), comp_id,
+    retval = hal_pin_new_ui32(comp_id, HAL_IO, &(addr->master_ppr), 0,
 			      "%s.master-ppr", prefix);
     if (retval != 0) {
 	return retval;
     }
-    retval = hal_pin_u32_newf(HAL_IO, &(addr->slave_ppr), comp_id,
+    retval = hal_pin_new_ui32(comp_id, HAL_IO, &(addr->slave_ppr), 0,
 			      "%s.slave-ppr", prefix);
     if (retval != 0) {
 	return retval;
     }
-    retval = hal_pin_u32_newf(HAL_IO, &(addr->master_teeth), comp_id,
+    retval = hal_pin_new_ui32(comp_id, HAL_IO, &(addr->master_teeth), 0,
 			      "%s.master-teeth", prefix);
     if (retval != 0) {
 	return retval;
     }
-    retval = hal_pin_u32_newf(HAL_IO, &(addr->slave_teeth), comp_id,
+    retval = hal_pin_new_ui32(comp_id, HAL_IO, &(addr->slave_teeth), 0,
 			      "%s.slave-teeth", prefix);
     if (retval != 0) {
 	return retval;

--- a/src/hal/components/matrix_kb.c
+++ b/src/hal/components/matrix_kb.c
@@ -29,30 +29,29 @@ MODULE_LICENSE("GPL");
 
 typedef struct {
     struct {
-        hal_bit_t **key;
-        hal_bit_t **rows;
-        hal_bit_t **cols;
-        hal_u32_t *keycode;
+        hal_bool_t *key;
+        hal_bool_t *rows;
+        hal_bool_t *cols;
+        hal_uint_t keycode;
     } hal;
     struct {
-        hal_u32_t rollover;
-        hal_bit_t invert;
+        hal_uint_t rollover;
+        hal_bool_t invert;
     } param;
-    hal_u32_t ncols;
-    hal_u32_t nrows;
-    hal_u32_t *now;
-    hal_u32_t *then;
-    hal_bit_t invert;
+    rtapi_u32 ncols;
+    rtapi_u32 nrows;
+    rtapi_u32 *now;
+    rtapi_u32 *then;
     char name[HAL_NAME_LEN + 1];
     struct input_dev *key_dev;
-    hal_u32_t index;
+    rtapi_u32 index;
     unsigned keydown;
     unsigned keyup;
     unsigned rowshift;
     unsigned row;
     unsigned num_keys;
-    hal_bit_t scan;
-    hal_bit_t keystroke;
+    rtapi_bool scan;
+    rtapi_bool keystroke;
 }kb_inst_t;
 
 typedef struct {
@@ -70,7 +69,7 @@ RTAPI_MP_ARRAY_STRING(names, MAX_CHAN, "component names");
 
 void keyup(kb_inst_t *inst){
     unsigned r, c;
-    unsigned keycode = *inst->hal.keycode & ~(inst->keydown | inst->keyup);
+    unsigned keycode = hal_get_ui32(inst->hal.keycode) & ~(inst->keydown | inst->keyup);
 
     r = keycode >> inst->rowshift;
     c = keycode & ~(0xFFFFFFFF << inst->rowshift);
@@ -83,11 +82,11 @@ void keyup(kb_inst_t *inst){
     
     if (inst->num_keys > 0) inst->num_keys--;
     
-    *inst->hal.key[r * inst->ncols + c] = 0;
+    hal_set_bool(inst->hal.key[r * inst->ncols + c], 0);
 }
 void keydown(kb_inst_t *inst){
     unsigned r, c;
-    unsigned keycode = *inst->hal.keycode & ~(inst->keydown | inst->keyup);
+    unsigned keycode = hal_get_ui32(inst->hal.keycode) & ~(inst->keydown | inst->keyup);
     
     r = keycode >> inst->rowshift;
     c = keycode & ~(0xFFFFFFFF << inst->rowshift);
@@ -98,60 +97,61 @@ void keydown(kb_inst_t *inst){
         return;
     }
     
-    if (inst->num_keys >= inst->param.rollover) return;
+    if (inst->num_keys >= hal_get_ui32(inst->param.rollover)) return;
     inst->num_keys++;
     
-    *inst->hal.key[r * inst->ncols + c] = 1;
+    hal_set_bool(inst->hal.key[r * inst->ncols + c], 1);
 }
 
 void loop(void *arg, long period){
     (void)period;
     unsigned c;
-    hal_u32_t scan = 0;
+    rtapi_u32 scan = 0;
     kb_inst_t *inst = arg;
     
     if (inst->scan){ //scanning request
         for (c = 0; c < inst->ncols; c++){
-            scan += ((*inst->hal.cols[c] != inst->param.invert) << c);
+            scan += ((hal_get_bool(inst->hal.cols[c]) != hal_get_bool(inst->param.invert)) << c);
         }
         if (scan == inst->now[inst->row] && scan != inst->then[inst->row]){
             // debounced and changed
             for (c = 0; c < inst->ncols; c++){
                 int mask = 1 << c;
                 if ((inst->then[inst->row] & mask) && !(scan & mask)){ //keyup
-                    *inst->hal.keycode = inst->keyup 
+                    hal_set_ui32(inst->hal.keycode, inst->keyup
                     + (inst->row << inst->rowshift) 
-                    + c;
+                    + c);
                     keyup(inst);
                 }
                 else if (!(inst->then[inst->row] & mask) && (scan & mask)){//keydown
-                    *inst->hal.keycode = inst->keydown 
+                    hal_set_ui32(inst->hal.keycode, inst->keydown
                     + (inst->row << inst->rowshift) 
-                    + c;
+                    + c);
                     
                     keydown(inst);
                 }
             }
         }
         else {
-            *inst->hal.keycode = 0x40;//nochange
+            hal_set_ui32(inst->hal.keycode, 0x40);//nochange
         }
         
         inst->then[inst->row] = inst->now[inst->row];
         inst->now[inst->row] = scan;
         
-        *inst->hal.rows[inst->row] = inst->param.invert;
+        hal_set_bool(inst->hal.rows[inst->row], hal_get_bool(inst->param.invert));
         inst->row++;
         if (inst->row >= inst->nrows) inst->row = 0;
-        *inst->hal.rows[inst->row] = !inst->param.invert;
+        hal_set_bool(inst->hal.rows[inst->row], !hal_get_bool(inst->param.invert));
     }
     else
     {
-        if (*inst->hal.keycode == 0x40) return;
-        if ((*inst->hal.keycode & inst->keydown) == inst->keydown){
+        rtapi_u32 keycode = hal_get_ui32(inst->hal.keycode);
+        if (keycode == 0x40) return;
+        if ((keycode & inst->keydown) == inst->keydown){
             keydown(inst);
         }
-        else if ((*inst->hal.keycode & inst->keydown) == inst->keyup)
+        else if ((keycode & inst->keydown) == inst->keyup)
         {
             keyup(inst);
         }
@@ -169,7 +169,7 @@ int rtapi_app_main(void){
     }
     
     // allocate shared memory for data
-    kb = hal_malloc(sizeof(kb_t));
+    kb = hal_malloc(sizeof(*kb));
     if (kb == 0) {
         rtapi_print_msg(RTAPI_MSG_ERR,
                         "matrix_kb component: Out of Memory\n");
@@ -189,7 +189,7 @@ int rtapi_app_main(void){
         return -1;
     }
     
-    kb->insts = hal_malloc(kb->num_insts * sizeof(kb_inst_t));
+    kb->insts = hal_malloc(kb->num_insts * sizeof(*kb->insts));
     
     for (i = 0; i < kb->num_insts; i++){
         int a = 0;
@@ -201,8 +201,7 @@ int rtapi_app_main(void){
         inst->ncols = 0;
         inst->scan = 0;
         inst->keystroke = 0;
-        inst->param.invert = 1;
-        
+
         for(j = 0; config[i][j] !=0; j++){
             int n = (config[i][j] | 0x20); //lower case
             if (n == 'x'){
@@ -237,11 +236,10 @@ int rtapi_app_main(void){
              ; (inst->nrows << inst->rowshift) > inst->keydown
              ; inst->keydown <<= 1, inst->keyup <<= 1);
         
-        inst->hal.key = (hal_bit_t **)hal_malloc(inst->nrows * inst->ncols * sizeof(hal_bit_t*));
-        inst->now = hal_malloc(inst->nrows * sizeof(hal_u32_t));
-        inst->then = hal_malloc(inst->nrows * sizeof(hal_u32_t));
+        inst->hal.key = hal_malloc(inst->nrows * inst->ncols * sizeof(*inst->hal.key));
+        inst->now = hal_malloc(inst->nrows * sizeof(*inst->now));
+        inst->then = hal_malloc(inst->nrows * sizeof(*inst->then));
         inst->row = 0;
-        inst->param.rollover = 2;
         
         
         if (names[i]){
@@ -254,9 +252,9 @@ int rtapi_app_main(void){
         
         for (c = 0; c < inst->ncols; c++){
             for (r = 0; r < inst->nrows; r++){  
-                retval = hal_pin_bit_newf(HAL_OUT,
+                retval = hal_pin_new_bool(comp_id, HAL_OUT,
                                           &(inst->hal.key[r * inst->ncols + c]), 
-                                          comp_id,
+                                          0,
                                           "%s.key.r%xc%x", 
                                           inst->name, r, c);
                 if (retval != 0) {
@@ -269,12 +267,12 @@ int rtapi_app_main(void){
         }
         
         if (inst->scan){ //internally generated scanning
-            inst->hal.rows = (hal_bit_t **)hal_malloc(inst->nrows * sizeof(hal_bit_t*));
-            inst->hal.cols = (hal_bit_t **)hal_malloc(inst->ncols * sizeof(hal_bit_t*));
+            inst->hal.rows = hal_malloc(inst->nrows * sizeof(*inst->hal.rows));
+            inst->hal.cols = hal_malloc(inst->ncols * sizeof(*inst->hal.cols));
             
             for (r = 0; r < inst->nrows; r++){
-                retval = hal_pin_bit_newf(HAL_OUT,
-                                          &(inst->hal.rows[r]), comp_id,
+                retval = hal_pin_new_bool(comp_id, HAL_OUT,
+                                          &(inst->hal.rows[r]), 0,
                                           "%s.row-%02i-out",inst->name, r);
                 if (retval != 0) {
                     rtapi_print_msg(RTAPI_MSG_ERR,
@@ -284,8 +282,8 @@ int rtapi_app_main(void){
                 }
             }
             for (c = 0; c < inst->ncols; c++){
-                retval = hal_pin_bit_newf(HAL_IN,
-                                          &(inst->hal.cols[c]), comp_id,
+                retval = hal_pin_new_bool(comp_id, HAL_IN,
+                                          &(inst->hal.cols[c]), 0,
                                           "%s.col-%02i-in",inst->name, c);
                 if (retval != 0) {
                     rtapi_print_msg(RTAPI_MSG_ERR,
@@ -295,8 +293,8 @@ int rtapi_app_main(void){
                 }
             }
                 
-            retval = hal_pin_u32_newf(HAL_OUT,
-                                      &(inst->hal.keycode), comp_id,
+            retval = hal_pin_new_ui32(comp_id, HAL_OUT,
+                                      &(inst->hal.keycode), 0,
                                       "%s.keycode",inst->name);
             if (retval != 0) {
                 rtapi_print_msg(RTAPI_MSG_ERR,
@@ -305,8 +303,8 @@ int rtapi_app_main(void){
                 return -1;
             }
             
-            retval = hal_param_bit_newf(HAL_RW,
-                                      &(inst->param.invert), comp_id,
+            retval = hal_param_new_bool(comp_id, HAL_RW,
+                                      &(inst->param.invert), 1,
                                       "%s.negative-logic",inst->name);
             if (retval != 0) {
                 rtapi_print_msg(RTAPI_MSG_ERR,
@@ -316,8 +314,8 @@ int rtapi_app_main(void){
             }
             
             
-            retval = hal_param_u32_newf(HAL_RW,
-                                      &(inst->param.rollover), comp_id,
+            retval = hal_param_new_ui32(comp_id, HAL_RW,
+                                      &(inst->param.rollover), 2,
                                       "%s.key_rollover",inst->name);
             if (retval != 0) {
                 rtapi_print_msg(RTAPI_MSG_ERR,
@@ -329,8 +327,8 @@ int rtapi_app_main(void){
         }
         else // scanning by 7i73 or similar
         {
-            retval = hal_pin_u32_newf(HAL_IN,
-                                      &(inst->hal.keycode), comp_id,
+            retval = hal_pin_new_ui32(comp_id, HAL_IN,
+                                      &(inst->hal.keycode), 0,
                                       "%s.keycode",inst->name);
             if (retval != 0) {
                 rtapi_print_msg(RTAPI_MSG_ERR,

--- a/src/hal/components/max31855.comp
+++ b/src/hal/components/max31855.comp
@@ -28,16 +28,16 @@ A maximum of 15 sensors are supported.
 
 """;
 
-pin in  bit data.#.in [15 : (personality & 0xf)]  "Pin(s) connected to data out.";
-pin out bit cs.out         "Pin connected to cs, pulled low to shift data, pulled high for data refresh.";
-pin out bit clk.out        "Pin connected to clk.";
+pin in  bool data.#.in [15 : (personality & 0xf)]  "Pin(s) connected to data out.";
+pin out bool cs.out         "Pin connected to cs, pulled low to shift data, pulled high for data refresh.";
+pin out bool clk.out        "Pin connected to clk.";
 
-pin out float temp_celsius.# [15 : (personality & 0xf)] """Temperature output values in Celsius.""";
-pin out float temp_fahrenheit.# [15 : (personality & 0xf)] """Temperature in Fahrenheit.""";
-pin out float temp_kelvin.# [15 : (personality & 0xf)] """Temperature in Kelvin.""";
+pin out real temp_celsius.# [15 : (personality & 0xf)] """Temperature output values in Celsius.""";
+pin out real temp_fahrenheit.# [15 : (personality & 0xf)] """Temperature in Fahrenheit.""";
+pin out real temp_kelvin.# [15 : (personality & 0xf)] """Temperature in Kelvin.""";
 
-pin out bit fault.# [15 : (personality & 0xf)]  "Fault condition detected.";
-pin out unsigned fault_flags.# [15 : (personality & 0xf)]  "Fault flags: 0x1  = open sensor, 0x2 short to gnd, 0x3 short to vcc.";
+pin out bool fault.# [15 : (personality & 0xf)]  "Fault condition detected.";
+pin out ui32 fault_flags.# [15 : (personality & 0xf)]  "Fault flags: 0x1  = open sensor, 0x2 short to gnd, 0x3 short to vcc.";
 
 variable unsigned data_frame [15];
 variable unsigned state = 1;
@@ -52,24 +52,24 @@ author "Joseph Calderon";
 
 #include <rtapi_math.h>
 
-static float accpoly(float *v, size_t n, float p) {
+static rtapi_real accpoly(rtapi_real *v, size_t n, rtapi_real p) {
   size_t i;
-  float ret = 0;
+  rtapi_real ret = 0;
   for (i = 0; i < n; i++) {
     ret += v[i] * pow(p, i);
   }
   return ret;
 }
 
-static float to_kelvin(float celsius) {
+static rtapi_real to_kelvin(rtapi_real celsius) {
   return celsius + 273.15;
 }
 
-static float to_fahrenheit(float celsius) {
+static rtapi_real to_fahrenheit(rtapi_real celsius) {
   return celsius * 1.80 + 32.0;
 }
 
-static float read_celsius(int32_t v) {
+static rtapi_real read_celsius(int32_t v) {
   if (v & 0x7) {
     return nan(""); /* fault bit(s) set */
   }
@@ -83,7 +83,7 @@ static float read_celsius(int32_t v) {
   return v / 4.0; /* 0.25 degree resolution */
 }
 
-static float read_internal(int32_t v) {
+static rtapi_real read_internal(int32_t v) {
   if (v & 0x7) {
     return nan(""); /* fault bit(s) set */
   }
@@ -98,16 +98,16 @@ static float read_internal(int32_t v) {
   return v / 16.0; /* 0.0625 degree resolution */
 }
 
-static float read_celsius_adjusted(int32_t sensor_data) {
-  float temp_raw = read_celsius(sensor_data);
-  float temp_internal = read_internal(sensor_data);
-  float voltage_internal = 0, voltage_thermocouple = 0, temp_corrected = 0;
+static rtapi_real read_celsius_adjusted(int32_t sensor_data) {
+  rtapi_real temp_raw = read_celsius(sensor_data);
+  rtapi_real temp_internal = read_internal(sensor_data);
+  rtapi_real voltage_internal = 0, voltage_thermocouple = 0, temp_corrected = 0;
 
   if (isnan(temp_raw) || isnan(temp_internal))
     return nan("");
 
   /* NIST K-Type table (http://srdata.nist.gov/its90/download/type_k.tab) */
-  float coeff[][11] = {
+  rtapi_real coeff[][11] = {
       {-0.0176004134, 0.0389212035, 1.85587705e-05, -9.94575942e-08,
        3.18409465e-10, -5.60728439e-13, 5.60750581e-16, -3.20207199e-19,
        9.71511487e-23, -1.21047216e-26, 0},
@@ -120,14 +120,14 @@ static float read_celsius_adjusted(int32_t sensor_data) {
        0.000980403624, -4.41302982e-05, 1.05773404e-06, -1.05275504e-08, 0},
       {-131.805801, 48.3022194, -1.64603102, 0.0546473116, -0.000965071493,
        8.80219341e-06, -3.1108101e-08, 0, 0, 0, 0}};
-  int coeff_cols = sizeof(coeff[0]) / sizeof(float);
+  int coeff_cols = sizeof(coeff[0]) / sizeof(*coeff[0]);
 
   /* determine thermocouple voltage by subtracting internal temp and adjusting
    * for K-type thermocouple */
   voltage_thermocouple = (temp_raw - temp_internal) * 0.041276;
 
   if (temp_internal >= 0) {
-    float a[] = {0.118597597, -0.000118343203, 126.968597};
+    rtapi_real a[] = {0.118597597, -0.000118343203, 126.968597};
     /* for positive temps additional exponential coefficients are needed */
     voltage_internal += accpoly(coeff[0], coeff_cols, temp_internal);
     voltage_internal += a[0] * exp(a[1] * pow((temp_internal - a[2]), 2));
@@ -135,7 +135,7 @@ static float read_celsius_adjusted(int32_t sensor_data) {
     voltage_internal += accpoly(coeff[1], coeff_cols, temp_internal);
   }
 
-  float voltage_total = voltage_thermocouple + voltage_internal;
+  rtapi_real voltage_total = voltage_thermocouple + voltage_internal;
 
   /* linearize temperature depending on voltage range */
   if (voltage_total < 0) {
@@ -160,7 +160,7 @@ FUNCTION(bitbang_spi) {
   int delay = (state >> 7) & 0x3ff;
   int cs = state & 0x1;
 
-  clk_out ^= 0x1;
+  clk_out_set(!clk_out);
   if (cs) {
     /* data refreshes when cs is pulled high */
     delay--;
@@ -179,15 +179,15 @@ FUNCTION(bitbang_spi) {
     }
     if (nbit < 0) {
       for (i = 0; i < n; i++) {
-        float f = read_celsius_adjusted((int32_t)data_frame[i]);
-        fault(i) = (data_frame[i] & 0x7) ? TRUE : FALSE;
-        fault_flags(i) = data_frame[i] & 0x7;
+        rtapi_real f = read_celsius_adjusted((int32_t)data_frame[i]);
+        fault_set(i, (data_frame[i] & 0x7) ? TRUE : FALSE);
+        fault_flags_set(i, data_frame[i] & 0x7);
         if (isnan(f)) {
           rtapi_print("max31855: sensor %d detected fault %x\n", i, data_frame[i] & 0x7);
         } else {
-          temp_celsius(i) = f;
-          temp_fahrenheit(i) = to_fahrenheit(f);
-          temp_kelvin(i) = to_kelvin(f);
+          temp_celsius_set(i, f);
+          temp_fahrenheit_set(i, to_fahrenheit(f));
+          temp_kelvin_set(i, to_kelvin(f));
         }
         data_frame[i] = 0;
       }
@@ -197,7 +197,7 @@ FUNCTION(bitbang_spi) {
     delay++;
   }
   state = (delay << 7) | (nbit << 1) | cs;
-  cs_out = cs;
+  cs_out_set(cs);
 }
 
 EXTRA_SETUP(){

--- a/src/hal/components/mux_generic.c
+++ b/src/hal/components/mux_generic.c
@@ -19,6 +19,7 @@
 
 #include <rtapi.h>
 #include <rtapi_app.h>
+#include <rtapi_math.h>
 #include <hal.h>
 
 
@@ -30,18 +31,16 @@ MODULE_LICENSE("GPL");
 #define MAX_CHAN 100
 #define MAX_SIZE 1024
 #define EPS 2e-7
-#define MAX_S32 0x7FFFFFFF
-#define MAX_U32 0xFFFFFFFF
 
 typedef struct {
-    hal_data_u **inputs;
-    hal_data_u *output;
-    hal_u32_t *sel_int;
-    hal_bit_t **sel_bit;
-    unsigned int selection;
-    hal_u32_t *debounce;
-    unsigned int timer;
-    hal_bit_t *suppress;
+    hal_refs_u *inputs;
+    hal_refs_u output;
+    hal_uint_t sel_int;
+    hal_bool_t *sel_bit;
+    hal_uint_t selection;
+    hal_uint_t debounce;
+    hal_uint_t timer;
+    hal_bool_t suppress;
     int in_type;
     int out_type;
     int size;
@@ -56,7 +55,6 @@ typedef struct {
 static int comp_id;
 static mux_t *mux;
 static void write_fp(void *arg, long period);
-static void write_nofp(void *arg, long period);
 
 char *config[MAX_CHAN];
 RTAPI_MP_ARRAY_STRING(config, MAX_CHAN, "mux specifiers inNUMout");
@@ -79,7 +77,7 @@ int rtapi_app_main(void){
     }
 
     // allocate shared memory for the base struct
-    mux = hal_malloc(sizeof(mux_t));
+    mux = hal_malloc(sizeof(*mux));
     if (mux == 0) {
         rtapi_print_msg(RTAPI_MSG_ERR,
                 "mux_generic component: Out of Memory\n");
@@ -89,7 +87,7 @@ int rtapi_app_main(void){
 
     // Count the instances.
     for (mux->num_insts = 0; config[mux->num_insts];mux->num_insts++) {}
-    mux->insts = hal_malloc(mux->num_insts * sizeof(mux_inst_t));
+    mux->insts = hal_malloc(mux->num_insts * sizeof(*mux->insts));
     // Parse the config string
     for (i = 0; i < mux->num_insts; i++) {
         char c;
@@ -116,11 +114,11 @@ int rtapi_app_main(void){
                 break;
             case 'b':
             case 'B':
-                type = HAL_BIT;
+                type = HAL_BOOL;
                 break;
             case 'f':
             case 'F':
-                type = HAL_FLOAT;
+                type = HAL_REAL;
                 break;
             case 's':
             case 'S':
@@ -168,22 +166,13 @@ int rtapi_app_main(void){
             inst->out_type = inst->in_type;
         }
 
-        if (inst->in_type == HAL_FLOAT || inst->out_type == HAL_FLOAT) {
-            retval = hal_export_functf(write_fp, inst, 1, 0, comp_id, "mux-gen.%02i", i);
-            if (retval < 0) {
-                rtapi_print_msg(RTAPI_MSG_ERR, "mux_generic: ERROR: function export"
-                        " failed\n");
-                goto fail0;
-            }
-        }
-        else
-        {
-            retval = hal_export_functf(write_nofp, inst, 0, 0, comp_id, "mux-gen.%02i", i);
-            if (retval < 0) {
-                rtapi_print_msg(RTAPI_MSG_ERR, "mux_generic: ERROR: function export"
-                        " failed\n");
-                goto fail0;
-            }
+        // We did away with the no-fp thread.
+        // Always export the float case. It can do any-to-any.
+        retval = hal_export_functf(write_fp, inst, 1, 0, comp_id, "mux-gen.%02i", i);
+        if (retval < 0) {
+            rtapi_print_msg(RTAPI_MSG_ERR, "mux_generic: ERROR: function export"
+                    " failed\n");
+            goto fail0;
         }
 
         // Input pins
@@ -194,9 +183,9 @@ int rtapi_app_main(void){
         if (s !=1){
             inst->num_bits = 0;
         } else { //make the bit pins
-            inst->sel_bit = hal_malloc(inst->num_bits * sizeof(hal_bit_t*));
+            inst->sel_bit = hal_malloc(inst->num_bits * sizeof(*inst->sel_bit));
             for (p = 0; p < inst->num_bits; p++) {
-                retval = hal_pin_bit_newf(HAL_IN, &inst->sel_bit[p], comp_id,
+                retval = hal_pin_new_bool(comp_id, HAL_IN, &inst->sel_bit[p], 0,
                         "mux-gen.%02i.sel-bit-%02i", i, p);
                 if (retval != 0) {
                     goto fail0;
@@ -204,43 +193,51 @@ int rtapi_app_main(void){
             }
         }
 
-        retval = hal_pin_u32_newf(HAL_IN, &(inst->sel_int), comp_id,
+        retval = hal_pin_new_ui32(comp_id, HAL_IN, &(inst->sel_int), 0,
                 "mux-gen.%02i.sel-int", i);
         if (retval != 0) {
             goto fail0;
         }
 
-        inst->inputs = hal_malloc(inst->size * sizeof(hal_data_u*));
+        inst->inputs = hal_malloc(inst->size * sizeof(*inst->inputs));
         for (p = 0; p < inst->size; p++) {
             retval = rtapi_snprintf(hal_name, HAL_NAME_LEN,
                     "mux-gen.%02i.in-%s-%02i", i, types[inst->in_type], p);
             if (retval >= HAL_NAME_LEN) {
                 goto fail0;
             }
-            retval = hal_pin_new(hal_name, inst->in_type, HAL_IN,
-                    (void**)&(inst->inputs[p]), comp_id);
+            switch(inst->in_type) {
+            case HAL_BOOL: retval = hal_pin_new_bool(comp_id, HAL_IN, &inst->inputs[p].b, 0, "%s", hal_name); break;
+            case HAL_REAL: retval = hal_pin_new_real(comp_id, HAL_IN, &inst->inputs[p].r, 0, "%s", hal_name); break;
+            case HAL_S32:  retval = hal_pin_new_si32(comp_id, HAL_IN, &inst->inputs[p].s, 0, "%s", hal_name); break;
+            case HAL_U32:  retval = hal_pin_new_ui32(comp_id, HAL_IN, &inst->inputs[p].u, 0, "%s", hal_name); break;
+            // FIXME: Future...when we switch types
+            case HAL_SINT: retval = hal_pin_new_sint(comp_id, HAL_IN, &inst->inputs[p].s, 0, "%s", hal_name); break;
+            case HAL_UINT: retval = hal_pin_new_uint(comp_id, HAL_IN, &inst->inputs[p].u, 0, "%s", hal_name); break;
+            default: retval = -ENOENT; break;
+            }
             if (retval != 0) {
                 goto fail0;
             }
         }
 
         // Behaviour-modifiers
-        retval = hal_pin_bit_newf(HAL_IN, &inst->suppress, comp_id,
+        retval = hal_pin_new_bool(comp_id, HAL_IN, &inst->suppress, 0,
                 "mux-gen.%02i.suppress-no-input", i);
         if (retval != 0) {
             goto fail0;
         }
-        retval = hal_pin_u32_newf(HAL_IN, &inst->debounce, comp_id,
+        retval = hal_pin_new_ui32(comp_id, HAL_IN, &inst->debounce, 0,
                 "mux-gen.%02i.debounce-us", i);
         if (retval != 0) {
             goto fail0;
         }
-        retval = hal_param_u32_newf(HAL_RO, &inst->timer, comp_id,
+        retval = hal_param_new_ui32(comp_id, HAL_RO, &inst->timer, 0,
                 "mux-gen.%02i.elapsed", i);
         if (retval != 0) {
             goto fail0;
         }
-        retval = hal_param_u32_newf(HAL_RO, &inst->selection, comp_id,
+        retval = hal_param_new_ui32(comp_id, HAL_RO, &inst->selection, 0,
                 "mux-gen.%02i.selected", i);
         if (retval != 0) {
             goto fail0;
@@ -252,8 +249,16 @@ int rtapi_app_main(void){
         if (retval >= HAL_NAME_LEN) {
             goto fail0;
         }
-        retval = hal_pin_new(hal_name, inst->out_type, HAL_OUT,
-                (void**)&(inst->output), comp_id);
+        switch(inst->out_type) {
+        case HAL_BOOL: retval = hal_pin_new_bool(comp_id, HAL_OUT, &inst->output.b, 0, "%s", hal_name); break;
+        case HAL_REAL: retval = hal_pin_new_real(comp_id, HAL_OUT, &inst->output.r, 0, "%s", hal_name); break;
+        case HAL_S32:  retval = hal_pin_new_si32(comp_id, HAL_OUT, &inst->output.s, 0, "%s", hal_name); break;
+        case HAL_U32:  retval = hal_pin_new_ui32(comp_id, HAL_OUT, &inst->output.u, 0, "%s", hal_name); break;
+        // FIXME: Future...when we switch types
+        case HAL_SINT: retval = hal_pin_new_sint(comp_id, HAL_OUT, &inst->output.s, 0, "%s", hal_name); break;
+        case HAL_UINT: retval = hal_pin_new_uint(comp_id, HAL_OUT, &inst->output.u, 0, "%s", hal_name); break;
+        default: retval = -ENOENT; break;
+        }
         if (retval != 0) {
             goto fail0;
         }
@@ -269,124 +274,102 @@ int rtapi_app_main(void){
 
 }
 
+// From 'f' to 't' conversion
+#define FT(f,t) ((((f) & 0x0f) << 4) + ((t) & 0x0f))
+
 void write_fp(void *arg, long period) {
     mux_inst_t *inst = arg;
     int i = 0;
     unsigned s = 0;
     if (inst->num_bits > 0) {
         while (i < inst->num_bits) {
-            s += (*inst->sel_bit[i] != 0) << i;
+            s += (hal_get_bool(inst->sel_bit[i]) != 0) << i;
             i++;
         }
     }
     // if you document it, it's not a bug, it's a feature. Might even be useful
-    s += *inst->sel_int;
+    s += hal_get_ui32(inst->sel_int);
 
-    if (*inst->suppress && s == 0)
+    if (hal_get_bool(inst->suppress) && s == 0)
         return;
-    if (s != inst->selection && inst->timer < *inst->debounce) {
-        inst->timer += period / 1000;
+    if (s != hal_get_ui32(inst->selection) && hal_get_ui32(inst->timer) < hal_get_ui32(inst->debounce)) {
+        hal_set_ui32(inst->timer, hal_get_ui32(inst->timer) + period / 1000);
         return;
     }
 
-    inst->selection = s;
-    inst->timer = 0;
+    hal_set_ui32(inst->selection, s);
+    hal_set_ui32(inst->timer, 0);
 
     if ((int)s >= inst->size)
         s = inst->size - 1;
 
-    switch (inst->in_type * 8 + inst->out_type) {
-    case 012: //HAL_BIT => HAL_FLOAT
-        inst->output->f = inst->inputs[s]->b ? 1.0 : 0.0; //
+    switch (FT(inst->in_type, inst->out_type)) {
+    case FT(HAL_BOOL, HAL_BOOL):
+        hal_set_bool(inst->output.b, hal_get_bool(inst->inputs[s].b));
         break;
-    case 021: //HAL_FLOAT => HAL_BIT
-        inst->output->b =
-                (inst->inputs[s]->f > EPS || inst->inputs[s]->f < -EPS) ? 1 : 0;
+    case FT(HAL_BOOL, HAL_S32):
+        hal_set_si32(inst->output.s, hal_get_bool(inst->inputs[s].b));
         break;
-    case 022: //HAL_FLOAT => HAL_FLOAT
-        inst->output->f = inst->inputs[s]->f;
+    case FT(HAL_BOOL, HAL_U32):
+        hal_set_ui32(inst->output.u, hal_get_bool(inst->inputs[s].b));
         break;
-    case 023: //HAL_FLOAT => HAL_S32
-        if (inst->inputs[s]->f > MAX_S32) {
-            inst->output->s = MAX_S32;
-        } else if (inst->inputs[s]->f < -MAX_S32) {
-            inst->output->s = -MAX_S32;
+    case FT(HAL_BOOL, HAL_REAL):
+        hal_set_real(inst->output.r, hal_get_bool(inst->inputs[s].b) ? 1.0 : 0.0);
+        break;
+
+    case FT(HAL_REAL, HAL_BOOL):
+        hal_set_bool(inst->output.b, fabs(hal_get_real(inst->inputs[s].r)) > EPS);
+        break;
+    case FT(HAL_REAL, HAL_REAL):
+        hal_set_real(inst->output.r, hal_get_real(inst->inputs[s].r));
+        break;
+    case FT(HAL_REAL, HAL_S32): {
+        rtapi_real v = hal_get_real(inst->inputs[s].r);
+        if (v > RTAPI_INT32_MAX) {
+            hal_set_si32(inst->output.s, RTAPI_INT32_MAX);
+        } else if (v < RTAPI_INT32_MIN) {
+            hal_set_si32(inst->output.s, RTAPI_INT32_MIN);
         } else {
-            inst->output->s = inst->inputs[s]->f;
+            hal_set_si32(inst->output.s, v);
         }
-        break;
-    case 024: //HAL_FLOAT => HAL_U32
-        if (inst->inputs[s]->f > MAX_U32) {
-            inst->output->u = MAX_U32;
-        } else if (inst->inputs[s]->f < 0) {
-            inst->output->u = 0;
+        break; }
+    case FT(HAL_REAL, HAL_U32): {
+        rtapi_real v = hal_get_real(inst->inputs[s].r);
+        if (v > RTAPI_UINT32_MAX) {
+            hal_set_ui32(inst->output.u, RTAPI_UINT32_MAX);
+        } else if (v < 0) {
+            hal_set_ui32(inst->output.u, 0);
         } else {
-            inst->output->u = inst->inputs[s]->f;
+            hal_set_ui32(inst->output.u, v);
         }
-        break;
-    case 032: //HAL_S32 => HAL_FLOAT
-        inst->output->f = inst->inputs[s]->s;
-        break;
-    case 042: //HAL_U32 => HAL_FLOAT
-        inst->output->f = (unsigned int) inst->inputs[s]->u;
-        break;
-    }
-}
+        break; }
 
-void write_nofp(void *arg, long period) {
-    mux_inst_t *inst = arg;
-    int i = 0;
-    unsigned s = 0;
-    if (inst->num_bits > 0) {
-        while (i < inst->num_bits) {
-            s += (*inst->sel_bit[i] != 0) << i;
-            i++;
-        }
-    }
+    case FT(HAL_S32, HAL_BOOL):
+        hal_set_bool(inst->output.b, hal_get_si32(inst->inputs[s].s) != 0);
+        break;
+    case FT(HAL_S32, HAL_S32):
+        hal_set_si32(inst->output.s, hal_get_si32(inst->inputs[s].s));
+        break;
+    case FT(HAL_S32, HAL_U32): {
+        rtapi_s32 v = hal_get_si32(inst->inputs[s].s);
+        hal_set_ui32(inst->output.u, v >= 0 ? v : 0);
+        break; }
+    case FT(HAL_S32, HAL_REAL):
+        hal_set_real(inst->output.r, hal_get_si32(inst->inputs[s].s));
+        break;
 
-    s += *inst->sel_int;
-
-    if (*inst->suppress && s == 0)
-        return;
-    if (s != inst->selection && inst->timer < *inst->debounce) {
-        inst->timer += period / 1000;
-        return;
-    }
-
-    inst->selection = s;
-    inst->timer = 0;
-
-    if ((int)s >= inst->size)
-        s = inst->size - 1;
-    switch (inst->in_type * 8 + inst->out_type) {
-    case 011: //HAL_BIT => HAL_BIT
-        inst->output->b = inst->inputs[s]->b;
+    case FT(HAL_U32, HAL_BOOL):
+        hal_set_bool(inst->output.b, hal_get_ui32(inst->inputs[s].u) != 0);
         break;
-    case 013: //HAL_BIT => HAL_S32
-        inst->output->s = inst->inputs[s]->b;
+    case FT(HAL_U32, HAL_S32): {
+        rtapi_u32 v = hal_get_ui32(inst->inputs[s].u);
+        hal_set_si32(inst->output.s, v > RTAPI_INT32_MAX ? RTAPI_INT32_MAX : v);
+        break; }
+    case FT(HAL_U32, HAL_U32):
+        hal_set_ui32(inst->output.u, hal_get_ui32(inst->inputs[s].u));
         break;
-    case 014: //HAL_BIT => HAL_U32
-        inst->output->u = inst->inputs[s]->b;
-        break;
-    case 031: //HAL_S32 => HAL_BIT
-        inst->output->b = inst->inputs[s]->s == 0 ? 0 : 1;
-        break;
-    case 033: //HAL_S32 => HAL_S32
-        inst->output->s = inst->inputs[s]->s;
-        break;
-    case 034: //HAL_S32 => HAL_U32
-        inst->output->u = (inst->inputs[s]->s > 0) ? inst->inputs[s]->s : 0;
-        break;
-    case 041: //HAL_U32 => HAL_BIT
-        inst->output->b = inst->inputs[s]->u == 0 ? 0 : 1;
-        break;
-    case 043: //HAL_U32 => HAL_S32
-        inst->output->s =
-                ((unsigned int) inst->inputs[s]->u > MAX_S32) ?
-                        MAX_S32 : inst->inputs[s]->u;
-        break;
-    case 044: //HAL_U32 => HAL_U32
-        inst->output->u = inst->inputs[s]->u;
+    case FT(HAL_U32, HAL_REAL):
+        hal_set_real(inst->output.r, hal_get_ui32(inst->inputs[s].u));
         break;
     }
 }

--- a/src/hal/components/pushmsg.comp
+++ b/src/hal/components/pushmsg.comp
@@ -73,9 +73,9 @@ loadrt pushmsg msgs=[PUSHMSG]MSGS
 addf pushmsg servo-thread
 ...
 ----
-""";
+"""; //" to fix vim syntax highlight
 
-pin in bit enable = TRUE "Enable message generation through trigger input pins";
+pin in bool enable = TRUE "Enable message generation through trigger input pins";
 
 modparam dummy msgs "Comma separated list of custom messages in format level|pinname|message";
 
@@ -104,10 +104,10 @@ RTAPI_MP_ARRAY_STRING(msgs, MSG_N_MAX, "Message slots in 't|pin|message' format"
 
 // The HAL structure lives in HAL memory space
 typedef struct {
-    hal_bit_t  *trigger;
-    hal_bit_t  *force;
-    hal_bit_t  *edge;
-    hal_data_u *substs[MSG_SUBST_MAX];
+    hal_bool_t trigger;
+    hal_bool_t force;
+    hal_bool_t edge;
+    hal_refs_u substs[MSG_SUBST_MAX];
 } msg_hal_t;
 
 // The admin structure lives in normal memory space
@@ -214,15 +214,15 @@ static int setup_message(const char *pfx, int idx, const char *msg, msg_slot_t *
     }
 
     // Create the trigger, force and edge input pins
-    if ((rv = hal_pin_bit_newf(HAL_IN, &pin->trigger, comp_id, "%s.trigger", pinname)) < 0) {
+    if ((rv = hal_pin_new_bool(comp_id, HAL_IN, &pin->trigger, 0, "%s.trigger", pinname)) < 0) {
         rtapi_print_msg(RTAPI_MSG_ERR, "%s: Message %d cannot create trigger pin (duplicate?)\n", pfx, idx);
         return rv;
     }
-    if ((rv = hal_pin_bit_newf(HAL_IN, &pin->force, comp_id, "%s.force", pinname)) < 0) {
+    if ((rv = hal_pin_new_bool(comp_id, HAL_IN, &pin->force, 0, "%s.force", pinname)) < 0) {
         rtapi_print_msg(RTAPI_MSG_ERR, "%s: Message %d cannot create force pin (duplicate?)\n", pfx, idx);
         return rv;
     }
-    if ((rv = hal_pin_bit_newf(HAL_IN, &pin->edge, comp_id, "%s.edge", pinname)) < 0) {
+    if ((rv = hal_pin_new_bool(comp_id, HAL_IN, &pin->edge, 0, "%s.edge", pinname)) < 0) {
         rtapi_print_msg(RTAPI_MSG_ERR, "%s: Message %d cannot create edge pin (duplicate?)\n", pfx, idx);
         return rv;
     }
@@ -279,33 +279,33 @@ static int setup_message(const char *pfx, int idx, const char *msg, msg_slot_t *
             // to merge pin substitution references into one pool.
             switch (tchar) {
             case 'b': case 'B':
-                slot->substtype[subst] = HAL_BIT;
-                if ((rv = hal_pin_bit_newf(HAL_IN, (hal_bit_t **)&pin->substs[subst], comp_id, "%s.%s", pinname, cptr)) < 0)
+                slot->substtype[subst] = HAL_BOOL;
+                if ((rv = hal_pin_new_bool(comp_id, HAL_IN, &pin->substs[subst].b, 0, "%s.%s", pinname, cptr)) < 0)
                     return rv;
                 break;
             case 's': case 'S':
                 slot->substtype[subst] = HAL_S32;
-                if ((rv = hal_pin_s32_newf(HAL_IN, (hal_s32_t **)&pin->substs[subst], comp_id, "%s.%s", pinname, cptr)) < 0)
+                if ((rv = hal_pin_new_si32(comp_id, HAL_IN, &pin->substs[subst].s, 0, "%s.%s", pinname, cptr)) < 0)
                     return rv;
                 break;
             case 'u': case 'U':
                 slot->substtype[subst] = HAL_U32;
-                if ((rv = hal_pin_u32_newf(HAL_IN, (hal_u32_t **)&pin->substs[subst], comp_id, "%s.%s", pinname, cptr)) < 0)
+                if ((rv = hal_pin_new_ui32(comp_id, HAL_IN, &pin->substs[subst].u, 0, "%s.%s", pinname, cptr)) < 0)
                     return rv;
                 break;
             case 'l': case 'L':
-                slot->substtype[subst] = HAL_S64;
-                if ((rv = hal_pin_s64_newf(HAL_IN, (hal_s64_t **)&pin->substs[subst], comp_id, "%s.%s", pinname, cptr)) < 0)
+                slot->substtype[subst] = HAL_SINT;
+                if ((rv = hal_pin_new_sint(comp_id, HAL_IN, &pin->substs[subst].s, 0, "%s.%s", pinname, cptr)) < 0)
                     return rv;
                 break;
             case 'k': case 'K':
-                slot->substtype[subst] = HAL_U64;
-                if ((rv = hal_pin_u64_newf(HAL_IN, (hal_u64_t **)&pin->substs[subst], comp_id, "%s.%s", pinname, cptr)) < 0)
+                slot->substtype[subst] = HAL_UINT;
+                if ((rv = hal_pin_new_uint(comp_id, HAL_IN, &pin->substs[subst].u, 0, "%s.%s", pinname, cptr)) < 0)
                     return rv;
                 break;
             case 'f': case 'F':
-                slot->substtype[subst] = HAL_FLOAT;
-                if ((rv = hal_pin_float_newf(HAL_IN, (hal_float_t **)&pin->substs[subst], comp_id, "%s.%s", pinname, cptr)) < 0)
+                slot->substtype[subst] = HAL_REAL;
+                if ((rv = hal_pin_new_real(comp_id, HAL_IN, &pin->substs[subst].r, 0.0, "%s.%s", pinname, cptr)) < 0)
                     return rv;
                 break;
             default:
@@ -381,29 +381,29 @@ static void print_slot(int s)
 {
     char buf[MSG_LEN_MAX];
     char *end = strcpy(buf, slots[s].msgbuf) + slots[s].msglen;
-    for (int i = 0; i < MSG_SUBST_MAX && pins[s].substs[i]; i++) {
+    for (int i = 0; i < MSG_SUBST_MAX && pins[s].substs[i].b; i++) {
         int left = sizeof(buf) - (end - buf);
         int n;
         if (left <= 1)  // Need room for terminator
             break;
         switch (slots[s].substtype[i]) {
-        case HAL_BIT:
-            n = rtapi_snprintf(end, left, "%d%s", (int)!!pins[s].substs[i]->b, slots[s].parts[i]);
+        case HAL_BOOL:
+            n = rtapi_snprintf(end, left, "%d%s", (int)hal_get_bool(pins[s].substs[i].b), slots[s].parts[i]);
             break;
         case HAL_S32:
-            n = rtapi_snprintf(end, left, "%d%s", (int)pins[s].substs[i]->s, slots[s].parts[i]);
+            n = rtapi_snprintf(end, left, "%d%s", (int)hal_get_si32(pins[s].substs[i].s), slots[s].parts[i]);
             break;
         case HAL_U32:
-            n = rtapi_snprintf(end, left, "%u%s", (unsigned)pins[s].substs[i]->u, slots[s].parts[i]);
+            n = rtapi_snprintf(end, left, "%u%s", (unsigned)hal_get_ui32(pins[s].substs[i].u), slots[s].parts[i]);
             break;
-        case HAL_S64:
-            n = rtapi_snprintf(end, left, "%ld%s", (long)pins[s].substs[i]->ls, slots[s].parts[i]);
+        case HAL_SINT:
+            n = rtapi_snprintf(end, left, "%ld%s", (long)hal_get_sint(pins[s].substs[i].s), slots[s].parts[i]);
             break;
-        case HAL_U64:
-            n = rtapi_snprintf(end, left, "%lu%s", (unsigned long)pins[s].substs[i]->lu, slots[s].parts[i]);
+        case HAL_UINT:
+            n = rtapi_snprintf(end, left, "%lu%s", (unsigned long)hal_get_uint(pins[s].substs[i].u), slots[s].parts[i]);
             break;
-        case HAL_FLOAT:
-            n = rtapi_snprintf(end, left, "%lf%s", (double)pins[s].substs[i]->f, slots[s].parts[i]);
+        case HAL_REAL:
+            n = rtapi_snprintf(end, left, "%lf%s", (double)hal_get_real(pins[s].substs[i].r), slots[s].parts[i]);
             break;
         default:
             n = 0;
@@ -424,8 +424,8 @@ FUNCTION(_)
     bool en = enable;  // Cache enable pin
     // For each slot, test the trigger and save the trigger state
     for (int i = 0; i < nslots; i++) {
-        bool trig = (int)!!*(pins[i].trigger) ^ (int)!!*(pins[i].edge);
-        bool force = *(pins[i].force);
+        bool trig = (int)hal_get_bool(pins[i].trigger) ^ (int)hal_get_bool(pins[i].edge);
+        bool force = hal_get_bool(pins[i].force);
         if ((en && trig && !slots[i].prevtrig) || (force && !slots[i].prevforce)) {
             print_slot(i);  // Rising edge -> print message
         }

--- a/src/hal/components/pwmgen.c
+++ b/src/hal/components/pwmgen.c
@@ -99,22 +99,22 @@ typedef struct {
     unsigned char output_type;
     unsigned char pwm_mode;
     unsigned char direction;
-    hal_bit_t *out[2];		/* pins for output signals */
+    hal_bool_t out[2];		/* pins for output signals */
 
-    hal_bit_t *enable;		/* pin for enable signal */
-    hal_float_t *value;		/* command value */
-    hal_float_t *scale;		/* pin: scaling from value to duty cycle */
-    hal_float_t *offset;	/* pin: offset: this is added to duty cycle */
+    hal_bool_t enable;		/* pin for enable signal */
+    hal_real_t value;		/* command value */
+    hal_real_t scale;		/* pin: scaling from value to duty cycle */
+    hal_real_t offset;	/* pin: offset: this is added to duty cycle */
     double old_scale;		/* stored scale value */
     double scale_recip;		/* reciprocal value used for scaling */
-    hal_float_t *pwm_freq;	/* pin: (max) output frequency in Hz */
+    hal_real_t pwm_freq;	/* pin: (max) output frequency in Hz */
     double old_pwm_freq;	/* used to detect changes */
     int periods;		/* number of periods in PWM cycle */
     double periods_recip;	/* reciprocal */
-    hal_bit_t *dither_pwm;	/* 0 = pure PWM, 1 = dithered PWM */
-    hal_float_t *min_dc;	/* pin: minimum duty cycle */
-    hal_float_t *max_dc;	/* pin: maximum duty cycle */
-    hal_float_t *curr_dc;	/* pin: current duty cycle */
+    hal_bool_t dither_pwm;	/* 0 = pure PWM, 1 = dithered PWM */
+    hal_real_t min_dc;	/* pin: minimum duty cycle */
+    hal_real_t max_dc;	/* pin: maximum duty cycle */
+    hal_real_t curr_dc;	/* pin: current duty cycle */
 } pwmgen_t;
 
 /* ptr to array of pwmgen_t structs in shared memory, 1 per channel */
@@ -316,11 +316,11 @@ static void make_pulses(void *arg, long period)
 	if (pwmgen->output_type < 2) {
 	    /* PWM (and maybe DIR) output */
 	    /* DIR is set by update(), we only do PWM */
-	    *(pwmgen->out[PWM_PIN]) = pwmgen->curr_output;
+	    hal_set_bool(pwmgen->out[PWM_PIN], pwmgen->curr_output);
 	} else {
 	    /* UP and DOWN output */
-	    *(pwmgen->out[UP_PIN]) = pwmgen->curr_output & ~pwmgen->direction;
-	    *(pwmgen->out[DOWN_PIN]) = pwmgen->curr_output & pwmgen->direction;
+	    hal_set_bool(pwmgen->out[UP_PIN], pwmgen->curr_output & ~pwmgen->direction);
+	    hal_set_bool(pwmgen->out[DOWN_PIN], pwmgen->curr_output & pwmgen->direction);
 	}
 	/* move on to next PWM generator */
 	pwmgen++;
@@ -344,42 +344,44 @@ static void update(void *arg, long period)
 
 	/* validate duty cycle limits, both limits must be between
 	   0.0 and 1.0 (inclusive) and max must be greater then min */
-	if ( *(pwmgen->max_dc) > 1.0 ) {
-	    *(pwmgen->max_dc) = 1.0;
+	rtapi_real max_dc = hal_get_real(pwmgen->max_dc);
+	rtapi_real min_dc = hal_get_real(pwmgen->min_dc);
+	if ( max_dc > 1.0 ) {
+	    max_dc = hal_set_real(pwmgen->max_dc, 1.0);
 	}
-	if ( *(pwmgen->min_dc) > *(pwmgen->max_dc) ) {
-	    *(pwmgen->min_dc) = *(pwmgen->max_dc);
+	if ( min_dc > max_dc ) {
+	    min_dc = hal_set_real(pwmgen->min_dc, max_dc);
 	}
-	if ( *(pwmgen->min_dc) < 0.0 ) {
-	    *(pwmgen->min_dc) = 0.0;
+	if ( min_dc < 0.0 ) {
+	    min_dc = hal_set_real(pwmgen->min_dc, 0.0);
 	}
-	if ( *(pwmgen->max_dc) < *(pwmgen->min_dc) ) {
-	    *(pwmgen->max_dc) = *(pwmgen->min_dc);
+	if ( max_dc < min_dc ) {
+	    max_dc = hal_set_real(pwmgen->max_dc, min_dc);
 	}
 	/* do scale calcs only when scale changes */
-	if ( *(pwmgen->scale) != pwmgen->old_scale ) {
+	rtapi_real scale = hal_get_real(pwmgen->scale);
+	if ( scale != pwmgen->old_scale ) {
 	    /* get ready to detect future scale changes */
-	    pwmgen->old_scale = *(pwmgen->scale);
+	    pwmgen->old_scale = scale;
 	    /* validate the new scale value */
-	    if ((*(pwmgen->scale) < 1e-20)
-		&& (*(pwmgen->scale) > -1e-20)) {
+	    if ((scale < 1e-20)	&& (scale > -1e-20)) {
 		/* value too small, divide by zero is a bad thing */
-		*(pwmgen->scale) = 1.0;
+		scale = hal_set_real(pwmgen->scale, 1.0);
 	    }
 	    /* we will need the reciprocal */
-	    pwmgen->scale_recip = 1.0 / *(pwmgen->scale);
+	    pwmgen->scale_recip = 1.0 / scale;
 	}
-	if ( *(pwmgen->enable) == 0 ) {
+	if ( hal_get_bool(pwmgen->enable) == 0 ) {
 	    new_pwm_mode = PWM_DISABLED;
-	} else if ( *(pwmgen->pwm_freq) == 0 ) {
+	} else if ( hal_get_real(pwmgen->pwm_freq) == 0 ) {
 	    new_pwm_mode = PWM_PDM;
-	} else if ( *(pwmgen->dither_pwm) != 0 ) {
+	} else if ( hal_get_bool(pwmgen->dither_pwm) != 0 ) {
 	    new_pwm_mode = PWM_DITHER;
 	} else {
 	    new_pwm_mode = PWM_PURE;
 	}
 	/* force recalc if max_freq is changed */
-	if ( *(pwmgen->pwm_freq) != pwmgen->old_pwm_freq ) {
+	if ( hal_get_real(pwmgen->pwm_freq) != pwmgen->old_pwm_freq ) {
 	    pwmgen->pwm_mode = PWM_DISABLED;
 	}
 	/* do the period calcs when mode, pwm_freq, or periodns changes */
@@ -388,35 +390,35 @@ static void update(void *arg, long period)
 	    /* disable output during calcs */
 	    pwmgen->pwm_mode = PWM_DISABLED;
 	    /* validate max_freq */
-	    if ( *(pwmgen->pwm_freq) <= 0.0 ) {
+	    if ( hal_get_real(pwmgen->pwm_freq) <= 0.0 ) {
 		/* zero or negative means PDM mode */
-		*(pwmgen->pwm_freq) = 0.0;
+		hal_set_real(pwmgen->pwm_freq, 0.0);
 		pwmgen->period = periodns;
 	    } else {
 		/* positive means PWM mode */
-		if ( *(pwmgen->pwm_freq) < 0.5 ) {
+		if ( hal_get_real(pwmgen->pwm_freq) < 0.5 ) {
  		    /* min freq is 0.5 Hz (2 billion nsec period) */
-		    *(pwmgen->pwm_freq) = 0.5;
-		} else if ( *(pwmgen->pwm_freq) > ((1e9/2.0) / periodns) ) {
+		    hal_set_real(pwmgen->pwm_freq, 0.5);
+		} else if ( hal_get_real(pwmgen->pwm_freq) > ((1e9/2.0) / periodns) ) {
 		    /* max freq is 2 base periods */
-		    *(pwmgen->pwm_freq) = (1e9/2.0) / periodns;
+		    hal_set_real(pwmgen->pwm_freq, (1e9/2.0) / periodns);
 		}
 		if ( new_pwm_mode == PWM_PURE ) {
 		    /* period must be integral multiple of periodns */
-		    pwmgen->periods = (( 1e9 / *(pwmgen->pwm_freq) ) / periodns ) + 0.5;
+		    pwmgen->periods = (( 1e9 / hal_get_real(pwmgen->pwm_freq) ) / periodns ) + 0.5;
 		    pwmgen->periods_recip = 1.0 / pwmgen->periods;
 		    pwmgen->period = pwmgen->periods * periodns;
 		    /* actual max freq after rounding */
-		    *(pwmgen->pwm_freq) = 1.0e9 / pwmgen->period;
+		    hal_set_real(pwmgen->pwm_freq, 1.0e9 / pwmgen->period);
 		} else {
-		    pwmgen->period = 1.0e9 / *(pwmgen->pwm_freq);
+		    pwmgen->period = 1.0e9 / hal_get_real(pwmgen->pwm_freq);
 		}
 	    }
 	    /* save freq to detect changes */
-	    pwmgen->old_pwm_freq = *(pwmgen->pwm_freq);
+	    pwmgen->old_pwm_freq = hal_get_real(pwmgen->pwm_freq);
 	}
 	/* convert value command to duty cycle */
-	tmpdc = *(pwmgen->value) * pwmgen->scale_recip + *(pwmgen->offset);
+	tmpdc = hal_get_real(pwmgen->value) * pwmgen->scale_recip + hal_get_real(pwmgen->offset);
 	if ( pwmgen->output_type == 0 ) {
 	    /* unidirectional mode, no negative output */
 	    if ( tmpdc < 0.0 ) {
@@ -425,18 +427,18 @@ static void update(void *arg, long period)
 	}
 	/* limit the duty cycle */
 	if (tmpdc >= 0.0) {
-	    if ( tmpdc > *(pwmgen->max_dc) ) {
-		tmpdc = *(pwmgen->max_dc);
-	    } else if ( tmpdc < *(pwmgen->min_dc) ) {
-		tmpdc = *(pwmgen->min_dc);
+	    if ( tmpdc > max_dc ) {
+		tmpdc = max_dc;
+	    } else if ( tmpdc < min_dc ) {
+		tmpdc = min_dc;
 	    }
 	    pwmgen->direction = 0;
 	    outdc = tmpdc;
 	} else {
-	    if ( tmpdc < -*(pwmgen->max_dc) ) {
-		tmpdc = -*(pwmgen->max_dc);
-	    } else if ( tmpdc > -*(pwmgen->min_dc) ) {
-		tmpdc = -*(pwmgen->min_dc);
+	    if ( tmpdc < -max_dc ) {
+		tmpdc = -max_dc;
+	    } else if ( tmpdc > -min_dc ) {
+		tmpdc = -min_dc;
 	    }
 	    pwmgen->direction = 1;
 	    outdc = -tmpdc;
@@ -447,18 +449,18 @@ static void update(void *arg, long period)
 	    pwmgen->high_time = high_periods * periodns;
 	    /* save rounded value to curr_dc pin */
 	    if ( tmpdc >= 0 ) {
-		*(pwmgen->curr_dc) = high_periods * pwmgen->periods_recip;
+		hal_set_real(pwmgen->curr_dc, high_periods * pwmgen->periods_recip);
 	    } else {
-		*(pwmgen->curr_dc) = -high_periods * pwmgen->periods_recip;
+		hal_set_real(pwmgen->curr_dc, -high_periods * pwmgen->periods_recip);
 	    }
 	} else {
 	    pwmgen->high_time = ( pwmgen->period * outdc ) + 0.5;
 	    /* save duty cycle to curr_dc pin */
-	    *(pwmgen->curr_dc) = tmpdc;
+	    hal_set_real(pwmgen->curr_dc, tmpdc);
 	}
 	/* if using PWM/DIR outputs, set DIR pin */
 	if ( pwmgen->output_type == 1 ) {
-	    *(pwmgen->out[DIR_PIN]) = pwmgen->direction;
+	    hal_set_bool(pwmgen->out[DIR_PIN], pwmgen->direction);
 	}
 	/* save new mode */
 	pwmgen->pwm_mode = new_pwm_mode;
@@ -486,97 +488,79 @@ static int export_pwmgen(int num, pwmgen_t * addr, int output_type)
     rtapi_set_msg_level(RTAPI_MSG_WARN);
 
     /* export pins */
-    retval = hal_pin_float_newf(HAL_IO, &(addr->scale), comp_id,
+    retval = hal_pin_new_real(comp_id, HAL_IO, &(addr->scale), 1.0,
 	    "pwmgen.%d.scale", num);
     if (retval != 0) {
 	return retval;
     }
-    retval = hal_pin_float_newf(HAL_IO, &(addr->offset), comp_id,
+    retval = hal_pin_new_real(comp_id, HAL_IO, &(addr->offset), 0.0,
 	    "pwmgen.%d.offset", num);
     if (retval != 0) {
 	return retval;
     }
-    retval = hal_pin_bit_newf(HAL_IO, &(addr->dither_pwm), comp_id,
+    retval = hal_pin_new_bool(comp_id, HAL_IO, &(addr->dither_pwm), 0,
 	    "pwmgen.%d.dither-pwm", num);
     if (retval != 0) {
 	return retval;
     }
-    retval = hal_pin_float_newf(HAL_IO, &(addr->pwm_freq), comp_id,
+    retval = hal_pin_new_real(comp_id, HAL_IO, &(addr->pwm_freq), 0.0,
 	    "pwmgen.%d.pwm-freq", num);
     if (retval != 0) {
 	return retval;
     }
-    retval = hal_pin_float_newf(HAL_IO, &(addr->min_dc), comp_id,
+    retval = hal_pin_new_real(comp_id, HAL_IO, &(addr->min_dc), 0.0,
 	    "pwmgen.%d.min-dc", num);
     if (retval != 0) {
 	return retval;
     }
-    retval = hal_pin_float_newf(HAL_IO, &(addr->max_dc), comp_id,
+    retval = hal_pin_new_real(comp_id, HAL_IO, &(addr->max_dc), 1.0,
 	    "pwmgen.%d.max-dc", num);
     if (retval != 0) {
 	return retval;
     }
-    retval = hal_pin_float_newf(HAL_OUT, &(addr->curr_dc), comp_id,
+    retval = hal_pin_new_real(comp_id, HAL_OUT, &(addr->curr_dc), 0.0,
 	    "pwmgen.%d.curr-dc", num);
     if (retval != 0) {
 	return retval;
     }
-    retval = hal_pin_bit_newf(HAL_IN, &(addr->enable), comp_id,
+    retval = hal_pin_new_bool(comp_id, HAL_IN, &(addr->enable), 0,
 	    "pwmgen.%d.enable", num);
     if (retval != 0) {
 	return retval;
     }
-    *(addr->enable) = 0;
-    retval = hal_pin_float_newf(HAL_IN, &(addr->value), comp_id,
+    retval = hal_pin_new_real(comp_id, HAL_IN, &(addr->value), 0.0,
 	    "pwmgen.%d.value", num);
     if (retval != 0) {
 	return retval;
     }
-    *(addr->value) = 0.0;
     if (output_type == 2) {
 	/* export UP/DOWN pins */
-	retval = hal_pin_bit_newf(HAL_OUT, &(addr->out[UP_PIN]), comp_id,
+	retval = hal_pin_new_bool(comp_id, HAL_OUT, &(addr->out[UP_PIN]), 0,
 		"pwmgen.%d.up", num);
 	if (retval != 0) {
 	    return retval;
 	}
-	/* init the pin */
-	*(addr->out[UP_PIN]) = 0;
-	retval = hal_pin_bit_newf(HAL_OUT, &(addr->out[DOWN_PIN]), comp_id,
+	retval = hal_pin_new_bool(comp_id, HAL_OUT, &(addr->out[DOWN_PIN]), 0,
 		"pwmgen.%d.down", num);
 	if (retval != 0) {
 	    return retval;
 	}
-	/* init the pin */
-	*(addr->out[DOWN_PIN]) = 0;
     } else {
 	/* export PWM pin */
-	retval = hal_pin_bit_newf(HAL_OUT, &(addr->out[PWM_PIN]), comp_id,
+	retval = hal_pin_new_bool(comp_id, HAL_OUT, &(addr->out[PWM_PIN]), 0,
 		"pwmgen.%d.pwm", num);
 	if (retval != 0) {
 	    return retval;
 	}
-	/* init the pin */
-	*(addr->out[PWM_PIN]) = 0;
 	if ( output_type == 1 ) {
 	    /* export DIR pin */
-	    retval = hal_pin_bit_newf(HAL_OUT, &(addr->out[DIR_PIN]), comp_id,
+	    retval = hal_pin_new_bool(comp_id, HAL_OUT, &(addr->out[DIR_PIN]), 0,
 		    "pwmgen.%d.dir", num);
 	    if (retval != 0) {
 		return retval;
 	    }
-	    /* init the pin */
-	    *(addr->out[DIR_PIN]) = 0;
 	}
     }
-    /* set default pin values */
-    *(addr->scale) = 1.0;
-    *(addr->offset) = 0.0;
-    *(addr->dither_pwm) = 0;
-    *(addr->pwm_freq) = 0;
-    *(addr->min_dc) = 0.0;
-    *(addr->max_dc) = 1.0;
-    *(addr->curr_dc) = 0.0;
     /* init other fields */
     addr->period = 50000;
     addr->high_time = 0;
@@ -586,7 +570,7 @@ static int export_pwmgen(int num, pwmgen_t * addr, int output_type)
     addr->output_type = output_type;
     addr->pwm_mode = PWM_DISABLED;
     addr->direction = 0;
-    addr->old_scale = *(addr->scale) + 1.0;
+    addr->old_scale = hal_get_real(addr->scale) + 1.0;
     addr->old_pwm_freq = -1;
     /* restore saved message level */
     rtapi_set_msg_level(msg);

--- a/src/hal/components/weighted_sum.c
+++ b/src/hal/components/weighted_sum.c
@@ -48,17 +48,17 @@ RTAPI_MP_ARRAY_INT(wsum_sizes, MAX_SUMMERS, "Sizes of up to 8 weighted summers")
 
 /* Data needed for each bit of a weighted summer */
 typedef struct {
-    hal_bit_t *bit;		/* pin: the input bit HAL pin */
-    hal_s32_t *weight;		/* pin: the numeric weight of this pin */
+    hal_bool_t bit;     /* pin: the input bit HAL pin */
+    hal_sint_t weight;  /* pin: the numeric weight of this pin */
 } wsum_bit_t;
 
 /* Base data for a weighted summer. */
 typedef struct {
-    hal_s32_t *sum;		/* output pin: the calculated sum */
-    hal_s32_t *offset;		/* pin: offset for this summer */
-    hal_bit_t *hold;		/* input pin: hold value if 1, update if 0 */
-    int num_bits;		/* internal: How many bits are in this summer */
-    wsum_bit_t *bits;		/* internal: pointer to the input bits and weights */
+    hal_sint_t sum;     /* output pin: the calculated sum */
+    hal_sint_t offset;  /* pin: offset for this summer */
+    hal_bool_t hold;    /* input pin: hold value if 1, update if 0 */
+    int num_bits;       /* internal: How many bits are in this summer */
+    wsum_bit_t *bits;   /* internal: pointer to the input bits and weights */
 } wsum_t;
 
 /* pointer to array of wsum structs in shmem */
@@ -179,17 +179,17 @@ static void process_wsums(void *arg, long period)
     wsums = (wsum_t *)arg;
 
     for (n=0 ; n<num_summers ; n++) {
-	thissum = &(wsums[n]);
-	if (*(thissum->hold)) continue;
-	else {
-	    running_total = *(thissum->offset);
-	    for (b=0 ; b<thissum->num_bits ; b++) {
-		if (*(thissum->bits[b].bit)) {
-		    running_total += *(thissum->bits[b].weight);
-		}
-	    }
-	}
-	*(thissum->sum) = running_total;
+        thissum = &(wsums[n]);
+        if (hal_get_bool(thissum->hold)) continue;
+        else {
+            running_total = hal_get_si32(thissum->offset);
+            for (b=0 ; b<thissum->num_bits ; b++) {
+                if (hal_get_bool(thissum->bits[b].bit)) {
+                    running_total += hal_get_si32(thissum->bits[b].weight);
+                }
+            }
+        }
+        hal_set_si32(thissum->sum, running_total);
     }
 }
 
@@ -200,34 +200,28 @@ static void process_wsums(void *arg, long period)
 static int export_wsum(int num, int num_bits, wsum_t *addr, wsum_bit_t *bitaddr)
 {
     int retval, i, w;
-    char buf[HAL_NAME_LEN+1], base[HAL_NAME_LEN+1];
+    char base[HAL_NAME_LEN+1];
 
-    rtapi_snprintf(base, sizeof(base), "wsum.%d", num);
     /* export pin for offset (input) */
-    rtapi_snprintf(buf, sizeof(buf), "%s.offset", base);
-    retval = hal_pin_s32_new(buf, HAL_IO, &(addr->offset), comp_id);
+    rtapi_snprintf(base, sizeof(base), "wsum.%d", num);
+    retval = hal_pin_new_si32(comp_id, HAL_IO, &(addr->offset), 0, "%s.offset", base);
     if (retval != 0) {
-	rtapi_print_msg(RTAPI_MSG_ERR,
-	    "WEIGHTED_SUM: ERROR: '%s' param export failed\n", buf);
-	return retval;
+        rtapi_print_msg(RTAPI_MSG_ERR, "WEIGHTED_SUM: ERROR: '%s.offset' param export failed\n", base);
+        return retval;
     }
 
     /* export pin for output sum */
-    rtapi_snprintf(buf, sizeof(buf), "%s.sum", base);
-    retval = hal_pin_s32_new(buf, HAL_OUT, &(addr->sum), comp_id);
+    retval = hal_pin_new_si32(comp_id, HAL_OUT, &(addr->sum), 0, "%s.sum", base);
     if (retval != 0) {
-	rtapi_print_msg(RTAPI_MSG_ERR,
-	    "WEIGHTED_SUM: ERROR: '%s' pin export failed\n", buf);
-	return retval;
+        rtapi_print_msg(RTAPI_MSG_ERR, "WEIGHTED_SUM: ERROR: '%s.sum' pin export failed\n", base);
+        return retval;
     }
 
     /* export pin for update hold */
-    rtapi_snprintf(buf, sizeof(buf), "%s.hold", base);
-    retval = hal_pin_bit_new(buf, HAL_IN, &(addr->hold), comp_id);
+    retval = hal_pin_new_bool(comp_id, HAL_IN, &(addr->hold), 0, "%s.hold", base);
     if (retval != 0) {
-	rtapi_print_msg(RTAPI_MSG_ERR,
-	    "WEIGHTED_SUM: ERROR: '%s' pin export failed\n", buf);
-	return retval;
+        rtapi_print_msg(RTAPI_MSG_ERR, "WEIGHTED_SUM: ERROR: '%s.hold' pin export failed\n", base);
+        return retval;
     }
 
     addr->bits = bitaddr;
@@ -235,26 +229,17 @@ static int export_wsum(int num, int num_bits, wsum_t *addr, wsum_bit_t *bitaddr)
     /* export the input bits and weight parameters, and set the default weights */
     w = 1;
     for (i=0;i<num_bits;i++) {
-	rtapi_snprintf(buf, sizeof(buf), "%s.bit.%d.in", base, i);
-	retval = hal_pin_bit_new(buf, HAL_IN, &(addr->bits[i].bit), comp_id);
-	if (retval != 0) {
-	    rtapi_print_msg(RTAPI_MSG_ERR,
-	    "WEIGHTED_SUM: ERROR: '%s' pin export failed\n", buf);
-	    return retval;
-	}
-	rtapi_snprintf(buf, sizeof(buf), "%s.bit.%d.weight", base, i);
-	retval = hal_pin_s32_new(buf, HAL_IO, &(addr->bits[i].weight), comp_id);
-	if (retval != 0) {
-	    rtapi_print_msg(RTAPI_MSG_ERR,
-	    "WEIGHTED_SUM: ERROR: '%s' param export failed\n", buf);
-	    return retval;
-	}
-	*(addr->bits[i].weight) = w;
-	w <<= 1;
+        retval = hal_pin_new_bool(comp_id, HAL_IN, &(addr->bits[i].bit), 0, "%s.bit.%d.in", base, i);
+        if (retval != 0) {
+            rtapi_print_msg(RTAPI_MSG_ERR, "WEIGHTED_SUM: ERROR: '%s.bit.%d.in' pin export failed\n", base, i);
+            return retval;
+        }
+        retval = hal_pin_new_si32(comp_id, HAL_IO, &(addr->bits[i].weight), w, "%s.bit.%d.weight", base, i);
+        if (retval != 0) {
+            rtapi_print_msg(RTAPI_MSG_ERR, "WEIGHTED_SUM: ERROR: '%s.bit.%d.weight' param export failed\n", base, i);
+            return retval;
+        }
+        w <<= 1;
     }
-
-    /* set initial parameter and pin values */
-    *(addr->offset) = 0;
-    *(addr->sum) = 0;
     return 0;
 }


### PR DESCRIPTION
Next set of components upgraded to getter/setter. Quite straight forward.

Both demux_generic.c and mux_generic.c have removed the distinction between FP/non-FP thread function export. All threads are FP and we can make it easier. The implementation is no a all-to-all version (except is still does not have 64-bit pins). The magic numbers have been replaced with a macro.

The max31855.comp has had the `float` types replaced with `rtapi_real` (effectively double), which means that a numeric difference can occur at 5..6 decimals. However, I don't believe that this stuff can measure temperatures at those levels, so it should be academic.

In pwmgen.c several pins are now cached because they were read quite often. This should all work as expected. There are several more optimizations possible, but that is for another time.
