### PR TITLE
gmoccapy: don't show_all() containers holding embedded tabs

### DIFF
--- a/src/emc/usr_intf/gmoccapy/gmoccapy.py
+++ b/src/emc/usr_intf/gmoccapy/gmoccapy.py
@@ -1828,7 +1828,8 @@ class gmoccapy(object):
                 cmd = c.replace('{XID}', str(xid))
                 child = subprocess.Popen(cmd.split())
                 self._dynamic_childs[xid] = child
-                nb.show_all()
+                # not show_all(): it would resurrect widgets hidden on purpose
+                nb.show()
         except:
             LOG.error(_("ERROR, trying to initialize the user tabs or panels, check for typos"))
             LOG.error(tab_locations)
@@ -1839,10 +1840,14 @@ class gmoccapy(object):
     def _dynamic_tab(self, widget, text):
         s = Gtk.Socket()
         try:
-            widget.append_page(s, Gtk.Label.new(" " + text + " "))
+            label = Gtk.Label.new(" " + text + " ")
+            widget.append_page(s, label)
+            s.show()
+            label.show()
         except:
             try:
                 widget.pack_end(s, True, True, 0)
+                s.show()
             except:
                 return None
         return s.get_id()


### PR DESCRIPTION
Fixes #4353

_init_dynamic_tabs() called show_all() on the container receiving an
embedded tab. show_all() is recursive, so with
EMBED_TAB_LOCATION = ntb_preview it undid the hides gmoccapy applied at
startup, e.g. the lathe-only back-tool view button rbt_view_y2, which
then showed up as a bogus second "Y" view button on mill configs.

Show only the container itself plus the added socket and its tab label
instead.

Tested with gmoccapy_with_user_tabs.ini and works for me: single "Y"
button on the preview row, both embedded tabs still populate. Back-tool
lathe configs keep their two Y views.

@zz912 could you test this with your config?
