### PR TITLE
hal: Update kernel-only components (RTAI) to getter/setter

### DIFF
--- a/src/hal/drivers/hal_ax5214h.c
+++ b/src/hal/drivers/hal_ax5214h.c
@@ -120,10 +120,10 @@ RTAPI_MP_STRING(cfg, "config string");
 */
 
 typedef struct {
-    hal_bit_t *data;		/* basic pin for input or output */
+    hal_bool_t data;		/* basic pin for input or output */
     union {
-	hal_bit_t *not;		/* pin for inverted data (input only) */
-	hal_bit_t invert;	/* param for inversion (output only) */
+	hal_bool_t not;		/* pin for inverted data (input only) */
+	hal_bool_t invert;	/* param for inversion (output only) */
 	} io;
 } io_pin_t;
 
@@ -295,12 +295,12 @@ static void split_input(unsigned char data, io_pin_t *dest, int num)
     for (b = 0 ; b < num ; b++ ) {
 	if ( data & mask ) {
 	    /* input high, which means FALSE (active low) */
-	    *(dest->data) = 0;
-	    *(dest->io.not) = 1;
+	    hal_set_bool(dest->data, 0);
+	    hal_set_bool(dest->io.not, 1);
 	} else {
 	    /* input low, which means TRUE */
-	    *(dest->data) = 1;
-	    *(dest->io.not) = 0;
+	    hal_set_bool(dest->data, 1);
+	    hal_set_bool(dest->io.not, 0);
 	}
 	mask <<= 1;
 	dest++;
@@ -361,12 +361,12 @@ unsigned char build_output(io_pin_t *src, int num)
     /* assemble output byte for data port from 'num' source variables */
     for (b = 0; b < num; b++) {
 	/* get the data, add to output byte */
-	if ( *(src->data) ) {
-	    if ( !(src->io.invert) ) {
+	if ( hal_get_bool(src->data) ) {
+	    if ( !hal_get_bool(src->io.invert) ) {
 		data |= mask;
 	    }
 	} else {
-	    if ( (src->io.invert) ) {
+	    if ( hal_get_bool(src->io.invert) ) {
 		data |= mask;
 	    }
 	}
@@ -644,17 +644,14 @@ static int export_input_pin(int boardnum, int pinnum, io_pin_t *pin)
     int retval;
 
     /* export read only HAL pin for input data */
-    retval = hal_pin_bit_newf(HAL_OUT, &(pin->data), comp_id,
+    retval = hal_pin_new_bool(comp_id, HAL_OUT, &(pin->data), 0,
 			      "ax5214h.%d.in-%02d", boardnum, pinnum);
     if (retval != 0) {
 	return retval;
     }
     /* export additional pin for inverted input data */
-    retval = hal_pin_bit_newf(HAL_OUT, &(pin->io.not), comp_id,
+    retval = hal_pin_new_bool(comp_id, HAL_OUT, &(pin->io.not), 1,
 			      "ax5214h.%d.in-%02d-not", boardnum, pinnum);
-    /* initialize HAL pins */
-    *(pin->data) = 0;
-    *(pin->io.not) = 1;
     return retval;
 }
 
@@ -663,16 +660,13 @@ static int export_output_pin(int boardnum, int pinnum, io_pin_t *pin)
     int retval;
 
     /* export read only HAL pin for output data */
-    retval = hal_pin_bit_newf(HAL_IN, &(pin->data), comp_id,
+    retval = hal_pin_new_bool(comp_id, HAL_IN, &(pin->data), 0,
 			      "ax5214h.%d.out-%02d", boardnum, pinnum);
     if (retval != 0) {
 	return retval;
     }
     /* export parameter for polarity */
-    retval = hal_param_bit_newf(HAL_RW, &(pin->io.invert), comp_id,
+    retval = hal_param_new_bool(comp_id, HAL_RW, &(pin->io.invert), 0,
 				"ax5214h.%d.out-%02d-invert", boardnum, pinnum);
-    /* initialize HAL pin and param */
-    *(pin->data) = 0;
-    pin->io.invert = 0;
     return retval;
 }

--- a/src/hal/drivers/hal_motenc.c
+++ b/src/hal/drivers/hal_motenc.c
@@ -146,17 +146,17 @@ MODULE_LICENSE("GPL");
 
 typedef struct {
     // Pins.
-    hal_s32_t				*pCount;	// Captured binary count value.
-    hal_float_t				*pPosition;	// Scaled position (floating point).
-    hal_bit_t				*pIndex;	// Current state of index.
-    hal_bit_t				*pIndexEnable;	// Setting this pin causes the count
+    hal_sint_t				pCount;	// Captured binary count value.
+    hal_real_t				pPosition;	// Scaled position (floating point).
+    hal_bool_t				pIndex;	// Current state of index.
+    hal_bool_t				pIndexEnable;	// Setting this pin causes the count
 							// to be cleared on the next index pulse.
 							// Use this feature at your own risk as the PID loop
 							// may get upset. This pin is self clearing.
-    hal_bit_t				*pReset;	// Setting this pin causes Count to be reset.
+    hal_bool_t				pReset;	// Setting this pin causes Count to be reset.
 
     // Parameters.
-    hal_float_t				scale;		// Scaling factor for position.
+    hal_real_t				scale;		// Scaling factor for position.
 
     // Private data.
     double				oldScale;	// Stored scale value.
@@ -165,44 +165,44 @@ typedef struct {
 
 typedef struct {
     // Pins.
-    hal_float_t				*pValue;	// Desired value.
+    hal_real_t				pValue;	// Desired value.
 
     // Parameters.
-    hal_float_t				offset;
-    hal_float_t				gain;
+    hal_real_t				offset;
+    hal_real_t				gain;
 } DacPinsParams;
 
 typedef struct {
     // Pins.
-    hal_float_t				*pValue;	// Converted value.
+    hal_real_t				pValue;	// Converted value.
 
     // Parameters.
-    hal_float_t				offset;
-    hal_float_t				gain;
+    hal_real_t				offset;
+    hal_real_t				gain;
 } AdcPinsParams;
 
 typedef struct {
     // Pins.
-    hal_bit_t				*pValue;
-    hal_bit_t				*pValueNot;
+    hal_bool_t				pValue;
+    hal_bool_t				pValueNot;
 } DigitalInPinsParams;
 
 typedef struct {
     // Pins.
-    hal_bit_t				*pValue;
+    hal_bool_t				pValue;
 
     // Parameters.
-    hal_bit_t				invert;
+    hal_bool_t				invert;
 } DigitalOutPinsParams;
 
 typedef struct {
     // Pins.
-    hal_bit_t				*pEstopIn;
-    hal_bit_t				*pEstopInNot;
-    hal_bit_t				*pWatchdogReset;// This pin is self clearing.
+    hal_bool_t				pEstopIn;
+    hal_bool_t				pEstopInNot;
+    hal_bool_t				pWatchdogReset;// This pin is self clearing.
 
     // Parameters.
-    hal_u32_t				watchdogControl;
+    hal_uint_t				watchdogControl;
 } MiscPinsParams;
 
 typedef struct {
@@ -213,7 +213,7 @@ typedef struct {
     int					boardID;
     int					numFpga;
     int					adcState;
-    hal_u32_t				watchdogControl;// Shadow HW register.
+    rtapi_u32				watchdogControl;// Shadow HW register.
 
     // Exported to HAL.
     EncoderPinsParams			encoder[MOTENC_NUM_ENCODER_CHANNELS];
@@ -490,40 +490,34 @@ Device_ExportEncoderPinsParametersFunctions(Device *this, int componentId, int b
     halError = 0;
     for(channel = 0; channel < this->numFpga * MOTENC_FPGA_NUM_ENCODER_CHANNELS; channel++){
 	// Pins.
-	if((halError = hal_pin_s32_newf(HAL_OUT, &(this->encoder[channel].pCount),
-	  componentId, "motenc.%d.enc-%02d-count", boardId, channel)) != 0)
+	if((halError = hal_pin_new_si32(componentId, HAL_OUT, &(this->encoder[channel].pCount),
+	  0, "motenc.%d.enc-%02d-count", boardId, channel)) != 0)
 	    break;
 
-	if((halError = hal_pin_float_newf(HAL_OUT, &(this->encoder[channel].pPosition),
-	  componentId, "motenc.%d.enc-%02d-position", boardId, channel)) != 0)
+	if((halError = hal_pin_new_real(componentId, HAL_OUT, &(this->encoder[channel].pPosition),
+	  0.0, "motenc.%d.enc-%02d-position", boardId, channel)) != 0)
 	    break;
 
-	if((halError = hal_pin_bit_newf(HAL_OUT, &(this->encoder[channel].pIndex),
-	  componentId, "motenc.%d.enc-%02d-index", boardId, channel)) != 0)
+	if((halError = hal_pin_new_bool(componentId, HAL_OUT, &(this->encoder[channel].pIndex),
+	  0, "motenc.%d.enc-%02d-index", boardId, channel)) != 0)
 	    break;
 
-	if((halError = hal_pin_bit_newf(HAL_IO, &(this->encoder[channel].pIndexEnable),
-	  componentId, "motenc.%d.enc-%02d-index-enable", boardId, channel)) != 0)
+	if((halError = hal_pin_new_bool(componentId, HAL_IO, &(this->encoder[channel].pIndexEnable),
+	  0, "motenc.%d.enc-%02d-index-enable", boardId, channel)) != 0)
 	    break;
 
-	if((halError = hal_pin_bit_newf(HAL_IN, &(this->encoder[channel].pReset),
-	  componentId, "motenc.%d.enc-%02d-reset", boardId, channel)) != 0)
+	if((halError = hal_pin_new_bool(componentId, HAL_IN, &(this->encoder[channel].pReset),
+	  0, "motenc.%d.enc-%02d-reset", boardId, channel)) != 0)
 	    break;
 
 	// Parameters.
-	if((halError = hal_param_float_newf(HAL_RW, &(this->encoder[channel].scale),
-	  componentId, "motenc.%d.enc-%02d-scale", boardId, channel)) != 0)
+	if((halError = hal_param_new_real(componentId, HAL_RW, &(this->encoder[channel].scale),
+	  1.0, "motenc.%d.enc-%02d-scale", boardId, channel)) != 0)
 	    break;
 
 	// Init encoder.
-	*(this->encoder[channel].pCount) = 0;
-	*(this->encoder[channel].pPosition) = 0.0;
-	*(this->encoder[channel].pIndex) = 0;
-	*(this->encoder[channel].pIndexEnable) = 0;
-	*(this->encoder[channel].pReset) = 0;
-	this->encoder[channel].scale = 1.0;
 	this->encoder[channel].oldScale = 1.0;
-	this->encoder[channel].scaleRecip = 1.0 / this->encoder[channel].scale;
+	this->encoder[channel].scaleRecip = 1.0 / hal_get_real(this->encoder[channel].scale);
     }
 
     // Export functions.
@@ -549,23 +543,18 @@ Device_ExportDacPinsParametersFunctions(Device *this, int componentId, int board
     halError = 0;
     for(channel = 0; channel < MOTENC_NUM_DAC_CHANNELS; channel++){
 	// Pins.
-	if((halError = hal_pin_float_newf(HAL_IN, &(this->dac[channel].pValue),
-	  componentId, "motenc.%d.dac-%02d-value", boardId, channel)) != 0)
+	if((halError = hal_pin_new_real(componentId, HAL_IN, &(this->dac[channel].pValue),
+	  0.0, "motenc.%d.dac-%02d-value", boardId, channel)) != 0)
 	    break;
 
 	// Parameters.
-	if((halError = hal_param_float_newf(HAL_RW, &(this->dac[channel].offset),
-	  componentId, "motenc.%d.dac-%02d-offset", boardId, channel)) != 0)
+	if((halError = hal_param_new_real(componentId, HAL_RW, &(this->dac[channel].offset),
+	  0.0, "motenc.%d.dac-%02d-offset", boardId, channel)) != 0)
 	    break;
 
-	if((halError = hal_param_float_newf(HAL_RW, &(this->dac[channel].gain),
-	  componentId, "motenc.%d.dac-%02d-gain", boardId, channel)) != 0)
+	if((halError = hal_param_new_real(componentId, HAL_RW, &(this->dac[channel].gain),
+	  1.0, "motenc.%d.dac-%02d-gain", boardId, channel)) != 0)
 	    break;
-
-	// Init DAC.
-	*(this->dac[channel].pValue) = 0.0;
-	this->dac[channel].offset = 0.0;
-	this->dac[channel].gain = 1.0;
     }
 
     // Export functions.
@@ -591,23 +580,18 @@ Device_ExportAdcPinsParametersFunctions(Device *this, int componentId, int board
     halError = 0;
     for(channel = 0; channel < MOTENC_NUM_ADC_CHANNELS; channel++){
 	// Pins.
-	if((halError = hal_pin_float_newf(HAL_OUT, &(this->adc[channel].pValue),
-	  componentId, "motenc.%d.adc-%02d-value", boardId, channel)) != 0)
+	if((halError = hal_pin_new_real(componentId, HAL_OUT, &(this->adc[channel].pValue),
+	  0.0, "motenc.%d.adc-%02d-value", boardId, channel)) != 0)
 	    break;
 
 	// Parameters.
-	if((halError = hal_param_float_newf(HAL_RW, &(this->adc[channel].offset),
-	  componentId, "motenc.%d.adc-%02d-offset", boardId, channel)) != 0)
+	if((halError = hal_param_new_real(componentId, HAL_RW, &(this->adc[channel].offset),
+	  0.0, "motenc.%d.adc-%02d-offset", boardId, channel)) != 0)
 	    break;
 
-	if((halError = hal_param_float_newf(HAL_RW, &(this->adc[channel].gain),
-	  componentId, "motenc.%d.adc-%02d-gain", boardId, channel)) != 0)
+	if((halError = hal_param_new_real(componentId, HAL_RW, &(this->adc[channel].gain),
+	  1.0, "motenc.%d.adc-%02d-gain", boardId, channel)) != 0)
 	    break;
-
-	// Init ADC.
-	*(this->adc[channel].pValue) = 0.0;
-	this->adc[channel].offset = 0.0;
-	this->adc[channel].gain = 1.0;
     }
 
     // Export functions.
@@ -633,17 +617,13 @@ Device_ExportDigitalInPinsParametersFunctions(Device *this, int componentId, int
     halError = 0;
     for(channel = 0; channel < (this->numFpga * MOTENC_FPGA_NUM_DIGITAL_INPUTS - 4); channel++){
 	// Pins.
-	if((halError = hal_pin_bit_newf(HAL_OUT, &(this->in[channel].pValue),
-	  componentId, "motenc.%d.in-%02d", boardId, channel)) != 0)
+	if((halError = hal_pin_new_bool(componentId, HAL_OUT, &(this->in[channel].pValue),
+	  0, "motenc.%d.in-%02d", boardId, channel)) != 0)
 	    break;
 
-	if((halError = hal_pin_bit_newf(HAL_OUT, &(this->in[channel].pValueNot),
-	  componentId, "motenc.%d.in-%02d-not", boardId, channel)) != 0)
+	if((halError = hal_pin_new_bool(componentId, HAL_OUT, &(this->in[channel].pValueNot),
+	  1, "motenc.%d.in-%02d-not", boardId, channel)) != 0)
 	    break;
-
-	// Init pin.
-	*(this->in[channel].pValue) = 0;
-	*(this->in[channel].pValueNot) = 1;
     }
 
     // Export functions.
@@ -669,18 +649,14 @@ Device_ExportDigitalOutPinsParametersFunctions(Device *this, int componentId, in
     halError = 0;
     for(channel = 0; channel < this->numFpga * MOTENC_FPGA_NUM_DIGITAL_OUTPUTS; channel++){
 	// Pins.
-	if((halError = hal_pin_bit_newf(HAL_IN, &(this->out[channel].pValue),
-	  componentId, "motenc.%d.out-%02d", boardId, channel)) != 0)
+	if((halError = hal_pin_new_bool(componentId, HAL_IN, &(this->out[channel].pValue),
+	  0, "motenc.%d.out-%02d", boardId, channel)) != 0)
 	    break;
 
 	// Parameters.
-	if((halError = hal_param_bit_newf(HAL_RW, &(this->out[channel].invert),
-	  componentId, "motenc.%d.out-%02d-invert", boardId, channel)) != 0)
+	if((halError = hal_param_new_bool(componentId, HAL_RW, &(this->out[channel].invert),
+	  0, "motenc.%d.out-%02d-invert", boardId, channel)) != 0)
 	    break;
-
-	// Init pin.
-	*(this->out[channel].pValue) = 0;
-	this->out[channel].invert = 0;
     }
 
     // Export functions.
@@ -703,31 +679,23 @@ Device_ExportMiscPinsParametersFunctions(Device *this, int componentId, int boar
     int					halError;
 
     // Export Pins.
-    halError = hal_pin_bit_newf(HAL_OUT, &(this->misc.pEstopIn), componentId,
+    halError = hal_pin_new_bool(componentId, HAL_OUT, &(this->misc.pEstopIn), 0,
 				"motenc.%d.estop-in", boardId);
 
     if(!halError){
-	halError = hal_pin_bit_newf(HAL_OUT, &(this->misc.pEstopInNot), componentId,
+	halError = hal_pin_new_bool(componentId, HAL_OUT, &(this->misc.pEstopInNot), 1,
 				    "motenc.%d.estop-in-not", boardId);
     }
 
     if(!halError){
-	halError = hal_pin_bit_newf(HAL_IO, &(this->misc.pWatchdogReset), componentId,
+	halError = hal_pin_new_bool(componentId, HAL_IO, &(this->misc.pWatchdogReset), 0,
 				    "motenc.%d.watchdog-reset", boardId);
     }
 
     // Export Parameters.
     if(!halError){
-	halError = hal_param_u32_newf(HAL_RW, &(this->misc.watchdogControl), componentId,
+	halError = hal_param_new_ui32(componentId, HAL_RW, &(this->misc.watchdogControl), this->watchdogControl,
 				      "motenc.%d.watchdog-control", boardId);
-    }
-
-    // Init pins.
-    if(!halError){
-	*(this->misc.pEstopIn) = 0;
-	*(this->misc.pEstopInNot) = 1;
-	*(this->misc.pWatchdogReset) = 0;
-	this->misc.watchdogControl = this->watchdogControl;
     }
 
     // Export functions.
@@ -755,7 +723,7 @@ Device_EncoderRead(void *arg, long period)
     MotencRegMap			*pCard = this->pCard;
     EncoderPinsParams			*pEncoder;
     int					i, j;
-    hal_u32_t				status;
+    rtapi_u32				status;
 
     pEncoder = &this->encoder[0];
 
@@ -769,22 +737,22 @@ Device_EncoderRead(void *arg, long period)
 	for(j = 0; j < MOTENC_FPGA_NUM_ENCODER_CHANNELS; j++, pEncoder++){
 
 	    // Check reset pin.
-	    if(*(pEncoder->pReset)){
+	    if(hal_get_bool(pEncoder->pReset)){
 		// Reset encoder.
 		pCard->fpga[i].statusControl = 1 << (MOTENC_CONTROL_ENCODER_RESET_SHFT + j);
 	    }
 
 	    // check state of hardware index pin
-	    *(pEncoder->pIndex) = (status >> (MOTENC_STATUS_INDEX_SHFT + j)) & 1;
+	    hal_set_bool(pEncoder->pIndex, (status >> (MOTENC_STATUS_INDEX_SHFT + j)) & 1);
 
 	    // check for index pulse detected
 	    if((status >> (MOTENC_STATUS_INDEX_LATCH_SHFT + j)) & 1){
 		// cancel index-enable
-		*(pEncoder->pIndexEnable) = 0;
+		hal_set_bool(pEncoder->pIndexEnable, 0);
 	    }
 
 	    // Check for index enable request from HAL
-	    if(*(pEncoder->pIndexEnable)){
+	    if(hal_get_bool(pEncoder->pIndexEnable)){
 		// tell hardware to latch on index
 		pCard->fpga[i].encoderCount[j] = 1;
 	    } else {
@@ -793,25 +761,25 @@ Device_EncoderRead(void *arg, long period)
 	    }
 
 	    // Read encoder counts.
-	    *(pEncoder->pCount) = pCard->fpga[i].encoderCount[j];
+	    hal_set_si32(pEncoder->pCount, pCard->fpga[i].encoderCount[j]);
 
 	    // Check for change in scale value.
-	    if ( pEncoder->scale != pEncoder->oldScale ) {
+	    if ( hal_get_real(pEncoder->scale) != pEncoder->oldScale ) {
 		// Get ready to detect future scale changes.
-		pEncoder->oldScale = pEncoder->scale;
+		pEncoder->oldScale = hal_get_real(pEncoder->scale);
 
 		// Validate the new scale value.
-		if ((pEncoder->scale < 1e-20) && (pEncoder->scale > -1e-20)) {
+		if ((hal_get_real(pEncoder->scale) < 1e-20) && (hal_get_real(pEncoder->scale) > -1e-20)) {
 		    // Value too small, divide by zero is a bad thing.
-		    pEncoder->scale = 1.0;
+		    hal_set_real(pEncoder->scale, 1.0);
 		}
 
 		// We will need the reciprocal.
-		pEncoder->scaleRecip = 1.0 / pEncoder->scale;
+		pEncoder->scaleRecip = 1.0 / hal_get_real(pEncoder->scale);
 	    }
 
 	    // Scale count to make floating point position.
-	    *(pEncoder->pPosition) = *(pEncoder->pCount) * pEncoder->scaleRecip;
+	    hal_set_real(pEncoder->pPosition, hal_get_si32(pEncoder->pCount) * pEncoder->scaleRecip);
 	}
     }
 }
@@ -824,8 +792,8 @@ Device_DacWrite(void *arg, long period)
     MotencRegMap			*pCard = this->pCard;
     DacPinsParams			*pDac;
     int					i;
-    hal_float_t				volts;
-    hal_u32_t				dacCount;
+    rtapi_real				volts;
+    rtapi_u32				dacCount;
 
     pDac = &this->dac[0];
 
@@ -833,7 +801,7 @@ Device_DacWrite(void *arg, long period)
     for(i = 0; i < MOTENC_NUM_DAC_CHANNELS; i++, pDac++){
 
 	// Calculate hardware register value.
-	volts = (*(pDac->pValue) - pDac->offset) * pDac->gain;
+	volts = (hal_get_real(pDac->pValue) - hal_get_real(pDac->offset)) * hal_get_real(pDac->gain);
 
 	// Truncate volts to DAC limits.
 	if(volts > MOTENC_DAC_VOLTS_MAX){
@@ -843,7 +811,7 @@ Device_DacWrite(void *arg, long period)
 	}
 
 	// Transform volts to counts.
-	dacCount = (hal_u32_t)(volts * MOTENC_DAC_SCALE_MULTIPLY /
+	dacCount = (rtapi_u32)(volts * MOTENC_DAC_SCALE_MULTIPLY /
 				MOTENC_DAC_SCALE_DIVIDE + MOTENC_DAC_COUNT_ZERO);
 
 	// Write DAC.
@@ -900,8 +868,8 @@ Device_AdcRead4(Device *this, int startChannel)
     MotencRegMap			*pCard = this->pCard;
     AdcPinsParams			*pAdc;
     int					i;
-    hal_s32_t				adcCount;
-    hal_float_t				volts;
+    rtapi_s32				adcCount;
+    rtapi_real				volts;
 
     if(pCard->fpga[0].statusControl & MOTENC_STATUS_ADC_DONE)
 	return(0);
@@ -921,10 +889,10 @@ Device_AdcRead4(Device *this, int startChannel)
 	volts = adcCount * MOTENC_ADC_SCALE_MULTIPLY / MOTENC_ADC_SCALE_DIVIDE;
 
 	// Scale and offset volts.
-	volts = volts * pAdc->gain - pAdc->offset;
+	volts = volts * hal_get_real(pAdc->gain) - hal_get_real(pAdc->offset);
 
 	// Update pin.
-	*(pAdc->pValue) = volts;
+	hal_set_real(pAdc->pValue, volts);
     }
 
     return(1);
@@ -938,7 +906,7 @@ Device_DigitalInRead(void *arg, long period)
     MotencRegMap			*pCard = this->pCard;
     DigitalInPinsParams			*pDigitalIn;
     int					i, j, n;
-    hal_u32_t				pins;
+    rtapi_u32				pins;
 
     pDigitalIn = &this->in[0];
 
@@ -952,8 +920,8 @@ Device_DigitalInRead(void *arg, long period)
 	for(j = 0; j < 16; j++, pDigitalIn++){
 
 	    // Update pins.
-	    *(pDigitalIn->pValue) = pins & 1;
-	    *(pDigitalIn->pValueNot) = !*(pDigitalIn->pValue);
+	    rtapi_bool b = hal_set_bool(pDigitalIn->pValue, pins & 1);
+	    hal_set_bool(pDigitalIn->pValueNot, !b);
 
 	    pins >>= 1;
 	}
@@ -969,8 +937,8 @@ Device_DigitalInRead(void *arg, long period)
 	for(j = 0; j < n; j++, pDigitalIn++){
 
 	    // Update pins.
-	    *(pDigitalIn->pValue) = pins & 1;
-	    *(pDigitalIn->pValueNot) = !*(pDigitalIn->pValue);
+	    rtapi_bool b = hal_set_bool(pDigitalIn->pValue, pins & 1);
+	    hal_set_bool(pDigitalIn->pValueNot, !b);
 
 	    pins >>= 1;
 	}
@@ -985,7 +953,7 @@ Device_DigitalOutWrite(void *arg, long period)
     MotencRegMap			*pCard = this->pCard;
     DigitalOutPinsParams		*pDigitalOut;
     int					i, j;
-    hal_u32_t				pins, mask;
+    rtapi_u32				pins, mask;
 
     pDigitalOut = &this->out[0];
 
@@ -999,7 +967,7 @@ Device_DigitalOutWrite(void *arg, long period)
 	for(j = 0; j < MOTENC_FPGA_NUM_DIGITAL_OUTPUTS; j++, pDigitalOut++){
 
 	    // Build hardware register value.
-	    if(*(pDigitalOut->pValue) != pDigitalOut->invert){
+	    if(hal_get_bool(pDigitalOut->pValue) != hal_get_bool(pDigitalOut->invert)){
 		pins |= mask;
 	    }
 
@@ -1020,24 +988,24 @@ Device_MiscUpdate(void *arg, long period)
     MotencRegMap			*pCard = this->pCard;
 
     // Check watchdog control parameter.
-    if(this->watchdogControl != this->misc.watchdogControl){
+    if(this->watchdogControl != hal_get_ui32(this->misc.watchdogControl)){
 	// Update shadow register.
-	this->watchdogControl = this->misc.watchdogControl;
+	this->watchdogControl = hal_get_ui32(this->misc.watchdogControl);
 
 	// Write hardware.
 	pCard->watchdogControl = this->watchdogControl;
     }
 
     // Check watchdog reset pin.
-    if(*(this->misc.pWatchdogReset)){
+    if(hal_get_bool(this->misc.pWatchdogReset)){
 	// Clear pin.
-	*(this->misc.pWatchdogReset) = 0;
+	hal_set_bool(this->misc.pWatchdogReset, 0);
 
 	// Reset the watchdog timer.
 	pCard->watchdogReset = MOTENC_WATCHDOG_RESET_VALUE;
     }
 
     // Update E-STOP pin.
-    *(this->misc.pEstopIn) = (pCard->fpga[0].statusControl & MOTENC_STATUS_ESTOP)? 1: 0;
-    *(this->misc.pEstopInNot) = !*(this->misc.pEstopIn);
+    rtapi_bool b = hal_set_bool(this->misc.pEstopIn, (pCard->fpga[0].statusControl & MOTENC_STATUS_ESTOP)? 1: 0);
+    hal_set_bool(this->misc.pEstopInNot, !b);
 }

--- a/src/hal/drivers/hal_stg.c
+++ b/src/hal/drivers/hal_stg.c
@@ -161,33 +161,33 @@ RTAPI_MP_STRING(dio, "dio config string - expects something like IIOO");
 ************************************************************************/
 
 typedef struct {
-    hal_bit_t *data;		/* basic pin for input or output */
+    hal_bool_t data;		/* basic pin for input or output */
     union {
-	hal_bit_t *not;		/* pin for inverted data (input only) */
-	hal_bit_t invert;	/* param for inversion (output only) */
+	hal_bool_t not;		/* pin for inverted data (input only) */
+	hal_bool_t invert;	/* param for inversion (output only) */
 	} io;
 } io_pin;
 
 typedef struct {
 /* counter data */
-    hal_s32_t *count[MAX_CHANS];		/* captured binary count value */
-	hal_s32_t offset[MAX_CHANS];		/* offset to hold latched position from index pulse */
-    hal_float_t *pos[MAX_CHANS];		/* scaled position (floating point) */
-    hal_float_t pos_scale[MAX_CHANS];		/* parameter: scaling factor for pos */
-    hal_bit_t *index_enable[MAX_CHANS];		/* pins for index homing */
-    hal_bit_t *index_latch[MAX_CHANS];    /* value of the index latch for the axis */
+    hal_sint_t count[MAX_CHANS];		/* captured binary count value */
+    rtapi_s32  offset[MAX_CHANS];		/* offset to hold latched position from index pulse */
+    hal_real_t pos[MAX_CHANS];		/* scaled position (floating point) */
+    hal_real_t pos_scale[MAX_CHANS];		/* parameter: scaling factor for pos */
+    hal_bool_t index_enable[MAX_CHANS];		/* pins for index homing */
+    hal_bool_t index_latch[MAX_CHANS];    /* value of the index latch for the axis */
 //    hal_s32_t check_index[MAX_CHANS];           /* internal marker for two stage index pulse check */
-    hal_bit_t *index_polarity[MAX_CHANS];       /* Polarity of index pulse */
+    hal_bool_t index_polarity[MAX_CHANS];       /* Polarity of index pulse */
 
 /* dac data */
-    hal_float_t *dac_value[MAX_CHANS];		/* value to be written to dac */
-    hal_float_t dac_offset[MAX_CHANS];		/* offset value for DAC */
-    hal_float_t dac_gain[MAX_CHANS];		/* gain to be applied */
+    hal_real_t dac_value[MAX_CHANS];		/* value to be written to dac */
+    hal_real_t dac_offset[MAX_CHANS];		/* offset value for DAC */
+    hal_real_t dac_gain[MAX_CHANS];		/* gain to be applied */
 
 /* adc data */
-    hal_float_t *adc_value[MAX_CHANS];		/* value to be read from adc */
-    hal_float_t adc_offset[MAX_CHANS];		/* offset value for ADC */
-    hal_float_t adc_gain[MAX_CHANS];		/* gain to be applied */
+    hal_real_t adc_value[MAX_CHANS];		/* value to be read from adc */
+    hal_real_t adc_offset[MAX_CHANS];		/* offset value for ADC */
+    hal_real_t adc_gain[MAX_CHANS];		/* gain to be applied */
     int adc_current_chan;			/* holds the currently converting channel */
 
 /* dio data */
@@ -357,23 +357,23 @@ int rtapi_app_main(void)
 	    return -1;
 	}
 	/* init counter */
-	*(stg_driver->count[n]) = 0;
+	hal_set_si32(stg_driver->count[n], 0);
 	stg_driver->offset[n] = 0;
-	*(stg_driver->pos[n]) = 0.0;
+	hal_set_real(stg_driver->pos[n], 0.0);
 
     /* By default the index pulse is not processed/used */
-	*(stg_driver->index_enable[n]) = 0;
+	hal_set_bool(stg_driver->index_enable[n], 0);
 
     /* Default polarity for the index pulse is active high */
     if( stg_driver->model == 1 )
     {
-	    *(stg_driver->index_polarity[n]) = 1;
+	    hal_set_bool(stg_driver->index_polarity[n], 1);
     }
 
     /* Default value for the index latch output is false */
-	  *(stg_driver->index_latch[n]) = 0;
+	hal_set_bool(stg_driver->index_latch[n], 0);
 
-	stg_driver->pos_scale[n] = 1.0;
+	hal_set_real(stg_driver->pos_scale[n], 1.0);
 
 	/* init counter chip */
 	stg_counter_init(n);
@@ -386,9 +386,9 @@ int rtapi_app_main(void)
 	    return -1;
 	}
 	/* init counter */
-	*(stg_driver->dac_value[n]) = 0;
-	stg_driver->dac_offset[n] = 0.0;
-	stg_driver->dac_gain[n] = 1.0;
+	hal_set_real(stg_driver->dac_value[n], 0);
+	hal_set_real(stg_driver->dac_offset[n], 0.0);
+	hal_set_real(stg_driver->dac_gain[n], 1.0);
 
 	/* init dac chip */
 	stg_dac_init(n);
@@ -401,9 +401,9 @@ int rtapi_app_main(void)
 	    return -1;
 	}
 	/* init counter */
-	*(stg_driver->adc_value[n]) = 0;
-	stg_driver->adc_offset[n] = 0.0;
-	stg_driver->adc_gain[n] = 1.0;
+	hal_set_real(stg_driver->adc_value[n], 0);
+	hal_set_real(stg_driver->adc_offset[n], 0.0);
+	hal_set_real(stg_driver->adc_gain[n], 1.0);
 	
 	stg_driver->adc_current_chan = -1; /* notify that no conversion has been started yet */
 
@@ -521,15 +521,15 @@ static void stg_counter_capture(void *arg, long period)
 
       if (stg1_get_index_pulse_latch(arg, n)) 
       {
-        *(stg->index_latch[n]) = 1;
+        hal_set_bool(stg->index_latch[n], 1);
 
-      	if ( *(stg->index_enable[n]) == 1 ) 
+        if (hal_get_bool(stg->index_enable[n]))
         {
           // read the value without latching, latching was done on index
           // remember this as an offset, it will be substracted from nominal
           stg->offset[n] = stg_counter_read(n);
     			/* set index-enable false, so outside knows we found the index, and reset the position */
-  				*(stg->index_enable[n]) = 0;
+          hal_set_bool(stg->index_enable[n], 0);
 
           /*
           msg = rtapi_get_msg_level();
@@ -542,7 +542,7 @@ static void stg_counter_capture(void *arg, long period)
            *  pair is selected */   
 		} 
       } else {
-        *(stg->index_latch[n]) = 0;
+        hal_set_bool(stg->index_latch[n], 0);
       }
 
     }
@@ -555,7 +555,7 @@ static void stg_counter_capture(void *arg, long period)
     // Set IDLEN
     for( mask = 0, n = 0; n < num_chan; n++ ) 
     {
-      if( *(stg->index_enable[n]) == 1 )
+      if(hal_get_bool(stg->index_enable[n]))
       {
         mask |= ( 1<<n );
       }
@@ -571,15 +571,15 @@ static void stg_counter_capture(void *arg, long period)
     {
       if( index_pulse_latches & (1<<n) )
       {
-        *(stg->index_latch[n]) = 1;
+        hal_set_bool(stg->index_latch[n], 1);
 
-      	if ( *(stg->index_enable[n]) == 1 ) 
+        if (hal_get_bool(stg->index_enable[n]))
         {
           // read the value without latching, latching was done on index
 														// remember this as an offset, it will be substracted from nominal
           stg->offset[n] = stg_counter_read(n);
 				/* set index-enable false, so outside knows we found the index, and reset the position */
-				*(stg->index_enable[n]) = 0;
+				hal_set_bool(stg->index_enable[n], 0);
 
           /*
           msg = rtapi_get_msg_level();
@@ -591,7 +591,7 @@ static void stg_counter_capture(void *arg, long period)
           /* NOP, no action needed, since all index latches will be clearer for the next iteration anyway */
         }
       } else {
-        *(stg->index_latch[n]) = 0;
+        hal_set_bool(stg->index_latch[n], 0);
 			}
 		}
     // Reset all latches
@@ -606,17 +606,17 @@ static void stg_counter_capture(void *arg, long period)
 	/* capture raw counts to latches */
 	stg_counter_latch(n);
 	/* read raw count, and substract the offset (determined by indexed homing) */
-	*(stg->count[n]) = stg_counter_read(n) - stg->offset[n]; 
+	hal_set_si32(stg->count[n], stg_counter_read(n) - stg->offset[n]);
 	/* make sure scale isn't zero or tiny to avoid divide error */
-	if (stg->pos_scale[n] < 0.0) {
-	    if (stg->pos_scale[n] > -EPSILON)
-		stg->pos_scale[n] = -1.0;
+	if (hal_get_real(stg->pos_scale[n]) < 0.0) {
+	    if (hal_get_real(stg->pos_scale[n]) > -EPSILON)
+		hal_set_real(stg->pos_scale[n], -1.0);
 	} else {
-	    if (stg->pos_scale[n] < EPSILON)
-		stg->pos_scale[n] = 1.0;
+	    if (hal_get_real(stg->pos_scale[n]) < EPSILON)
+		hal_set_real(stg->pos_scale[n], 1.0);
 	}
 	/* scale count to make floating point position */
-	*(stg->pos[n]) = *(stg->count[n]) / stg->pos_scale[n];
+	hal_set_real(stg->pos[n], hal_get_si32(stg->count[n]) / hal_get_real(stg->pos_scale[n]));
     }
     /* done */
   return;
@@ -682,7 +682,7 @@ static void stg_dacs_write(void *arg, long period)
     stg=arg;
     for (i=0;i < num_chan; i++) {
 	/* scale the voltage to be written based on offset and gain */
-	volts = (*(stg->dac_value[i]) - stg->dac_offset[i]) * stg->dac_gain[i];
+	volts = (hal_get_real(stg->dac_value[i]) - hal_get_real(stg->dac_offset[i])) * hal_get_real(stg->dac_gain[i]);
         /* clamp the scaled voltage value to the -10V to 10V output range of the STG */
         if (volts < -10.0)
                 volts = -10.0;
@@ -731,7 +731,7 @@ static void stg_adcs_read(void *arg, long period)
 	/* we should have the conversion done for adc_num_chan */
 	ncounts = stg_adc_read(stg,i);
 	volts = ncounts * 10.0 / 4096;
-	*(stg->adc_value[i]) = volts * stg->adc_gain[i] - stg->adc_offset[i];
+	hal_set_real(stg->adc_value[i], volts * hal_get_real(stg->adc_gain[i]) - hal_get_real(stg->adc_offset[i]));
     }
     /* if adc_num_chan < 0, it's the first time this routine runs
        thus we don't have any ready data, we simply start the next conversion */
@@ -757,12 +757,12 @@ static void split_input(unsigned char data, io_pin *dest, int num)
     for (b = 0 ; b < num ; b++ ) {
 	if ( data & mask ) {
 	    /* input high, which means FALSE (active low) */
-	    *(dest->data) = 0;
-	    *(dest->io.not) = 1;
+	    hal_set_bool(dest->data, 0);
+	    hal_set_bool(dest->io.not, 1);
 	} else {
 	    /* input low, which means TRUE */
-	    *(dest->data) = 1;
-	    *(dest->io.not) = 0;
+	    hal_set_bool(dest->data, 1);
+	    hal_set_bool(dest->io.not, 0);
 	}
 	mask <<= 1;
 	dest++;
@@ -782,12 +782,12 @@ unsigned char build_output(io_pin *src, int num)
     /* assemble output byte for data port from 'num' source variables */
     for (b = 0; b < num; b++) {
 	/* get the data, add to output byte */
-	if ( *(src->data) ) {
-	    if ( !(src->io.invert) ) {
+	if ( hal_get_bool(src->data) ) {
+	    if ( !hal_get_bool(src->io.invert) ) {
 		data |= mask;
 	    }
 	} else {
-	    if ( (src->io.invert) ) {
+	    if ( hal_get_bool(src->io.invert) ) {
 		data |= mask;
 	    }
 	}
@@ -1054,7 +1054,7 @@ static void stg1_select_index_axis(void *arg, unsigned int channel)
     /*
      * Set polarity to low active if that is requested
      */
-    if( *(stg->index_polarity[channel]) == 0 ) 
+    if( hal_get_bool(stg->index_polarity[channel]) == 0 )
     {
       byPol = 0;
     }
@@ -1436,34 +1436,34 @@ static int export_counter(int num, stg_struct *addr)
     rtapi_set_msg_level( STG_MSG_LEVEL );
 
     /* export pin for counts captured by update() */
-    retval = hal_pin_s32_newf(HAL_OUT, &addr->count[num],
-			      comp_id, "stg.%d.counts", num);
+    retval = hal_pin_new_si32(comp_id, HAL_OUT, &addr->count[num],
+			      0, "stg.%d.counts", num);
     if (retval != 0) {
 	return retval;
     }
     /* export pin for scaled position captured by update() */
-    retval = hal_pin_float_newf(HAL_OUT, &addr->pos[num],
-				comp_id, "stg.%d.position", num);
+    retval = hal_pin_new_real(comp_id, HAL_OUT, &addr->pos[num],
+				0.0, "stg.%d.position", num);
     if (retval != 0) {
 	return retval;
     }
     /* export parameter for scaling */
-    retval = hal_param_float_newf(HAL_RW, &addr->pos_scale[num],
-				  comp_id, "stg.%d.position-scale", num);
+    retval = hal_param_new_real(comp_id, HAL_RW, &addr->pos_scale[num],
+				  1.0, "stg.%d.position-scale", num);
     if (retval != 0) {
 	return retval;
     }
 
   /* export pin for index homing */
-    retval = hal_pin_bit_newf(HAL_IO, &addr->index_enable[num],
-			      comp_id, "stg.%d.index-enable", num);
+    retval = hal_pin_new_bool(comp_id, HAL_IO, &addr->index_enable[num],
+			      0, "stg.%d.index-enable", num);
     if (retval != 0) {
 	return retval;
     }
 
   /* export pin for reading the index latch */
-  retval = hal_pin_bit_newf(HAL_OUT, &addr->index_latch[num],
-			    comp_id, "stg.%d.index-latch", num);
+  retval = hal_pin_new_bool(comp_id, HAL_OUT, &addr->index_latch[num],
+			    0, "stg.%d.index-latch", num);
   if (retval != 0) {
     return retval;
   }
@@ -1476,8 +1476,8 @@ static int export_counter(int num, stg_struct *addr)
   if( addr->model == 1 ) 
   {
     /* export read only HAL pin for index pulse polarity */
-    retval = hal_pin_bit_newf(HAL_IN, &addr->index_polarity[num],
-			      comp_id, "stg.%d.index-polarity", num);
+    retval = hal_pin_new_bool(comp_id, HAL_IN, &addr->index_polarity[num],
+			      0, "stg.%d.index-polarity", num);
     if (retval != 0) 
     {
       return retval;
@@ -1502,20 +1502,20 @@ static int export_dac(int num, stg_struct *addr)
     rtapi_set_msg_level( STG_MSG_LEVEL );
 
     /* export pin for voltage received by the board() */
-    retval = hal_pin_float_newf(HAL_IN, &addr->dac_value[num],
-				comp_id, "stg.%d.dac-value", num);
+    retval = hal_pin_new_real(comp_id, HAL_IN, &addr->dac_value[num],
+				0.0, "stg.%d.dac-value", num);
     if (retval != 0) {
 	return retval;
     }
     /* export parameter for offset */
-    retval = hal_param_float_newf(HAL_RW, &addr->dac_offset[num],
-				  comp_id, "stg.%d.dac-offset", num);
+    retval = hal_param_new_real(comp_id, HAL_RW, &addr->dac_offset[num],
+				  0.0, "stg.%d.dac-offset", num);
     if (retval != 0) {
 	return retval;
     }
     /* export parameter for gain */
-    retval = hal_param_float_newf(HAL_RW, &addr->dac_gain[num],
-				  comp_id, "stg.%d.dac-gain", num);
+    retval = hal_param_new_real(comp_id, HAL_RW, &addr->dac_gain[num],
+				  1.0, "stg.%d.dac-gain", num);
     if (retval != 0) {
 	return retval;
     }
@@ -1537,20 +1537,20 @@ static int export_adc(int num, stg_struct *addr)
     rtapi_set_msg_level( STG_MSG_LEVEL );
 
     /* export pin for voltage received by the board() */
-    retval = hal_pin_float_newf(HAL_OUT, &addr->adc_value[num],
-				comp_id, "stg.%d.adc-value", num);
+    retval = hal_pin_new_real(comp_id, HAL_OUT, &addr->adc_value[num],
+				0.0, "stg.%d.adc-value", num);
     if (retval != 0) {
 	return retval;
     }
     /* export parameter for offset */
-    retval = hal_param_float_newf(HAL_RW, &addr->adc_offset[num],
-				  comp_id, "stg.%d.adc-offset", num);
+    retval = hal_param_new_real(comp_id, HAL_RW, &addr->adc_offset[num],
+				  0.0, "stg.%d.adc-offset", num);
     if (retval != 0) {
 	return retval;
     }
     /* export parameter for gain */
-    retval = hal_param_float_newf(HAL_RW, &addr->adc_gain[num],
-				  comp_id, "stg.%d.adc-gain", num);
+    retval = hal_param_new_real(comp_id, HAL_RW, &addr->adc_gain[num],
+				  1.0, "stg.%d.adc-gain", num);
     if (retval != 0) {
 	return retval;
     }
@@ -1599,17 +1599,14 @@ static int export_input_pin(int pinnum, io_pin * pin)
     rtapi_set_msg_level( STG_MSG_LEVEL );
 
     /* export read only HAL pin for input data */
-    retval = hal_pin_bit_newf(HAL_OUT, &(pin->data), comp_id,
+    retval = hal_pin_new_bool(comp_id, HAL_OUT, &(pin->data), 0,
 			      "stg.in-%02d", pinnum);
     if (retval != 0) {
 	return retval;
     }
     /* export additional pin for inverted input data */
-    retval = hal_pin_bit_newf(HAL_OUT, &(pin->io.not), comp_id,
+    retval = hal_pin_new_bool(comp_id, HAL_OUT, &(pin->io.not), 1,
 			      "stg.in-%02d-not", pinnum);
-    /* initialize HAL pins */
-    *(pin->data) = 0;
-    *(pin->io.not) = 1;
 
     /* restore saved message level */
     rtapi_set_msg_level(msg);
@@ -1632,18 +1629,14 @@ static int export_output_pin(int pinnum, io_pin * pin)
   rtapi_set_msg_level( STG_MSG_LEVEL );
 
     /* export read only HAL pin for output data */
-    retval = hal_pin_bit_newf(HAL_IN, &(pin->data),
-			      comp_id, "stg.out-%02d", pinnum);
+    retval = hal_pin_new_bool(comp_id, HAL_IN, &(pin->data),
+			      0, "stg.out-%02d", pinnum);
     if (retval != 0) {
 	return retval;
     }
     /* export parameter for polarity */
-    retval = hal_param_bit_newf(HAL_RW, &(pin->io.invert),
-				comp_id, "stg.out-%02d-invert", pinnum);
-    /* initialize HAL pin and param */
-    *(pin->data) = 0;
-    pin->io.invert = 0;
-
+    retval = hal_param_new_bool(comp_id, HAL_RW, &(pin->io.invert),
+				0, "stg.out-%02d-invert", pinnum);
 
     /* restore saved message level */
     rtapi_set_msg_level(msg);

--- a/src/hal/drivers/hal_tiro.c
+++ b/src/hal/drivers/hal_tiro.c
@@ -85,9 +85,9 @@ RTAPI_MP_INT(num_chan, "number of channels");
 /* this structure contains the runtime data for a single counter */
 
 typedef struct {
-    hal_s32_t *count;		/* captured binary count value */
-    hal_float_t *pos;		/* scaled position (floating point) */
-    hal_float_t pos_scale;	/* parameter: scaling factor for pos */
+    hal_sint_t count;		/* captured binary count value */
+    hal_real_t pos;		/* scaled position (floating point) */
+    hal_real_t pos_scale;	/* parameter: scaling factor for pos */
 } counter_t;
 
 /* pointer to array of counter_t structs in shmem, 1 per counter */
@@ -149,9 +149,9 @@ int rtapi_app_main(void)
 			return -1;
 		}
 		/* init counter */
-		*(counter_array[n].count) = 0;
-		*(counter_array[n].pos) = 0.0;
-		counter_array[n].pos_scale = 1.0;
+		hal_set_si32(counter_array[n].count, 0);
+		hal_set_real(counter_array[n].pos, 0.0);
+		hal_set_real(counter_array[n].pos_scale, 1.0);
 		
 		/* init counter chip */		
 		LS7166Init(n);
@@ -189,9 +189,9 @@ static void capture(void *arg, long period)
     for (n = 0; n < num_chan; n++) {
 
 	/* capture raw counts to latches */
-	*(cntr->count) = LS7166Read(n);
+	hal_set_si32(cntr->count, LS7166Read(n));
 	/* scale count to make floating point position */
-	*(cntr->pos) = *(cntr->count) * cntr->pos_scale;
+	hal_set_real(cntr->pos, hal_get_si32(cntr->count) * hal_get_real(cntr->pos_scale));
 	/* move on to next channel */
 	cntr++;
     }
@@ -254,19 +254,19 @@ static int export_counter(int num, counter_t * addr)
     rtapi_set_msg_level(RTAPI_MSG_WARN);
 
     /* export pin for counts captured by update() */
-    retval = hal_pin_s32_newf(HAL_OUT, &(addr->count), comp_id,
+    retval = hal_pin_new_si32(comp_id, HAL_OUT, &(addr->count), 0,
 			      "tiro.%d.counts", num);
     if (retval != 0) {
 	return retval;
     }
     /* export pin for scaled position captured by update() */
-    retval = hal_pin_float_newf(HAL_OUT, &(addr->pos), comp_id,
+    retval = hal_pin_new_real(comp_id, HAL_OUT, &(addr->pos), 0.0,
 				"tiro.%d.position", num);
     if (retval != 0) {
 	return retval;
     }
     /* export parameter for scaling */
-    retval = hal_param_float_newf(HAL_RW, &(addr->pos_scale), comp_id,
+    retval = hal_param_new_real(comp_id, HAL_RW, &(addr->pos_scale), 1.0,
 				  "tiro.%d.position-scale", num);
     if (retval != 0) {
 	return retval;

--- a/src/hal/drivers/hal_vti.c
+++ b/src/hal/drivers/hal_vti.c
@@ -174,28 +174,29 @@ RTAPI_MP_STRING(dio, "dio config string - expects something like IOiooi");
 ************************************************************************/
 
 typedef struct {
-    hal_bit_t *data;		/* basic pin for input or output */
+    hal_bool_t data;		/* basic pin for input or output */
     union {
-	hal_bit_t *not;		/* pin for inverted data (input only) */
-	hal_bit_t invert;	/* param for inversion (output only) */
+	hal_bool_t not;		/* pin for inverted data (input only) */
+	hal_bool_t invert;	/* param for inversion (output only) */
     } io;
 } io_pin;
 
 typedef struct {
 /* counter data */
-    hal_s32_t *count[MAX_CHANS];	/* captured binary count value */
-    hal_float_t *pos[MAX_CHANS];	/* scaled position (floating point) */
-    hal_float_t pos_scale[MAX_CHANS];	/* parameter: scaling factor for pos */
+    hal_sint_t count[MAX_CHANS];	/* captured binary count value */
+    hal_real_t pos[MAX_CHANS];	/* scaled position (floating point) */
+    hal_real_t pos_scale[MAX_CHANS];	/* parameter: scaling factor for pos */
 
 /* dac data */
-    hal_float_t *dac_value[MAX_CHANS];	/* value to be written to dac */
-    hal_float_t dac_offset[MAX_CHANS];	/* offset value for DAC */
-    hal_float_t dac_gain[MAX_CHANS];	/* gain to be applied */
+    hal_real_t dac_value[MAX_CHANS];	/* value to be written to dac */
+    hal_real_t dac_offset[MAX_CHANS];	/* offset value for DAC */
+    hal_real_t dac_gain[MAX_CHANS];	/* gain to be applied */
 
 /* adc data */
-    hal_float_t *adc_value[MAX_CHANS];	/* value to be read from adc */
-    hal_float_t adc_offset[MAX_CHANS];	/* offset value for ADC */
-    hal_float_t adc_gain[MAX_CHANS];	/* gain to be applied */
+    // These adc thingies are apparently unused...
+    hal_real_t adc_value[MAX_CHANS];	/* value to be read from adc */
+    hal_real_t adc_offset[MAX_CHANS];	/* offset value for ADC */
+    hal_real_t adc_gain[MAX_CHANS];	/* gain to be applied */
     int adc_current_chan;	/* holds the currently converting channel */
 
 /* dio data */
@@ -219,7 +220,7 @@ volatile struct ip *ip = NULL;
 static int comp_id;		/* component ID */
 static int outpinnum = 0, inputpinnum = 0;
 static int diocount = 0;
-static hal_s32_t enc_counts[MAX_CHANS];
+static rtapi_s32 enc_counts[MAX_CHANS];
 
 /***********************************************************************
 *                  LOCAL FUNCTION DECLARATIONS                         *
@@ -456,15 +457,15 @@ static void vti_counter_capture(void *arg, long period)
     vti = arg;
     for (i = 0; i < num_chan; i++) {
 	/* capture raw counts to latches */
-	*(vti->count[i]) = vti_counter_read(i);
+	hal_set_si32(vti->count[i], vti_counter_read(i));
 	/* scale count to make floating point position */
-	if (vti->pos_scale[i] < 0.0) {
-	  if (vti->pos_scale[i] > -EPSILON)
-	    vti->pos_scale[i] = -1.0;}
+	if (hal_get_real(vti->pos_scale[i]) < 0.0) {
+	  if (hal_get_real(vti->pos_scale[i]) > -EPSILON)
+	    hal_set_real(vti->pos_scale[i], -1.0);}
 	else {
-	  if (vti->pos_scale[i] < EPSILON)
-	    vti->pos_scale[i] = 1.0; }
-	*(vti->pos[i]) = *(vti->count[i]) / vti->pos_scale[i];
+	  if (hal_get_real(vti->pos_scale[i]) < EPSILON)
+	    hal_set_real(vti->pos_scale[i], 1.0); }
+	hal_set_real(vti->pos[i], hal_get_si32(vti->count[i]) / hal_get_real(vti->pos_scale[i]));
     }
     /* done */
 }
@@ -481,7 +482,7 @@ static void vti_dacs_write(void *arg, long period)
     for (i = 0; i < num_chan; i++) {
 	/* scale the voltage to be written based on offset and gain */
 	volts =
-	    (*(vti->dac_value[i]) - vti->dac_offset[i]) * vti->dac_gain[i];
+	    (hal_get_real(vti->dac_value[i]) - hal_get_real(vti->dac_offset[i])) * hal_get_real(vti->dac_gain[i]);
 	/* compute the value for the DAC, the extra - in there is vti specific */
         ncounts = ((volts / 10) * 0x7fff) + 0x8000;
 	
@@ -510,12 +511,12 @@ static void split_input(unsigned char data, io_pin * dest, int num)
     for (b = 0; b < num; b++) {
 	if (data & mask) {
 	    /* input high, which means FALSE (active low) */
-	    *(dest->data) = 0;
-	    *(dest->io.not) = 1;
+	    hal_set_bool(dest->data, 0);
+	    hal_set_bool(dest->io.not, 1);
 	} else {
 	    /* input low, which means TRUE */
-	    *(dest->data) = 1;
-	    *(dest->io.not) = 0;
+	    hal_set_bool(dest->data, 1);
+	    hal_set_bool(dest->io.not, 0);
 	}
 	mask <<= 1;
 	dest++;
@@ -534,12 +535,12 @@ unsigned char build_output(io_pin * src, int num)
     /* assemble output byte for data port from 'num' source variables */
     for (b = 0; b < num; b++) {
 	/* get the data, add to output byte */
-	if (*(src->data)) {
-	    if (!(src->io.invert)) {
+	if (hal_get_bool(src->data)) {
+	    if (!hal_get_bool(src->io.invert)) {
 		data |= mask;
 	    }
 	} else {
-	    if ((src->io.invert)) {
+	    if (hal_get_bool(src->io.invert)) {
 		data |= mask;
 	    }
 	}
@@ -622,9 +623,9 @@ static int vti_counter_init(int counters)
 	    return -1;
 	}
 	/* init counter */
-	*(vti_driver->count[i]) = 0;
-	*(vti_driver->pos[i]) = 0.0;
-	vti_driver->pos_scale[i] = 1.0;
+	hal_set_si32(vti_driver->count[i], 0);
+	hal_set_real(vti_driver->pos[i], 0.0);
+	hal_set_real(vti_driver->pos_scale[i], 1.0);
     }
     return 0;
 }
@@ -648,9 +649,9 @@ static int vti_dac_init(int channels)
 	    return -1;
 	}
 	/* init counter */
-	*(vti_driver->dac_value[i]) = 0;
-	vti_driver->dac_offset[i] = 0.0;
-	vti_driver->dac_gain[i] = 1.0;
+	hal_set_real(vti_driver->dac_value[i], 0);
+	hal_set_real(vti_driver->dac_offset[i], 0.0);
+	hal_set_real(vti_driver->dac_gain[i], 1.0);
 	vti_dac_write(i, DAC_ZERO_VOLTS);
     }
     return 0;
@@ -848,20 +849,20 @@ static int export_counter(int num, vti_struct * addr)
     msg = rtapi_get_msg_level();
     rtapi_set_msg_level(RTAPI_MSG_WARN);
     /* export pin for counts captured by update() */
-    retval = hal_pin_s32_newf(HAL_OUT, &addr->count[num],
-			      comp_id, "vti.%d.counts", num);
+    retval = hal_pin_new_si32(comp_id, HAL_OUT, &addr->count[num],
+			      0, "vti.%d.counts", num);
     if (retval != 0) {
 	return retval;
     }
     /* export pin for scaled position captured by update() */
-    retval = hal_pin_float_newf(HAL_OUT, &addr->pos[num],
-				comp_id, "vti.%d.position", num);
+    retval = hal_pin_new_real(comp_id, HAL_OUT, &addr->pos[num],
+				0.0, "vti.%d.position", num);
     if (retval != 0) {
 	return retval;
     }
     /* export parameter for scaling */
-    retval = hal_param_float_newf(HAL_RW, &addr->pos_scale[num],
-				  comp_id, "vti.%d.position-scale", num);
+    retval = hal_param_new_real(comp_id, HAL_RW, &addr->pos_scale[num],
+				  1.0, "vti.%d.position-scale", num);
     if (retval != 0) {
 	return retval;
     }
@@ -880,20 +881,20 @@ static int export_dac(int num, vti_struct * addr)
     msg = rtapi_get_msg_level();
     rtapi_set_msg_level(RTAPI_MSG_WARN);
     /* export pin for voltage received by the board() */
-    retval = hal_pin_float_newf(HAL_IN, &addr->dac_value[num],
-				comp_id, "vti.%d.dac-value", num);
+    retval = hal_pin_new_real(comp_id, HAL_IN, &addr->dac_value[num],
+				0.0, "vti.%d.dac-value", num);
     if (retval != 0) {
 	return retval;
     }
     /* export parameter for offset */
-    retval = hal_param_float_newf(HAL_RW, &addr->dac_offset[num],
-				  comp_id, "vti.%d.dac-offset", num);
+    retval = hal_param_new_real(comp_id, HAL_RW, &addr->dac_offset[num],
+				  0.0, "vti.%d.dac-offset", num);
     if (retval != 0) {
 	return retval;
     }
     /* export parameter for gain */
-    retval = hal_param_float_newf(HAL_RW, &addr->dac_gain[num],
-				  comp_id, "vti.%d.dac-gain", num);
+    retval = hal_param_new_real(comp_id, HAL_RW, &addr->dac_gain[num],
+				  1.0, "vti.%d.dac-gain", num);
     if (retval != 0) {
 	return retval;
     }
@@ -943,31 +944,25 @@ static int export_input_pin(int pinnum, io_pin * pin)
 {
     int retval;
     /* export read only HAL pin for input data */
-    retval = hal_pin_bit_newf(HAL_OUT, &(pin->data),
-			      comp_id, "vti.in-%02d", pinnum);
+    retval = hal_pin_new_bool(comp_id, HAL_OUT, &(pin->data),
+			      0, "vti.in-%02d", pinnum);
     if (retval != 0)
 	return retval;
     /* export additional pin for inverted input data */
-    retval = hal_pin_bit_newf(HAL_OUT, &(pin->io.not),
-			      comp_id, "vti.in-%02d-not", pinnum);
-    /* initialize HAL pins */
-    *(pin->data) = 0;
-    *(pin->io.not) = 1;
+    retval = hal_pin_new_bool(comp_id, HAL_OUT, &(pin->io.not),
+			      1, "vti.in-%02d-not", pinnum);
     return retval;
 }
 static int export_output_pin(int pinnum, io_pin * pin)
 {
     int retval;
     /* export read only HAL pin for output data */
-    retval = hal_pin_bit_newf(HAL_IN, &(pin->data),
-			      comp_id, "vti.out-%02d", pinnum);
+    retval = hal_pin_new_bool(comp_id, HAL_IN, &(pin->data),
+			      0, "vti.out-%02d", pinnum);
     if (retval != 0)
 	return retval;
     /* export parameter for polarity */
-    retval = hal_param_bit_newf(HAL_RW, &(pin->io.invert),
-				comp_id, "vti.out-%02d-invert", pinnum);
-    /* initialize HAL pin and param */
-    *(pin->data) = 0;
-    pin->io.invert = 0;
+    retval = hal_param_new_bool(comp_id, HAL_RW, &(pin->io.invert),
+				0, "vti.out-%02d-invert", pinnum);
     return retval;
 }

--- a/src/hal/drivers/motenc.h
+++ b/src/hal/drivers/motenc.h
@@ -64,11 +64,11 @@
 
 
 typedef struct {
-    hal_s32_t				encoderCount[MOTENC_FPGA_NUM_ENCODER_CHANNELS];
-    hal_u32_t				digitalIo;
-    hal_u32_t				statusControl;
-    hal_u32_t				reserved;
-    hal_u32_t				boardVersion;
+    volatile rtapi_s32			encoderCount[MOTENC_FPGA_NUM_ENCODER_CHANNELS];
+    volatile rtapi_u32			digitalIo;
+    volatile rtapi_u32			statusControl;
+    volatile rtapi_u32			reserved;
+    volatile rtapi_u32			boardVersion;
 } volatile MotencFpgaRegMap;
 
 // For use with digitalIo reg.
@@ -96,16 +96,16 @@ typedef struct {
 
 typedef struct {
     MotencFpgaRegMap			fpga[MOTENC_NUM_FPGA];
-    hal_u32_t				timerCompare;
-    hal_u32_t				timerIrqDisable;
-    hal_u32_t				timerIrqEnable;
-    hal_u32_t				watchdogControl;
-    hal_u32_t				watchdogReset;
-    hal_u32_t				reserved1[3];
-    hal_u32_t				dac[MOTENC_NUM_DAC_CHANNELS];
-    hal_u32_t				adcDataCommand;
-    hal_u32_t				reserved2[7];
-    hal_u32_t				adcStartConversion;
+    volatile rtapi_u32			timerCompare;
+    volatile rtapi_u32			timerIrqDisable;
+    volatile rtapi_u32			timerIrqEnable;
+    volatile rtapi_u32			watchdogControl;
+    volatile rtapi_u32			watchdogReset;
+    volatile rtapi_u32			reserved1[3];
+    volatile rtapi_u32			dac[MOTENC_NUM_DAC_CHANNELS];
+    volatile rtapi_u32			adcDataCommand;
+    volatile rtapi_u32			reserved2[7];
+    volatile rtapi_u32			adcStartConversion;
 } volatile MotencRegMap;
 
 // For use with watchdogControl reg.

--- a/src/hal/drivers/opto_ac5.c
+++ b/src/hal/drivers/opto_ac5.c
@@ -247,17 +247,13 @@ static int Device_ExportDigitalInPinsParametersFunctions(board_data_t *this, int
 			if ((this->port[portnum].mask & mask)==0)//physical input?
 			{
 			// Pins.
-			if((halError = hal_pin_bit_newf(HAL_OUT, &(this->port[portnum].io[channel].pValue),
-			  comp_id, "opto-ac5.%d.port%d.in-%02d", boardId, portnum, channel)) != 0)
+			if((halError = hal_pin_new_bool(comp_id, HAL_OUT, &(this->port[portnum].io[channel].pValue),
+			  0, "opto-ac5.%d.port%d.in-%02d", boardId, portnum, channel)) != 0)
 			    break;
 
-			if((halError = hal_pin_bit_newf(HAL_OUT, &(this->port[portnum].io[channel].pValueNot),
-			  comp_id, "opto-ac5.%d.port%d.in-%02d-not", boardId, portnum, channel)) != 0)
+			if((halError = hal_pin_new_bool(comp_id, HAL_OUT, &(this->port[portnum].io[channel].pValueNot),
+			  1, "opto-ac5.%d.port%d.in-%02d-not", boardId, portnum, channel)) != 0)
 			    break;
-
-			// Init pin.
-			*(this->port[portnum].io[channel].pValue) = 0;
-			*(this->port[portnum].io[channel].pValueNot) = 1;
 			}
 			mask <<=1;
 		   }
@@ -299,18 +295,14 @@ static int Device_ExportDigitalOutPinsParametersFunctions(board_data_t *this, in
 			if ((this->port[portnum].mask & mask)!=0)//phyical output?
 			{
 			// Pins.
-			if((halError = hal_pin_bit_newf(HAL_IN, &(this->port[portnum].io[channel].pValue),
-			  comp_id, "opto-ac5.%d.port%d.out-%02d", boardId, portnum, channel)) != 0)
+			if((halError = hal_pin_new_bool(comp_id, HAL_IN, &(this->port[portnum].io[channel].pValue),
+			  0, "opto-ac5.%d.port%d.out-%02d", boardId, portnum, channel)) != 0)
 			    break;
 
 			// Parameters.
-			if((halError = hal_param_bit_newf(HAL_RW, &(this->port[portnum].io[channel].invert),
-			  comp_id, "opto-ac5.%d.port%d.out-%02d-invert", boardId, portnum, channel)) != 0)
+			if((halError = hal_param_new_bool(comp_id, HAL_RW, &(this->port[portnum].io[channel].invert),
+			  0, "opto-ac5.%d.port%d.out-%02d-invert", boardId, portnum, channel)) != 0)
 			    break;
-
-			// Init pin.
-			*(this->port[portnum].io[channel].pValue) = 0;
-			this->port[portnum].io[channel].invert = 0;
 		   	}
 			mask <<=1;
 		   }
@@ -320,12 +312,12 @@ static int Device_ExportDigitalOutPinsParametersFunctions(board_data_t *this, in
 		portnum=0;
 		for(channel = 0; channel < 2; channel++)
 		{
-			if((halError = hal_pin_bit_newf(HAL_IN, &(this->port[portnum].io[24].pValue),
-			  comp_id, "opto-ac5.%d.led%d", boardId, channel+portnum)) != 0)
+			if((halError = hal_pin_new_bool(comp_id, HAL_IN, &(this->port[portnum].io[24].pValue),
+			  0, "opto-ac5.%d.led%d", boardId, channel+portnum)) != 0)
 			    break;
 
-			if((halError = hal_pin_bit_newf(HAL_IN, &(this->port[portnum].io[25].pValue),
-			  comp_id, "opto-ac5.%d.led%d", boardId, channel+portnum+1)) != 0)
+			if((halError = hal_pin_new_bool(comp_id, HAL_IN, &(this->port[portnum].io[25].pValue),
+			  0, "opto-ac5.%d.led%d", boardId, channel+portnum+1)) != 0)
 			    break;
 			portnum++;
 		}
@@ -370,10 +362,10 @@ Device_DigitalInRead(void *arg, long period)
 			{
 				if ((pboard->port[portnum].mask & mask) ==0) // is it an input bit ?
 				{
-				    if ((pins & mask) !=0){	*(pDigital->pValue) =0;
-					}else{	*(pDigital->pValue) = 1;	}
+				    if ((pins & mask) !=0){	hal_set_bool(pDigital->pValue, 0);
+					}else{	hal_set_bool(pDigital->pValue, 1);	}
 					// Update not pin.
-				    *(pDigital->pValueNot) = !*(pDigital->pValue);
+				    hal_set_bool(pDigital->pValueNot, !hal_get_bool(pDigital->pValue));
 				}
 	  		 	 mask <<=1;// shift mask
 			}
@@ -414,8 +406,8 @@ Device_DigitalOutWrite(void *arg, long period)
 				if ((pboard->port[portnum].mask & mask) !=0) //is it an output?
 				{
 			 	   // add mask to pins if HAL pin + invert =true.
-				    if( (!*(pDigital->pValue) && !(pDigital->invert) ) ||
-				       ( *(pDigital->pValue) &&  (pDigital->invert) ))
+				    if( (!hal_get_bool(pDigital->pValue) && !hal_get_bool(pDigital->invert) ) ||
+				       ( hal_get_bool(pDigital->pValue) &&  hal_get_bool(pDigital->invert) ))
 					 {	pins |= mask;	    }
 				}
 	   			mask <<=1; // shift mask
@@ -429,7 +421,7 @@ Device_DigitalOutWrite(void *arg, long period)
 				mask = (unsigned int) 1 << (31-i);
 				pDigital++;
 				
-				if ( *(pDigital->pValue) == 0 ) {	pins |= mask;	    }	
+				if ( hal_get_bool(pDigital->pValue) == 0 ) {	pins |= mask;	    }
 			}
 			// Write digital I/O register.
 			writel(pins,pboard->base + (offset));

--- a/src/hal/drivers/opto_ac5.h
+++ b/src/hal/drivers/opto_ac5.h
@@ -33,10 +33,10 @@ Copyright (C) 2008 Chris Morley
 *************************************************************************/
 typedef struct  DigitalPinsParams {
     // Pins.
-    hal_bit_t				*pValue;
-    hal_bit_t				*pValueNot;
+    hal_bool_t				pValue;
+    hal_bool_t				pValueNot;
     // Parameters.
-    hal_bit_t				invert;
+    hal_bool_t				invert;
 } DigitalPinsParams;
 
 

--- a/src/hal/drivers/pci_8255.c
+++ b/src/hal/drivers/pci_8255.c
@@ -28,24 +28,24 @@ RTAPI_MP_ARRAY_INT(dir, MAX, "I/O direction of 8255s");
 
 static int comp_id;
 
-union inv { hal_bit_t *not_; hal_bit_t invert; };
+union inv { hal_bool_t not_; hal_bool_t invert; };
 
 struct port {
-    hal_bit_t *a[8];
-    hal_bit_t *b[8];
-    hal_bit_t *c[8];
+    hal_bool_t a[8];
+    hal_bool_t b[8];
+    hal_bool_t c[8];
     union inv ai[8];
     union inv bi[8];
     union inv ci[8];
-    hal_u32_t dir_;
-    hal_u32_t ioaddr;
+    hal_uint_t dir_;
+    hal_uint_t ioaddr;
 };
 
 struct state {
     struct port ports[3];
-    hal_bit_t *relay;
-    hal_bit_t relay_invert;
-    hal_u32_t ioaddr;
+    hal_bool_t relay;
+    hal_bool_t relay_invert;
+    hal_uint_t ioaddr;
 };
 
 static void read(struct port *inst, long period);
@@ -58,13 +58,13 @@ static void extra_cleanup(void);
 
 #include <asm/io.h>
 #define SHIFT 4
-static inline void pci_8255_outb(int value, hal_u32_t base, int offset) { 
+static inline void pci_8255_outb(int value, rtapi_u32 base, int offset) {
     // int *mem = (int*) base;
     outb(value, base + SHIFT*offset);
     // mem[offset] = value;
 }
 
-static inline int pci_8255_inb(hal_u32_t base, int offset) {
+static inline int pci_8255_inb(rtapi_u32 base, int offset) {
     return inb(base + SHIFT*offset);
     // int *mem = (int*) base;
     // return mem[offset];
@@ -77,58 +77,59 @@ static int export(char *prefix, struct port *inst, int ioaddr, int dir) {
     hal_pin_dir_t direction;
     int sz = sizeof(struct port);
     memset(inst, 0, sz);
-    inst->dir_ = dir;
-    inst->ioaddr = ioaddr;
+    if(0 != (r = hal_param_new_fake(comp_id, (hal_refs_u *)&inst->ioaddr)))
+        return r;
+    hal_set_ui32(inst->ioaddr, ioaddr);
 
-    if(inst->dir_ & 8) direction = HAL_OUT; else direction = HAL_IN;
+    if(dir & 8) direction = HAL_OUT; else direction = HAL_IN;
     for(i=0; i<8; i++) {
-        r = hal_pin_bit_newf(direction, &(inst->a[i]), comp_id,
+        r = hal_pin_new_bool(comp_id, direction, &(inst->a[i]), 0,
             "%s.a%d", prefix, i);
         if(r != 0) return r;
         if(direction == HAL_OUT) {
-            r = hal_pin_bit_newf(direction, &(inst->ai[i].not_), comp_id,
+            r = hal_pin_new_bool(comp_id, direction, &(inst->ai[i].not_), 0,
                 "%s.a%d-not", prefix, i);
         } else {
-            r = hal_param_bit_newf(HAL_RW, &(inst->ai[i].invert), comp_id,
+            r = hal_param_new_bool(comp_id, HAL_RW, &(inst->ai[i].invert), 0,
                     "%s.a%d-invert", prefix, i);
         }
         if(r != 0) return r;
     }
-    if(inst->dir_ & 2) direction = HAL_OUT; else direction = HAL_IN;
+    if(dir & 2) direction = HAL_OUT; else direction = HAL_IN;
     for(i=0; i<8; i++) {
-        r = hal_pin_bit_newf(direction, &(inst->b[i]), comp_id,
+        r = hal_pin_new_bool(comp_id, direction, &(inst->b[i]), 0,
             "%s.b%d", prefix, i);
         if(r != 0) return r;
         if(direction == HAL_OUT) {
-            r = hal_pin_bit_newf(direction, &(inst->bi[i].not_), comp_id,
+            r = hal_pin_new_bool(comp_id, direction, &(inst->bi[i].not_), 0,
                 "%s.b%d-not", prefix, i);
         } else {
-            r = hal_param_bit_newf(HAL_RW, &(inst->bi[i].invert), comp_id,
+            r = hal_param_new_bool(comp_id, HAL_RW, &(inst->bi[i].invert), 0,
                     "%s.b%d-invert", prefix, i);
         }
         if(r != 0) return r;
     }
     for(i=0; i<8; i++) {
         if(i < 4) {
-            if(inst->dir_ & 1) direction = HAL_OUT;
+            if(dir & 1) direction = HAL_OUT;
             else direction = HAL_IN;
         } else { 
-            if(inst->dir_ & 4) direction = HAL_OUT;
+            if(dir & 4) direction = HAL_OUT;
             else direction = HAL_IN;
         }
-        r = hal_pin_bit_newf(direction, &(inst->c[i]), comp_id,
+        r = hal_pin_new_bool(comp_id, direction, &(inst->c[i]), 0,
             "%s.c%d", prefix, i);
         if(r != 0) return r;
         if(direction == HAL_OUT) {
-            r = hal_pin_bit_newf(direction, &(inst->ci[i].not_), comp_id,
+            r = hal_pin_new_bool(comp_id, direction, &(inst->ci[i].not_), 0,
                 "%s.c%d-not", prefix, i);
         } else {
-            r = hal_param_bit_newf(HAL_RW, &(inst->ci[i].invert), comp_id,
+            r = hal_param_new_bool(comp_id, HAL_RW, &(inst->ci[i].invert), 0,
                     "%s.c%d-invert", prefix, i);
         }
         if(r != 0) return r;
     }
-    r = hal_param_u32_newf(HAL_RO, &(inst->dir_), comp_id,
+    r = hal_param_new_ui32(comp_id, HAL_RO, &(inst->dir_), dir,
         "%s.dir", prefix);
     if(r != 0) return r;
     r = hal_export_functf((void(*)(void *inst, long))read, inst, 0, 0, comp_id, "%s.read", prefix);
@@ -148,12 +149,12 @@ static struct state *inst = 0;
 static int count = 0;
 
 static void write_relay(struct state *inst, long period) {
-    int val = (!*inst->relay) ^ (!inst->relay_invert);
+    int val = (!hal_get_bool(inst->relay)) ^ (!hal_get_bool(inst->relay_invert));
     // relay is active low
     if(val) {
-	pci_8255_outb(0, inst->ioaddr, 3);
+	pci_8255_outb(0, hal_get_ui32(inst->ioaddr), 3);
     } else {
-	pci_8255_outb(0x10, inst->ioaddr, 3);
+	pci_8255_outb(0x10, hal_get_ui32(inst->ioaddr), 3);
     }
 }
 
@@ -196,19 +197,18 @@ int rtapi_app_main(void) {
 	// relay, CS# as outputs
 	pci_8255_outb(0x11, io[i]+2, 0);
 
+	r = hal_param_new_ui32(comp_id, HAL_RO, &(inst[i].ioaddr), io[i],
+	    "pci8255.%d.io-addr", i);
 	for(j=0; j<3; j++) {
 	    rtapi_snprintf(buf, sizeof(buf), "pci8255.%d.%d", i, j);
 	    r = export(buf, &inst[i].ports[j],
 		    io[i] + 0xc0 + 16*j, (dir[i] >> (4*j)) & 0xf);
 	    if(r != 0) goto out_error;
 	}
-	hal_pin_bit_newf(HAL_IN, &(inst[i].relay), comp_id, "pci8255.%d.relay", i);
-	hal_param_bit_newf(HAL_RW, &(inst[i].relay_invert), comp_id, 
+	hal_pin_new_bool(comp_id, HAL_IN, &(inst[i].relay), 0, "pci8255.%d.relay", i);
+	hal_param_new_bool(comp_id, HAL_RW, &(inst[i].relay_invert), 0,
 		    "pci8255.%d.relay-invert", i);
 	r = hal_export_functf((void(*)(void *inst, long))write_relay, &inst[i], 0, 0, comp_id, "pci8255.%d.write-relay", i);
-	r = hal_param_u32_newf(HAL_RO, &(inst->ioaddr), comp_id,
-	    "pci8255.%d.io-addr", i);
-	inst->ioaddr = io[i];
 	if(r != 0) return r;
     }
     r = hal_export_funct("pci8255.read-all", (void(*)(void *inst, long))read_all, inst, 0, 0, comp_id);
@@ -231,15 +231,18 @@ void rtapi_app_exit(void) {
 #define FUNCTION(name) static void name(struct state *inst, long period)
 #define EXTRA_CLEANUP() static void extra_cleanup(void)
 #define fperiod (period * 1e-9)
-#define a(i) (*inst->a[i])
-#define b(i) (*inst->b[i])
-#define c(i) (*inst->c[i])
-#define ai_invert(i) (inst->ai[i].invert)
-#define bi_invert(i) (inst->bi[i].invert)
-#define ci_invert(i) (inst->ci[i].invert)
-#define ai_not(i) (*inst->ai[i].not_)
-#define bi_not(i) (*inst->bi[i].not_)
-#define ci_not(i) (*inst->ci[i].not_)
+#define a(i) (hal_get_bool(inst->a[(i)]))
+#define b(i) (hal_get_bool(inst->b[(i)]))
+#define c(i) (hal_get_bool(inst->c[(i)]))
+#define a_set(i,v) (hal_set_bool(inst->a[(i)], (v)))
+#define b_set(i,v) (hal_set_bool(inst->b[(i)], (v)))
+#define c_set(i,v) (hal_set_bool(inst->c[(i)], (v)))
+#define ai_invert(i) (hal_get_bool(inst->ai[i].invert))
+#define bi_invert(i) (hal_get_bool(inst->bi[i].invert))
+#define ci_invert(i) (hal_get_bool(inst->ci[i].invert))
+#define ai_not_set(i,v) (hal_set_bool(inst->ai[(i)].not_, (v)))
+#define bi_not_set(i,v) (hal_set_bool(inst->bi[(i)].not_, (v)))
+#define ci_not_set(i,v) (hal_set_bool(inst->ci[(i)].not_, (v)))
 #define ioaddr (inst->ioaddr)
 #define dir_ (inst->dir_)
 
@@ -286,7 +289,8 @@ static void extra_cleanup(void) {
 }
 
 static void write(struct port *inst, long period) {
-    int p = dir_;
+    int p = hal_get_ui32(dir_);
+    rtapi_u32 xioaddr = hal_get_ui32(ioaddr);
     static int first=1;
 
     int i;
@@ -296,7 +300,7 @@ static void write(struct port *inst, long period) {
             int t = (c(i) != 0) ^ (ci_invert(i) != 0);
             if(t) byte |= 1 << i;
         }
-        pci_8255_outb(byte, ioaddr, 2);
+        pci_8255_outb(byte, xioaddr, 2);
 	if(first) rtapi_print_msg(RTAPI_MSG_DBG, "write: 2a %02x\n", byte);
     } else if((p & 5) == 4) {
         int byte = 0;
@@ -304,7 +308,7 @@ static void write(struct port *inst, long period) {
             int t = (c(i) != 0) ^ (ci_invert(i) != 0);
             if(t) byte |= 1 << i;
         }
-        pci_8255_outb(byte, ioaddr, 2);
+        pci_8255_outb(byte, xioaddr, 2);
 	if(first) rtapi_print_msg(RTAPI_MSG_DBG, "write: 2b %02x\n", byte);
     } else if((p & 5) == 1) {
         int byte = 0;
@@ -312,7 +316,7 @@ static void write(struct port *inst, long period) {
             int t = (c(i) != 0) ^ (ci_invert(i) != 0);
             if(t) byte |= 1 << i;
         }
-        pci_8255_outb(byte, ioaddr, 2);
+        pci_8255_outb(byte, xioaddr, 2);
 	if(first) rtapi_print_msg(RTAPI_MSG_DBG, "write: 2c %02x\n", byte);
     }
 
@@ -322,7 +326,7 @@ static void write(struct port *inst, long period) {
             int t = (b(i) != 0) ^ (bi_invert(i) != 0);
             if(t) byte |= 1 << i;
         }
-        pci_8255_outb(byte, ioaddr, 1);
+        pci_8255_outb(byte, xioaddr, 1);
 	if(first) rtapi_print_msg(RTAPI_MSG_DBG, "write: 1 %02x\n", byte);
     }
 
@@ -332,53 +336,54 @@ static void write(struct port *inst, long period) {
             int t = (a(i) != 0) ^ (ai_invert(i) != 0);
             if(t) byte |= 1 << i;
         }
-        pci_8255_outb(byte, ioaddr, 0);
+        pci_8255_outb(byte, xioaddr, 0);
 	if(first) rtapi_print_msg(RTAPI_MSG_DBG, "write: 0 %02x\n", byte);
     }
     first = 0;
 }
 
 static void read(struct port *inst, long period) {
-    int p = dir_;
+    int p = hal_get_ui32(dir_);
+    rtapi_u32 xioaddr = hal_get_ui32(ioaddr);
     int i;
     if((p & 5) == 5) {
-        int byte = pci_8255_inb(ioaddr, 2);
+        int byte = pci_8255_inb(xioaddr, 2);
         for(i=0; i<8; i++) {
             int t = (byte & (1<<i)) != 0;
-            c(i) = t;
-            ci_not(i) = !t;
+            c_set(i, t);
+            ci_not_set(i, !t);
         }
     } else if((p & 5) == 4) {
-        int byte = pci_8255_inb(ioaddr, 2);
+        int byte = pci_8255_inb(xioaddr, 2);
         for(i=4; i<8; i++) {
             int t = (byte & (1<<i)) != 0;
-            c(i) = t;
-            ci_not(i) = !t;
+            c_set(i, t);
+            ci_not_set(i, !t);
         }
     } else if((p & 5) == 1) {
-        int byte = pci_8255_inb(ioaddr, 2);
+        int byte = pci_8255_inb(xioaddr, 2);
         for(i=0; i<4; i++) {
             int t = (byte & (1<<i)) != 0;
-            c(i) = t;
-            ci_not(i) = !t;
+            c_set(i, t);
+            ci_not_set(i, !t);
         }
     }
 
     if(p & 2) {
-        int byte = pci_8255_inb(ioaddr, 1);
+        int byte = pci_8255_inb(xioaddr, 1);
         for(i=0; i<8; i++) {
             int t = (byte & (1<<i)) != 0;
-            b(i) = t;
-            bi_not(i) = !t;
+            b_set(i, t);
+            bi_not_set(i, !t);
         }
     }
 
     if(p & 8) {
-        int byte = pci_8255_inb(ioaddr, 0);
+        int byte = pci_8255_inb(xioaddr, 0);
         for(i=0; i<8; i++) {
             int t = (byte & (1<<i)) != 0;
-            a(i) = t;
-            ai_not(i) = !t;
+            a_set(i, t);
+            ai_not_set(i, !t);
         }
     }
 }

--- a/src/hal/drivers/pcl720.comp
+++ b/src/hal/drivers/pcl720.comp
@@ -4,16 +4,16 @@ work with the PCI version too, but this is untested.
  It creates hal pins corresponding to the digital inputs and outputs, but does
 not support the the counters/timers.""";
 
-pin in bit pin-##-out[32] "Output pins";
-pin out bit pin-##-in[32] "Input pins";
-pin out bit pin-##-in-not[32] "Inverted version of each input pin";
-param rw unsigned reset-time = 5000 """The time in nanoseconds after the write function
+pin in bool pin-##-out[32] "Output pins";
+pin out bool pin-##-in[32] "Input pins";
+pin out bool pin-##-in-not[32] "Inverted version of each input pin";
+param rw ui32 reset-time = 5000 """The time in nanoseconds after the write function
 has run to reset the pins for which the "reset" parameter is set.""";
-param rw bit pin-##-reset[32] """specifies if the pin should be reset by the "reset"
+param rw bool pin-##-reset[32] """specifies if the pin should be reset by the "reset"
 function""";
-param rw bit pin-##-out-invert[32] "Set to true to invert the sense of the output pin";
+param rw bool pin-##-out-invert[32] "Set to true to invert the sense of the output pin";
 
-pin out  unsigned wait_clocks;
+pin out  ui32 wait_clocks;
 
 function read "Reads each of the digital inputs and updates the HAL pins";
 function write "Writes the values of the output HAL pins to the digital IO";
@@ -60,8 +60,8 @@ FUNCTION(read){
         + (inb(base_addr + 3) << 24);
     
     for (i = 0;i <= 31;i++){
-        pin_in(i) = R & (1 << i);
-        pin_in_not(i) = !pin_in(i);
+        pin_in_set(i, R & (1 << i));
+        pin_in_not_set(i, !pin_in(i));
     }
 }
 
@@ -104,7 +104,7 @@ FUNCTION(reset){
     tmp = (out ^ inv) & (~res);
     if (tmp == out) {return;} // nothing to reset
     
-    if(reset_time > period/4) reset_time = period/4;
+    if(reset_time > period/4) reset_time_set(period/4);
     
     //compensate for any time elapsed since the write
     rtapi_delay(reset_time - (rtapi_get_time() - write_time));

--- a/src/hal/drivers/pluto_servo.comp
+++ b/src/hal/drivers/pluto_servo.comp
@@ -47,29 +47,29 @@ described in the HAL manual.
 The digital input pins conform to the `canonical digital input' interface
 described in the HAL manual.
 """;
-pin out s32 encoder.#.count[4];
-pin out float encoder.#.position[4];
-pin out float encoder.#.velocity[4];
-pin in bit encoder.#.reset[4];
-pin io bit encoder.#.index-enable[4] """encoder.\\fIM\\fR corresponds to the
+pin out si32 encoder.#.count[4];
+pin out real encoder.#.position[4];
+pin out real encoder.#.velocity[4];
+pin in bool encoder.#.reset[4];
+pin io bool encoder.#.index-enable[4] """encoder.\\fIM\\fR corresponds to the
 pins labeled QA\\fIM\\fR, QB\\fIM\\fR, and QZ\\fIM\\fR on the pinout diagram""";
-param rw float encoder.#.scale[4] =1;
+param rw real encoder.#.scale[4] =1;
 
-param rw bit encoder.z-polarity "Set to TRUE if the index pulse is active low, FALSE if it is active high.  Affects all encoders.";
+param rw bool encoder.z-polarity "Set to TRUE if the index pulse is active low, FALSE if it is active high.  Affects all encoders.";
 
-pin in float pwm.#.value[4];
-pin in bit pwm.#.enable[4] "pwm.\\fIM\\fR corresponds to the pins labeled UP\\fIM\\fR and DN\\fIM\\fR on the pinout diagram";
-param rw float pwm.#.offset[4];
-param rw float pwm.#.scale[4]=1;
-param rw float pwm.#.max-dc[4]=1;
-param rw float pwm.#.min-dc[4]=0;
-param rw bit pwm.#.pwmdir[4]=0
+pin in real pwm.#.value[4];
+pin in bool pwm.#.enable[4] "pwm.\\fIM\\fR corresponds to the pins labeled UP\\fIM\\fR and DN\\fIM\\fR on the pinout diagram";
+param rw real pwm.#.offset[4];
+param rw real pwm.#.scale[4]=1;
+param rw real pwm.#.max-dc[4]=1;
+param rw real pwm.#.min-dc[4]=0;
+param rw bool pwm.#.pwmdir[4]=0
 "Set to TRUE use PWM+direction mode.  Set to FALSE to use Up/Down mode.";
 
-param rw bit pwm.is-pdm "Set to TRUE to use PDM (also called interleaved PWM) mode.  Set to FALSE to use traditional PWM mode.  Affects all PWM outputs.";
+param rw bool pwm.is-pdm "Set to TRUE to use PDM (also called interleaved PWM) mode.  Set to FALSE to use traditional PWM mode.  Affects all PWM outputs.";
 
 
-pin in bit dout.##[20]
+pin in bool dout.##[20]
 """dout.\\fI0M\\fR corresponds to the pin labeled
 OUT\\fIM\\fR on the pinout diagram.  Other pins are shared with the PWM
 function, as follows:
@@ -100,11 +100,11 @@ dout.19\tDOWN3
 .PP
 .RE 
 .DT""";
-param rw bit dout.##-invert[20]
+param rw bool dout.##-invert[20]
 "If TRUE, the output on the corresponding \\fBdout.\\fIMM\\fR is inverted.";
 
-pin out bit din.##[20];
-pin out bit din.##_not[20]
+pin out bool din.##[20];
+pin out bool din.##_not[20]
 """For M=0 through 7, din.\\fI0M\\fR corresponds to the pin labeled
 IN\\fIM\\fR on the pinout diagram.  Other pins are shared with the encoder
 function, as follows:
@@ -142,7 +142,7 @@ din.19\tQA3
 .RE
 .DT""";
 
-param rw u32 communication_error """Incremented each time 
+param rw ui32 communication_error """Incremented each time
 pluto-servo.read detects an error code in the EPP status register.  While
 this register is nonzero, new values are not being written to the Pluto-P
 board, and the status of digital outputs and the PWM duty cycle of the PWM
@@ -150,8 +150,8 @@ outputs will remain unchanged.  If the watchdog is enabled, it will activate
 soon after the communication error is detected.  To continue after a
 communication error, set this parameter back to zero.""";
 
-param rw s32 debug_0;
-param rw s32 debug_1 """These parameters can display values which are useful to developers or for debugging the driver and firmware.  They are not useful for integrators or users.""";
+param rw si32 debug_0;
+param rw si32 debug_1 """These parameters can display values which are useful to developers or for debugging the driver and firmware.  They are not useful for integrators or users.""";
 
 option singleton;
 option extra_setup;
@@ -236,10 +236,10 @@ FUNCTION(write) {
     EPP_ADDR(0);
 
     for(i=0; i<4; i++) {
-        if(pwm_max_dc(i) > 1) pwm_max_dc(i) = 1;
-        else if(pwm_max_dc(i) < 0) pwm_max_dc(i) = 0;
-        if(pwm_min_dc(i) < 0) pwm_min_dc(i) = 0;
-        else if(pwm_min_dc(i) > pwm_max_dc(i)) pwm_min_dc(i) = pwm_max_dc(i);
+        if(pwm_max_dc(i) > 1) pwm_max_dc_set(i, 1);
+        else if(pwm_max_dc(i) < 0) pwm_max_dc_set(i, 0);
+        if(pwm_min_dc(i) < 0) pwm_min_dc_set(i, 0);
+        else if(pwm_min_dc(i) > pwm_max_dc(i)) pwm_min_dc_set(i, pwm_max_dc(i));
     }
 
 #define D(x) (!dout(x) ^ !dout_invert(x))
@@ -273,7 +273,7 @@ FUNCTION(read) {
         if(i == 0) {
             int status = inb(ioaddr+1) & 1;
             if(status) {
-                communication_error ++;
+                communication_error_set(communication_error + 1);
 		pluto_clear_error_register();
             }
             if(communication_error) { EPP_DIR_WRITE(); return; }
@@ -290,20 +290,20 @@ FUNCTION(read) {
 	    index = data.last_index[i];
 
         if(encoder_index_enable(i) && indexed) {
-            encoder_index_enable(i) = 0;
+            encoder_index_enable_set(i, 0);
             data.reset_count[i] = index;
         }
-        if(reset) encoder_velocity(i) = 0;
-        else encoder_velocity(i) = (count - data.last_count[i]) /
-            encoder_scale(i) / fperiod;
+        if(reset) encoder_velocity_set(i, 0);
+        else encoder_velocity_set(i, (count - data.last_count[i]) /
+            encoder_scale(i) / fperiod);
         data.last_index[i] = index;
         data.last_count[i] = count;
         if(reset) data.reset_count[i] = count;
-        encoder_count(i) = count - data.reset_count[i];
-        encoder_position(i) = encoder_count(i) / encoder_scale(i);
+        encoder_count_set(i, count - data.reset_count[i]);
+        encoder_position_set(i, encoder_count(i) / encoder_scale(i));
 
         if(i == 0) {
-            debug_0 = ppdata; debug_1 = count;
+            debug_0_set(ppdata); debug_1_set(count);
         }
     }
 
@@ -311,7 +311,7 @@ FUNCTION(read) {
 
     for(i=0; i< 20; i++) {
         int b = ppdata & (1<<i);
-        din(i) = !!b; din_not(i) = !b;
+        din_set(i, !!b); din_not_set(i, !b);
     }
 
     EPP_DIR_WRITE();

--- a/src/hal/drivers/pluto_step.comp
+++ b/src/hal/drivers/pluto_step.comp
@@ -91,32 +91,32 @@ described in the HAL manual.
 The digital input pins conform to the `canonical digital input' interface
 described in the HAL manual.
 """;
-pin in float stepgen.#.position-cmd[4];
-pin out float stepgen.#.velocity-fb[4];
-pin out float stepgen.#.position-fb[4];
-pin out s32 stepgen.#.counts[4];
-pin in bit stepgen.#.enable[4];
-pin in bit stepgen.#.reset[4] "When TRUE, reset position-fb to 0";
-param rw float stepgen.#.scale[4] = 1.0;
-param rw float stepgen.#.maxvel[4] = 0;
-param rw bit stepgen.step_polarity;
+pin in real stepgen.#.position-cmd[4];
+pin out real stepgen.#.velocity-fb[4];
+pin out real stepgen.#.position-fb[4];
+pin out si32 stepgen.#.counts[4];
+pin in bool stepgen.#.enable[4];
+pin in bool stepgen.#.reset[4] "When TRUE, reset position-fb to 0";
+param rw real stepgen.#.scale[4] = 1.0;
+param rw real stepgen.#.maxvel[4] = 0;
+param rw bool stepgen.step_polarity;
 
-param rw u32 stepgen.steplen "Step length in ns.";
-param rw u32 stepgen.stepspace "Step space in ns";
-param rw u32 stepgen.dirtime "Dir hold/setup in ns.  Refer to the pdf documentation for a diagram of what these timings mean.";
+param rw ui32 stepgen.steplen "Step length in ns.";
+param rw ui32 stepgen.stepspace "Step space in ns";
+param rw ui32 stepgen.dirtime "Dir hold/setup in ns.  Refer to the pdf documentation for a diagram of what these timings mean.";
 
-pin in bit dout.##[14]
+pin in bool dout.##[14]
 """dout.\\fIMM\\fR corresponds to the pin labeled
 OUT\\fIM\\fR on the pinout diagram.""";
-param rw bit dout.##-invert[14]
+param rw bool dout.##-invert[14]
 "If TRUE, the output on the corresponding \\fBdout.\\fIMM\\fR is inverted.";
 
-pin out bit din.##[16];
-pin out bit din.##_not[16]
+pin out bool din.##[16];
+pin out bool din.##_not[16]
 """din.\\fIMM\\fR corresponds to the pin labeled
 IN\\fIM\\fR on the pinout diagram.""";
 
-param rw u32 communication_error """Incremented each time 
+param rw ui32 communication_error """Incremented each time
 pluto-step.read detects an error code in the EPP status register.  While
 this register is nonzero, new values are not being written to the Pluto-P
 board, and the status of digital outputs and the PWM duty cycle of the PWM
@@ -124,10 +124,10 @@ outputs will remain unchanged.  If the hardware watchdog is enabled, it will
 activate shortly after the communication error is detected by LinuxCNC.  To continue
 after a communication error, set this parameter back to zero.""";
 
-param rw s32 debug_0;
-param rw s32 debug_1;
-param rw float debug_2=.5;
-param rw float debug_3=2.0
+param rw si32 debug_0;
+param rw si32 debug_1;
+param rw real debug_2=.5;
+param rw real debug_3=2.0
  """Registers that hold debugging information of interest to developers""";
 
 option singleton;
@@ -184,7 +184,7 @@ FUNCTION(write) {
             "Requested step length %dns decreased to %dns "
             "due to hardware limitations\n",
             stepgen_steplen, TMAX * PLUTO_SPEED_NS);
-        stepgen_steplen = TMAX * PLUTO_SPEED_NS;
+        stepgen_steplen_set(TMAX * PLUTO_SPEED_NS);
     }
 
     if(dirtime_ticks > TMAX) {
@@ -193,7 +193,7 @@ FUNCTION(write) {
             "Requested direction change time %dns decreased to %dns "
             "due to hardware limitations\n",
             stepgen_dirtime, TMAX * PLUTO_SPEED_NS);
-        stepgen_dirtime = TMAX * PLUTO_SPEED_NS;
+        stepgen_dirtime_set(TMAX * PLUTO_SPEED_NS);
     }
 
     // Speed limits come from several sources
@@ -224,7 +224,7 @@ FUNCTION(write) {
 	data.old_position_cmd[i] = new_position_cmd;
 	data.old_velocity_cmd[i] = v;
         actual_max = fmax / scale_abs;
-        if(stepgen_maxvel(i) < 0) stepgen_maxvel(i) = -stepgen_maxvel(i);
+        if(stepgen_maxvel(i) < 0) stepgen_maxvel_set(i, -stepgen_maxvel(i));
         if(stepgen_maxvel(i) != 0 && stepgen_maxvel(i) > actual_max) {
             static int message_printed[4] = {0,0,0,0};
             if(!message_printed[i]) {
@@ -235,7 +235,7 @@ FUNCTION(write) {
                     (int)(fmax));
                 message_printed[i] = 1;
             }
-            stepgen_maxvel(i) = actual_max;
+            stepgen_maxvel_set(i, actual_max);
         }
 
         if(stepgen_maxvel(i) == 0) {
@@ -251,7 +251,7 @@ FUNCTION(write) {
 	if(rate < -maxrate) rate = -maxrate;
 
 	if(!stepgen_enable(i)) rate = 0;
-        if(i == 0) debug_1 = rate;
+        if(i == 0) debug_1_set(rate);
 	write16(rate);
     }
 
@@ -284,7 +284,7 @@ FUNCTION(read) {
         if(i == 0) {
             int status = inb(ioaddr+1) & 1;
             if(status) {
-                communication_error ++;
+                communication_error_set(communication_error + 1);
 		pluto_clear_error_register();
             }
             if(communication_error) { EPP_DIR_WRITE(); return; }
@@ -293,21 +293,21 @@ FUNCTION(read) {
 	newlow = ppdata & MASK;
 
         count = extend(data.last_count[i], newlow, W+F);
-	stepgen_velocity_fb(i) = (count - data.last_count[i]) / stepgen_scale(i) / fperiod / (1 << F);
+	stepgen_velocity_fb_set(i, (count - data.last_count[i]) / stepgen_scale(i) / fperiod / (1 << F));
         data.last_count[i] = count;
         if(reset) data.reset_count[i] = count;
         fcount = (count - data.reset_count[i]) * 1. / (1<<F);
-        stepgen_counts(i) = fcount;
-        stepgen_position_fb(i) = fcount / stepgen_scale(i);
+        stepgen_counts_set(i, fcount);
+        stepgen_position_fb_set(i, fcount / stepgen_scale(i));
 
-        if(i == 0) { debug_0 = ppdata; }
+        if(i == 0) { debug_0_set(ppdata); }
     }
 
     ppdata = read32();
 
     for(i=0; i<16; i++) {
         int b = ppdata & (1<<i);
-        din(i) = !!b; din_not(i) = !b;
+        din_set(i, !!b); din_not_set(i, !b);
     }
 
     EPP_DIR_WRITE();


### PR DESCRIPTION
These are the components that only build as a kernel module. Some are ancient and are for ISA boards. You'd need a - too expensive for my pay grade - industrial PC to get that working today. I'd wonder what linux kernel version you need too.

The pluto_servo.comp and pluto_step.comp still have their troff formatted documentation. They never got converted to adoc and nobody complained.

Anyhoo,... the conversions should be rather straight forward. We can probably never test this. We really should do a survey on what hardware is used out there. There comes a time when you need to prune the ballast.

Please check for any parameter gremlins ;-)

The old hal types used in hal_motenc.comp/motenc.h (hardware MMIO map) was fixed using the rtapi types marked volatile. That should be fully compatible.