### PR TITLE
hal: Update rs274 interpreter hal data fetch to query API

### DIFF
--- a/src/emc/rs274ngc/interp_namedparams.cc
+++ b/src/emc/rs274ngc/interp_namedparams.cc
@@ -243,74 +243,97 @@ int Interp::fetch_ini_param( const char *nameBuf, int *status, double *value)
 // if the variable is of the form '_hal[hal_name]', then treat it as
 // a HAL pin, signal or param. Lookup value, convert to float, and export as global and read-only.
 // do not cache.
-// the shortest possible INI variable is '_hal[x]' or 7 chars long .
+// the shortest possible HAL variable is '_hal[x]' or 7 chars long .
 int Interp::fetch_hal_param( const char *nameBuf, int *status, double *value)
 {
-    static int comp_id;
     int retval;
-    hal_type_t type = HAL_TYPE_UNINITIALIZED;
-    hal_data_u* ptr;
-    bool conn;
-    char hal_name[HAL_NAME_LEN];
+    int n = strlen(nameBuf);
 
     *status = 0;
-    if (!comp_id) {
-	char hal_comp[HAL_NAME_LEN];
-	snprintf(hal_comp, sizeof(hal_comp),"interp%d",getpid());
-	comp_id = hal_init(hal_comp); // manpage says: NULL ok - which fails miserably
-	CHKS(comp_id < 0,_("fetch_hal_param: hal_init(%s): %d"), hal_comp,comp_id);
-	CHKS((retval = hal_ready(comp_id)), _("fetch_hal_param: hal_ready(): %d"),retval);
+
+    if(n < 7) {
+        return INTERP_OK;
     }
-    char *s;
-    int n = strlen(nameBuf);
-    if ((n > 6) &&
-	((s = (char *) strchr(&nameBuf[5],']')) != NULL)) {
 
-	int closeBracket = s - nameBuf;
+    // Make sure we can query pins/params/signals
+    // Calling hal_lib_init() here would make it impossible for us to determine
+    // when to call hal_lib_exit() to satisfy the init/exit reference counting.
+    // Neither do we want to create a temporary component. The overhead is
+    // huge. An alternative would be wrapping this code in hal_lib_init() and
+    // hal_lib_exit(), but that also creates a large overhead.
+    //
+    // The old code just created a component (using a persistent static comp_id
+    // check in this function), but that never gets cleaned up, which is also
+    // bad. If the change should result in a program to fail the below test,
+    // then we should fix the program and not hack this library.
+    // Now it is the responsibility of the program using the rs274ngc library
+    // to attach to HAL shared memory before running programs that use this.
+    retval = hal_is_init();
+    CHKS(retval == 0, "fetch_hal_param: HAL is not initialized (hal_is_init() returned zero)");
 
-	strncpy(hal_name, &nameBuf[5], closeBracket);
-	hal_name[closeBracket - 5] = '\0';
-	if (nameBuf[closeBracket + 1]) {
-	    logOword("%s: trailing garbage after closing bracket", hal_name);
-	    *status = 0;
-	    ERS("%s: trailing garbage after closing bracket", nameBuf);
-	}
-	// the result of these lookups could be cached in the parameter struct, but I'm not sure
-	// this is a good idea - a removed pin/signal will not be noticed
-
-	// I dont think that's needed - no change in pins/sigs/params
-	// rtapi_mutex_get(&(hal_data->mutex)); 
-        // rtapi_mutex_give(&(hal_data->mutex));
-
-        if (hal_get_pin_value_by_name(hal_name, &type, &ptr, &conn) == 0) {
-            if (!conn)
-		logOword("%s: no signal connected", hal_name);
-	    goto assign;
-	}
-        if (hal_get_signal_value_by_name(hal_name, &type, &ptr, &conn) == 0) {
-	    if (!conn)
-		logOword("%s: signal has no writer", hal_name);
-	    goto assign;
-	}
-        if (hal_get_param_value_by_name(hal_name, &type, &ptr) == 0) {
-	    goto assign;
-	}
-	*status = 0;
-	ERS("Named hal parameter #<%s> not found", nameBuf);
+    hal_type_t type = HAL_TYPE_UNINITIALIZED;
+    hal_query_value_u qval;
+    std::string hal_name = nameBuf + 5;  // skip the '_hal[' part
+    size_t i = hal_name.find(']');
+    if(std::string::npos == i) {
+        ERS(_("_hal expansion missing ']'"));
+        return INTERP_OK;
     }
+    if(hal_name.size()-1 > i) {
+        logOword("%s: trailing garbage after closing bracket", hal_name.c_str());
+        *status = 0;
+        ERS(_("%s: trailing garbage after closing bracket"), nameBuf);
+    }
+    hal_name.erase(i); // Remove everything from ']'and after
+
+    // Retrieve the active value from the pin/signal/param (in that order)
+    hal_query_t q = {};
+    q.name = hal_name.c_str();
+    q.qtype = HAL_QTYPE_PIN;
+    if(0 == hal_get_p(&q, NULL, NULL)) {
+        // FIXME: It is not always logical to complain on an pin that is
+        // not attached to a signal. HAL_OUT pins should always give a real
+        // result. HAL_IO pins could be fine, but that depends on whether
+        // there has been written proper data on it yet.
+        if(!q.pp.signal)
+            logOword("%s: no signal connected", hal_name.c_str());
+        qval = q.pp.value;
+        type = q.pp.type;
+        goto assign;
+    }
+    q = {};
+    q.name = hal_name.c_str();
+    if(0 == hal_get_s(&q, NULL, NULL)) {
+        if(q.sig.writers <= 0)
+            logOword("%s: signal has no writer", hal_name.c_str());
+        qval = q.sig.value;
+        type = q.sig.type;
+        goto assign;
+    }
+    q = {};
+    q.name = hal_name.c_str();
+    q.qtype = HAL_QTYPE_PARAM;
+    if(0 == hal_get_p(&q, NULL, NULL)) {
+        qval = q.pp.value;
+        type = q.pp.type;
+        goto assign;
+    }
+    *status = 0;
+    ERS(_("Named hal parameter #<%s> not found"), nameBuf);
+
     return INTERP_OK;
 
     assign:
     switch (type) {
-    case HAL_BIT: *value = (double) (ptr->b); break;
-    case HAL_U32: *value = (double) (ptr->u); break;
-    case HAL_S32: *value = (double) (ptr->s); break;
-    case HAL_U64: *value = (double) (ptr->lu); break;
-    case HAL_S64: *value = (double) (ptr->ls); break;
-    case HAL_FLOAT: *value = (double) (ptr->f); break;
+    case HAL_BOOL: *value = (double)qval.b; break;
+    case HAL_U32:  *value = (double)qval.u; break;
+    case HAL_S32:  *value = (double)qval.s; break;
+    case HAL_UINT: *value = (double)qval.u; break;
+    case HAL_SINT: *value = (double)qval.s; break;
+    case HAL_REAL: *value = (double)qval.r; break;
     default: return -1;
     }
-    logOword("%s: value=%f", hal_name, *value);
+    logOword("%s: value=%f", hal_name.c_str(), *value);
     *status = 1;
     return INTERP_OK; 
 }


### PR DESCRIPTION
The GCode interpreter can fetch HAL data using the `_hal[name]` tag. This PR updates that to the query API.

There is one functional change. The old code would create a temporary/fake component with ID `interp<pid>`. This is no longer the case because this component was never cleaned up. The component ID only existed inside the `fetch_hal_param()` function as a static variable, so it could not be removed.

The new code does not create a component. It checks whether HAL has been initialized (accessible) and fails if it was not initialized. Programs linking to librs274.so should do their own HAL init/exit and not leave it to the library that has no control over program exit. If this should be a problem, then those programs should be fixed.

There is also a FIXME note on the inconsistency of logging a message requiring a signal attached to a pin, even when the pin is a HAL_OUT. Both HAL_IO and HAL_IN without a signal could have some potential problem, but still, it should always give a valid result (especially when halcmd set it).

BTW, there does not seem to be a test for this code. Maybe we should write one and see whether it is actually functional in practice.