### PR TITLE
hal: Update the user component xhc pendants to getter/setter

### DIFF
--- a/src/hal/user_comps/xhc-hb04.cc
+++ b/src/hal/user_comps/xhc-hb04.cc
@@ -103,49 +103,50 @@ static int stepsize_last_idx  =  0; //calculated`
 
 
 typedef struct {
-	hal_float_t *x_wc, *y_wc, *z_wc, *a_wc;
-	hal_float_t *x_mc, *y_mc, *z_mc, *a_mc;
+	hal_real_t x_wc, y_wc, z_wc, a_wc;
+	hal_real_t x_mc, y_mc, z_mc, a_mc;
 
-	hal_float_t *feedrate_override, *feedrate;
-	hal_float_t *spindle_override, *spindle_rps;
+	hal_real_t feedrate_override, feedrate;
+	hal_real_t spindle_override, spindle_rps;
 
-	hal_bit_t *button_pin[NB_MAX_BUTTONS];
+	hal_bool_t button_pin[NB_MAX_BUTTONS];
 
-    hal_bit_t *jog_enable_off;
-	hal_bit_t *jog_enable_x;
-	hal_bit_t *jog_enable_y;
-	hal_bit_t *jog_enable_z;
-	hal_bit_t *jog_enable_a;
-	hal_bit_t *jog_enable_feedrate;
-	hal_bit_t *jog_enable_spindle;
-	hal_float_t *jog_scale;
-	hal_s32_t *jog_counts, *jog_counts_neg;
+	hal_bool_t jog_enable_off;
+	hal_bool_t jog_enable_x;
+	hal_bool_t jog_enable_y;
+	hal_bool_t jog_enable_z;
+	hal_bool_t jog_enable_a;
+	hal_bool_t jog_enable_feedrate;
+	hal_bool_t jog_enable_spindle;
+	hal_real_t jog_scale;
+	hal_sint_t jog_counts;
+	hal_sint_t jog_counts_neg;
 
-	hal_float_t *jog_velocity;
-	hal_float_t *jog_max_velocity;
-	hal_float_t *jog_increment;
-	hal_bit_t *jog_plus_x, *jog_plus_y, *jog_plus_z, *jog_plus_a;
-	hal_bit_t *jog_minus_x, *jog_minus_y, *jog_minus_z, *jog_minus_a;
+	hal_real_t jog_velocity;
+	hal_real_t jog_max_velocity;
+	hal_real_t jog_increment;
+	hal_bool_t jog_plus_x,  jog_plus_y,  jog_plus_z,  jog_plus_a;
+	hal_bool_t jog_minus_x, jog_minus_y, jog_minus_z, jog_minus_a;
 
-	hal_bit_t *stepsize_up;
-	hal_bit_t *stepsize_down;
-	hal_s32_t *stepsize;
-	hal_bit_t *sleeping;
-	hal_bit_t *connected;
-	hal_bit_t *require_pendant;
-	hal_bit_t *inch_icon;
-	hal_bit_t *zero_x;
-	hal_bit_t *zero_y;
-	hal_bit_t *zero_z;
-	hal_bit_t *zero_a;
-	hal_bit_t *gotozero_x;
-	hal_bit_t *gotozero_y;
-	hal_bit_t *gotozero_z;
-	hal_bit_t *gotozero_a;
-	hal_bit_t *half_x;
-	hal_bit_t *half_y;
-	hal_bit_t *half_z;
-	hal_bit_t *half_a;
+	hal_bool_t stepsize_up;
+	hal_bool_t stepsize_down;
+	hal_sint_t stepsize;
+	hal_bool_t sleeping;
+	hal_bool_t connected;
+	hal_bool_t require_pendant;
+	hal_bool_t inch_icon;
+	hal_bool_t zero_x;
+	hal_bool_t zero_y;
+	hal_bool_t zero_z;
+	hal_bool_t zero_a;
+	hal_bool_t gotozero_x;
+	hal_bool_t gotozero_y;
+	hal_bool_t gotozero_z;
+	hal_bool_t gotozero_a;
+	hal_bool_t half_x;
+	hal_bool_t half_y;
+	hal_bool_t half_z;
+	hal_bool_t half_a;
 } xhc_hal_t;
 
 #define STEP_UNDEFINED  -1
@@ -163,7 +164,7 @@ typedef struct {
 	unsigned char button_step;	// Used in simulation mode to handle the STEP increment
 
 	// Variables for velocity computation
-	hal_s32_t last_jog_counts;
+	rtapi_s32 last_jog_counts;
 	struct timeval last_tv;
 
 	struct timeval last_wakeup;
@@ -219,20 +220,20 @@ void xhc_display_encode(xhc_t *xhc, unsigned char *data, int len)
 	*p++ = 0xFD;
 	*p++ = 0x0C;
 
-	if (xhc->axis == axis_a) p += xhc_encode_float(round(1000 * *(xhc->hal->a_wc)) / 1000, p);
-	else p += xhc_encode_float(round(1000 * *(xhc->hal->x_wc)) / 1000, p);
-	p += xhc_encode_float(round(1000 * *(xhc->hal->y_wc)) / 1000, p);
-	p += xhc_encode_float(round(1000 * *(xhc->hal->z_wc)) / 1000, p);
-	if (xhc->axis == axis_a) p += xhc_encode_float(round(1000 * *(xhc->hal->a_mc)) / 1000, p);
-	else p += xhc_encode_float(round(1000 * *(xhc->hal->x_mc)) / 1000, p);
-	p += xhc_encode_float(round(1000 * *(xhc->hal->y_mc)) / 1000, p);
-	p += xhc_encode_float(round(1000 * *(xhc->hal->z_mc)) / 1000, p);
-	p += xhc_encode_s16(round(100.0 * *(xhc->hal->feedrate_override)), p);
-	p += xhc_encode_s16(round(100.0 * *(xhc->hal->spindle_override)), p);
-	p += xhc_encode_s16(round(60.0 * *(xhc->hal->feedrate)), p);
-	p += xhc_encode_s16(round(60.0 * *(xhc->hal->spindle_rps)), p);
+	if (xhc->axis == axis_a) p += xhc_encode_float(round(1000 * hal_get_real(xhc->hal->a_wc)) / 1000, p);
+	else p += xhc_encode_float(round(1000 * hal_get_real(xhc->hal->x_wc)) / 1000, p);
+	p += xhc_encode_float(round(1000 * hal_get_real(xhc->hal->y_wc)) / 1000, p);
+	p += xhc_encode_float(round(1000 * hal_get_real(xhc->hal->z_wc)) / 1000, p);
+	if (xhc->axis == axis_a) p += xhc_encode_float(round(1000 * hal_get_real(xhc->hal->a_mc)) / 1000, p);
+	else p += xhc_encode_float(round(1000 * hal_get_real(xhc->hal->x_mc)) / 1000, p);
+	p += xhc_encode_float(round(1000 * hal_get_real(xhc->hal->y_mc)) / 1000, p);
+	p += xhc_encode_float(round(1000 * hal_get_real(xhc->hal->z_mc)) / 1000, p);
+	p += xhc_encode_s16(round(100.0 * hal_get_real(xhc->hal->feedrate_override)), p);
+	p += xhc_encode_s16(round(100.0 * hal_get_real(xhc->hal->spindle_override)), p);
+	p += xhc_encode_s16(round(60.0 * hal_get_real(xhc->hal->feedrate)), p);
+	p += xhc_encode_s16(round(60.0 * hal_get_real(xhc->hal->spindle_rps)), p);
 
-	switch (*(xhc->hal->stepsize)) {
+	switch (hal_get_si32(xhc->hal->stepsize)) {
 	case    0: buf[STEPSIZE_BYTE] = STEPSIZE_DISPLAY_0; break;
 	case    1: buf[STEPSIZE_BYTE] = STEPSIZE_DISPLAY_1; break;
 	case    5: buf[STEPSIZE_BYTE] = STEPSIZE_DISPLAY_5; break;
@@ -249,7 +250,7 @@ void xhc_display_encode(xhc_t *xhc, unsigned char *data, int len)
 	}
 
     buf[FLAGS_BYTE] = 0;
-    if (*(xhc->hal->inch_icon)) {
+    if (hal_get_bool(xhc->hal->inch_icon)) {
         buf[FLAGS_BYTE] |= 0x80;
     }
 
@@ -299,46 +300,46 @@ void linuxcnc_simu(xhc_t *xhc)
 	xhc_hal_t *hal = xhc->hal;
 
 	// for simu, always step up
-	*(hal->stepsize_up) = (xhc->button_step && xhc->button_code == xhc->button_step);
+	hal_set_bool(hal->stepsize_up, (xhc->button_step && xhc->button_code == xhc->button_step));
 
-	if (*(hal->jog_counts) != last_jog_counts) {
-		int delta_int = *(hal->jog_counts) - last_jog_counts;
-		float delta = delta_int * *(hal->jog_scale);
-		if (*(hal->jog_enable_x)) {
-			*(hal->x_mc) = *(hal->x_mc) + delta;
-			*(hal->x_wc) = *(hal->x_wc) + delta;
+	if (hal_get_si32(hal->jog_counts) != last_jog_counts) {
+		int delta_int = hal_get_si32(hal->jog_counts) - last_jog_counts;
+		float delta = delta_int * hal_get_real(hal->jog_scale);
+		if (hal_get_bool(hal->jog_enable_x)) {
+			hal_set_real(hal->x_mc, hal_get_real(hal->x_mc) + delta);
+			hal_set_real(hal->x_wc, hal_get_real(hal->x_wc) + delta);
 		}
 
-		if (*(hal->jog_enable_y)) {
-			*(hal->y_mc) = *(hal->y_mc) + delta;
-			*(hal->y_wc) = *(hal->y_wc) + delta;
+		if (hal_get_bool(hal->jog_enable_y)) {
+			hal_set_real(hal->y_mc, hal_get_real(hal->y_mc) + delta);
+			hal_set_real(hal->y_wc, hal_get_real(hal->y_wc) + delta);
 		}
 
-		if (*(hal->jog_enable_z)) {
-			*(hal->z_mc) = *(hal->z_mc) + delta;
-			*(hal->z_wc) = *(hal->z_wc) + delta;
+		if (hal_get_bool(hal->jog_enable_z)) {
+			hal_set_real(hal->z_mc, hal_get_real(hal->z_mc) + delta);
+			hal_set_real(hal->z_wc, hal_get_real(hal->z_wc) + delta);
 		}
 
-		if (*(hal->jog_enable_a)) {
-			*(hal->a_mc) = *(hal->a_mc) + delta;
-			*(hal->a_wc) = *(hal->a_wc) + delta;
+		if (hal_get_bool(hal->jog_enable_a)) {
+			hal_set_real(hal->a_mc, hal_get_real(hal->a_mc) + delta);
+			hal_set_real(hal->a_wc, hal_get_real(hal->a_wc) + delta);
 		}
 
-		if (*(hal->jog_enable_spindle)) {
-			*(hal->spindle_override) = *(hal->spindle_override) + delta_int * 0.01;
-			if (*(hal->spindle_override) > 1) *(hal->spindle_override) = 1;
-			if (*(hal->spindle_override) < 0) *(hal->spindle_override) = 0;
-			*(hal->spindle_rps) = 25000.0/60.0 * *(hal->spindle_override);
+		if (hal_get_bool(hal->jog_enable_spindle)) {
+			hal_set_real(hal->spindle_override, hal_get_real(hal->spindle_override) + delta_int * 0.01);
+			if (hal_get_real(hal->spindle_override) > 1) hal_set_real(hal->spindle_override, 1);
+			if (hal_get_real(hal->spindle_override) < 0) hal_set_real(hal->spindle_override, 0);
+			hal_set_real(hal->spindle_rps, 25000.0/60.0 * hal_get_real(hal->spindle_override));
 		}
 
-		if (*(hal->jog_enable_feedrate)) {
-			*(hal->feedrate_override) = *(hal->feedrate_override) + delta_int * 0.01;
-			if (*(hal->feedrate_override) > 1) *(hal->feedrate_override) = 1;
-			if (*(hal->feedrate_override) < 0) *(hal->feedrate_override) = 0;
-			*(hal->feedrate) = 3000.0/60.0 * *(hal->feedrate_override);
+		if (hal_get_bool(hal->jog_enable_feedrate)) {
+			hal_set_real(hal->feedrate_override, hal_get_real(hal->feedrate_override) + delta_int * 0.01);
+			if (hal_get_real(hal->feedrate_override) > 1) hal_set_real(hal->feedrate_override, 1);
+			if (hal_get_real(hal->feedrate_override) < 0) hal_set_real(hal->feedrate_override, 0);
+			hal_set_real(hal->feedrate, 3000.0/60.0 * hal_get_real(hal->feedrate_override));
 		}
 
-		last_jog_counts = *(hal->jog_counts);
+		last_jog_counts = hal_get_si32(hal->jog_counts);
 	}
 }
 
@@ -352,36 +353,36 @@ void compute_velocity(xhc_t *xhc)
 	float elapsed = delta_tv.tv_sec + 1e-6f*delta_tv.tv_usec;
 	if (elapsed <= 0) return;
 
-	float delta_pos = (*(xhc->hal->jog_counts) - xhc->last_jog_counts) * *(xhc->hal->jog_scale);
-	float velocity = *(xhc->hal->jog_max_velocity) * 60.0f * *(xhc->hal->jog_scale);
+	float delta_pos = (hal_get_si32(xhc->hal->jog_counts) - xhc->last_jog_counts) * hal_get_real(xhc->hal->jog_scale);
+	float velocity = hal_get_real(xhc->hal->jog_max_velocity) * 60.0f * hal_get_real(xhc->hal->jog_scale);
 	float k = 0.05f;
 
 	if (delta_pos) {
-		*(xhc->hal->jog_velocity) = (1 - k) * *(xhc->hal->jog_velocity) + k * velocity;
-		*(xhc->hal->jog_increment) = fabs(delta_pos);
-		*(xhc->hal->jog_plus_x) = (delta_pos > 0) && *(xhc->hal->jog_enable_x);
-		*(xhc->hal->jog_minus_x) = (delta_pos < 0) && *(xhc->hal->jog_enable_x);
-		*(xhc->hal->jog_plus_y) = (delta_pos > 0) && *(xhc->hal->jog_enable_y);
-		*(xhc->hal->jog_minus_y) = (delta_pos < 0) && *(xhc->hal->jog_enable_y);
-		*(xhc->hal->jog_plus_z) = (delta_pos > 0) && *(xhc->hal->jog_enable_z);
-		*(xhc->hal->jog_minus_z) = (delta_pos < 0) && *(xhc->hal->jog_enable_z);
-		*(xhc->hal->jog_plus_a) = (delta_pos > 0) && *(xhc->hal->jog_enable_a);
-		*(xhc->hal->jog_minus_a) = (delta_pos < 0) && *(xhc->hal->jog_enable_a);
-		xhc->last_jog_counts = *(xhc->hal->jog_counts);
+		hal_set_real(xhc->hal->jog_velocity, (1 - k) * hal_get_real(xhc->hal->jog_velocity) + k * velocity);
+		hal_set_real(xhc->hal->jog_increment, fabs(delta_pos));
+		hal_set_bool(xhc->hal->jog_plus_x,  (delta_pos > 0) && hal_get_bool(xhc->hal->jog_enable_x));
+		hal_set_bool(xhc->hal->jog_minus_x, (delta_pos < 0) && hal_get_bool(xhc->hal->jog_enable_x));
+		hal_set_bool(xhc->hal->jog_plus_y,  (delta_pos > 0) && hal_get_bool(xhc->hal->jog_enable_y));
+		hal_set_bool(xhc->hal->jog_minus_y, (delta_pos < 0) && hal_get_bool(xhc->hal->jog_enable_y));
+		hal_set_bool(xhc->hal->jog_plus_z,  (delta_pos > 0) && hal_get_bool(xhc->hal->jog_enable_z));
+		hal_set_bool(xhc->hal->jog_minus_z, (delta_pos < 0) && hal_get_bool(xhc->hal->jog_enable_z));
+		hal_set_bool(xhc->hal->jog_plus_a,  (delta_pos > 0) && hal_get_bool(xhc->hal->jog_enable_a));
+		hal_set_bool(xhc->hal->jog_minus_a, (delta_pos < 0) && hal_get_bool(xhc->hal->jog_enable_a));
+		xhc->last_jog_counts = hal_get_si32(xhc->hal->jog_counts);
 		xhc->last_tv = now;
 	}
 	else {
-		*(xhc->hal->jog_velocity) = (1 - k) * *(xhc->hal->jog_velocity);
+		hal_set_real(xhc->hal->jog_velocity, (1 - k) * hal_get_real(xhc->hal->jog_velocity));
 		if (elapsed > 0.25) {
-			*(xhc->hal->jog_velocity) = 0;
-			*(xhc->hal->jog_plus_x) = 0;
-			*(xhc->hal->jog_minus_x) = 0;
-			*(xhc->hal->jog_plus_y) = 0;
-			*(xhc->hal->jog_minus_y) = 0;
-			*(xhc->hal->jog_plus_z) = 0;
-			*(xhc->hal->jog_minus_z) = 0;
-			*(xhc->hal->jog_plus_a) = 0;
-			*(xhc->hal->jog_minus_a) = 0;
+			hal_set_real(xhc->hal->jog_velocity, 0);
+			hal_set_bool(xhc->hal->jog_plus_x,  0);
+			hal_set_bool(xhc->hal->jog_minus_x, 0);
+			hal_set_bool(xhc->hal->jog_plus_y,  0);
+			hal_set_bool(xhc->hal->jog_minus_y, 0);
+			hal_set_bool(xhc->hal->jog_plus_z,  0);
+			hal_set_bool(xhc->hal->jog_minus_z, 0);
+			hal_set_bool(xhc->hal->jog_plus_a,  0);
+			hal_set_bool(xhc->hal->jog_minus_a, 0);
 		}
 	}
 }
@@ -389,14 +390,14 @@ void compute_velocity(xhc_t *xhc)
 void handle_step(xhc_t *xhc)
 {
 	int _inc_step_status = STEP_NONE;
-	int _stepsize = *(xhc->hal->stepsize);	// Use a local variable to avoid STEP display as 0 on pendant during transitions
+	int _stepsize = hal_get_si32(xhc->hal->stepsize);	// Use a local variable to avoid STEP display as 0 on pendant during transitions
 
-	if (*(xhc->hal->stepsize_up)) {
+	if (hal_get_bool(xhc->hal->stepsize_up)) {
 	       _inc_step_status = STEP_UP;
-	   if (*(xhc->hal->stepsize_down)) {
+	   if (hal_get_bool(xhc->hal->stepsize_down)) {
 	       _inc_step_status = STEP_NONE; // none if both pressed
 	   }
-	} else if (*(xhc->hal->stepsize_down)) {
+	} else if (hal_get_bool(xhc->hal->stepsize_down)) {
 	      _inc_step_status = STEP_DOWN;
 	} else {
 	      _inc_step_status = STEP_NONE;
@@ -418,14 +419,14 @@ void handle_step(xhc_t *xhc)
 
 	xhc->old_inc_step_status = _inc_step_status;
 
-	*(xhc->hal->stepsize) = _stepsize;
-	*(xhc->hal->jog_scale) = *(xhc->hal->stepsize) * 0.001f;
+	hal_set_si32(xhc->hal->stepsize, _stepsize);
+	hal_set_real(xhc->hal->jog_scale, hal_get_si32(xhc->hal->stepsize) * 0.001f);
 }
 
 void cb_response_in(struct libusb_transfer *transfer)
 {
 	int i;
-	if (!*(xhc.hal->connected)) return;
+	if (!hal_get_bool(xhc.hal->connected)) return;
 
 	if (transfer->actual_length > 0) {
 		if (simu_mode) hexdump(in_buf, transfer->actual_length);
@@ -433,38 +434,38 @@ void cb_response_in(struct libusb_transfer *transfer)
 		xhc.button_code = in_buf[1];
 		xhc.axis = (xhc_axis_t)in_buf[3];
 
-		*(xhc.hal->jog_counts) = *(xhc.hal->jog_counts) + ((signed char)in_buf[4]);
-		*(xhc.hal->jog_counts_neg) = - *(xhc.hal->jog_counts);
-		*(xhc.hal->jog_enable_off) = (xhc.axis == axis_off);
-		*(xhc.hal->jog_enable_x) = (xhc.axis == axis_x);
-		*(xhc.hal->jog_enable_y) = (xhc.axis == axis_y);
-		*(xhc.hal->jog_enable_z) = (xhc.axis == axis_z);
-		*(xhc.hal->jog_enable_a) = (xhc.axis == axis_a);
-		*(xhc.hal->jog_enable_feedrate) = (xhc.axis == axis_feed);
-		*(xhc.hal->jog_enable_spindle) = (xhc.axis == axis_spindle);
+		hal_set_si32(xhc.hal->jog_counts, hal_get_si32(xhc.hal->jog_counts) + ((signed char)in_buf[4]));
+		hal_set_si32(xhc.hal->jog_counts_neg, - hal_get_si32(xhc.hal->jog_counts));
+		hal_set_bool(xhc.hal->jog_enable_off,      xhc.axis == axis_off);
+		hal_set_bool(xhc.hal->jog_enable_x,        xhc.axis == axis_x);
+		hal_set_bool(xhc.hal->jog_enable_y,        xhc.axis == axis_y);
+		hal_set_bool(xhc.hal->jog_enable_z,        xhc.axis == axis_z);
+		hal_set_bool(xhc.hal->jog_enable_a,        xhc.axis == axis_a);
+		hal_set_bool(xhc.hal->jog_enable_feedrate, xhc.axis == axis_feed);
+		hal_set_bool(xhc.hal->jog_enable_spindle,  xhc.axis == axis_spindle);
 
 		for (i=0; i<NB_MAX_BUTTONS; i++) {
 			if (!xhc.hal->button_pin[i]) continue;
-			*(xhc.hal->button_pin[i]) = (xhc.button_code == xhc.buttons[i].code);
+			hal_set_bool(xhc.hal->button_pin[i], xhc.button_code == xhc.buttons[i].code);
             if (strcmp("button-zero", xhc.buttons[i].pin_name) == 0) {
-               *(xhc.hal->zero_x) = (xhc.button_code == xhc.buttons[i].code) && (xhc.axis == axis_x);
-               *(xhc.hal->zero_y) = (xhc.button_code == xhc.buttons[i].code) && (xhc.axis == axis_y);
-               *(xhc.hal->zero_z) = (xhc.button_code == xhc.buttons[i].code) && (xhc.axis == axis_z);
-               *(xhc.hal->zero_a) = (xhc.button_code == xhc.buttons[i].code) && (xhc.axis == axis_a);
+               hal_set_bool(xhc.hal->zero_x, (xhc.button_code == xhc.buttons[i].code) && (xhc.axis == axis_x));
+               hal_set_bool(xhc.hal->zero_y, (xhc.button_code == xhc.buttons[i].code) && (xhc.axis == axis_y));
+               hal_set_bool(xhc.hal->zero_z, (xhc.button_code == xhc.buttons[i].code) && (xhc.axis == axis_z));
+               hal_set_bool(xhc.hal->zero_a, (xhc.button_code == xhc.buttons[i].code) && (xhc.axis == axis_a));
             }
             if (strcmp("button-goto-zero", xhc.buttons[i].pin_name) == 0) {
-               *(xhc.hal->gotozero_x) = (xhc.button_code == xhc.buttons[i].code) && (xhc.axis == axis_x);
-               *(xhc.hal->gotozero_y) = (xhc.button_code == xhc.buttons[i].code) && (xhc.axis == axis_y);
-               *(xhc.hal->gotozero_z) = (xhc.button_code == xhc.buttons[i].code) && (xhc.axis == axis_z);
-               *(xhc.hal->gotozero_a) = (xhc.button_code == xhc.buttons[i].code) && (xhc.axis == axis_a);
+               hal_set_bool(xhc.hal->gotozero_x, (xhc.button_code == xhc.buttons[i].code) && (xhc.axis == axis_x));
+               hal_set_bool(xhc.hal->gotozero_y, (xhc.button_code == xhc.buttons[i].code) && (xhc.axis == axis_y));
+               hal_set_bool(xhc.hal->gotozero_z, (xhc.button_code == xhc.buttons[i].code) && (xhc.axis == axis_z));
+               hal_set_bool(xhc.hal->gotozero_a, (xhc.button_code == xhc.buttons[i].code) && (xhc.axis == axis_a));
             }
             if (strcmp("button-half", xhc.buttons[i].pin_name) == 0) {
-               *(xhc.hal->half_x) = (xhc.button_code == xhc.buttons[i].code) && (xhc.axis == axis_x);
-               *(xhc.hal->half_y) = (xhc.button_code == xhc.buttons[i].code) && (xhc.axis == axis_y);
-               *(xhc.hal->half_z) = (xhc.button_code == xhc.buttons[i].code) && (xhc.axis == axis_z);
-               *(xhc.hal->half_a) = (xhc.button_code == xhc.buttons[i].code) && (xhc.axis == axis_a);
+               hal_set_bool(xhc.hal->half_x, (xhc.button_code == xhc.buttons[i].code) && (xhc.axis == axis_x));
+               hal_set_bool(xhc.hal->half_y, (xhc.button_code == xhc.buttons[i].code) && (xhc.axis == axis_y));
+               hal_set_bool(xhc.hal->half_z, (xhc.button_code == xhc.buttons[i].code) && (xhc.axis == axis_z));
+               hal_set_bool(xhc.hal->half_a, (xhc.button_code == xhc.buttons[i].code) && (xhc.axis == axis_a));
             }
-			if (simu_mode && *(xhc.hal->button_pin[i])) {
+			if (simu_mode && hal_get_bool(xhc.hal->button_pin[i])) {
 				printf("%s pressed", xhc.buttons[i].pin_name);
 			}
 		}
@@ -480,7 +481,7 @@ void cb_response_in(struct libusb_transfer *transfer)
 			&& in_buf[3]==0
 			&& in_buf[4]==0
 			&& in_buf[5]==0) {
-				*(xhc.hal->sleeping) = 1;
+				hal_set_bool(xhc.hal->sleeping, 1);
 				if (simu_mode) {
 					struct timeval now;
 					gettimeofday(&now, NULL);
@@ -489,12 +490,12 @@ void cb_response_in(struct libusb_transfer *transfer)
 				}
 			} else {
 				gettimeofday(&xhc.last_wakeup, NULL);
-				if (*(xhc.hal->sleeping)) {
+				if (hal_get_bool(xhc.hal->sleeping)) {
 					if (simu_mode) {
 						fprintf(stderr,"Wake\n");
 					}
 				}
-				*(xhc.hal->sleeping) = 0;
+				hal_set_bool(xhc.hal->sleeping, 0);
 			}
 	}
 
@@ -517,12 +518,15 @@ static void quit(int sig)
 
 static int hal_pin_simu(char *pin_name, void **ptr, int s)
 {
+	if(s < (int)sizeof(hal_query_value_u))
+		s = sizeof(hal_query_value_u);
+
 	printf("Creating pin: %s\n", pin_name);
 	*ptr = calloc(1, s);
 	return 0;
 }
 
-int _hal_pin_float_newf(hal_pin_dir_t dir, hal_float_t ** data_ptr_addr, int comp_id, const char *fmt, ...)
+int _hal_pin_float_newf(hal_pin_dir_t dir, hal_real_t *data_ptr_addr, int comp_id, const char *fmt, ...)
 {
 	char pin_name[256];
     va_list args;
@@ -531,14 +535,14 @@ int _hal_pin_float_newf(hal_pin_dir_t dir, hal_float_t ** data_ptr_addr, int com
 	va_end(args);
 
     if (simu_mode) {
-    	return hal_pin_simu(pin_name, ( void**)data_ptr_addr, sizeof(*data_ptr_addr));
+        return hal_pin_simu(pin_name, ( void**)data_ptr_addr, sizeof(hal_query_value_u));
     }
     else {
-    	return hal_pin_float_new(pin_name, dir, data_ptr_addr, comp_id);
+        return hal_pin_new_real(comp_id, dir, data_ptr_addr, 0.0, "%s", pin_name);
     }
 }
 
-int _hal_pin_s32_newf(hal_pin_dir_t dir, hal_s32_t ** data_ptr_addr, int comp_id, const char *fmt, ...)
+int _hal_pin_s32_newf(hal_pin_dir_t dir, hal_sint_t *data_ptr_addr, int comp_id, const char *fmt, ...)
 {
 	char pin_name[256];
     va_list args;
@@ -547,14 +551,14 @@ int _hal_pin_s32_newf(hal_pin_dir_t dir, hal_s32_t ** data_ptr_addr, int comp_id
 	va_end(args);
 
     if (simu_mode) {
-    	return hal_pin_simu(pin_name, ( void**)data_ptr_addr, sizeof(*data_ptr_addr));
+        return hal_pin_simu(pin_name, (void**)data_ptr_addr, sizeof(hal_query_value_u));
     }
     else {
-    	return hal_pin_s32_new(pin_name, dir, data_ptr_addr, comp_id);
+        return hal_pin_new_si32(comp_id, dir, data_ptr_addr, 0, "%s", pin_name);
     }
 }
 
-int _hal_pin_bit_newf(hal_pin_dir_t dir, hal_bit_t ** data_ptr_addr, int comp_id, const char *fmt, ...)
+int _hal_pin_bit_newf(hal_pin_dir_t dir, hal_bool_t *data_ptr_addr, int comp_id, const char *fmt, ...)
 {
 	char pin_name[256];
     va_list args;
@@ -563,10 +567,10 @@ int _hal_pin_bit_newf(hal_pin_dir_t dir, hal_bit_t ** data_ptr_addr, int comp_id
 	va_end(args);
 
     if (simu_mode) {
-    	return hal_pin_simu(pin_name, ( void**)data_ptr_addr, sizeof(*data_ptr_addr));
+        return hal_pin_simu(pin_name, ( void**)data_ptr_addr, sizeof(hal_query_value_u));
     }
     else {
-    	return hal_pin_bit_new(pin_name, dir, data_ptr_addr, comp_id);
+        return hal_pin_new_bool(comp_id, dir, data_ptr_addr, 0, "%s", pin_name);
     }
 }
 
@@ -805,10 +809,10 @@ int main (int argc,char **argv)
 		// use environmental variable LIBUSB_DEBUG if needed
 
 		printf("%s: waiting for XHC-HB04 device\n",modname);
-		*(xhc.hal->connected) = 0;
+		hal_set_bool(xhc.hal->connected, 0);
 		wait_secs = 0;
-		*(xhc.hal->require_pendant) = wait_for_pendant_before_HAL;
-		*(xhc.hal->stepsize) = stepsize_sequence[0];
+		hal_set_bool(xhc.hal->require_pendant, wait_for_pendant_before_HAL);
+		hal_set_si32(xhc.hal->stepsize, stepsize_sequence[0]);
 
 		do {
 			cnt = libusb_get_device_list(ctx, &devs);
@@ -850,7 +854,7 @@ int main (int argc,char **argv)
 			transfer_in  = libusb_alloc_transfer(0);
 		}
 
-		*(xhc.hal->connected) = 1;
+		hal_set_bool(xhc.hal->connected, 1);
 
 	    if (!hal_ready_done && !simu_mode) {
 	    	hal_ready(hal_comp_id);
@@ -873,9 +877,9 @@ int main (int argc,char **argv)
 				handle_step(&xhc);
 				xhc_set_display(dev_handle, &xhc);
 			}
-			*(xhc.hal->connected) = 0;
+			hal_set_bool(xhc.hal->connected, 0);
             printf("%s: connection lost, cleaning up\n",modname);
-			if (*(xhc.hal->require_pendant)) {
+			if (hal_get_bool(xhc.hal->require_pendant)) {
 				do_exit = 1;
 			}
 			libusb_cancel_transfer(transfer_in); // ignore result

--- a/src/hal/user_comps/xhc-whb04b-6/hal.cc
+++ b/src/hal/user_comps/xhc-whb04b-6/hal.cc
@@ -130,7 +130,7 @@ Hal::~Hal()
 
     freeSimulatedPin((void**)(&memory->in.isMachineOn));
 
-    constexpr size_t pinsCount = sizeof(memory->out.button_pin) / sizeof(hal_bit_t * );
+    constexpr size_t pinsCount = sizeof(memory->out.button_pin) / sizeof(*memory->out.button_pin);
     for (size_t      idx       = 0; idx < pinsCount; idx++)
     {
         freeSimulatedPin((void**)(&memory->out.button_pin[idx]));
@@ -223,13 +223,16 @@ Hal::~Hal()
 // ----------------------------------------------------------------------
 int Hal::newSimulatedHalPin(char* /*pin_name*/, void** ptr, int s)
 {
+    if(s < (int)sizeof(hal_query_value_u))
+        s = sizeof(hal_query_value_u);
+
     *ptr = calloc(s, 1);
     assert(*ptr != nullptr);
     memset(*ptr, 0, s);
     return 0;
 }
 // ----------------------------------------------------------------------
-int Hal::newHalFloat(hal_pin_dir_t direction, hal_float_t** ptr, int componentId, const char* fmt, ...)
+int Hal::newHalFloat(hal_pin_dir_t direction, hal_real_t *ptr, int componentId, const char *fmt, ...)
 {
     char    pin_name[256];
     va_list args;
@@ -255,17 +258,17 @@ int Hal::newHalFloat(hal_pin_dir_t direction, hal_float_t** ptr, int componentId
 
     if (mIsSimulationMode)
     {
-        return newSimulatedHalPin(pin_name, (void**)ptr, sizeof(hal_float_t));
+        return newSimulatedHalPin(pin_name, (void**)ptr, sizeof(hal_query_value_u));
     }
     else
     {
-        int r = hal_pin_float_new(pin_name, direction, ptr, componentId);
+        int r = hal_pin_new_real(componentId, direction, ptr, 0.0, "%s", pin_name);
         assert(r == 0);
         return r;
     }
 }
 // ----------------------------------------------------------------------
-int Hal::newHalSigned32(hal_pin_dir_t direction, hal_s32_t** ptr, int componentId, const char* fmt, ...)
+int Hal::newHalSigned32(hal_pin_dir_t direction, hal_sint_t *ptr, int componentId, const char *fmt, ...)
 {
     char    pin_name[256];
     va_list args;
@@ -291,17 +294,17 @@ int Hal::newHalSigned32(hal_pin_dir_t direction, hal_s32_t** ptr, int componentI
 
     if (mIsSimulationMode)
     {
-        return newSimulatedHalPin(pin_name, (void**)ptr, sizeof(hal_s32_t));
+        return newSimulatedHalPin(pin_name, (void**)ptr, sizeof(hal_query_value_u));
     }
     else
     {
-        int r = hal_pin_s32_new(pin_name, direction, ptr, componentId);
+        int r = hal_pin_new_si32(componentId, direction, ptr, 0, "%s", pin_name);
         assert(r == 0);
         return r;
     }
 }
 // ----------------------------------------------------------------------
-int Hal::newHalUnsigned32(hal_pin_dir_t direction, hal_u32_t** ptr, int componentId, const char* fmt, ...)
+int Hal::newHalUnsigned32(hal_pin_dir_t direction, hal_uint_t *ptr, int componentId, const char *fmt, ...)
 {
     char    pin_name[256];
     va_list args;
@@ -327,17 +330,17 @@ int Hal::newHalUnsigned32(hal_pin_dir_t direction, hal_u32_t** ptr, int componen
 
     if (mIsSimulationMode)
     {
-        return newSimulatedHalPin(pin_name, (void**)ptr, sizeof(hal_u32_t));
+        return newSimulatedHalPin(pin_name, (void**)ptr, sizeof(hal_query_value_u));
     }
     else
     {
-        int r = hal_pin_u32_new(pin_name, direction, ptr, componentId);
+        int r = hal_pin_new_ui32(componentId, direction, ptr, 0, "%s", pin_name);
         assert(r == 0);
         return r;
     }
 }
 // ----------------------------------------------------------------------
-int Hal::newHalBit(hal_pin_dir_t direction, hal_bit_t** ptr, int componentId, const char* fmt, ...)
+int Hal::newHalBit(hal_pin_dir_t direction, hal_bool_t *ptr, int componentId, const char *fmt, ...)
 {
     char    pin_name[256];
     va_list args;
@@ -363,11 +366,11 @@ int Hal::newHalBit(hal_pin_dir_t direction, hal_bit_t** ptr, int componentId, co
 
     if (mIsSimulationMode)
     {
-        return newSimulatedHalPin(pin_name, (void**)ptr, sizeof(hal_bit_t));
+        return newSimulatedHalPin(pin_name, (void**)ptr, sizeof(hal_query_value_u));
     }
     else
     {
-        int r = hal_pin_bit_new(pin_name, direction, ptr, componentId);
+        int r = hal_pin_new_bool(componentId, direction, ptr, 0, "%s", pin_name);
         assert(r == 0);
         return r;
     }
@@ -575,58 +578,58 @@ void Hal::init(const MetaButtonCodes* metaButtons, const KeyCodes& keyCodes)
     mIsInitialized = true;
 }
 // ----------------------------------------------------------------------
-real_t Hal::getAxisXPosition(bool absolute) const
+rtapi_real Hal::getAxisXPosition(bool absolute) const
 {
     if (absolute)
     {
-        return *memory->in.axisXPosition;
+        return hal_get_real(memory->in.axisXPosition);
     }
-    return *memory->in.axisXPositionRelative;
+    return hal_get_real(memory->in.axisXPositionRelative);
 }
 // ----------------------------------------------------------------------
-real_t Hal::getAxisYPosition(bool absolute) const
+rtapi_real Hal::getAxisYPosition(bool absolute) const
 {
     if (absolute)
     {
-        return *memory->in.axisYPosition;
+        return hal_get_real(memory->in.axisYPosition);
     }
-    return *memory->in.axisYPositionRelative;
+    return hal_get_real(memory->in.axisYPositionRelative);
 }
 // ----------------------------------------------------------------------
-real_t Hal::getAxisZPosition(bool absolute) const
+rtapi_real Hal::getAxisZPosition(bool absolute) const
 {
     if (absolute)
     {
-        return *memory->in.axisZPosition;
+        return hal_get_real(memory->in.axisZPosition);
     }
-    return *memory->in.axisZPositionRelative;
+    return hal_get_real(memory->in.axisZPositionRelative);
 }
 // ----------------------------------------------------------------------
-real_t Hal::getAxisAPosition(bool absolute) const
+rtapi_real Hal::getAxisAPosition(bool absolute) const
 {
     if (absolute)
     {
-        return *memory->in.axisAPosition;
+        return hal_get_real(memory->in.axisAPosition);
     }
-    return *memory->in.axisAPositionRelative;
+    return hal_get_real(memory->in.axisAPositionRelative);
 }
 // ----------------------------------------------------------------------
-real_t Hal::getAxisBPosition(bool absolute) const
+rtapi_real Hal::getAxisBPosition(bool absolute) const
 {
     if (absolute)
     {
-        return *memory->in.axisBPosition;
+        return hal_get_real(memory->in.axisBPosition);
     }
-    return *memory->in.axisBPositionRelative;
+    return hal_get_real(memory->in.axisBPositionRelative);
 }
 // ----------------------------------------------------------------------
-real_t Hal::getAxisCPosition(bool absolute) const
+rtapi_real Hal::getAxisCPosition(bool absolute) const
 {
     if (absolute)
     {
-        return *memory->in.axisCPosition;
+        return hal_get_real(memory->in.axisCPosition);
     }
-    return *memory->in.axisCPositionRelative;
+    return hal_get_real(memory->in.axisCPositionRelative);
 }
 // ----------------------------------------------------------------------
 void Hal::enableVerbose(bool enable)
@@ -648,54 +651,54 @@ void Hal::setNoAxisActive(bool /*enabled*/)
 // ----------------------------------------------------------------------
 void Hal::setAxisXActive(bool enabled)
 {
-    *memory->out.axisXSelect   = enabled;
-    *memory->out.axisXJogEnable = enabled;
+    hal_set_bool(memory->out.axisXSelect,    enabled);
+    hal_set_bool(memory->out.axisXJogEnable, enabled);
     *mHalCout << "hal   X axis active" << endl;
 }
 // ----------------------------------------------------------------------
 void Hal::setAxisYActive(bool enabled)
 {
-    *memory->out.axisYSelect   = enabled;
-    *memory->out.axisYJogEnable = enabled;
+    hal_set_bool(memory->out.axisYSelect,    enabled);
+    hal_set_bool(memory->out.axisYJogEnable, enabled);
     *mHalCout << "hal   Y axis active" << endl;
 }
 // ----------------------------------------------------------------------
 void Hal::setAxisZActive(bool enabled)
 {
-    *memory->out.axisZSelect   = enabled;
-    *memory->out.axisZJogEnable = enabled;
+    hal_set_bool(memory->out.axisZSelect,    enabled);
+    hal_set_bool(memory->out.axisZJogEnable, enabled);
     *mHalCout << "hal   Z axis active" << endl;
 }
 // ----------------------------------------------------------------------
 void Hal::setAxisAActive(bool enabled)
 {
-    *memory->out.axisASelect   = enabled;
-    *memory->out.axisAJogEnable = enabled;
+    hal_set_bool(memory->out.axisASelect,    enabled);
+    hal_set_bool(memory->out.axisAJogEnable, enabled);
     *mHalCout << "hal   A axis active" << endl;
 }
 // ----------------------------------------------------------------------
 void Hal::setAxisBActive(bool enabled)
 {
-    *memory->out.axisBSelect   = enabled;
-    *memory->out.axisBJogEnable = enabled;
+    hal_set_bool(memory->out.axisBSelect,    enabled);
+    hal_set_bool(memory->out.axisBJogEnable, enabled);
     *mHalCout << "hal   B axis active" << endl;
 }
 // ----------------------------------------------------------------------
 void Hal::setAxisCActive(bool enabled)
 {
-    *memory->out.axisCSelect   = enabled;
-    *memory->out.axisCJogEnable = enabled;
+    hal_set_bool(memory->out.axisCSelect,    enabled);
+    hal_set_bool(memory->out.axisCJogEnable, enabled);
     *mHalCout << "hal   C axis active" << endl;
 }
 // ----------------------------------------------------------------------
-void Hal::setStepSize(const real_t stepSize)
+void Hal::setStepSize(const rtapi_real stepSize)
 {
-    *memory->out.axisXJogScale = stepSize;
-    *memory->out.axisYJogScale = stepSize;
-    *memory->out.axisZJogScale = stepSize;
-    *memory->out.axisAJogScale = stepSize;
-    *memory->out.axisBJogScale = stepSize;
-    *memory->out.axisCJogScale = stepSize;
+    hal_set_real(memory->out.axisXJogScale, stepSize);
+    hal_set_real(memory->out.axisYJogScale, stepSize);
+    hal_set_real(memory->out.axisZJogScale, stepSize);
+    hal_set_real(memory->out.axisAJogScale, stepSize);
+    hal_set_real(memory->out.axisBJogScale, stepSize);
+    hal_set_real(memory->out.axisCJogScale, stepSize);
     *mHalCout << "hal   step size " << stepSize << endl;
 }
 // ----------------------------------------------------------------------
@@ -709,20 +712,20 @@ void Hal::setLead()
 // ----------------------------------------------------------------------
 void Hal::setReset(bool enabled)
 {
-    if (*memory->in.isMachineOn)
+    if (hal_get_bool(memory->in.isMachineOn))
     { // disable machine
         clearStartResumeProgramStates();
-        *memory->out.doMachineOff = true;
+        hal_set_bool(memory->out.doMachineOff, true);
     }
     else
     { // enable machine
-        *memory->out.doMachineOn = true;
+        hal_set_bool(memory->out.doMachineOn, true);
     }
 
     if (!enabled)
     {
-        *memory->out.doMachineOff = false;
-        *memory->out.doMachineOn  = false;
+        hal_set_bool(memory->out.doMachineOff, false);
+        hal_set_bool(memory->out.doMachineOn,  false);
     }
     setPin(enabled, KeyCodes::Buttons.reset.text);
 }
@@ -730,7 +733,7 @@ void Hal::setReset(bool enabled)
 void Hal::setStop(bool enabled)
 {
     clearStartResumeProgramStates();
-    *memory->out.doStopProgram = enabled;
+    hal_set_bool(memory->out.doStopProgram, enabled);
     setPin(enabled, KeyCodes::Buttons.stop.text);
 }
 // ----------------------------------------------------------------------
@@ -753,47 +756,47 @@ void Hal::setStart(bool enabled)
 // ----------------------------------------------------------------------
 bool Hal::getIsMachineOn() const
 {
-    return *memory->in.isMachineOn;
+    return hal_get_bool(memory->in.isMachineOn);
 }
 // ----------------------------------------------------------------------
 void Hal::setIsPendantSleeping(bool isSleeping)
 {
-    *memory->out.isPendantSleeping = isSleeping;
+    hal_set_bool(memory->out.isPendantSleeping, isSleeping);
 }
 // ----------------------------------------------------------------------
 bool Hal::getIsPendantSleeping() const
 {
-    return *memory->out.isPendantSleeping;
+    return hal_get_bool(memory->out.isPendantSleeping);
 }
 // ----------------------------------------------------------------------
 void Hal::setIsPendantConnected(bool isSleeping)
 {
-    *memory->out.isPendantConnected = isSleeping;
+    hal_set_bool(memory->out.isPendantConnected, isSleeping);
 }
 // ----------------------------------------------------------------------
 bool Hal::getIsPendantConnected() const
 {
-    return *memory->out.isPendantConnected;
+    return hal_get_bool(memory->out.isPendantConnected);
 }
 // ----------------------------------------------------------------------
 void Hal::clearStartResumeProgramStates()
 {
-    *memory->out.doModeTeleop      = false;
-    *memory->out.doModeJoint       = false;
-    *memory->out.doModeAuto        = false;
-    *memory->out.doPauseProgram    = false;
-    *memory->out.doRunProgram      = false;
-    *memory->out.doResumeProgram   = false;
+    hal_set_bool(memory->out.doModeTeleop,    false);
+    hal_set_bool(memory->out.doModeJoint,     false);
+    hal_set_bool(memory->out.doModeAuto,      false);
+    hal_set_bool(memory->out.doPauseProgram,  false);
+    hal_set_bool(memory->out.doRunProgram,    false);
+    hal_set_bool(memory->out.doResumeProgram, false);
 }
 
-void Hal::checkState(bool state, hal_bit_t *pin)
+void Hal::checkState(bool state, hal_bool_t pin)
 {
     // 500 milliseconds timeout
     unsigned int timeouts=500;
     unsigned int timeoutMs=1;
     do
     {
-        if (state == *pin)
+        if (state == hal_get_bool(pin))
         {
             usleep(timeoutMs * 1000);
         }
@@ -801,129 +804,129 @@ void Hal::checkState(bool state, hal_bit_t *pin)
         {
             break;
         }
-    } while ((state == *pin) && (--timeouts) > 0);
+    } while ((state == hal_get_bool(pin)) && (--timeouts) > 0);
 }
 // ----------------------------------------------------------------------
 void Hal::toggleStartResumeProgram()
 {
-    if (*memory->in.isProgramPaused)
+    if (hal_get_bool(memory->in.isProgramPaused))
     {
-        *memory->out.doPauseProgram  = false;
-        *memory->out.doRunProgram    = false;
-        *memory->out.doResumeProgram = true;
+        hal_set_bool(memory->out.doPauseProgram,  false);
+        hal_set_bool(memory->out.doRunProgram,    false);
+        hal_set_bool(memory->out.doResumeProgram, true);
         checkState(true, memory->in.isProgramPaused);
-        *memory->out.doResumeProgram = false;
-    } else if (*memory->in.isProgramRunning)
+        hal_set_bool(memory->out.doResumeProgram, false);
+    } else if (hal_get_bool(memory->in.isProgramRunning))
     {
-        *memory->out.doPauseProgram  = true;
+        hal_set_bool(memory->out.doPauseProgram,  true);
         checkState(false, memory->in.isProgramPaused);
-        *memory->out.doPauseProgram  = false;
-        *memory->out.doRunProgram    = false;
-        *memory->out.doResumeProgram = false;
-    } else if (*memory->in.isProgramIdle)
+        hal_set_bool(memory->out.doPauseProgram,  false);
+        hal_set_bool(memory->out.doRunProgram,    false);
+        hal_set_bool(memory->out.doResumeProgram, false);
+    } else if (hal_get_bool(memory->in.isProgramIdle))
     {
-        *memory->out.doPauseProgram  = false;
-        *memory->out.doRunProgram    = true;
+        hal_set_bool(memory->out.doPauseProgram,  false);
+        hal_set_bool(memory->out.doRunProgram,    true);
         checkState(false, memory->in.isProgramRunning);
-        *memory->out.doRunProgram    = false;
-        *memory->out.doResumeProgram = false;
+        hal_set_bool(memory->out.doRunProgram,    false);
+        hal_set_bool(memory->out.doResumeProgram, false);
     }
 }
 // ----------------------------------------------------------------------
 void Hal::setFeedPlus(bool enabled)
 {
-    *memory->out.feedOverrideScale = 0.05;
-    *memory->out.feedOverrideIncrease = enabled;
+    hal_set_real(memory->out.feedOverrideScale, 0.05);
+    hal_set_bool(memory->out.feedOverrideIncrease, enabled);
     setPin(enabled, KeyCodes::Buttons.feed_plus.text);
 }
 // ----------------------------------------------------------------------
 void Hal::setFeedMinus(bool enabled)
 {
-    *memory->out.feedOverrideScale = 0.05;
-    *memory->out.feedOverrideDecrease = enabled;
+    hal_set_real(memory->out.feedOverrideScale, 0.05);
+    hal_set_bool(memory->out.feedOverrideDecrease, enabled);
     setPin(enabled, KeyCodes::Buttons.feed_minus.text);
 }
 // ----------------------------------------------------------------------
-real_t Hal::getspindleSpeedCmd() const
+rtapi_real Hal::getspindleSpeedCmd() const
 {
-    return *memory->in.spindleSpeedCmd;
+    return hal_get_real(memory->in.spindleSpeedCmd);
 }
 // ----------------------------------------------------------------------
-real_t Hal::getspindleSpeedChangeIncrease() const
+rtapi_real Hal::getspindleSpeedChangeIncrease() const
 {
-    return *memory->out.spindleDoIncrease;
+    return hal_get_bool(memory->out.spindleDoIncrease);
 }
 // ----------------------------------------------------------------------
-real_t Hal::getspindleSpeedChangeDecrease() const
+rtapi_real Hal::getspindleSpeedChangeDecrease() const
 {
-    return *memory->out.spindleDoDecrease;
+    return hal_get_bool(memory->out.spindleDoDecrease);
 }
 // ----------------------------------------------------------------------
-real_t Hal::getSpindleOverrideValue() const
+rtapi_real Hal::getSpindleOverrideValue() const
 {
-    return *memory->in.spindleOverrideValue;
+    return hal_get_real(memory->in.spindleOverrideValue);
 }
 // ----------------------------------------------------------------------
-real_t Hal::getFeedOverrideMaxVel() const
+rtapi_real Hal::getFeedOverrideMaxVel() const
 {
-    return *memory->in.feedOverrideMaxVel;
+    return hal_get_real(memory->in.feedOverrideMaxVel);
 }
 // ----------------------------------------------------------------------
-real_t Hal::getFeedOverrideValue() const
+rtapi_real Hal::getFeedOverrideValue() const
 {
-    return *memory->in.feedOverrideValue;
+    return hal_get_real(memory->in.feedOverrideValue);
 }
 // ----------------------------------------------------------------------
 void Hal::setFeedValueSelected2(bool selected)
 {
-    *memory->out.feedValueSelected_2 = selected;
+    hal_set_bool(memory->out.feedValueSelected_2, selected);
 }
 // ----------------------------------------------------------------------
 void Hal::setFeedValueSelected5(bool selected)
 {
-    *memory->out.feedValueSelected_5 = selected;
+    hal_set_bool(memory->out.feedValueSelected_5, selected);
 }
 // ----------------------------------------------------------------------
 void Hal::setFeedValueSelected10(bool selected)
 {
-    *memory->out.feedValueSelected_10 = selected;
+    hal_set_bool(memory->out.feedValueSelected_10, selected);
 }
 // ----------------------------------------------------------------------
 void Hal::setFeedValueSelected30(bool selected)
 {
-    *memory->out.feedValueSelected_30 = selected;
+    hal_set_bool(memory->out.feedValueSelected_30, selected);
 }
 // ----------------------------------------------------------------------
 void Hal::setFeedValueSelected60(bool selected)
 {
-    *memory->out.feedValueSelected_60 = selected;
+    hal_set_bool(memory->out.feedValueSelected_60, selected);
 }
 // ----------------------------------------------------------------------
 void Hal::setFeedValueSelected100(bool selected)
 {
-    *memory->out.feedValueSelected_100 = selected;
+    hal_set_bool(memory->out.feedValueSelected_100, selected);
 }
 // ----------------------------------------------------------------------
 void Hal::setFeedValueSelectedLead(bool selected)
 {
-    *memory->out.feedValueSelected_lead = selected;
+    hal_set_bool(memory->out.feedValueSelected_lead, selected);
 }
 // ----------------------------------------------------------------------
-void Hal::setFeedOverrideScale(real_t scale)
+void Hal::setFeedOverrideScale(rtapi_real scale)
 {
-    *memory->out.feedOverrideScale = scale;
+    hal_set_real(memory->out.feedOverrideScale, scale);
 }
 // ----------------------------------------------------------------------
 void Hal::setSpindleOverridePlus(bool enabled)
 {
     if (enabled)
     {
-        *memory->out.spindleOverrideScale = 0.05;
-        *memory->out.spindleOverrideDoIncrease = true;
+        hal_set_real(memory->out.spindleOverrideScale, 0.05);
+        hal_set_bool(memory->out.spindleOverrideDoIncrease, true);
     }
     else
     {
-        *memory->out.spindleOverrideDoIncrease = false;
+        hal_set_bool(memory->out.spindleOverrideDoIncrease, false);
     }
     setPin(enabled, KeyCodes::Buttons.spindle_plus.text);
 }
@@ -932,12 +935,12 @@ void Hal::setSpindleOverrideMinus(bool enabled)
 {
     if (enabled)
     {
-        *memory->out.spindleOverrideScale = 0.05;
-        *memory->out.spindleOverrideDoDecrease = true;
+        hal_set_real(memory->out.spindleOverrideScale, 0.05);
+        hal_set_bool(memory->out.spindleOverrideDoDecrease, true);
     }
     else
     {
-        *memory->out.spindleOverrideDoDecrease = false;
+        hal_set_bool(memory->out.spindleOverrideDoDecrease, false);
     }
     setPin(enabled, KeyCodes::Buttons.spindle_minus.text);
 }
@@ -1008,26 +1011,26 @@ void Hal::toggleSpindleDirection(bool enabled)
     }
 
     // on running spindle update direction immediately
-    if (*memory->in.spindleIsOn)
+    if (hal_get_bool(memory->in.spindleIsOn))
     {
         if (enabled)
         {
             if (mIsSpindleDirectionForward)
             {
-                *memory->out.spindleDoRunForward = true;
-                *memory->out.spindleDoIncrease = true;
+                hal_set_bool(memory->out.spindleDoRunForward, true);
+                hal_set_bool(memory->out.spindleDoIncrease,   true);
             }
             else
             {
-                *memory->out.spindleDoRunReverse = true;
-                *memory->out.spindleDoIncrease = true;
+                hal_set_bool(memory->out.spindleDoRunReverse, true);
+                hal_set_bool(memory->out.spindleDoIncrease,   true);
             }
         }
         else
         {
-            *memory->out.spindleDoRunForward = false;
-            *memory->out.spindleDoRunReverse = false;
-            *memory->out.spindleDoIncrease   = false;
+            hal_set_bool(memory->out.spindleDoRunForward, false);
+            hal_set_bool(memory->out.spindleDoRunReverse, false);
+            hal_set_bool(memory->out.spindleDoIncrease,   false);
         }
     }
 }
@@ -1036,25 +1039,25 @@ void Hal::toggleSpindleOnOff(bool enabled)
 {
     if (enabled)
     {
-        if (*memory->in.spindleIsOn)
+        if (hal_get_bool(memory->in.spindleIsOn))
         {
             // on spindle stop
-            *memory->out.spindleStop = true;
+            hal_set_bool(memory->out.spindleStop, true);
         }
         else
         {
             // on spindle start
             if (mIsSpindleDirectionForward)
             {
-                *memory->out.spindleDoRunForward = true;
-                *memory->out.spindleDoIncrease = true;
-                *memory->out.spindleStart = true;
+                hal_set_bool(memory->out.spindleDoRunForward, true);
+                hal_set_bool(memory->out.spindleDoIncrease,   true);
+                hal_set_bool(memory->out.spindleStart,        true);
             }
             else
             {
-                *memory->out.spindleDoRunReverse = true;
-                *memory->out.spindleDoIncrease = true;
-                *memory->out.spindleStart = true;
+                hal_set_bool(memory->out.spindleDoRunReverse, true);
+                hal_set_bool(memory->out.spindleDoIncrease,   true);
+                hal_set_bool(memory->out.spindleStart,        true);
                 
             }
         }
@@ -1062,11 +1065,11 @@ void Hal::toggleSpindleOnOff(bool enabled)
     else
     {
         // on button released
-        *memory->out.spindleStop         = false;
-        *memory->out.spindleDoRunForward = false;
-        *memory->out.spindleDoRunReverse = false;
-        *memory->out.spindleDoIncrease   = false;
-        *memory->out.spindleStart        = false;
+        hal_set_bool(memory->out.spindleStop,         false);
+        hal_set_bool(memory->out.spindleDoRunForward, false);
+        hal_set_bool(memory->out.spindleDoRunReverse, false);
+        hal_set_bool(memory->out.spindleDoIncrease,   false);
+        hal_set_bool(memory->out.spindleStart,        false);
     }
     setPin(enabled, KeyCodes::Buttons.spindle_on_off.text);
 }
@@ -1075,22 +1078,22 @@ void Hal::toggleFloodOnOff(bool enabled)
 {
     if (enabled)
     {
-        if (*memory->in.floodIsOn)
+        if (hal_get_bool(memory->in.floodIsOn))
         {
             // on flood stop
-            *memory->out.floodStop = true;
+            hal_set_bool(memory->out.floodStop, true);
         }
         else
         {
             // on flood start
-            *memory->out.floodStart = true;
+            hal_set_bool(memory->out.floodStart, true);
         }
     }
     else
     {
         // on button released
-        *memory->out.floodStop         = false;
-        *memory->out.floodStart        = false;
+        hal_set_bool(memory->out.floodStop,  false);
+        hal_set_bool(memory->out.floodStart, false);
     }
 }
 // ----------------------------------------------------------------------
@@ -1098,22 +1101,22 @@ void Hal::toggleMistOnOff(bool enabled)
 {
     if (enabled)
     {
-        if (*memory->in.mistIsOn)
+        if (hal_get_bool(memory->in.mistIsOn))
         {
             // on mist stop
-            *memory->out.mistStop = true;
+            hal_set_bool(memory->out.mistStop, true);
         }
         else
         {
             // on mist start
-            *memory->out.mistStart = true;
+            hal_set_bool(memory->out.mistStart, true);
         }
     }
     else
     {
         // on button released
-        *memory->out.mistStop         = false;
-        *memory->out.mistStart        = false;
+        hal_set_bool(memory->out.mistStop,  false);
+        hal_set_bool(memory->out.mistStart, false);
     }
 }
 // ----------------------------------------------------------------------
@@ -1140,16 +1143,16 @@ void Hal::setConMode(bool enabled)
 {
     if (enabled)
     {
-        *memory->out.axisXSetVelocityMode = true;
-        *memory->out.axisYSetVelocityMode = true;
-        *memory->out.axisZSetVelocityMode = true;
-        *memory->out.axisASetVelocityMode = true;
-        *memory->out.axisBSetVelocityMode = true;
-        *memory->out.axisCSetVelocityMode = true;
+        hal_set_bool(memory->out.axisXSetVelocityMode, true);
+        hal_set_bool(memory->out.axisYSetVelocityMode, true);
+        hal_set_bool(memory->out.axisZSetVelocityMode, true);
+        hal_set_bool(memory->out.axisASetVelocityMode, true);
+        hal_set_bool(memory->out.axisBSetVelocityMode, true);
+        hal_set_bool(memory->out.axisCSetVelocityMode, true);
         *mHalCout << "hal   step mode is con" << endl;
-        *memory->out.feedValueSelected_mpg_feed = false;
-        *memory->out.feedValueSelected_continuous = true;
-        *memory->out.feedValueSelected_step = false;
+        hal_set_bool(memory->out.feedValueSelected_mpg_feed, false);
+        hal_set_bool(memory->out.feedValueSelected_continuous, true);
+        hal_set_bool(memory->out.feedValueSelected_step, false);
     }
     setPin(enabled, KeyCodes::Buttons.continuous.text);
 }
@@ -1158,16 +1161,16 @@ void Hal::setStepMode(bool enabled)
 {
     if (enabled)
     {
-        *memory->out.axisXSetVelocityMode = false;
-        *memory->out.axisYSetVelocityMode = false;
-        *memory->out.axisZSetVelocityMode = false;
-        *memory->out.axisASetVelocityMode = false;
-        *memory->out.axisBSetVelocityMode = false;
-        *memory->out.axisCSetVelocityMode = false;
+        hal_set_bool(memory->out.axisXSetVelocityMode, false);
+        hal_set_bool(memory->out.axisYSetVelocityMode, false);
+        hal_set_bool(memory->out.axisZSetVelocityMode, false);
+        hal_set_bool(memory->out.axisASetVelocityMode, false);
+        hal_set_bool(memory->out.axisBSetVelocityMode, false);
+        hal_set_bool(memory->out.axisCSetVelocityMode, false);
         *mHalCout << "hal   step mode is step" << endl;
-        *memory->out.feedValueSelected_mpg_feed = false;
-        *memory->out.feedValueSelected_continuous = false;
-        *memory->out.feedValueSelected_step = true;
+        hal_set_bool(memory->out.feedValueSelected_mpg_feed, false);
+        hal_set_bool(memory->out.feedValueSelected_continuous, false);
+        hal_set_bool(memory->out.feedValueSelected_step, true);
     }
     setPin(enabled, KeyCodes::Buttons.step.text);
 }
@@ -1176,16 +1179,16 @@ void Hal::setMpgMode(bool enabled)
 {
     if (enabled)
     {
-        *memory->out.axisXSetVelocityMode = false;
-        *memory->out.axisYSetVelocityMode = false;
-        *memory->out.axisZSetVelocityMode = false;
-        *memory->out.axisASetVelocityMode = false;
-        *memory->out.axisBSetVelocityMode = false;
-        *memory->out.axisCSetVelocityMode = false;
+        hal_set_bool(memory->out.axisXSetVelocityMode, false);
+        hal_set_bool(memory->out.axisYSetVelocityMode, false);
+        hal_set_bool(memory->out.axisZSetVelocityMode, false);
+        hal_set_bool(memory->out.axisASetVelocityMode, false);
+        hal_set_bool(memory->out.axisBSetVelocityMode, false);
+        hal_set_bool(memory->out.axisCSetVelocityMode, false);
         *mHalCout << "hal   step mode is mpg" << endl;
-        *memory->out.feedValueSelected_mpg_feed = true;
-        *memory->out.feedValueSelected_continuous = false;
-        *memory->out.feedValueSelected_step = false;
+        hal_set_bool(memory->out.feedValueSelected_mpg_feed, true);
+        hal_set_bool(memory->out.feedValueSelected_continuous, false);
+        hal_set_bool(memory->out.feedValueSelected_step, false);
     }
 }
 // ----------------------------------------------------------------------
@@ -1203,14 +1206,14 @@ void Hal::setMacro3(bool enabled)
 {
     if (enabled)
     {
-        if (*memory->in.spindleIsOn)
+        if (hal_get_bool(memory->in.spindleIsOn))
         {
-            *memory->out.spindleDoIncrease = true;
+            hal_set_bool(memory->out.spindleDoIncrease, true);
         }
     }
     else
     {
-        *memory->out.spindleDoIncrease = false;
+        hal_set_bool(memory->out.spindleDoIncrease, false);
     }
     setPin(enabled, KeyCodes::Buttons.spindle_plus.altText);
 }
@@ -1219,14 +1222,14 @@ void Hal::setMacro4(bool enabled)
 {
     if (enabled)
     {
-        if (*memory->in.spindleIsOn)
+        if (hal_get_bool(memory->in.spindleIsOn))
         {
-            *memory->out.spindleDoDecrease = true;
+            hal_set_bool(memory->out.spindleDoDecrease, true);
         }
     }
     else
     {
-        *memory->out.spindleDoDecrease = false;
+        hal_set_bool(memory->out.spindleDoDecrease, false);
     }
     setPin(enabled, KeyCodes::Buttons.spindle_minus.altText);
 }
@@ -1295,7 +1298,7 @@ void Hal::setPin(bool enabled, size_t pinNumber, const char* pinName)
 {
     *mHalCout << "hal   " << pinName << ((enabled) ? " enabled" : " disabled") << " (pin # " << pinNumber << ")"
               << endl;
-    *(memory->out.button_pin[pinNumber]) = enabled;
+    hal_set_bool((memory->out.button_pin[pinNumber]), enabled);
 }
 // ----------------------------------------------------------------------
 void Hal::setPin(bool enabled, const char* pinName)
@@ -1310,20 +1313,20 @@ void Hal::setJogCounts(const HandWheelCounters& counters)
 {
     // If axis is not homed we need to ask Teleop mode but we need to bypass that if machine is homed
     // https://forum.linuxcnc.org/49-basic-configuration/40581-how-to-configure-a-xhc-whb04b-pendant
-    if      (*memory->out.axisXSelect && false == *memory->in.JointXisHomed) {requestTeleopMode(true);}
-    else if (*memory->out.axisYSelect && false == *memory->in.JointYisHomed) {requestTeleopMode(true);}
-    else if (*memory->out.axisZSelect && false == *memory->in.JointZisHomed) {requestTeleopMode(true);}
-    else if (*memory->out.axisASelect && false == *memory->in.JointAisHomed) {requestTeleopMode(true);}
-    else if (*memory->out.axisBSelect && false == *memory->in.JointBisHomed) {requestTeleopMode(true);}
-    else if (*memory->out.axisCSelect && false == *memory->in.JointCisHomed) {requestTeleopMode(true);}
+    if      (hal_get_bool(memory->out.axisXSelect) && !hal_get_bool(memory->in.JointXisHomed)) {requestTeleopMode(true);}
+    else if (hal_get_bool(memory->out.axisYSelect) && !hal_get_bool(memory->in.JointYisHomed)) {requestTeleopMode(true);}
+    else if (hal_get_bool(memory->out.axisZSelect) && !hal_get_bool(memory->in.JointZisHomed)) {requestTeleopMode(true);}
+    else if (hal_get_bool(memory->out.axisASelect) && !hal_get_bool(memory->in.JointAisHomed)) {requestTeleopMode(true);}
+    else if (hal_get_bool(memory->out.axisBSelect) && !hal_get_bool(memory->in.JointBisHomed)) {requestTeleopMode(true);}
+    else if (hal_get_bool(memory->out.axisCSelect) && !hal_get_bool(memory->in.JointCisHomed)) {requestTeleopMode(true);}
     {requestManualMode(true);}
 
-    *memory->out.axisXJogCounts = counters.counts(HandWheelCounters::CounterNameToIndex::AXIS_X);
-    *memory->out.axisYJogCounts = counters.counts(HandWheelCounters::CounterNameToIndex::AXIS_Y);
-    *memory->out.axisZJogCounts = counters.counts(HandWheelCounters::CounterNameToIndex::AXIS_Z);
-    *memory->out.axisAJogCounts = counters.counts(HandWheelCounters::CounterNameToIndex::AXIS_A);
-    *memory->out.axisBJogCounts = counters.counts(HandWheelCounters::CounterNameToIndex::AXIS_B);
-    *memory->out.axisCJogCounts = counters.counts(HandWheelCounters::CounterNameToIndex::AXIS_C);
+    hal_set_si32(memory->out.axisXJogCounts, counters.counts(HandWheelCounters::CounterNameToIndex::AXIS_X));
+    hal_set_si32(memory->out.axisYJogCounts, counters.counts(HandWheelCounters::CounterNameToIndex::AXIS_Y));
+    hal_set_si32(memory->out.axisZJogCounts, counters.counts(HandWheelCounters::CounterNameToIndex::AXIS_Z));
+    hal_set_si32(memory->out.axisAJogCounts, counters.counts(HandWheelCounters::CounterNameToIndex::AXIS_A));
+    hal_set_si32(memory->out.axisBJogCounts, counters.counts(HandWheelCounters::CounterNameToIndex::AXIS_B));
+    hal_set_si32(memory->out.axisCJogCounts, counters.counts(HandWheelCounters::CounterNameToIndex::AXIS_C));
     
     requestManualMode(false);
     requestTeleopMode(false);
@@ -1341,7 +1344,7 @@ bool Hal::requestAutoMode(bool isRisingEdge)
 // ----------------------------------------------------------------------
 bool Hal::requestManualMode(bool isRisingEdge)
 {
-    if(isRisingEdge && !*memory->in.isProgramIdle)
+    if(isRisingEdge && !hal_get_bool(memory->in.isProgramIdle))
     {
         //Don't try to change to manual when not idle
         //When a program is running, this will fail
@@ -1366,34 +1369,34 @@ bool Hal::requestJointMode(bool isRisingEdge)
     return requestMode(isRisingEdge, memory->out.doModeJoint, memory->in.isModeJoint);
 }
 // ----------------------------------------------------------------------
-bool Hal::requestMode(bool isRisingEdge, hal_bit_t *requestPin, hal_bit_t * modeFeedbackPin)
+bool Hal::requestMode(bool isRisingEdge, hal_bool_t requestPin, hal_bool_t modeFeedbackPin)
 {
     if (isRisingEdge)
     {
         bool rv;
-        if (true == *modeFeedbackPin)
+        if (hal_get_bool(modeFeedbackPin))
         {
             // shortcut for mode request which is already active
             return true;
         }
         // request mode
-        *requestPin = true;
+        hal_set_bool(requestPin, true);
         usleep(mHalRequestProfile.mode.holdMs * 1000);
         rv = waitForRequestedMode(modeFeedbackPin);
-        *requestPin = false;
+        hal_set_bool(requestPin, false);
         usleep(mHalRequestProfile.mode.spaceMs * 1000);
         return rv;
     }
     else
     {
       // on button released always clear request
-      *requestPin = false;
+      hal_set_bool(requestPin, false);
       return false;
     }
     return false;
 }
 // ----------------------------------------------------------------------
-bool Hal::waitForRequestedMode(volatile hal_bit_t * condition)
+bool Hal::waitForRequestedMode(hal_bool_t condition)
 {
     if(mIsSimulationMode)
     {
@@ -1405,7 +1408,7 @@ bool Hal::waitForRequestedMode(volatile hal_bit_t * condition)
 
     do
     {
-        if (false == *condition)
+        if (!hal_get_bool(condition))
         {
             usleep(timeoutMs * 1000);
         }
@@ -1413,8 +1416,8 @@ bool Hal::waitForRequestedMode(volatile hal_bit_t * condition)
         {
             return true;
         }
-    } while ((false == *condition) && (--timeouts) > 0);
-    if (false == *condition)
+    } while (!hal_get_bool(condition) && (--timeouts) > 0);
+    if (!hal_get_bool(condition))
     {
         auto delay = (maxTimeouts - timeouts) * timeoutMs;
         std::cerr << "hal   failed to wait for requested mode. waited " << delay << "ms\n";
@@ -1429,53 +1432,53 @@ bool Hal::waitForRequestedMode(volatile hal_bit_t * condition)
 // ----------------------------------------------------------------------
 void Hal::toggleSpindleOverrideIncrease()
 {
-    if (*memory->out.spindleOverrideDoIncrease)
+    if (hal_get_bool(memory->out.spindleOverrideDoIncrease))
     {
-        *memory->out.spindleOverrideDoIncrease = false;
+        hal_set_bool(memory->out.spindleOverrideDoIncrease, false);
     }
     else
     {
-        *memory->out.spindleOverrideScale = 0.01;
-        *memory->out.spindleOverrideDoIncrease = true;
+        hal_set_real(memory->out.spindleOverrideScale, 0.01);
+        hal_set_bool(memory->out.spindleOverrideDoIncrease, true);
     }
 }
 // ----------------------------------------------------------------------
 void Hal::toggleSpindleOverrideDecrease()
 {
-    if (*memory->out.spindleOverrideDoDecrease)
+    if (hal_get_bool(memory->out.spindleOverrideDoDecrease))
     {
-        *memory->out.spindleOverrideDoDecrease = false;
+        hal_set_bool(memory->out.spindleOverrideDoDecrease, false);
     }
     else
     {
-        *memory->out.spindleOverrideScale = 0.01;
-        *memory->out.spindleOverrideDoDecrease = true;
+        hal_set_real(memory->out.spindleOverrideScale, 0.01);
+        hal_set_bool(memory->out.spindleOverrideDoDecrease, true);
     }
 }
 // ----------------------------------------------------------------------
 void Hal::toggleFeedrateIncrease()
 {
-    if (*memory->out.feedOverrideIncrease)
+    if (hal_get_bool(memory->out.feedOverrideIncrease))
     {
-        *memory->out.feedOverrideIncrease = false;
+        hal_set_bool(memory->out.feedOverrideIncrease, false);
     }
     else
     {
-        *memory->out.feedOverrideScale = 0.01;
-        *memory->out.feedOverrideIncrease = true;
+        hal_set_real(memory->out.feedOverrideScale, 0.01);
+        hal_set_bool(memory->out.feedOverrideIncrease, true);
     }
 }
 // ----------------------------------------------------------------------
 void Hal::toggleFeedrateDecrease()
 {
-    if (*memory->out.feedOverrideDecrease)
+    if (hal_get_bool(memory->out.feedOverrideDecrease))
     {
-        *memory->out.feedOverrideDecrease = false;
+        hal_set_bool(memory->out.feedOverrideDecrease, false);
     }
     else
     {
-        *memory->out.feedOverrideScale = 0.01;
-        *memory->out.feedOverrideDecrease = true;
+        hal_set_real(memory->out.feedOverrideScale, 0.01);
+        hal_set_bool(memory->out.feedOverrideDecrease, true);
     }
 }
 }

--- a/src/hal/user_comps/xhc-whb04b-6/hal.h
+++ b/src/hal/user_comps/xhc-whb04b-6/hal.h
@@ -96,82 +96,82 @@ public:
     public:
 
         //! to be connected to \ref halui.flood.is-on
-        hal_bit_t  * floodIsOn{nullptr};
+        hal_bool_t floodIsOn{nullptr};
         //! to be connected to \ref halui.mist.is-on
-        hal_bit_t  * mistIsOn{nullptr};
+        hal_bool_t mistIsOn{nullptr};
 
         //! to be connected to \ref halui.axis.x.pos-feedback
-        hal_float_t* axisXPosition{nullptr};
+        hal_real_t axisXPosition{nullptr};
         //! to be connected to \ref halui.axis.y.pos-feedback
-        hal_float_t* axisYPosition{nullptr};
+        hal_real_t axisYPosition{nullptr};
         //! to be connected to \ref halui.axis.z.pos-feedback
-        hal_float_t* axisZPosition{nullptr};
+        hal_real_t axisZPosition{nullptr};
         //! to be connected to \ref halui.axis.a.pos-feedback
-        hal_float_t* axisAPosition{nullptr};
+        hal_real_t axisAPosition{nullptr};
         //! to be connected to \ref halui.axis.b.pos-feedback
-        hal_float_t* axisBPosition{nullptr};
+        hal_real_t axisBPosition{nullptr};
         //! to be connected to \ref halui.axis.c.pos-feedback
-        hal_float_t* axisCPosition{nullptr};
+        hal_real_t axisCPosition{nullptr};
 
         //! to be connected to \ref halui.axis.x.pos-relative
-        hal_float_t* axisXPositionRelative{nullptr};
+        hal_real_t axisXPositionRelative{nullptr};
         //! to be connected to \ref halui.axis.y.pos-relative
-        hal_float_t* axisYPositionRelative{nullptr};
+        hal_real_t axisYPositionRelative{nullptr};
         //! to be connected to \ref halui.axis.z.pos-relative
-        hal_float_t* axisZPositionRelative{nullptr};
+        hal_real_t axisZPositionRelative{nullptr};
         //! to be connected to \ref halui.axis.a.pos-relative
-        hal_float_t* axisAPositionRelative{nullptr};
+        hal_real_t axisAPositionRelative{nullptr};
         //! to be connected to \ref halui.axis.b.pos-relative
-        hal_float_t* axisBPositionRelative{nullptr};
+        hal_real_t axisBPositionRelative{nullptr};
         //! to be connected to \ref halui.axis.c.pos-relative
-        hal_float_t* axisCPositionRelative{nullptr};
+        hal_real_t axisCPositionRelative{nullptr};
 
         //! to be connected to \ref halui.spindle.is-on
-        hal_bit_t  * spindleIsOn{nullptr};
+        hal_bool_t spindleIsOn{nullptr};
         //! to be connected to \ref halui.spindle-override.value
-        hal_float_t* spindleOverrideValue{nullptr};
+        hal_real_t spindleOverrideValue{nullptr};
         //! To be connected to an encoded and correctly scaled value of an spindle feedback signal.
         //! See also \ref encoder and \ref scale.
-        hal_float_t* spindleSpeedCmd{nullptr};
+        hal_real_t spindleSpeedCmd{nullptr};
 
         //! to be connected to \ref halui.max-velocity.value
-        hal_float_t* feedOverrideMaxVel{nullptr};
+        hal_real_t feedOverrideMaxVel{nullptr};
         //! to be connected to \ref halui.feed-override.value
-        hal_float_t* feedOverrideValue{nullptr};
+        hal_real_t feedOverrideValue{nullptr};
 
         //! to be connected to \ref halui.program.is-running
-        hal_bit_t* isProgramRunning{nullptr};
+        hal_bool_t isProgramRunning{nullptr};
         //! to be connected to \ref halui.program.is-paused
-        hal_bit_t* isProgramPaused{nullptr};
+        hal_bool_t isProgramPaused{nullptr};
         //! to be connected to \ref halui.program.is-idle
-        hal_bit_t* isProgramIdle{nullptr};
+        hal_bool_t isProgramIdle{nullptr};
 
         //! to be connected to \ref halui.mode.is-auto
-        hal_bit_t* isModeAuto{nullptr};
+        hal_bool_t isModeAuto{nullptr};
         //! to be connected to \ref halui.mode.is-joint
-        hal_bit_t* isModeJoint{nullptr};
+        hal_bool_t isModeJoint{nullptr};
         //! to be connected to \ref halui.mode.is-manual
-        hal_bit_t* isModeManual{nullptr};
+        hal_bool_t isModeManual{nullptr};
         //! to be connected to \ref halui.mode.is-mdi
-        hal_bit_t* isModeMdi{nullptr};
+        hal_bool_t isModeMdi{nullptr};
         //! to be connected to \ref halui.mode.is-teleop
-        hal_bit_t* isModeTeleop{nullptr};
+        hal_bool_t isModeTeleop{nullptr};
 
 
         // If axis is not homed we need to ask Teleop mode but we need to bypass that if machine is homed
         // https://forum.linuxcnc.org/49-basic-configuration/40581-how-to-configure-a-xhc-whb04b-pendant
-        hal_bit_t* JointXisHomed{nullptr};
-        hal_bit_t* JointYisHomed{nullptr};
-        hal_bit_t* JointZisHomed{nullptr};
-        hal_bit_t* JointAisHomed{nullptr};
-        hal_bit_t* JointBisHomed{nullptr};
-        hal_bit_t* JointCisHomed{nullptr};
+        hal_bool_t JointXisHomed{nullptr};
+        hal_bool_t JointYisHomed{nullptr};
+        hal_bool_t JointZisHomed{nullptr};
+        hal_bool_t JointAisHomed{nullptr};
+        hal_bool_t JointBisHomed{nullptr};
+        hal_bool_t JointCisHomed{nullptr};
 
 
 
 
         //! to be connected to \ref halui.machine.is-on
-        hal_bit_t* isMachineOn{nullptr};
+        hal_bool_t isMachineOn{nullptr};
 
         In();
     };
@@ -179,149 +179,149 @@ public:
     struct Out
     {
     public:
-        hal_bit_t* button_pin[64] = {nullptr};
+        hal_bool_t button_pin[64] = {nullptr};
 
         //! to be connected to \ref halui.flood.off
-        hal_bit_t  * floodStop{nullptr};
+        hal_bool_t floodStop{nullptr};
         //! to be connected to \ref halui.flood.on
-        hal_bit_t  * floodStart{nullptr};
+        hal_bool_t floodStart{nullptr};
 
         //! to be connected to \ref halui.mist.off
-        hal_bit_t  * mistStop{nullptr};
+        hal_bool_t mistStop{nullptr};
         //! to be connected to \ref halui.mist.on
-        hal_bit_t  * mistStart{nullptr};
+        hal_bool_t mistStart{nullptr};
 
         //! to be connected to \ref axis.x.jog-counts
-        hal_s32_t* axisXJogCounts{nullptr};
+        hal_sint_t axisXJogCounts{nullptr};
         //! to be connected to \ref axis.y.jog-counts
-        hal_s32_t* axisYJogCounts{nullptr};
+        hal_sint_t axisYJogCounts{nullptr};
         //! to be connected to \ref axis.z.jog-counts
-        hal_s32_t* axisZJogCounts{nullptr};
+        hal_sint_t axisZJogCounts{nullptr};
         //! to be connected to \ref axis.a.jog-counts
-        hal_s32_t* axisAJogCounts{nullptr};
+        hal_sint_t axisAJogCounts{nullptr};
         //! to be connected to \ref axis.b.jog-counts
-        hal_s32_t* axisBJogCounts{nullptr};
+        hal_sint_t axisBJogCounts{nullptr};
         //! to be connected to \ref axis.c.jog-counts
-        hal_s32_t* axisCJogCounts{nullptr};
+        hal_sint_t axisCJogCounts{nullptr};
 
         //! to be connected to \ref axis.x.jog-enable
-        hal_bit_t* axisXJogEnable{nullptr};
+        hal_bool_t axisXJogEnable{nullptr};
         //! to be connected to \ref axis.y.jog-enable
-        hal_bit_t* axisYJogEnable{nullptr};
+        hal_bool_t axisYJogEnable{nullptr};
         //! to be connected to \ref axis.z.jog-enable
-        hal_bit_t* axisZJogEnable{nullptr};
+        hal_bool_t axisZJogEnable{nullptr};
         //! to be connected to \ref axis.a.jog-enable
-        hal_bit_t* axisAJogEnable{nullptr};
+        hal_bool_t axisAJogEnable{nullptr};
         //! to be connected to \ref axis.b.jog-enable
-        hal_bit_t* axisBJogEnable{nullptr};
+        hal_bool_t axisBJogEnable{nullptr};
         //! to be connected to \ref axis.c.jog-enable
-        hal_bit_t* axisCJogEnable{nullptr};
+        hal_bool_t axisCJogEnable{nullptr};
 
         //! to be connected to \ref axis.x.jog-scale
-        hal_float_t* axisXJogScale{nullptr};
+        hal_real_t axisXJogScale{nullptr};
         //! to be connected to \ref axis.y.jog-scale
-        hal_float_t* axisYJogScale{nullptr};
+        hal_real_t axisYJogScale{nullptr};
         //! to be connected to \ref axis.z.jog-scale
-        hal_float_t* axisZJogScale{nullptr};
+        hal_real_t axisZJogScale{nullptr};
         //! to be connected to \ref axis.a.jog-scale
-        hal_float_t* axisAJogScale{nullptr};
+        hal_real_t axisAJogScale{nullptr};
         //! to be connected to \ref axis.b.jog-scale
-        hal_float_t* axisBJogScale{nullptr};
+        hal_real_t axisBJogScale{nullptr};
         //! to be connected to \ref axis.c.jog-scale
-        hal_float_t* axisCJogScale{nullptr};
+        hal_real_t axisCJogScale{nullptr};
 
         //! to be connected to \ref axis.x.jog-vel-mode
-        hal_bit_t* axisXSetVelocityMode{nullptr};
+        hal_bool_t axisXSetVelocityMode{nullptr};
         //! to be connected to \ref axis.y.jog-vel-mode
-        hal_bit_t* axisYSetVelocityMode{nullptr};
+        hal_bool_t axisYSetVelocityMode{nullptr};
         //! to be connected to \ref axis.z.jog-vel-mode
-        hal_bit_t* axisZSetVelocityMode{nullptr};
+        hal_bool_t axisZSetVelocityMode{nullptr};
         //! to be connected to \ref axis.a.jog-vel-mode
-        hal_bit_t* axisASetVelocityMode{nullptr};
+        hal_bool_t axisASetVelocityMode{nullptr};
         //! to be connected to \ref axis.b.jog-vel-mode
-        hal_bit_t* axisBSetVelocityMode{nullptr};
+        hal_bool_t axisBSetVelocityMode{nullptr};
         //! to be connected to \ref axis.c.jog-vel-mode
-        hal_bit_t* axisCSetVelocityMode{nullptr};
+        hal_bool_t axisCSetVelocityMode{nullptr};
 
-        hal_bit_t* feedValueSelected_2{nullptr};
-        hal_bit_t* feedValueSelected_5{nullptr};
-        hal_bit_t* feedValueSelected_10{nullptr};
-        hal_bit_t* feedValueSelected_30{nullptr};
-        hal_bit_t* feedValueSelected_60{nullptr};
-        hal_bit_t* feedValueSelected_100{nullptr};
-        hal_bit_t* feedValueSelected_lead{nullptr};
-        hal_bit_t* feedValueSelected_mpg_feed{nullptr};
-        hal_bit_t* feedValueSelected_continuous{nullptr};
-        hal_bit_t* feedValueSelected_step{nullptr};
+        hal_bool_t feedValueSelected_2{nullptr};
+        hal_bool_t feedValueSelected_5{nullptr};
+        hal_bool_t feedValueSelected_10{nullptr};
+        hal_bool_t feedValueSelected_30{nullptr};
+        hal_bool_t feedValueSelected_60{nullptr};
+        hal_bool_t feedValueSelected_100{nullptr};
+        hal_bool_t feedValueSelected_lead{nullptr};
+        hal_bool_t feedValueSelected_mpg_feed{nullptr};
+        hal_bool_t feedValueSelected_continuous{nullptr};
+        hal_bool_t feedValueSelected_step{nullptr};
 
         //! to be connected to \ref  \ref halui.feed-override.scale
-        hal_float_t* feedOverrideScale{nullptr};
+        hal_real_t feedOverrideScale{nullptr};
         //! to be connected to \ref halui.feed-override.decrease
-        hal_bit_t  * feedOverrideDecrease{nullptr};
+        hal_bool_t feedOverrideDecrease{nullptr};
         //! to be connected to \ref halui.feed-override.increase
-        hal_bit_t  * feedOverrideIncrease{nullptr};
+        hal_bool_t feedOverrideIncrease{nullptr};
 
         //! to be connected to \ref halui.spindle.start
-        hal_bit_t* spindleStart{nullptr};
+        hal_bool_t spindleStart{nullptr};
         //! to be connected to \ref halui.spindle.stop
-        hal_bit_t* spindleStop{nullptr};
+        hal_bool_t spindleStop{nullptr};
         //! to be connected to \ref halui.spindle.forward
-        hal_bit_t* spindleDoRunForward{nullptr};
+        hal_bool_t spindleDoRunForward{nullptr};
         //! to be connected to \ref halui.spindle.reverse
-        hal_bit_t* spindleDoRunReverse{nullptr};
+        hal_bool_t spindleDoRunReverse{nullptr};
         //! to be connected to halui.spindle.decrease
-        hal_bit_t* spindleDoDecrease{nullptr};
+        hal_bool_t spindleDoDecrease{nullptr};
         //! to be connected to halui.spindle.increase
-        hal_bit_t* spindleDoIncrease{nullptr};
+        hal_bool_t spindleDoIncrease{nullptr};
         //! to be connected to halui.spindle-override.decrease
-        hal_bit_t* spindleOverrideDoDecrease{nullptr};
+        hal_bool_t spindleOverrideDoDecrease{nullptr};
         //! to be connected to halui.spindle-override.increase
-        hal_bit_t* spindleOverrideDoIncrease{nullptr};
+        hal_bool_t spindleOverrideDoIncrease{nullptr};
         //! to be connected to \ref  \ref halui.spindle-override.scale
-        hal_float_t* spindleOverrideScale{nullptr};
+        hal_real_t spindleOverrideScale{nullptr};
 
         //!to be connected to \ref halui.axis.N.select
-        hal_bit_t* axisXSelect{nullptr};
+        hal_bool_t axisXSelect{nullptr};
         //!to be connected to \ref halui.axis.N.select
-        hal_bit_t* axisYSelect{nullptr};
+        hal_bool_t axisYSelect{nullptr};
         //!to be connected to \ref halui.axis.N.select
-        hal_bit_t* axisZSelect{nullptr};
+        hal_bool_t axisZSelect{nullptr};
         //!to be connected to \ref halui.axis.N.select
-        hal_bit_t* axisASelect{nullptr};
+        hal_bool_t axisASelect{nullptr};
         //!to be connected to \ref halui.axis.N.select
-        hal_bit_t* axisBSelect{nullptr};
+        hal_bool_t axisBSelect{nullptr};
         //!to be connected to \ref halui.axis.N.select
-        hal_bit_t* axisCSelect{nullptr};
+        hal_bool_t axisCSelect{nullptr};
 
         //! reflects the pendant's idle state
-        hal_bit_t* isPendantSleeping{nullptr};
+        hal_bool_t isPendantSleeping{nullptr};
         //! reflects pendant's connectivity
-        hal_bit_t* isPendantConnected{nullptr};
+        hal_bool_t isPendantConnected{nullptr};
 
         //! to be connected to \ref halui.program.run
-        hal_bit_t* doRunProgram{nullptr};
+        hal_bool_t doRunProgram{nullptr};
         //! to be connected to \ref halui.program.pause
-        hal_bit_t* doPauseProgram{nullptr};
+        hal_bool_t doPauseProgram{nullptr};
         //! to be connected to \ref halui.program.resume
-        hal_bit_t* doResumeProgram{nullptr};
+        hal_bool_t doResumeProgram{nullptr};
         //! to be connected to \ref halui.program.stop
-        hal_bit_t* doStopProgram{nullptr};
+        hal_bool_t doStopProgram{nullptr};
 
         //! to be connected to \ref halui.mode.auto
-        hal_bit_t* doModeAuto{nullptr};
+        hal_bool_t doModeAuto{nullptr};
         //! to be connected to \ref halui.mode.joint
-        hal_bit_t* doModeJoint{nullptr};
+        hal_bool_t doModeJoint{nullptr};
         //! to be connected to \ref halui.mode.manual
-        hal_bit_t* doModeManual{nullptr};
+        hal_bool_t doModeManual{nullptr};
         //! to be connected to \ref halui.mode.mdi
-        hal_bit_t* doModeMdi{nullptr};
+        hal_bool_t doModeMdi{nullptr};
         //! to be connected to \ref halui.mode.teleop
-        hal_bit_t* doModeTeleop{nullptr};
+        hal_bool_t doModeTeleop{nullptr};
 
         //! to be connected to \ref halui.machine.on
-        hal_bit_t* doMachineOn{nullptr};
+        hal_bool_t doMachineOn{nullptr};
         //! to be connected to \ref halui.machine.off
-        hal_bit_t* doMachineOff{nullptr};
+        hal_bool_t doMachineOff{nullptr};
 
         Out();
     };
@@ -379,7 +379,7 @@ public:
 
     //! Sets the new feed rate. The step mode must be set accordingly.
     //! \param feedRate the new feed rate independent of step mode
-    void setStepSize(const real_t feedRate);
+    void setStepSize(const rtapi_real feedRate);
     //! If lead is active.
     void setLead();
     //! Sets the hal state of the respective pin (reset). Usually called in case the reset
@@ -422,13 +422,13 @@ public:
     void setFeedMinus(bool enabled);
     //! Returns the current Max Velocity value.
     //! \sa Hal::In::feedOverrideMaxVel
-    real_t getFeedOverrideMaxVel() const;
+    rtapi_real getFeedOverrideMaxVel() const;
     //! Returns the current feed override value.
     //! \sa Hal::In::feedOverrideValue
     //! \return the current feed override value v: 0 <= v <= 1
-    real_t getFeedOverrideValue() const;
+    rtapi_real getFeedOverrideValue() const;
     //! \xrefitem HalMemory::Out::feedOverrideScale setter
-    void setFeedOverrideScale(real_t scale);
+    void setFeedOverrideScale(rtapi_real scale);
 
     //! Propagates the feed value 0.001 selection state to hal.
     //! \sa Hal::Out::feedValueSelected_2
@@ -461,13 +461,13 @@ public:
 
     //! Returns the spindle speed.
     //! \return the spindle speed in rounds per second
-    real_t getspindleSpeedCmd() const;
-    real_t getspindleSpeedChangeIncrease() const;
-    real_t getspindleSpeedChangeDecrease() const;
+    rtapi_real getspindleSpeedCmd() const;
+    rtapi_real getspindleSpeedChangeIncrease() const;
+    rtapi_real getspindleSpeedChangeDecrease() const;
     //! Returns the current spindle override value.
     //! \sa Hal::In::spindleOverrideValue
     //! \return the current spindle override value v: 0 <= v <= 1
-    real_t getSpindleOverrideValue() const;
+    rtapi_real getSpindleOverrideValue() const;
     //! \sa setSpindleOverridePlus(bool, size_t)
     void setSpindleOverridePlus(bool enabled);
     //! \sa setSpindleOverrideMinus(bool, size_t)
@@ -549,22 +549,22 @@ public:
     //! waits until a given pin is set to a requested state 
     //! \param state requested state
     //! \param pin requested pin to compare with
-    void checkState(bool state, hal_bit_t *pin);
+    void checkState(bool state, hal_bool_t pin);
 
     //! Returns the axis position.
     //! \param absolute true absolute, false relative
     //! \return the absolute or relative position in machine units
-    real_t getAxisXPosition(bool absolute) const;
+    rtapi_real getAxisXPosition(bool absolute) const;
     //! \xrefitem getAxisXPosition(bool)
-    real_t getAxisYPosition(bool absolute) const;
+    rtapi_real getAxisYPosition(bool absolute) const;
     //! \xrefitem getAxisXPosition(bool)
-    real_t getAxisZPosition(bool absolute) const;
+    rtapi_real getAxisZPosition(bool absolute) const;
     //! \xrefitem getAxisXPosition(bool)
-    real_t getAxisAPosition(bool absolute) const;
+    rtapi_real getAxisAPosition(bool absolute) const;
     //! \xrefitem getAxisXPosition(bool)
-    real_t getAxisBPosition(bool absolute) const;
+    rtapi_real getAxisBPosition(bool absolute) const;
     //! \xrefitem getAxisXPosition(bool)
-    real_t getAxisCPosition(bool absolute) const;
+    rtapi_real getAxisCPosition(bool absolute) const;
 
 
 private:
@@ -581,26 +581,26 @@ private:
     bool mIsSpindleDirectionForward{true};
     Profiles::HalRequestProfile mHalRequestProfile;
 
-    //! //! Allocates new hal_bit_t pin according to \ref mIsSimulationMode. If \ref mIsSimulationMode then
-    //! mallocs memory, hal_pin_bit_new allocation otherwise.
+    //! //! Allocates new hal_bool_t pin according to \ref mIsSimulationMode. If \ref mIsSimulationMode then
+    //! mallocs memory, hal_pin_new_bool allocation otherwise.
     //! \param pin_name the pin name when registered to hal
     //! \param ptr will point to the allocated memory
     //! \param s size in bytes
     //! \return != 0 on error, 0 otherwise
     int newSimulatedHalPin(char* pin_name, void** ptr, int s);
-    //! \sa  newBitHalPin(hal_pin_dir_t, hal_bit_t**, int, const char*, ...)
-    int newHalFloat(hal_pin_dir_t direction, hal_float_t** ptr, int componentId, const char* fmt, ...);
-    //! \sa  newBitHalPin(hal_pin_dir_t, hal_bit_t**, int, const char*, ...)
-    int newHalSigned32(hal_pin_dir_t direction, hal_s32_t** ptr, int componentId, const char* fmt, ...);
-    //! \sa  newBitHalPin(hal_pin_dir_t, hal_bit_t**, int, const char*, ...)
-    int newHalUnsigned32(hal_pin_dir_t direction, hal_u32_t** ptr, int componentId, const char* fmt, ...);
+    //! \sa int newHalFloat(hal_pin_dir_t direction, hal_real_t* ptr, int componentId, const char* fmt, ...);
+    int newHalFloat(hal_pin_dir_t direction, hal_real_t* ptr, int componentId, const char* fmt, ...);
+    //! \sa int newHalSigned32(hal_pin_dir_t direction, hal_sint_t* ptr, int componentId, const char* fmt, ...);
+    int newHalSigned32(hal_pin_dir_t direction, hal_sint_t* ptr, int componentId, const char* fmt, ...);
+    //! \sa int newHalUnsigned32(hal_pin_dir_t direction, hal_sint_t* ptr, int componentId, const char* fmt, ...);
+    int newHalUnsigned32(hal_pin_dir_t direction, hal_uint_t* ptr, int componentId, const char* fmt, ...);
     //! \param direction module input or output
     //! \param ptr will point to the allocated memory
     //! \param componentId hal id
     //! \param fmt the pin name when registered to hal
     //! \param ... va args
     //! \return != 0 on error, 0 otherwise
-    int newHalBit(hal_pin_dir_t direction, hal_bit_t** ptr, int componentId, const char* fmt, ...);
+    int newHalBit(hal_pin_dir_t direction, hal_bool_t* ptr, int componentId, const char* fmt, ...);
     //! allocates new hal pin according to \ref mIsSimulationMode
     //! \param pin pointer reference to the memory to be fred
     //! \post pin == nullptr
@@ -619,7 +619,7 @@ private:
     //! \sa requestManualMode(bool)
     bool requestAutoMode(bool isRisingEdge);
     //! Requests manual mode if in MDI mode. Skips request if in AUTO mode.
-    //! \sa requestMode(bool, hal_bit_t*, hal_bit_t*)
+    //! \sa requestMode(bool, hal_bool_t, hal_bool_t)
     //! \return true if machine has selected the mode, false otherwise
     bool requestManualMode(bool isRisingEdge);
     //! \sa requestManualMode(bool)
@@ -637,7 +637,7 @@ private:
     //! \param timeout_ms delay in [ms] in between condition is checks
     //! \param max_timeouts maximum number of checks
     //! \return true if condition was met, false otherwise
-    bool waitForRequestedMode(volatile hal_bit_t* condition);
+    bool waitForRequestedMode(hal_bool_t condition);
 
     //! Requests machine mode such as auto, mdi, manual. When toggling it introduces hold and space delay.
     //! \sa mModesRequestProfile
@@ -645,7 +645,7 @@ private:
     //! \param modeFeedbackPin the (input) pin reflecting if the mode is set
     //! \return on rising edge: true if the machine has selected or is in the desired mode, false otherwise;
     //! on falling edge: false
-    bool requestMode(bool isRisingEdge, hal_bit_t* requestPin, hal_bit_t* modeFeedbackPin);
+    bool requestMode(bool isRisingEdge, hal_bool_t requestPin, hal_bool_t modeFeedbackPin);
 };
 }
 #endif


### PR DESCRIPTION
The XHC pendants are the last of the user components to be converted to getter/setter.

There are no parameters in the code, so conversion should be straight forward.

The one special thing is that there is a simulation mode for the pins in both pendants. Data is not in/from HAL shared memory, but is allocated in normal memory, when in simulation mode. This still works because the getter/setter code is oblivious to the memory it actually dereferences and just uses the pointer. The allocated fake pin target chunks are all sized properly and there is an extra guard before allocation.