### PR TITLE
hal: Migrate homecomp is_module pin declaration to bool

### DIFF
--- a/src/hal/components/homecomp.comp
+++ b/src/hal/components/homecomp.comp
@@ -51,7 +51,7 @@ HOMEMOD=user_homecomp
 https://github.com/LinuxCNC/linuxcnc/blob/BRANCHNAME/src/hal/components/homecomp.comp
 """;
 
-pin out bit is_module=1; //one pin is required to use halcompile)
+pin out bool is_module=1; //one pin is required to use halcompile)
 
 license "GPL";
 author "Dewey Garrett";


### PR DESCRIPTION
One leftover from the getter/setter migration: homecomp.comp still declares its dummy `is_module` pin with the legacy `bit` type, while the rest of the component was migrated in f107cd307a (#4296).

Found with a tree-wide `halcompupdate --check` sweep (from #4256) against current master; this was the only genuine declaration leftover among all in-tree .comp files not already covered by open migration PRs.

Change: `pin out bit is_module=1` => `pin out bool is_module=1`. Builds clean.
