### PR TITLE
linuxcncrsh: Fix typo in reply text asserting a SET as a GET command

### DIFF
--- a/src/emc/usr_intf/emcrsh.cc
+++ b/src/emc/usr_intf/emcrsh.cc
@@ -3080,7 +3080,7 @@ int commandGetSet(connectionRecType &ctx, cmdType getset)
 			errornl(
 				ctx,
 				fmt::format("Too few arguments to SET {}, have {}, need {} or more", tag->name, ctx.toks.size() - 2, tag->nset));
-			replynl(ctx, fmt::format("GET {} NAK", tag->name));
+			replynl(ctx, fmt::format("SET {} NAK", tag->name));
 			return -1;
 		}
 


### PR DESCRIPTION
This fixes a typo in the reply text from linuxcncrsh. A response would wrongfully reply `GET` where it was handling a `SET` command. This can desync automated systems that expect the correct response.
