### PR TITLE
docs: register dual-pid-example.adoc with po4a

### DIFF
--- a/docs/po4a.cfg
+++ b/docs/po4a.cfg
@@ -356,6 +356,7 @@
 [type: AsciiDoc_def] src/man/man9/weighted_sum.9.adoc $lang:build/adoc/$lang/man/man9/weighted_sum.9.adoc
 [type: AsciiDoc_def] src/motion/5-axis-kinematics.adoc $lang:build/adoc/$lang/motion/5-axis-kinematics.adoc
 [type: AsciiDoc_def] src/motion/dh-parameters.adoc $lang:build/adoc/$lang/motion/dh-parameters.adoc
+[type: AsciiDoc_def] src/motion/dual-pid-example.adoc $lang:build/adoc/$lang/motion/dual-pid-example.adoc
 [type: AsciiDoc_def] src/motion/external-offsets.adoc $lang:build/adoc/$lang/motion/external-offsets.adoc
 [type: AsciiDoc_def] src/motion/kinematics.adoc $lang:build/adoc/$lang/motion/kinematics.adoc
 [type: AsciiDoc_def] src/motion/pid-theory.adoc $lang:build/adoc/$lang/motion/pid-theory.adoc


### PR DESCRIPTION
The page was added without a po4a.cfg entry, so no translated versions are built and checklink reports dual-pid-example.html as a 404 in every language.
