### PR TITLE
CI: rewrite apt-mirrors.txt so the mirror switch actually applies

### DIFF
--- a/.github/scripts/use-main-ubuntu-mirror.sh
+++ b/.github/scripts/use-main-ubuntu-mirror.sh
@@ -1,15 +1,22 @@
 #!/bin/sh
 
 # The azure.archive.ubuntu.com apt mirror on GitHub-hosted runners
-# regularly degrades to trickle speeds for extended periods, which stalls
-# package downloads until the job hits its timeout. apt retries do not
-# help because the connection stays alive, only slow. Switch to the main
-# Ubuntu archive, which is consistently fast from Azure.
+# regularly degrades to trickle speeds, stalling jobs until they time
+# out. Switch to archive.ubuntu.com, which is consistently fast.
 
 set -eu #Needed so CI fails when anything is wrong
 set -x
 
-for f in /etc/apt/sources.list /etc/apt/sources.list.d/*.list /etc/apt/sources.list.d/*.sources; do
+# apt-mirrors.txt must be included: the runner image points apt at it
+# via mirror+file:// in ubuntu.sources, so the azure URL lives there.
+for f in /etc/apt/sources.list /etc/apt/sources.list.d/*.list /etc/apt/sources.list.d/*.sources /etc/apt/apt-mirrors.txt; do
     [ -e "$f" ] || continue
     sudo sed -i 's|http://azure\.archive\.ubuntu\.com/ubuntu|http://archive.ubuntu.com/ubuntu|g' "$f"
 done
+
+# Fail if azure is still referenced, so an image layout change cannot
+# turn this script into a silent no-op.
+if grep -rsq 'azure\.archive\.ubuntu\.com' /etc/apt; then
+    echo "error: azure.archive.ubuntu.com still referenced under /etc/apt after mirror switch" >&2
+    exit 1
+fi


### PR DESCRIPTION
Follow-up to #4336. That switch was a silent no-op: the runner image configures apt with `URIs: mirror+file:///etc/apt/apt-mirrors.txt` in `ubuntu.sources`, so the azure mirror URL lives in `/etc/apt/apt-mirrors.txt`, not in any of the files the script rewrote. CI logs from runs after #4336 confirm apt still fetched from `azure.archive.ubuntu.com` (look for `Get:1 file:/etc/apt/apt-mirrors.txt Mirrorlist` followed by `Get:N http://azure.archive.ubuntu.com/...`), and jobs kept stalling when the mirror degraded.

Changes:

- Add `/etc/apt/apt-mirrors.txt` to the rewrite list so the switch actually takes effect.
- After rewriting, fail the step if any `azure.archive.ubuntu.com` reference survives under `/etc/apt`. Without this, a future runner image layout change turns the script into a silent no-op again and the stalls come back with no indication why.

Verified locally against a simulated runner layout: rewrites the mirror list, catches a surviving azure reference in an unlisted file (exit 1), and passes when no azure reference exists.
