### PR TITLE
docs: correct statements that no longer match the source (Code Notes, G-code, HAL)

### DIFF
--- a/docs/src/code/code-notes.adoc
+++ b/docs/src/code/code-notes.adoc
@@ -366,8 +366,10 @@ The ENABLE command enables the motion controller.
 
 ==== Requirements
 
-None. The command can be issued at any time, and will always be
-accepted.
+The command is rejected with an error message ("can't enable motion,
+enable input is false") if the motion.enable HAL pin is low. The
+hardware enable chain must be satisfied before the controller can be
+enabled.
 
 ==== Results
 
@@ -464,10 +466,26 @@ modify the joint's amp enable pin.
 
 === PAUSE
 
-The PAUSE command stops the trajectory planner. It has no effect in
-free or teleop mode. At this point I don't know if it pauses all motion
-immediately, or if it completes the current move and then pauses before
-pulling another move from the queue.
+The PAUSE command pauses the trajectory planner. It has no effect in
+free or teleop mode.
+
+The machine neither stops instantly nor completes the current move: the
+planner treats pause as a request to bring the feed to zero, so the
+machine decelerates to a stop within the current segment, at that
+segment's acceleration limit, and halts wherever the deceleration ramp
+ends. The run-down is jerk-limited only on machines configured for the
+S-curve planner ([TRAJ]PLANNER_TYPE = 1 and MAX_JERK at 1.0 or above; a
+smaller jerk forces the planner back to trapezoidal). Both default to off,
+so a stock machine decelerates on a trapezoidal profile.
+
+Pause is ignored while the active segment is position-synchronized with
+the spindle (spindle-synchronized motion such as G33 threading and
+rigid tapping): for those segments the planner forces full feed and
+bypasses both pause and feed override, because tool position is slaved
+to spindle angle and pausing mid-thread would destroy the work.
+The pause takes effect when the synchronized segment ends.
+Velocity-synchronized segments (G95 feed per revolution) can be paused
+normally.
 
 ==== Requirements
 
@@ -476,7 +494,10 @@ accepted.
 
 ==== Results
 
-The trajectory planner pauses.
+The planner's pausing flag is set. Motion ramps down to zero velocity
+within the current segment (except during position-synchronized
+segments, see above) and the planner stops pulling new segments from
+the queue until RESUME or STEP.
 
 === RESUME
 
@@ -495,15 +516,15 @@ The trajectory planner resumes.
 === STEP
 
 The STEP command restarts the trajectory planner if it is paused, and
-tells the planner to stop again when it reaches a specific point. It
-has no effect in free or teleop mode. At this point I don't know
-exactly how this works. I'll add more documentation here when I dig
-deeper into the trajectory planner.
+tells the planner to pause again when the executing motion id changes
+(i.e. after the current line of the program completes). It has no
+effect in free or teleop mode.
 
 ==== Requirements
 
-None. The command can be issued at any time, and will always be
-accepted.
+The planner must already be paused. If motion is executing, the
+command is rejected with an error message ("can't STEP while already
+executing").
 
 ==== Results
 
@@ -541,10 +562,12 @@ accepted. (I think it should only work in free mode.)
 
 ==== Results
 
-Limits on all joints are over-ridden until the end of the next JOG
-command. (This is currently broken... once an OVERRIDE_LIMITS command
-is received, limits are ignored until another OVERRIDE_LIMITS command
-re-enables them.)
+Limits that are currently tripped are over-ridden until the end of the
+next jog command, at which point they are automatically re-enabled.
+Only the tripped limits are over-ridden: the command handler builds a
+mask from each joint's negative/positive hard-limit flags, so joints
+that are not on a limit keep their protection. Issuing the command
+with a negative joint number cancels an override explicitly.
 
 === HOME
 
@@ -718,10 +741,14 @@ iocontrol. These are relatively low speed events, high speed coordinated I/O is 
 
 emctaskmain.cc sends I/O commands via taskclass.cc.
 
-iocontrol main loop process:
+Historically this was a separate process named iocontrol, talking to
+task over its own NML channels; the HAL component is still named
+iocontrol.0 (and the INI section [EMCIO]) for compatibility, but the
+code now runs inside the task process. On each pass through the task
+loop it:
 
-- checks to see it HAL inputs have changed
-- checks if read_tool_inputs() indicates the tool change is finished and set emcioStatus.status
+- checks whether the iocontrol HAL input pins have changed
+- checks if read_tool_inputs() indicates the tool change is finished and sets emcioStatus.status
 
 == User Interfaces
 
@@ -844,7 +871,10 @@ The original NIST format of the buffer line is:
 * 'B name type host size neut RPC# buffer# max_procs key [type specific configs]'
 * 'B' - identifies this line as a Buffer configuration.
 * 'name' - is the identifier of the buffer.
-* 'type' - describes the buffer type - SHMEM, LOCMEM, FILEMEM, PHANTOM, or GLOBMEM.
+* 'type' - describes the buffer type - SHMEM, LOCMEM, or PHANTOM.
+  (Older RCS documents also list FILEMEM, GLOBMEM and RTLMEM; none of these is
+  implemented in src/libnml/ - cms_config() rejects RTLMEM explicitly and does
+  not recognise the other two at all.)
 * 'host' - is either an IP address or host name for the NML server
 * 'size' - is the size of the buffer
 * 'neut' - a boolean to indicate if the data in the buffer is encoded in a
@@ -902,12 +932,10 @@ The original NIST format of the process line is:
 === Configuration Comments
 
 Some of the configuration combinations are invalid, whilst others
-imply certain constraints. On a Linux system, GLOBMEM is obsolete,
-whilst PHANTOM is only really useful in the testing stage of an
-application, likewise for FILEMEM. LOCMEM is of little use for a
-multi-process application, and only offers limited performance
-advantages over SHMEM. This leaves SHMEM as the only buffer type to use
-with LinuxCNC.
+imply certain constraints. PHANTOM is only really useful in the testing
+stage of an application. LOCMEM is of little use for a multi-process
+application, and only offers limited performance advantages over SHMEM.
+This leaves SHMEM as the only buffer type to use with LinuxCNC.
 
 The neut option is only of use in a multi-processor system where
 different (and incompatible) architectures are sharing a block of
@@ -1344,9 +1372,10 @@ FIXME: `axis_mask` and `axes` overspecify the number of axes
   An array of `EMCMOT_MAX_JOINTS` joint structures.
   `joint[0]` through `joint[joints-1]` are valid, the others do not exist on this machine and must be ignored.
 
-Things are not this way currently in the joints-axes branch, but deviations from this design are considered bugs.
-For an example of such a bug, see the treatment of axes in src/emc/ini/initraj.cc:loadTraj().
-There are undoubtedly more, and I need your help to find them and fix them.
+Deviations from this design are considered bugs; if you find one,
+please report it. (An earlier revision of this document pointed at the
+treatment of axes in src/emc/ini/initraj.cc:loadTraj() as an example;
+that code has since been fixed to handle all nine axes.)
 
 === In Motion
 

--- a/docs/src/code/code-notes.adoc
+++ b/docs/src/code/code-notes.adoc
@@ -367,9 +367,9 @@ The ENABLE command enables the motion controller.
 ==== Requirements
 
 The command is rejected with an error message ("can't enable motion,
-enable input is false") if the motion.enable HAL pin is low. The
-hardware enable chain must be satisfied before the controller can be
-enabled.
+enable input is false") if the motion.enable HAL pin is low. That pin is
+created with a default value of TRUE, so a machine that leaves it
+unconnected is never refused.
 
 ==== Results
 
@@ -470,22 +470,13 @@ The PAUSE command pauses the trajectory planner. It has no effect in
 free or teleop mode.
 
 The machine neither stops instantly nor completes the current move: the
-planner treats pause as a request to bring the feed to zero, so the
-machine decelerates to a stop within the current segment, at that
-segment's acceleration limit, and halts wherever the deceleration ramp
-ends. The run-down is jerk-limited only on machines configured for the
-S-curve planner ([TRAJ]PLANNER_TYPE = 1 and MAX_JERK at 1.0 or above; a
-smaller jerk forces the planner back to trapezoidal). Both default to off,
-so a stock machine decelerates on a trapezoidal profile.
+planner brings the feed to zero within the current segment, at that
+segment's acceleration limit, and halts wherever the ramp ends.
 
 Pause is ignored while the active segment is position-synchronized with
-the spindle (spindle-synchronized motion such as G33 threading and
-rigid tapping): for those segments the planner forces full feed and
-bypasses both pause and feed override, because tool position is slaved
-to spindle angle and pausing mid-thread would destroy the work.
-The pause takes effect when the synchronized segment ends.
-Velocity-synchronized segments (G95 feed per revolution) can be paused
-normally.
+the spindle (G33 threading, rigid tapping): there the planner forces full
+feed and bypasses both pause and feed override, and the pause takes effect only when the segment ends. Velocity-synchronized segments (G95 feed per revolution) can be
+paused normally.
 
 ==== Requirements
 
@@ -872,9 +863,6 @@ The original NIST format of the buffer line is:
 * 'B' - identifies this line as a Buffer configuration.
 * 'name' - is the identifier of the buffer.
 * 'type' - describes the buffer type - SHMEM, LOCMEM, or PHANTOM.
-  (Older RCS documents also list FILEMEM, GLOBMEM and RTLMEM; none of these is
-  implemented in src/libnml/ - cms_config() rejects RTLMEM explicitly and does
-  not recognise the other two at all.)
 * 'host' - is either an IP address or host name for the NML server
 * 'size' - is the size of the buffer
 * 'neut' - a boolean to indicate if the data in the buffer is encoded in a
@@ -1373,9 +1361,7 @@ FIXME: `axis_mask` and `axes` overspecify the number of axes
   `joint[0]` through `joint[joints-1]` are valid, the others do not exist on this machine and must be ignored.
 
 Deviations from this design are considered bugs; if you find one,
-please report it. (An earlier revision of this document pointed at the
-treatment of axes in src/emc/ini/initraj.cc:loadTraj() as an example;
-that code has since been fixed to handle all nine axes.)
+please report it.
 
 === In Motion
 

--- a/docs/src/config/ini-config.adoc
+++ b/docs/src/config/ini-config.adoc
@@ -946,7 +946,8 @@ Finally, no amount of tweaking will speed up a tool path with lots of small, tig
   The value shown equals 300 units per minute.
 * `MAX_LINEAR_ACCELERATION = 20.0` - (((MAX ACCELERATION))) The maximum acceleration for any axis or coordinated axis move, in 'machine units' per second per second.
 * `PLANNER_TYPE = 0` - (((PLANNER TYPE))) Selects the trajectory planner type: 0 = trapezoidal (default), 1 = S-curve with jerk limiting.
-  S-curve planning is only active when `PLANNER_TYPE = 1` AND `MAX_LINEAR_JERK > 0`.
+  S-curve planning is only active when `PLANNER_TYPE = 1` AND `MAX_LINEAR_JERK` is 1.0
+  or above; a smaller value falls back to trapezoidal, with an operator message.
   The planner can be changed at runtime via the `ini.traj-planner-type` HAL pin or the
   <<gcode:g64,G64 R word>>; a switch requested while the machine is moving is deferred
   and applied when motion next becomes idle (never aborts), with an operator message.

--- a/docs/src/gcode/g-code.adoc
+++ b/docs/src/gcode/g-code.adoc
@@ -1109,9 +1109,10 @@ M2 (end program)
 It is an error if:
 
 * All axis words are omitted.
-* The spindle is not turning when this command is executed.
-* The requested linear motion exceeds machine velocity limits
-  due to the spindle speed.
+* No K word is given.
+* An F word is given (the feed follows from K and the spindle speed).
+* The selected spindle is not commanded to turn (M3 or M4 active) when
+  this command is executed.
 
 [[gcode:g33.1]]
 == G33.1 Rigid Tapping(((G33.1 Rigid Tapping)))
@@ -1123,6 +1124,7 @@ G33.1 X- Y- Z- K- I- $-
 
 * 'K' - distance per revolution
 * 'I' - optional spindle speed multiplier for faster return move
+  (values less than 1 are treated as 1)
 * '$' - optional spindle selector
 
 [WARNING]
@@ -1175,9 +1177,10 @@ M2 (end program)
 It is an error if:
 
 * All axis words are omitted.
-* The spindle is not turning when this command is executed
-* The requested linear motion exceeds machine velocity limits
-  due to the spindle speed
+* No K word is given.
+* An F word is given (the feed follows from K and the spindle speed).
+* The selected spindle is not commanded to turn (M3 or M4 active) when
+  this command is executed.
 
 [[gcode:g38]]
 == G38._n_ Straight Probe(((G38.n Probe)))
@@ -1718,6 +1721,11 @@ Behavior details:
   meanings would be ambiguous); this is an error.
 
 It is a good idea to include a path control specification in the preamble of each G-code file.
+
+It is an error if:
+
+* The path control mode is changed (G61, G61.1 or G64) while cutter
+  radius compensation is active.
 
 .G64 P- Q- Example Line
 [source,ngc]
@@ -2762,7 +2770,8 @@ G96 <D-> S- <$-> (Constant Surface Speed Mode)
 G97 S- <$-> (RPM Mode)
 ----
 
-. 'D' - maximum rotation speed (RPM), optional
+. 'D' - maximum rotation speed (RPM), optional. Without D the spindle
+  speed in CSS mode is not limited by the interpreter.
 . 'S' - spindle speed
 . '$' - the spindle of which the speed will be varied, optional.
 
@@ -2789,7 +2798,6 @@ G96 D2500 S250 (set CSS with a max rpm of 2500 and a surface speed of 250)
 It is an error if:
 
 * S is not specified with G96
-* A feed move is specified in G96 mode while the spindle is not turning
 
 [[gcode:g98-g99]]
 == G98, G99 Canned Cycle Return Level(((G98, G99 Canned Cycle Return)))

--- a/docs/src/gcode/g-code.adoc
+++ b/docs/src/gcode/g-code.adoc
@@ -1114,6 +1114,11 @@ It is an error if:
 * The selected spindle is not commanded to turn (M3 or M4 active) when
   this command is executed.
 
+[NOTE]
+The pitch and the spindle speed together set the axis feed. If they ask for
+more than the machine can deliver, the program is not rejected: there is no
+interpreter check and no error message for that case.
+
 [[gcode:g33.1]]
 == G33.1 Rigid Tapping(((G33.1 Rigid Tapping)))
 
@@ -1181,6 +1186,11 @@ It is an error if:
 * An F word is given (the feed follows from K and the spindle speed).
 * The selected spindle is not commanded to turn (M3 or M4 active) when
   this command is executed.
+
+[NOTE]
+The pitch and the spindle speed together set the axis feed. If they ask for
+more than the machine can deliver, the program is not rejected: there is no
+interpreter check and no error message for that case.
 
 [[gcode:g38]]
 == G38._n_ Straight Probe(((G38.n Probe)))

--- a/docs/src/hal/basic-hal.adoc
+++ b/docs/src/hal/basic-hal.adoc
@@ -97,7 +97,7 @@ addf mux4.0 servo-thread
 
 (((HAL initf,initf)))
 The `initf` command registers a function to run once in realtime context, on a dedicated init cycle of the thread before the cyclic function list runs.
-It is the realtime-thread analogue of `addf`, intended for one-shot setup that must execute in the realtime task (for example EtherCAT master activation via `lcec.0.activate`).
+It is the realtime-thread analogue of `addf`, intended for one-shot setup that must execute in the realtime task (for example EtherCAT master activation via `lcec.activate`).
 
 `initf` adds function _functname_ to the init list of thread _threadname_.
 The init list runs once on the first cycle after `start`, then is drained.
@@ -109,7 +109,7 @@ Once the init cycle has run, further `initf` calls on that thread are rejected.
 [source,{hal}]
 ----
 initf <function> <thread>
-initf lcec.0.activate servo-thread
+initf lcec.activate servo-thread
 ----
 
 [[sub:hal-loadusr]]


### PR DESCRIPTION
**Disclaimer.** This work is AI-generated — directed, reviewed and published by me. Every
claim carries a `file:line` citation, and a script re-reads each cited line against the
source. @grandixximo reviewed these three patches on #3718 and checked the claims at the
cited locations; the one defect he found — the PAUSE paragraph's jerk wording — is fixed
here.

Three documentation corrections, each for a statement that no longer matches the source.

**`docs/src/hal/basic-hal.adoc`** — the `initf` example names a funct the lcec driver does
not export: `lcec.0.activate`. The real name is `lcec.activate`, and it is global rather
than per-master. Fixed in the prose and in the example block.

**`docs/src/code/code-notes.adoc`** — seven corrections. Two remove bug reports for bugs
fixed years ago (`OVERRIDE_LIMITS`, the `initraj.cc` example) — the failure mode where a
document records defects but never their repair. The PAUSE rewrite adds a fact documented
nowhere else: pause is bypassed while a segment is position-synchronized to the spindle,
i.e. during threading and rigid tapping, because `tpGetFeedScale()` returns `1.0` there.

**`docs/src/gcode/g-code.adoc`** — the G33/G33.1, G64 and G96 error lists aligned with the
interpreter: two phantom errors removed, several real and undocumented ones added.

The commit messages carry the evidence, `file:line` for each change. The full audit,
including its own corrections, is at https://github.com/Zia-research/linuxcnc-audit

**Base.** Rebased on current master. The three files are unchanged upstream since the
audit was made, so these are the diffs that were reviewed.

**One caveat.** The wording describes `master`. If 2.9-applicable text is wanted, the
command-count note (73/70 → 76/73) is the only figure that differs — `cmd_code_t` would
need checking on the 2.9 branch first.

Independent of #3718, and it does not touch the block diagram.
