### PR TITLE
Update spindle orient docs

### DIFF
--- a/docs/src/gcode/m-code.adoc
+++ b/docs/src/gcode/m-code.adoc
@@ -235,7 +235,7 @@ M19 R- Q- [P-] [$-]
 M19 is a command of modal group 7, like M3, M4 and M5.
 M19 is cleared by any of M3,M4,M5.
 
-Spindle orientation requires a quadrature encoder with an index to sense the
+Spindle orientation requires a quadrature encoder to sense the
 spindle shaft position and direction of rotation.
 
 INI Settings in the [RS274NGC] section:

--- a/src/hal/components/orient.comp
+++ b/src/hal/components/orient.comp
@@ -26,9 +26,7 @@ to support the M19 code.
 The spindle is assumed to have stopped in an arbitrary position. The spindle
 encoder position is linked to the *position* pin.  The current value of the
 position pin is sampled on a positive edge on the *enable* pin, and *command*
-is computed and set as follows: +
-floor(number of full spindle revolutions in the *position* sampled on positive
-edge) plus *angle*/360 (the fractional revolution) +1/-1/0 depending on *mode*.
+is computed and set depending on *mode*.
 
 The *mode* pin is interpreted as follows:
 


### PR DESCRIPTION
This corrects misinformation in

- the m-code docs: M19 does not use encoder index.
- the 'orient.comp' man page: Function description does not match the current code.

See https://forum.linuxcnc.org/38-general-linuxcnc-questions/59064-m19-orientation-drift-with-external-encoder-and-orient-component-linuxcnc-2-9-4#348461