### PR TITLE
docs: topbar language label wrap, dropdown metrics, and anchor offset fixes

### DIFF
--- a/docs/src/lcnc-overrides.css
+++ b/docs/src/lcnc-overrides.css
@@ -144,6 +144,22 @@ body:has(.lcnc-topbar):not(.article):not(.book):not(.manpage) {
 }
 /* hide the links on narrow screens where they would collide */
 @media (max-width: 900px) { .lcnc-topbar-links { display: none; } }
+/* Slim the bar on phones: logo + language label (+ an injected search
+   icon, when present) must fit ~360px without wrapping or clipping. */
+@media (max-width: 480px) {
+  .lcnc-topbar { padding: 0 0.75rem; }
+  .lcnc-topbar-home img { height: 2rem; }
+  /* .lcnc-topbar prefix needed: the bare-class base rule below would
+     otherwise win on source order. */
+  .lcnc-topbar .lcnc-lang-label { padding: 0 0.5em; }
+}
+/* Tighter still for ~320-360px: the longest label (Українська) plus an
+   injected search icon must leave the icon its full width. */
+@media (max-width: 360px) {
+  .lcnc-topbar { padding: 0 0.5rem; }
+  .lcnc-topbar-home img { height: 1.75rem; }
+  .lcnc-topbar .lcnc-lang-label { font-size: 0.9em; padding: 0 0.4em; }
+}
 
 /* Language switcher: hidden checkbox + label drives the dropdown.
    Total CSS control, no native disclosure widget to fight. */
@@ -164,6 +180,7 @@ body:has(.lcnc-topbar):not(.article):not(.book):not(.manpage) {
 }
 .lcnc-lang-label {
   cursor: pointer;
+  white-space: nowrap; /* never drop the ▾ onto its own line */
   padding: 0 0.75em;
   color: hsla(0,0%,100%,.8);
   font-weight: 500;
@@ -190,10 +207,16 @@ body:has(.lcnc-topbar):not(.article):not(.book):not(.manpage) {
 .lcnc-lang-switcher:has(.lcnc-lang-toggle:checked) .lcnc-lang-list {
   display: block;
 }
-.lcnc-lang-list li {
+/* The base page sheets (index.css, asciidoctor.css) style bare ul/li
+   generically and that leaks into the dropdown: index adds li margin-top,
+   asciidoctor forces line-height 1.6.  Pin the metrics at #lcnc-topbar
+   specificity so the list looks the same on every page. */
+#lcnc-topbar .lcnc-lang-list { line-height: 1.35; }
+#lcnc-topbar .lcnc-lang-list li {
   margin: 0;
   padding: 0;
   list-style: none;
+  line-height: 1.35;
 }
 /* The #lcnc-topbar id (1,0,0) cleanly outranks the index-page rules
    body:not(.article):not(.book):not(.manpage) a / a:visited (0,4,2), so

--- a/docs/src/lcnc-overrides.css
+++ b/docs/src/lcnc-overrides.css
@@ -75,6 +75,11 @@ body:is(.article,.book,.manpage) .literalblock pre.highlight {
 body:has(.lcnc-topbar) {
   padding-top: 3rem;
 }
+/* Anchor jumps park the target at viewport top, which the fixed bar then
+   covers; drop every in-page target just below it instead. */
+body:has(.lcnc-topbar) [id] {
+  scroll-margin-top: 3.5rem;
+}
 /* Static landing pages (index.html, gcode.html) have no asciidoctor
    #header margin to space them off the topbar -- add some breathing room. */
 body:has(.lcnc-topbar):not(.article):not(.book):not(.manpage) {


### PR DESCRIPTION
Two small lcnc-overrides.css fixes for the docs topbar.

**Language label on phones:** the longest labels (Русский, Українська) wrapped below ~390px, dropping the ▾ onto a line of its own, and the open dropdown had visibly different row rhythm on index vs content pages (index.css adds li margin-top, asciidoctor.css forces line-height 1.6; both leak into the list). The dropdown metrics are now pinned at #lcnc-topbar specificity, the label is nowrap, and the bar slims below 480px and again below 360px, so the worst-case label plus an injected doc-search icon fits down to 320px. Verified on a served copy of the deployed docs at 390/360/320px with Українська, Русский and 中文, dropdown identical on index and content pages.

**Anchor offset:** in-page anchor jumps park the target heading at the viewport top, where the fixed 3rem translucent topbar covers it (headings bleed through the bar). A scroll-margin-top drops every in-page target, including docs search section results, just below the bar.
