### PR TITLE
CI: Use main Ubuntu archive instead of azure.archive.ubuntu.com

### DIFF
--- a/.github/scripts/install-deps.sh
+++ b/.github/scripts/install-deps.sh
@@ -3,6 +3,8 @@
 set -eu #Needed so CI fails when anything is wrong
 set -x
 
+.github/scripts/use-main-ubuntu-mirror.sh
+
 sudo apt-get --quiet update
 sudo apt-get install --yes --no-install-recommends devscripts equivs build-essential lintian clang
 debian/configure

--- a/.github/scripts/use-main-ubuntu-mirror.sh
+++ b/.github/scripts/use-main-ubuntu-mirror.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+# The azure.archive.ubuntu.com apt mirror on GitHub-hosted runners
+# regularly degrades to trickle speeds for extended periods, which stalls
+# package downloads until the job hits its timeout. apt retries do not
+# help because the connection stays alive, only slow. Switch to the main
+# Ubuntu archive, which is consistently fast from Azure.
+
+set -eu #Needed so CI fails when anything is wrong
+set -x
+
+for f in /etc/apt/sources.list /etc/apt/sources.list.d/*.list /etc/apt/sources.list.d/*.sources; do
+    [ -e "$f" ] || continue
+    sudo sed -i 's|http://azure\.archive\.ubuntu\.com/ubuntu|http://archive.ubuntu.com/ubuntu|g' "$f"
+done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,6 +131,7 @@ jobs:
     - name: Install dependencies
       run: |
         set -x
+        .github/scripts/use-main-ubuntu-mirror.sh
         sudo apt-get -q update
         sudo apt-get --yes install cppcheck
     - name: Cppcheck


### PR DESCRIPTION
## Problem

CI jobs that install build dependencies on GitHub-hosted runners occasionally stall until the 45 minute job timeout. The cause is the default apt mirror on the runners, azure.archive.ubuntu.com, which degrades to trickle speeds (tens of kB/s) for extended periods. Example: rip-rtai on #4335 spent 25 minutes downloading fonts-noto-cjk (61 MB) and was cancelled at the timeout.

This is a recurring upstream problem with the Azure mirror, reported many times in actions/runner-images (issues #7048, #12949, #675, #6913). GitHub's official response there is to use an alternative mirror.

Note that apt retries (Acquire::Retries) do not help here: the connection stays alive, it is only slow, so apt never sees an error to retry.

## Fix

Switch the apt sources on the runner from azure.archive.ubuntu.com to archive.ubuntu.com before installing packages, in a small script called from install-deps.sh and from the cppcheck job (which calls apt directly). This covers all jobs that install dependencies on the GitHub-hosted Ubuntu runners. The container based package jobs are unaffected, they use Debian mirrors.

The sed handles both the traditional /etc/apt/sources.list and the deb822 format .sources files used on 24.04 runners.

## Possible follow up

If we still see stalls after this (i.e. archive.ubuntu.com itself degrading from Azure), the next step would be a wrapper that runs apt under a timeout and, on expiry, rewrites the sources to a different mirror and retries. I did not include that here because it adds complexity for a failure mode we have not seen yet; the plain mirror swap removes the known offender. If stalls reappear I will implement the wrapper as a follow up.
