### PR TITLE
2.9 CI: Use main Ubuntu archive instead of azure.archive.ubuntu.com (backport of #4336)

### DIFF
--- a/.github/scripts/install-deps.sh
+++ b/.github/scripts/install-deps.sh
@@ -3,6 +3,8 @@
 set -eu #Needed so CI fails when anything is wrong
 set -x
 
+.github/scripts/use-main-ubuntu-mirror.sh
+
 sudo apt-get --quiet update
 sudo apt-get install --yes --no-install-recommends devscripts equivs build-essential lintian clang
 debian/configure

--- a/.github/scripts/use-main-ubuntu-mirror.sh
+++ b/.github/scripts/use-main-ubuntu-mirror.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+# The azure.archive.ubuntu.com apt mirror on GitHub-hosted runners
+# regularly degrades to trickle speeds for extended periods, which stalls
+# package downloads until the job hits its timeout. apt retries do not
+# help because the connection stays alive, only slow. Switch to the main
+# Ubuntu archive, which is consistently fast from Azure.
+
+set -eu #Needed so CI fails when anything is wrong
+set -x
+
+for f in /etc/apt/sources.list /etc/apt/sources.list.d/*.list /etc/apt/sources.list.d/*.sources; do
+    [ -e "$f" ] || continue
+    sudo sed -i 's|http://azure\.archive\.ubuntu\.com/ubuntu|http://archive.ubuntu.com/ubuntu|g' "$f"
+done

--- a/.github/scripts/use-main-ubuntu-mirror.sh
+++ b/.github/scripts/use-main-ubuntu-mirror.sh
@@ -1,15 +1,22 @@
 #!/bin/sh
 
 # The azure.archive.ubuntu.com apt mirror on GitHub-hosted runners
-# regularly degrades to trickle speeds for extended periods, which stalls
-# package downloads until the job hits its timeout. apt retries do not
-# help because the connection stays alive, only slow. Switch to the main
-# Ubuntu archive, which is consistently fast from Azure.
+# regularly degrades to trickle speeds, stalling jobs until they time
+# out. Switch to archive.ubuntu.com, which is consistently fast.
 
 set -eu #Needed so CI fails when anything is wrong
 set -x
 
-for f in /etc/apt/sources.list /etc/apt/sources.list.d/*.list /etc/apt/sources.list.d/*.sources; do
+# apt-mirrors.txt must be included: the runner image points apt at it
+# via mirror+file:// in ubuntu.sources, so the azure URL lives there.
+for f in /etc/apt/sources.list /etc/apt/sources.list.d/*.list /etc/apt/sources.list.d/*.sources /etc/apt/apt-mirrors.txt; do
     [ -e "$f" ] || continue
     sudo sed -i 's|http://azure\.archive\.ubuntu\.com/ubuntu|http://archive.ubuntu.com/ubuntu|g' "$f"
 done
+
+# Fail if azure is still referenced, so an image layout change cannot
+# turn this script into a silent no-op.
+if grep -rsq 'azure\.archive\.ubuntu\.com' /etc/apt; then
+    echo "error: azure.archive.ubuntu.com still referenced under /etc/apt after mirror switch" >&2
+    exit 1
+fi


### PR DESCRIPTION
Backport of #4336 (1d46401b07) to 2.9.

The azure.archive.ubuntu.com apt mirror on GitHub-hosted runners regularly degrades to trickle speeds, stalling package downloads until jobs hit their timeout. 2.9 CI suffers from the same problem. This switches the affected jobs to archive.ubuntu.com, which is consistently fast from Azure.

Differences from the master commit: the ci.yml hunk is dropped because the cppcheck job it touches is commented out on 2.9. All four host jobs that install packages on the runner (rip-and-test, rip-rtai, rip-and-test-clang, htmldocs) go through `.github/scripts/install-deps.sh`, so the mirror switch there covers them. The package-arch and package-indep jobs run inside Debian containers where apt uses deb.debian.org and is unaffected.
