### PR TITLE
halscope: fix "loadrt scope_rt failed" when reopening the scope

### DIFF
--- a/src/hal/utils/scope.c
+++ b/src/hal/utils/scope.c
@@ -99,6 +99,15 @@ static void exit_on_signal(int signum) {
     exit(1);
 }
 
+/* callback for hal_list_funct(), matches a function by name */
+static int find_funct_cb(hal_query_t *q, void *arg)
+{
+    if (!strcmp((const char *)arg, q->name)) {
+        return 1;  /* positive, break the loop without error */
+    }
+    return 0;
+}
+
 /* Read just the SAMPLES value from config file before loading scope_rt */
 static int read_samples_from_config(const char *filename)
 {
@@ -199,8 +208,9 @@ int main(int argc, gchar * argv[])
 	return -1;
     }
 
-    int rv = hal_comp_by_name("scope.sample", NULL);
-    if (-ENOENT == rv) {
+    hal_query_t qf = {};
+    int rv = hal_list_funct(&qf, find_funct_cb, (void *)"scope.sample");
+    if (0 == rv) {
 	char buf[1000];
 	snprintf(buf, sizeof(buf), EMC2_BIN_DIR "/halcmd loadrt scope_rt num_samples=%d",
 		num_samples);
@@ -209,12 +219,15 @@ int main(int argc, gchar * argv[])
 	    hal_exit(comp_id);
 	    exit(1);
 	}
-    } else {
+    } else if (rv > 0) {
 	/* scope_rt already loaded - we'll check if sample count matches later */
-        if(0 == rv)
-            rtapi_print_msg(RTAPI_MSG_DBG, "SCOPE: scope_rt already loaded, requested %d samples\n", num_samples);
-        else
-            rtapi_print_msg(RTAPI_MSG_DBG, "SCOPE: hal_comp_by_name() returned error %d\n", rv);
+        rtapi_print_msg(RTAPI_MSG_DBG, "SCOPE: scope_rt already loaded, requested %d samples\n", num_samples);
+    } else {
+	/* the query itself failed, we cannot tell whether scope_rt is loaded
+	   and must not try to load it again */
+        rtapi_print_msg(RTAPI_MSG_ERR, "SCOPE: ERROR: hal_list_funct() returned error %d (%s)\n", rv, hal_strerror(rv));
+        hal_exit(comp_id);
+        exit(1);
     }
     /* set up a shared memory region for the scope data */
     shm_id = rtapi_shmem_new(SCOPE_SHM_KEY, comp_id, sizeof(scope_shm_control_t));


### PR DESCRIPTION
Reopening halscope fails after the first time: the window never appears again and the terminal shows `loadrt scope_rt failed`. From AXIS (`Machine` > `Hal Scope`) it just looks like nothing happens until LinuxCNC is restarted.

Regression from d88d10db8f. `scope.c` checks whether the realtime half is already loaded before running `loadrt scope_rt`, and that check was converted from a funct lookup to a component lookup:

```c
- if (!halpr_find_funct_by_name("scope.sample")) {
+ int rv = hal_comp_by_name("scope.sample", NULL);
+ if (-ENOENT == rv) {
```

There is no component named `scope.sample`. The component is `scope_rt`, `scope.sample` is the funct it exports, so the lookup always returns `-ENOENT` and halscope always runs `halcmd loadrt scope_rt`.

Closing halscope does not unload `scope_rt`, it stays resident and attached to the thread. On the next launch the `loadrt` therefore fails and halscope calls `exit(1)` before creating its window.

`scope_horiz.c` was converted correctly in the same commit, using `hal_list_funct()`. This does the same in `scope.c`, restoring the original semantics.

Tested against a live HAL under Xvfb, closing the window with `WM_DELETE_WINDOW` between launches:

|            | launch 1 | launch 2 | launch 3 |
|------------|----------|----------|----------|
| before     | opens    | `loadrt scope_rt failed`, exits | exits |
| after      | opens    | opens    | opens    |

`scope.sample` stays attached to the servo thread across all three, and the `halscope` component is removed from HAL on each close.
