### PR TITLE
docs: add explicit anchors for sections referenced by auto-generated ids

### DIFF
--- a/docs/src/getting-started/getting-linuxcnc.adoc
+++ b/docs/src/getting-started/getting-linuxcnc.adoc
@@ -35,6 +35,7 @@ The outline of the process looks like this:
 
 This section describes some methods for downloading the Live/Install image.
 
+[[_normal_download]]
 === Normal Download
 
 Software for LinuxCNC to download is presented on the project's
@@ -242,6 +243,7 @@ In rare cases you might have to reset the BIOS to default settings if
 during the Live CD install it cannot recognize the hard drive
 during the boot up.
 
+[[_alternate_install_methods]]
 == Alternate Install Methods
 
 The easiest, preferred way to install LinuxCNC is to use the Live/Install Image as described above.

--- a/docs/src/gui/qtvcp.adoc
+++ b/docs/src/gui/qtvcp.adoc
@@ -77,6 +77,7 @@ You are free to mix them in any way on your panel.
 A very important widget for CNC control is the *`ScreenOptions` widget*:
 It does not add anything visually to the screen but, allows important details to be selected rather then be coded in the handler file.
 
+[[_ini_settings]]
 === INI Settings
 
 If you are using QtVCP to make a CNC motion control screen (rather then a HAL based panel), in the INI file, in the `[DISPLAY]` section, add a line with the following pattern:

--- a/docs/src/install/latency-test.adoc
+++ b/docs/src/install/latency-test.adoc
@@ -227,6 +227,7 @@ isolcpus::
     for latency>>.
 
 
+[[_latency_tuning]]
 == Latency tuning
 
 LinuxCNC can run on many different hardware platforms and with many

--- a/docs/src/man/man1/halcmd.1.adoc
+++ b/docs/src/man/man1/halcmd.1.adoc
@@ -58,6 +58,7 @@ and press tab to complete the names of items such as pins and signals.
   display a help screen and exit, displays extended help on _command_ if
   specified
 
+[[_commands]]
 == COMMANDS
 
 Commands tell *halcmd* what to do. Normally *halcmd* reads a single


### PR DESCRIPTION
The CI htmldocs job (`scripts/htmlcheck.sh -w`, W3C checklink) currently warns about broken URI fragments in the translated HTML docs. One class of those failures comes from sections that are linked to via their auto-generated AsciiDoc id rather than an explicit anchor.

Auto-generated ids are derived from the section title (`=== Normal Download` becomes `_normal_download`). When a translation translates the title, the derived id changes (`_normales_herunterladen`) and every link using the English-derived id breaks in that language. This currently affects the de, es, ru, uk and nb builds:

- `<<_normal_download,...>>` and `<<_alternate_install_methods,...>>` in getting-linuxcnc.adoc
- `<<_latency_tuning>>` in latency-test.adoc
- `link:../gui/qtvcp.html#_ini_settings[...]` in qtplasmac.adoc
- `link:../man/man1/halcmd.1.html#_commands[...]` in qtvcp-widgets.adoc

This PR pins the five ids with explicit `[[...]]` anchors. The explicit id is identical to the previously auto-generated one, so the English output is unchanged and all existing references (including external deep links) keep working. po4a treats standalone anchor lines as structural and passes them through untranslated, so all translations inherit the stable id without any .po changes.

I verified locally that the rendered HTML for all five pages emits the same ids as before. The remaining CI link warnings are mangled anchors inside translated strings in the .po files and have to be fixed on Weblate
