### PR TITLE
linuxcncrsh: Fix race between SET JOINT_HOME and SET JOINT_WAIT_HOMED

### DIFF
--- a/src/emc/usr_intf/emcrsh.cc
+++ b/src/emc/usr_intf/emcrsh.cc
@@ -63,7 +63,8 @@ using namespace linuxcnc;
 // Maximum wait time in WAIT_HEARTBEAT to see real-time move along
 #define WAIT_HEARTBEAT_TIMEOUT 1.0
 
-// Maximum number of heartbeats to wait for EMC_TASK_STATE to change
+// Maximum number of heartbeats to wait for the motion controller to catch
+// up and reflect a requested state change in the status
 #define WAIT_TASK_STATE_CHANGE_MAX 25
 
 typedef enum { cmdUnknown, cmdHello, cmdSet, cmdGet, cmdQuit, cmdShutdown, cmdHelp } cmdType;
@@ -875,8 +876,23 @@ static cmdResponseType setJointWaitHomed(connectionRecType &ctx)
 		return rtError;
 	}
 	if (joint >= 0 && !emcStatus->motion.joint[joint].homing && !emcStatus->motion.joint[joint].homed) {
-		errornl(ctx, fmt::format("Joint '{}' is not homed and not in the process of homing.", joint));
-		return rtError;
+		// The motion controller needs a servo-thread run to raise the
+		// homing flag after a 'SET JOINT_HOME' was acknowledged.
+		for (unsigned toc = 0; toc < WAIT_TASK_STATE_CHANGE_MAX; toc++) {
+			updateStatus(); // Get fresh value about joint status
+			if (emcStatus->motion.joint[joint].homing || emcStatus->motion.joint[joint].homed)
+				break;
+			// Wait for the motion control to run
+			if (rtOk != doWaitHeartbeat(ctx, 1, WAIT_HEARTBEAT_TIMEOUT)) {
+				// Bad sign,... can't wait for a heartbeat
+				errornl(ctx, "Waiting for motion controller heartbeat while running 'SET JOINT_WAIT_HOMED' failed");
+				return rtError;
+			}
+		}
+		if (!emcStatus->motion.joint[joint].homing && !emcStatus->motion.joint[joint].homed) {
+			errornl(ctx, fmt::format("Joint '{}' is not homed and not in the process of homing.", joint));
+			return rtError;
+		}
 	}
 
 	double timeout = JOINT_WAIT_HOMED_TIMEOUT;
@@ -1382,6 +1398,27 @@ static cmdResponseType setJointHome(connectionRecType &ctx)
 	}
 	if (sendHome(joint))
 		return rtError;
+
+	if (joint >= 0) {
+		// The motion controller needs a servo-thread run to raise the
+		// homing flag. Wait for it so that a following command, like
+		// 'SET JOINT_WAIT_HOMED', can rely on the state being visible.
+		// Note: a homed joint may not enter the homing state again
+		// (HOME_NO_REHOME), hence the check for either state.
+		for (unsigned toc = 0; toc < WAIT_TASK_STATE_CHANGE_MAX; toc++) {
+			// Wait for the motion control to run
+			if (rtOk != doWaitHeartbeat(ctx, 1, WAIT_HEARTBEAT_TIMEOUT)) {
+				// Bad sign,... can't wait for a heartbeat
+				errornl(ctx, "Waiting for motion controller heartbeat while running 'SET JOINT_HOME' failed");
+				return rtError;
+			}
+			updateStatus();
+			if (emcStatus->motion.joint[joint].homing || emcStatus->motion.joint[joint].homed)
+				return rtOk;
+		}
+		errornl(ctx, fmt::format("Joint '{}' did not start homing", joint));
+		return rtError;
+	}
 	return rtOk;
 }
 


### PR DESCRIPTION
## Problem

Intermittent `tests/linuxcncrsh` failures on slow CI runners (seen on ubuntu-24.04-arm, e.g. a recent docs-only PR).

`SET JOINT_HOME` is acknowledged when task has received the command, but the motion controller raises the `homing` flag only after its next servo-thread run, and the status needs to propagate back. A `SET JOINT_WAIT_HOMED` issued in that window was refused with "not homed and not in the process of homing". In the test this cascaded: homing was still in progress when the next `SET JOINT_HOME` arrived, which then failed with "Homing not possible until current homing process is finished", and the expected output no longer matched.

## Fix

Give the motion controller a chance to catch up before declaring the error: wait for the homing flag to appear one heartbeat at a time, the same way `SET MACHINE` and `SET ESTOP` already wait for the motion controller. If homing never commences, the same error is raised as before.

Verified: `tests/linuxcncrsh` and `tests/linuxcncrsh-tcp` pass, and `SET JOINT_WAIT_HOMED` on a joint that was never commanded to home still NAKs with the same message.
