### PR TITLE
hal: Update the hostmot2 drivers to getter/setter

### DIFF
--- a/src/hal/drivers/mesa-hostmot2/abs_encoder.c
+++ b/src/hal/drivers/mesa-hostmot2/abs_encoder.c
@@ -141,7 +141,7 @@ int hm2_absenc_setup_ssi(hostmot2_t *hm2, hm2_sserial_remote_t *chan,
 
     if ( hm2_sserial_create_pins(hm2, chan)) return -EINVAL;
     
-    chan->params = hal_malloc(sizeof(hm2_sserial_params_t));
+    chan->params = hal_malloc(sizeof(*chan->params));
     hm2->absenc.clock_frequency = md->clock_freq;
     hm2->absenc.ssi_version = md->version;
 
@@ -158,9 +158,12 @@ int hm2_absenc_setup_ssi(hostmot2_t *hm2, hm2_sserial_remote_t *chan,
             + (3 * md->register_stride);
     chan->data_written[0] = 0;
 
-    
-    chan->params->float_param = 500;
-    chan->params->timer_num = 0;
+    if (hal_param_new_real(hm2->llio->comp_id, HAL_RW, &(chan->params->param.r),
+            500.0, "%s.frequency-khz", chan->name)){
+        HM2_ERR("error adding frequency param for %s, aborting\n",
+                chan->name);
+        return -EINVAL;
+    }
     return 0;
 }
 
@@ -169,7 +172,7 @@ int hm2_absenc_setup_biss(hostmot2_t *hm2, hm2_sserial_remote_t *chan,
     
     if ( hm2_sserial_create_pins(hm2, chan)) return -EINVAL;
     
-    chan->params = hal_malloc(sizeof(hm2_sserial_params_t));
+    chan->params = hal_malloc(sizeof(*chan->params));
     hm2->absenc.clock_frequency = md->clock_freq;
     hm2->absenc.biss_version = md->version;
     
@@ -185,9 +188,13 @@ int hm2_absenc_setup_biss(hostmot2_t *hm2, hm2_sserial_remote_t *chan,
     hm2->absenc.biss_global_start_addr = md->base_address 
             + (3 * md->register_stride);
     chan->data_written[0] = 0;
-    
-    chan->params->float_param = 500;
-    chan->params->timer_num = 0;
+
+    if (hal_param_new_real(hm2->llio->comp_id, HAL_RW, &(chan->params->param.r),
+            500.0, "%s.frequency-khz", chan->name)){
+        HM2_ERR("error adding frequency param for %s, aborting\n",
+                chan->name);
+        return -EINVAL;
+    }
     return 0;
 }
 
@@ -196,7 +203,7 @@ int hm2_absenc_setup_fabs(hostmot2_t *hm2, hm2_sserial_remote_t *chan,
     
     if ( hm2_sserial_create_pins(hm2, chan)) return -EINVAL;
     
-    chan->params = hal_malloc(sizeof(hm2_sserial_params_t));
+    chan->params = hal_malloc(sizeof(*chan->params));
     hm2->absenc.clock_frequency = md->clock_freq;
     hm2->absenc.fanuc_version = md->version;
 
@@ -219,16 +226,23 @@ int hm2_absenc_setup_fabs(hostmot2_t *hm2, hm2_sserial_remote_t *chan,
             + (5 * md->register_stride);
     chan->data_written[0] = 0;
 
-    if (hal_param_u32_newf(HAL_RW, &(chan->params->u32_param),
-            hm2->llio->comp_id,"%s.filter",
-            chan->name)){
+    // Note:
+    // This parameter was abused by first writing 1024.0 to the floating point
+    // part and then overwriting the lower part with 0x0000000F. It is now
+    // exclusively set to the unsigned value.
+    // Setting the frequency parameter would overwrite the filter setting and
+    // is now separated out into a separate param storage reference (fanucf).
+    if (hal_param_new_ui32(hm2->llio->comp_id, HAL_RW, &(chan->params->param.u),
+            0xF, "%s.filter", chan->name)) {
         HM2_ERR("error adding param fanuc param 2, aborting\n");
         return -EINVAL;
     }
-    chan->params->float_param = 1024.0;
-    chan->params->u32_param = 0xF;
-    chan->params->timer_num = 0;
-
+    if (hal_param_new_real(hm2->llio->comp_id, HAL_RW, &(chan->params->fanucf),
+            1024.0, "%s.frequency-khz", chan->name)){
+        HM2_ERR("error adding frequency param for %s, aborting\n",
+                chan->name);
+        return -EINVAL;
+    }
     return 0;
 }
 
@@ -355,7 +369,7 @@ int hm2_absenc_parse_format(hm2_sserial_remote_t *chan,  hm2_absenc_format_t *de
 
 int hm2_absenc_parse_md(hostmot2_t *hm2, int md_index) {
     hm2_module_descriptor_t *md = &hm2->md[md_index];
-    hm2_absenc_format_t *def = 0;
+    hm2_absenc_format_t *def = NULL;
     struct rtapi_list_head *ptr;
     int index;
 
@@ -444,24 +458,15 @@ int hm2_absenc_parse_md(hostmot2_t *hm2, int md_index) {
                 }
                 
                 // Set up the common pins
-                if (hal_pin_bit_newf(HAL_OUT, &(chan->params->error),
-                        hm2->llio->comp_id,"%s.data-invalid",
-                        chan->name)){
+                if (hal_pin_new_bool(hm2->llio->comp_id, HAL_OUT, &(chan->params->error),
+                        0, "%s.data-invalid", chan->name)){
                     HM2_ERR("error adding %s over-run pin, aborting\n", 
                             chan->name);
                     return -EINVAL;
                 }
                 // And Params
-                if (hal_param_float_newf(HAL_RW, &(chan->params->float_param),
-                        hm2->llio->comp_id,"%s.frequency-khz",
-                        chan->name)){
-                    HM2_ERR("error adding frequency param for %s, aborting\n",
-                            chan->name);
-                    return -EINVAL;
-                }
-                if (hal_param_u32_newf(HAL_RW, &(chan->params->timer_num),
-                        hm2->llio->comp_id,"%s.timer-number",
-                        chan->name)){
+                if (hal_param_new_ui32(hm2->llio->comp_id, HAL_RW, &(chan->params->timer_num),
+                        0, "%s.timer-number", chan->name)){
                     HM2_ERR("error adding %s timer number param, aborting\n", 
                             chan->name);
                     return -EINVAL;
@@ -528,7 +533,7 @@ void hm2_absenc_process_tram_read(hostmot2_t *hm2, long period) {
                 HM2_ERR("Data transmission not complete on channel %s read."
                         " You  may need to change the timing of %s. This "
                         "warning  will not repeat\n",  chan->name,
-                        (chan->params->timer_num == 0) ? 
+                        (hal_get_ui32(chan->params->timer_num) == 0) ?
                                 "the trigger function" : "the hm2dpll timer");
                 err_tag[i] = 1;
             }
@@ -540,14 +545,14 @@ void hm2_absenc_process_tram_read(hostmot2_t *hm2, long period) {
             if (err_count[i] < 5001) {
                 ++err_count[i];
             } else {
-                *chan->params->error = 1;
+                hal_set_bool(chan->params->error, 1);
             }
                 
         } else {
             if (err_count[i] > 4950){
                 --err_count[i];
             } else {
-                *chan->params->error = 0;
+                hal_set_bool(chan->params->error, 0);
             }
         }
     }
@@ -562,14 +567,15 @@ void hm2_absenc_write(hostmot2_t *hm2){
 
     for (i = 0; i < hm2->absenc.num_chans; i ++) {
         hm2_sserial_remote_t *chan = &hm2->absenc.chans[i];
+        rtapi_u32 timer_num = hal_get_ui32(chan->params->timer_num);
         switch (chan->myinst){
         case HM2_GTAG_SSI:
-            if (chan->params->timer_num > 4) chan->params->timer_num = 4;
-            buff = ((rtapi_u32)(0x10000 * (chan->params->float_param * 1000
+            if (timer_num > 4) timer_num = hal_set_ui32(chan->params->timer_num, 4);
+            buff = ((rtapi_u32)(0x10000 * (hal_get_real(chan->params->param.r) * 1000
                     / hm2->absenc.clock_frequency))) << 16
-                    | chan->params->timer_num << 12
-                    | (chan->params->timer_num == 0) << 8
-                    | (chan->params->timer_num != 0) << 9
+                    |  timer_num << 12
+                    | (timer_num == 0) << 8
+                    | (timer_num != 0) << 9
                     | chan->num_read_bits;
             if (buff != chan->data_written[0]){
                 hm2->llio->write(hm2->llio,
@@ -581,8 +587,8 @@ void hm2_absenc_write(hostmot2_t *hm2){
             break;
         
         case HM2_GTAG_BISS:
-            if (chan->params->timer_num > 4) chan->params->timer_num = 4;
-            dds = ((rtapi_u32)(0x10000 * (chan->params->float_param * 1000
+            if (timer_num > 4) timer_num = hal_set_ui32(chan->params->timer_num, 4);
+            dds = ((rtapi_u32)(0x10000 * (hal_get_real(chan->params->param.r) * 1000
             / hm2->absenc.clock_frequency)));
             filt = 0x8000/dds;               // RX data filter set to 1/2 a clock period
             if (filt > 63) { filt = 63; }    // bound so we dont splatter into adjacent fields
@@ -598,9 +604,9 @@ void hm2_absenc_write(hostmot2_t *hm2){
                         sizeof(rtapi_u32));
                 chan->data_written[0] = buff;
              }     
-             buff2 =   chan->params->timer_num << 12
-                    | (chan->params->timer_num == 0) << 8
-                    | (chan->params->timer_num != 0) << 9;
+             buff2 =   timer_num << 12
+                    | (timer_num == 0) << 8
+                    | (timer_num != 0) << 9;
              if (buff2 != chan->data_written[1]){
                 hm2->llio->write(hm2->llio,
                         chan->rw_addr[2],
@@ -611,16 +617,27 @@ void hm2_absenc_write(hostmot2_t *hm2){
         break;
         
         case HM2_GTAG_FABS:
-            if (chan->params->timer_num > 4) chan->params->timer_num = 4;
-            if (chan->params->u32_param > 15) chan->params->u32_param = 15;
-            buff3 = chan->num_read_bits << 24
+            // Note:
+	    // The original calculation used an awkward overlapped parameter
+	    // storage between floating point and an unsigned value.
+	    // 'u32_param' would occupy the lower storage part of 'float_param.
+	    // The float would be set to 1024.0 and the lower part would get
+	    // set as an unsigned with 0x0000000F. The setting of the few lower
+	    // mantissa bits has no real bearing on the value as a float.
+	    // The paramater storage has now been split.
+            // Original:
+            //   buff2 = (u32_param << 28) | (rtapi_u32)(0x100000 * (float_param * 1000 / hm2->absenc.clock_frequency))
+            // Now
+            //   buff2 = (u32_param << 28) | (rtapi_u32)(0x100000 * (fanucf * 1000 / hm2->absenc.clock_frequency))
+            if (timer_num > 4) timer_num = hal_set_ui32(chan->params->timer_num, 4);
+            if (hal_get_ui32(chan->params->param.u) > 15) hal_set_ui32(chan->params->param.u, 15);
+            buff3 = (chan->num_read_bits << 24)
                     | (rtapi_u32)(8.0e-6 * hm2->absenc.clock_frequency) << 14;
-            buff2 = chan->params->u32_param << 28
-                    | ((rtapi_u32)(0x100000 * (chan->params->float_param * 1000
-                    / hm2->absenc.clock_frequency)));
-            buff =  chan->params->timer_num << 12
-                    | (chan->params->timer_num == 0) << 8
-                    | (chan->params->timer_num != 0) << 9
+            buff2 = (hal_get_ui32(chan->params->param.u) << 28)
+                    | ((rtapi_u32)(0x100000 * (hal_get_real(chan->params->fanucf) * 1000.0 / hm2->absenc.clock_frequency)));
+            buff =    (timer_num << 12)
+                    | (timer_num == 0) << 8
+                    | (timer_num != 0) << 9
                     | (buff3 != chan->data_written[2] || buff2 != chan->data_written[1]) << 7;
             if (buff != chan->data_written[0]){
                 // if necessary this will set the write flag, then next time through

--- a/src/hal/drivers/mesa-hostmot2/bspi.c
+++ b/src/hal/drivers/mesa-hostmot2/bspi.c
@@ -75,8 +75,7 @@ int hm2_bspi_parse_md(hostmot2_t *hm2, int md_index)
         hm2->bspi.num_instances = hm2->config.num_bspis;
     }
     
-    hm2->bspi.instance = (hm2_bspi_instance_t *)hal_malloc(hm2->bspi.num_instances 
-                                                     * sizeof(hm2_bspi_instance_t));
+    hm2->bspi.instance = hal_malloc(hm2->bspi.num_instances * sizeof(*hm2->bspi.instance));
     if (hm2->bspi.instance == NULL) {
         HM2_ERR("out of memory!\n");
         r = -ENOMEM;

--- a/src/hal/drivers/mesa-hostmot2/dpll.c
+++ b/src/hal/drivers/mesa-hostmot2/dpll.c
@@ -70,46 +70,39 @@ int hm2_dpll_parse_md(hostmot2_t *hm2, int md_index) {
     hm2->dpll.hm2_dpll_sync_addr = md->base_address + 6 * md->register_stride;
     
     // export to HAL
-    hm2->dpll.pins = hal_malloc(sizeof(hm2_dpll_pins_t));
+    hm2->dpll.pins = hal_malloc(sizeof(*hm2->dpll.pins));
 
-    r = hal_pin_float_newf(HAL_IN, &(hm2->dpll.pins->time1_us),
-            hm2->llio->comp_id, "%s.dpll.01.timer-us", hm2->llio->name);
-    r += hal_pin_float_newf(HAL_IN, &(hm2->dpll.pins->time2_us),
-            hm2->llio->comp_id, "%s.dpll.02.timer-us", hm2->llio->name);
-    r += hal_pin_float_newf(HAL_IN, &(hm2->dpll.pins->time3_us),
-            hm2->llio->comp_id, "%s.dpll.03.timer-us", hm2->llio->name);
-    r += hal_pin_float_newf(HAL_IN, &(hm2->dpll.pins->time4_us),
-            hm2->llio->comp_id, "%s.dpll.04.timer-us", hm2->llio->name);
-    r += hal_pin_float_newf(HAL_IN, &(hm2->dpll.pins->base_freq),
-            hm2->llio->comp_id, "%s.dpll.base-freq-khz", hm2->llio->name);
-    r += hal_pin_float_newf(HAL_OUT, &(hm2->dpll.pins->phase_error),
-            hm2->llio->comp_id, "%s.dpll.phase-error-us", hm2->llio->name);
-    r += hal_pin_u32_newf(HAL_IN, &(hm2->dpll.pins->time_const),
-            hm2->llio->comp_id, "%s.dpll.time-const", hm2->llio->name);
-    r += hal_pin_u32_newf(HAL_IN, &(hm2->dpll.pins->plimit),
-            hm2->llio->comp_id, "%s.dpll.plimit", hm2->llio->name);
-    r += hal_pin_u32_newf(HAL_OUT, &(hm2->dpll.pins->ddssize),
-            hm2->llio->comp_id, "%s.dpll.ddsize", hm2->llio->name);
-    r += hal_pin_u32_newf(HAL_OUT, &(hm2->dpll.pins->prescale),
-            hm2->llio->comp_id, "%s.dpll.prescale", hm2->llio->name);
-    if (r < 0) {
-        HM2_ERR("error adding hm2_dpll timer pins, Aborting\n");
-        goto fail0;
-    }
-    *hm2->dpll.pins->time1_us = 100.0;
-    *hm2->dpll.pins->time2_us = 100.0;
-    *hm2->dpll.pins->time3_us = 100.0;
-    *hm2->dpll.pins->time4_us = 100.0;
-    *hm2->dpll.pins->prescale = 1;
-    *hm2->dpll.pins->base_freq = -1; // An indication it needs init
-    /* This value is an empirical compromise between insensitivity to
+    r = hal_pin_new_real(hm2->llio->comp_id, HAL_IN, &(hm2->dpll.pins->time1_us),
+            100.0, "%s.dpll.01.timer-us", hm2->llio->name);
+    r += hal_pin_new_real(hm2->llio->comp_id, HAL_IN, &(hm2->dpll.pins->time2_us),
+            100.0, "%s.dpll.02.timer-us", hm2->llio->name);
+    r += hal_pin_new_real(hm2->llio->comp_id, HAL_IN, &(hm2->dpll.pins->time3_us),
+            100.0, "%s.dpll.03.timer-us", hm2->llio->name);
+    r += hal_pin_new_real(hm2->llio->comp_id, HAL_IN, &(hm2->dpll.pins->time4_us),
+            100.0, "%s.dpll.04.timer-us", hm2->llio->name);
+    // init=-1 is an indication it needs init
+    r += hal_pin_new_real(hm2->llio->comp_id, HAL_IN, &(hm2->dpll.pins->base_freq),
+            -1.0, "%s.dpll.base-freq-khz", hm2->llio->name);
+    r += hal_pin_new_real(hm2->llio->comp_id, HAL_OUT, &(hm2->dpll.pins->phase_error),
+            0.0, "%s.dpll.phase-error-us", hm2->llio->name);
+    /* The init value is an empirical compromise between insensitivity to
      * single-cycle variations (larger values) and being resilient to changes to
      * the Linux CLOCK_MONOTONIC timescale, which can instantly change by up to
      * +-500ppm from its nominal value, usually by timekeeping software like ntp
      * and ntpdate.
      */
-    *hm2->dpll.pins->time_const = 2000;
-    *hm2->dpll.pins->plimit = 0x400000;
+    r += hal_pin_new_ui32(hm2->llio->comp_id, HAL_IN, &(hm2->dpll.pins->time_const),
+            2000, "%s.dpll.time-const", hm2->llio->name);
+    r += hal_pin_new_ui32(hm2->llio->comp_id, HAL_IN, &(hm2->dpll.pins->plimit),
+            0x400000, "%s.dpll.plimit", hm2->llio->name);
+    r += hal_pin_new_ui32(hm2->llio->comp_id, HAL_OUT, &(hm2->dpll.pins->ddssize),
+            0, "%s.dpll.ddsize", hm2->llio->name);
+    r += hal_pin_new_ui32(hm2->llio->comp_id, HAL_OUT, &(hm2->dpll.pins->prescale),
+            1, "%s.dpll.prescale", hm2->llio->name);
+    if (r < 0) {
+        HM2_ERR("error adding hm2_dpll timer pins, Aborting\n");
+        goto fail0;
+    }
 
     r = hm2_register_tram_read_region(hm2, hm2->dpll.hm2_dpll_sync_addr,
             sizeof(rtapi_u32), &hm2->dpll.hm2_dpll_sync_reg);
@@ -138,9 +131,9 @@ void hm2_dpll_process_tram_read(hostmot2_t *hm2, long period){
     
      pins = hm2->dpll.pins;
     
-    *pins->phase_error = (rtapi_s32)*hm2->dpll.hm2_dpll_sync_reg
-            * (period / 4294967296000.00) ;
-    *pins->ddssize = *hm2->dpll.control_reg1_read & 0xFF;
+    hal_set_real(pins->phase_error, (rtapi_s32)*hm2->dpll.hm2_dpll_sync_reg
+            * (period / 4294967296000.00));
+    hal_set_ui32(pins->ddssize, *hm2->dpll.control_reg1_read & 0xFF);
 }
 
 void hm2_dpll_write(hostmot2_t *hm2, long period) {
@@ -163,18 +156,21 @@ void hm2_dpll_write(hostmot2_t *hm2, long period) {
     
     pins = hm2->dpll.pins;
     
-    if (*pins->base_freq < 0 ) {
-        *pins->base_freq = 1000.0/period_us;
+    rtapi_real base_freq = hal_get_real(pins->base_freq);
+    if (base_freq < 0 ) {
+        base_freq = hal_set_real(pins->base_freq, 1000.0/period_us);
     }
 
-    *pins->prescale = (0x40000000LL * hm2->dpll.clock_frequency)
-                    / ((1LL << *pins->ddssize) * *pins->base_freq * 1000.0);
+    rtapi_u32 ddssize = hal_get_ui32(pins->ddssize);
+    rtapi_u32 prescale = (0x40000000LL * hm2->dpll.clock_frequency)
+                    / ((1LL << ddssize) * base_freq * 1000.0);
 
-    if (*pins->prescale < 1) *pins->prescale = 1;
+    if (prescale < 1) prescale = 1;
+    hal_set_ui32(pins->prescale, prescale);
     
-    buff = (rtapi_u32)((*pins->base_freq * 1000.0
-            * (1LL << *pins->ddssize) 
-            * *pins->prescale)
+    buff = (rtapi_u32)((base_freq * 1000.0
+            * (1LL << ddssize) 
+            * prescale)
             / hm2->dpll.clock_frequency);
 
     if (buff != hm2->dpll.base_rate_written){
@@ -184,8 +180,8 @@ void hm2_dpll_write(hostmot2_t *hm2, long period) {
                 sizeof(rtapi_u32));
         hm2->dpll.base_rate_written= buff;
     }
-    buff = (rtapi_u32)(*pins->prescale << 24
-                | *pins->plimit);
+    buff = (rtapi_u32)(prescale << 24
+                | hal_get_ui32(pins->plimit));
     if (buff != hm2->dpll.control_reg0_written){
         hm2->llio->write(hm2->llio,
                 hm2->dpll.control_reg0_addr,
@@ -193,7 +189,7 @@ void hm2_dpll_write(hostmot2_t *hm2, long period) {
                 sizeof(rtapi_u32));
         hm2->dpll.control_reg0_written= buff;
     }
-    buff = (rtapi_u32)(*pins->time_const << 16);
+    buff = (rtapi_u32)(hal_get_ui32(pins->time_const) << 16);
     if (buff != hm2->dpll.control_reg1_written){
         hm2->llio->write(hm2->llio,
                 hm2->dpll.control_reg1_addr,
@@ -201,8 +197,8 @@ void hm2_dpll_write(hostmot2_t *hm2, long period) {
                 sizeof(rtapi_u32));
         hm2->dpll.control_reg1_written= buff;
     }
-    buff = (rtapi_u32)((-*hm2->dpll.pins->time2_us / period_us) * 0x10000) << 16
-         | ((rtapi_u32)((-*hm2->dpll.pins->time1_us / period_us) * 0x10000) & 0xFFFF);
+    buff = (rtapi_u32)((-hal_get_real(hm2->dpll.pins->time2_us) / period_us) * 0x10000) << 16
+         | ((rtapi_u32)((-hal_get_real(hm2->dpll.pins->time1_us) / period_us) * 0x10000) & 0xFFFF);
     if (buff != hm2->dpll.timer_12_written){
         hm2->llio->write(hm2->llio,
                 hm2->dpll.timer_12_addr,
@@ -210,8 +206,8 @@ void hm2_dpll_write(hostmot2_t *hm2, long period) {
                 sizeof(rtapi_u32));
         hm2->dpll.timer_12_written = buff;
     }
-    buff = (rtapi_u32)((-*hm2->dpll.pins->time4_us / period_us) * 0x10000) << 16
-         | ((rtapi_u32)((-*hm2->dpll.pins->time3_us / period_us) * 0x10000) & 0xFFFF);
+    buff = (rtapi_u32)((-hal_get_real(hm2->dpll.pins->time4_us) / period_us) * 0x10000) << 16
+         | ((rtapi_u32)((-hal_get_real(hm2->dpll.pins->time3_us) / period_us) * 0x10000) & 0xFFFF);
     if (buff != hm2->dpll.timer_34_written){
         hm2->llio->write(hm2->llio,
                 hm2->dpll.timer_34_addr,

--- a/src/hal/drivers/mesa-hostmot2/encoder.c
+++ b/src/hal/drivers/mesa-hostmot2/encoder.c
@@ -53,10 +53,10 @@ static void hm2_encoder_update_control_register(hostmot2_t *hm2) {
     int latch_polarity;
     for (i = 0; i < hm2->encoder.num_instances; i ++) {
         hm2_encoder_instance_t *e = &hm2->encoder.instance[i];
-        int index_enable = *e->hal.pin.index_enable;
+        int index_enable = hal_get_bool(e->hal.pin.index_enable);
         if (hm2->encoder.firmware_supports_probe) {
-            latch_enable = *e->hal.pin.latch_enable; 
-            latch_polarity = *e->hal.pin.latch_polarity; 
+            latch_enable = hal_get_bool(e->hal.pin.latch_enable);
+            latch_polarity = hal_get_bool(e->hal.pin.latch_polarity);
         }
         else {
             latch_enable = 0;
@@ -90,31 +90,31 @@ static void hm2_encoder_update_control_register(hostmot2_t *hm2) {
 
         do_flag(
             &hm2->encoder.control_reg[i],
-            e->hal.param.index_invert,
+            hal_get_bool(e->hal.param.index_invert),
             HM2_ENCODER_INDEX_POLARITY
         );
 
         do_flag(
             &hm2->encoder.control_reg[i],
-            e->hal.param.index_mask,
+            hal_get_bool(e->hal.param.index_mask),
             HM2_ENCODER_INDEX_MASK
         );
 
         do_flag(
             &hm2->encoder.control_reg[i],
-            e->hal.param.index_mask_invert,
+            hal_get_bool(e->hal.param.index_mask_invert),
             HM2_ENCODER_INDEX_MASK_POLARITY
         );
 
         do_flag(
             &hm2->encoder.control_reg[i],
-            e->hal.param.counter_mode,
+            hal_get_bool(e->hal.param.counter_mode),
             HM2_ENCODER_COUNTER_MODE
         );
 
         do_flag(
             &hm2->encoder.control_reg[i],
-            e->hal.param.filter,
+            hal_get_bool(e->hal.param.filter),
             HM2_ENCODER_FILTER
         );
         do_flag(
@@ -132,55 +132,55 @@ static void hm2_encoder_read_control_register(hostmot2_t *hm2) {
     for (i = 0; i < hm2->encoder.num_instances; i ++) {
         hm2_encoder_instance_t *e = &hm2->encoder.instance[i];
 
-        if (*e->hal.pin.quadrature_error_enable) {
+        if (hal_get_bool(e->hal.pin.quadrature_error_enable)) {
             e->reset_quadrature_error=0;
             if(!e->prev_quadrature_error_enable){ // detect rising edge of pin quadrature_error_enable
                 e->reset_quadrature_error = 1;
                 hm2_encoder_force_write(hm2);
             }
             int state = ((hm2->encoder.read_control_reg[i] & HM2_ENCODER_CONTROL_MASK) & HM2_ENCODER_QUADRATURE_ERROR) && e->prev_quadrature_error_enable;
-            if ((*e->hal.pin.quadrature_error == 0) && state) {
+            if ((hal_get_bool(e->hal.pin.quadrature_error) == 0) && state) {
                 HM2_ERR("Encoder %d: quadrature count error\n", i);
             }
-            *e->hal.pin.quadrature_error = (hal_bit_t) state;
+            hal_set_bool(e->hal.pin.quadrature_error, state);
         } else{ // quadrature error disabled, set reported error to 0
-            *e->hal.pin.quadrature_error = 0;
+            hal_set_bool(e->hal.pin.quadrature_error, 0);
         }
-        e->prev_quadrature_error_enable = *e->hal.pin.quadrature_error_enable;
+        e->prev_quadrature_error_enable = hal_get_bool(e->hal.pin.quadrature_error_enable);
 
-        *e->hal.pin.input_a = hm2->encoder.read_control_reg[i] & HM2_ENCODER_INPUT_A;
-        *e->hal.pin.input_b = hm2->encoder.read_control_reg[i] & HM2_ENCODER_INPUT_B;
-        *e->hal.pin.input_idx = hm2->encoder.read_control_reg[i] & HM2_ENCODER_INPUT_INDEX;
+        hal_set_bool(e->hal.pin.input_a, hm2->encoder.read_control_reg[i] & HM2_ENCODER_INPUT_A);
+        hal_set_bool(e->hal.pin.input_b, hm2->encoder.read_control_reg[i] & HM2_ENCODER_INPUT_B);
+        hal_set_bool(e->hal.pin.input_idx, hm2->encoder.read_control_reg[i] & HM2_ENCODER_INPUT_INDEX);
 
     }
 }
 
 
 static void hm2_encoder_set_filter_rate_and_skew(hostmot2_t *hm2) {
-    rtapi_u32 filter_rate = hm2->encoder.clock_frequency/(*hm2->encoder.hal->pin.sample_frequency);
+    rtapi_u32 filter_rate = hm2->encoder.clock_frequency/hal_get_ui32(hm2->encoder.hal->pin.sample_frequency);
     
     if (filter_rate == 1) {
         filter_rate = 0xFFF;
     } else {
         filter_rate -= 2;
     }
-    *hm2->encoder.hal->pin.sample_frequency = hm2->encoder.clock_frequency/(filter_rate + 2);
+    hal_set_ui32(hm2->encoder.hal->pin.sample_frequency, hm2->encoder.clock_frequency/(filter_rate + 2));
     HM2_DBG("Setting encoder QFilterRate to %d\n", filter_rate);
     if (hm2->encoder.has_skew) {
         rtapi_u32 divisor = (1e9/hm2->encoder.clock_frequency);
         // Unsigned division rounding for integers. This is only valid for unsigned division 
-        rtapi_u32 skew = (*hm2->encoder.hal->pin.skew + (divisor/2))/divisor;
+        rtapi_u32 skew = (hal_get_ui32(hm2->encoder.hal->pin.skew) + (divisor/2))/divisor;
         
         if (skew > 15) {
             skew = 15;
         }
         HM2_DBG("Setting mux encoder skew to %d\n", skew);
         filter_rate |= (skew & 0xF) << 28;
-        *hm2->encoder.hal->pin.skew = skew*(1e9/hm2->encoder.clock_frequency);
-        hm2->encoder.written_skew = *hm2->encoder.hal->pin.skew;
+        hal_set_ui32(hm2->encoder.hal->pin.skew, skew*(1e9/hm2->encoder.clock_frequency));
+        hm2->encoder.written_skew = hal_get_ui32(hm2->encoder.hal->pin.skew);
     }
     hm2->llio->write(hm2->llio, hm2->encoder.filter_rate_addr, &filter_rate, sizeof(rtapi_u32));
-    hm2->encoder.written_sample_frequency = *hm2->encoder.hal->pin.sample_frequency;
+    hm2->encoder.written_sample_frequency = hal_get_ui32(hm2->encoder.hal->pin.sample_frequency);
 }
 
 static void hm2_encoder_set_dpll_timer_if_present(hostmot2_t *hm2) {
@@ -209,16 +209,16 @@ void hm2_encoder_write(hostmot2_t *hm2) {
         }
     }
 
-    if (*hm2->encoder.hal->pin.sample_frequency != hm2->encoder.written_sample_frequency) {
+    if (hal_get_ui32(hm2->encoder.hal->pin.sample_frequency) != hm2->encoder.written_sample_frequency) {
         goto force_write;
     }
     if (hm2->encoder.has_skew) {
-        if (*hm2->encoder.hal->pin.skew != hm2->encoder.written_skew) {
+        if (hal_get_ui32(hm2->encoder.hal->pin.skew) != hm2->encoder.written_skew) {
             goto force_write;
         }
     }
 
-    if (*hm2->encoder.hal->pin.hires_timestamp != hm2->encoder.written_hires_timestamp) {    // 
+    if (hal_get_bool(hm2->encoder.hal->pin.hires_timestamp) != hm2->encoder.written_hires_timestamp) {    //
         // Set the Timestamp Divisor Register
         // 
         // We want the timestamp to count as quickly as possible, so we get the
@@ -255,7 +255,7 @@ void hm2_encoder_write(hostmot2_t *hm2) {
         //     seconds_per_clock = 1 / rate = (TSDiv+2) / ClockLow
         //
 
-        if (*hm2->encoder.hal->pin.hires_timestamp == 0) {
+        if (hal_get_bool(hm2->encoder.hal->pin.hires_timestamp) == 0) {
             hm2->encoder.timestamp_div_reg = (hm2->encoder.clock_frequency / 2e6) - 2;
         } else {
             hm2->encoder.timestamp_div_reg = (hm2->encoder.clock_frequency / 1e7) - 2;
@@ -263,12 +263,12 @@ void hm2_encoder_write(hostmot2_t *hm2) {
         
         hm2->encoder.seconds_per_tsdiv_clock = (double)(hm2->encoder.timestamp_div_reg + 2) / (double)hm2->encoder.clock_frequency;
 
-        hm2->encoder.written_hires_timestamp = *hm2->encoder.hal->pin.hires_timestamp;
+        hm2->encoder.written_hires_timestamp = hal_get_bool(hm2->encoder.hal->pin.hires_timestamp);
         goto force_write;
     }
 
     if(hm2->encoder.dpll_timer_num_addr) {
-        int32_t dpll_timer_num = *hm2->encoder.hal->pin.dpll_timer_num;
+        int32_t dpll_timer_num = hal_get_si32(hm2->encoder.hal->pin.dpll_timer_num);
         if(dpll_timer_num < -1 || dpll_timer_num > 4) dpll_timer_num = -1;
         if(dpll_timer_num == -1)
             hm2->encoder.desired_dpll_timer_reg = 0;
@@ -397,14 +397,14 @@ int hm2_encoder_parse_md(hostmot2_t *hm2, int md_index) {
 
 
     // allocate the module-global HAL shared memory
-    hm2->encoder.hal = (hm2_encoder_module_global_t *)hal_malloc(sizeof(hm2_encoder_module_global_t));
+    hm2->encoder.hal = hal_malloc(sizeof(*hm2->encoder.hal));
     if (hm2->encoder.hal == NULL) {
         HM2_ERR("out of memory!\n");
         r = -ENOMEM;
         goto fail0;
     }
 
-    hm2->encoder.instance = (hm2_encoder_instance_t *)hal_malloc(hm2->encoder.num_instances * sizeof(hm2_encoder_instance_t));
+    hm2->encoder.instance = hal_malloc(hm2->encoder.num_instances * sizeof(*hm2->encoder.instance));
     if (hm2->encoder.instance == NULL) {
         HM2_ERR("out of memory!\n");
         r = -ENOMEM;
@@ -459,269 +459,248 @@ int hm2_encoder_parse_md(hostmot2_t *hm2, int md_index) {
 
 
     // export the encoders to HAL
-    // FIXME: r hides the r in enclosing function, and it returns the wrong thing
     {
-        int i;
-        int r;
-        char name[HAL_NAME_LEN + 1];
-
         // these hal parameters affect all encoder instances
+        const char *sfpinname;
         if (md->gtag == HM2_GTAG_MUXED_ENCODER) {
-            rtapi_snprintf(name, sizeof(name), "%s.encoder.muxed-sample-frequency", hm2->llio->name);
+            sfpinname = "encoder.muxed-sample-frequency";
         } else {
-            rtapi_snprintf(name, sizeof(name), "%s.encoder.sample-frequency", hm2->llio->name);
+            sfpinname = "encoder.sample-frequency";
         }
-        r = hal_pin_u32_new(name, HAL_IN, &(hm2->encoder.hal->pin.sample_frequency), hm2->llio->comp_id);
+        r = hal_pin_new_ui32(hm2->llio->comp_id, HAL_IN, &(hm2->encoder.hal->pin.sample_frequency),
+                             0, "%s.%s", hm2->llio->name, sfpinname);
         if (r < 0) {
-            HM2_ERR("error adding pin %s, aborting\n", name);
+            HM2_ERR("error %d adding pin %s.%s, aborting\n", r, hm2->llio->name, sfpinname);
             goto fail1;
         }
         if ((md->gtag == HM2_GTAG_MUXED_ENCODER) && (md->version > 3 )) {   // >3 to include modules with probe enable
-            rtapi_snprintf(name, sizeof(name), "%s.encoder.muxed-skew", hm2->llio->name);
-            r = hal_pin_u32_new(name, HAL_IN, &(hm2->encoder.hal->pin.skew), hm2->llio->comp_id);
+            r = hal_pin_new_ui32(hm2->llio->comp_id, HAL_IN, &(hm2->encoder.hal->pin.skew),
+                                 0, "%s.encoder.muxed-skew", hm2->llio->name);
             if (r < 0) {
-                HM2_ERR("error adding pin %s, aborting\n", name);
+                HM2_ERR("error %d adding pin %s.encoder.muxed-skew, aborting\n", r, hm2->llio->name);
                 goto fail1;
             }
             hm2->encoder.has_skew = 1;
         }
         if(hm2->encoder.dpll_timer_num_addr) {
-            r = hal_pin_s32_newf(HAL_IN, &(hm2->encoder.hal->pin.dpll_timer_num), hm2->llio->comp_id, "%s.encoder.timer-number", hm2->llio->name);
+            r = hal_pin_new_si32(hm2->llio->comp_id, HAL_IN, &(hm2->encoder.hal->pin.dpll_timer_num),
+                                 -1, "%s.encoder.timer-number", hm2->llio->name);
             if (r < 0) {
-                HM2_ERR("error adding pin %s, aborting\n", name);
+                HM2_ERR("error %d adding pin %s.encoder.timer-number, aborting\n", r, hm2->llio->name);
                 goto fail1;
             }
-            *(hm2->encoder.hal->pin.dpll_timer_num) = -1;
         }
 
-        rtapi_snprintf(name, sizeof(name), "%s.encoder.hires-timestamp", hm2->llio->name);
-        r = hal_pin_bit_new(name, HAL_IN, &(hm2->encoder.hal->pin.hires_timestamp), hm2->llio->comp_id);
+        r = hal_pin_new_bool(hm2->llio->comp_id, HAL_IN, &(hm2->encoder.hal->pin.hires_timestamp),
+                             0, "%s.encoder.hires-timestamp", hm2->llio->name);
         if (r < 0) {
-            HM2_ERR("error adding pin %s, aborting\n", name);
+            HM2_ERR("error %d adding pin %s.encoder.hires-timestamp, aborting\n", r, hm2->llio->name);
             goto fail1;
         }
 
-        for (i = 0; i < hm2->encoder.num_instances; i ++) {
+        for (int i = 0; i < hm2->encoder.num_instances; i ++) {
             // pins
-            rtapi_snprintf(name, sizeof(name), "%s.encoder.%02d.rawcounts", hm2->llio->name, i);
-            r = hal_pin_s32_new(name, HAL_OUT, &(hm2->encoder.instance[i].hal.pin.rawcounts), hm2->llio->comp_id);
+            r = hal_pin_new_si32(hm2->llio->comp_id, HAL_OUT, &(hm2->encoder.instance[i].hal.pin.rawcounts),
+                                 0, "%s.encoder.%02d.rawcounts", hm2->llio->name, i);
             if (r < 0) {
-                HM2_ERR("error adding pin '%s', aborting\n", name);
+                HM2_ERR("error %d adding pin '%s.encoder.%02d.rawcounts', aborting\n", r, hm2->llio->name, i);
                 goto fail1;
             }
 
-            rtapi_snprintf(name, sizeof(name), "%s.encoder.%02d.rawlatch", hm2->llio->name, i);
-            r = hal_pin_s32_new(name, HAL_OUT, &(hm2->encoder.instance[i].hal.pin.rawlatch), hm2->llio->comp_id);
+            r = hal_pin_new_si32(hm2->llio->comp_id, HAL_OUT, &(hm2->encoder.instance[i].hal.pin.rawlatch),
+                                 0, "%s.encoder.%02d.rawlatch", hm2->llio->name, i);
             if (r < 0) {
-                HM2_ERR("error adding pin '%s', aborting\n", name);
+                HM2_ERR("error %d adding pin '%s.encoder.%02d.rawlatch', aborting\n", r, hm2->llio->name, i);
                 goto fail1;
             }
 
-            rtapi_snprintf(name, sizeof(name), "%s.encoder.%02d.count", hm2->llio->name, i);
-            r = hal_pin_s32_new(name, HAL_OUT, &(hm2->encoder.instance[i].hal.pin.count), hm2->llio->comp_id);
+            r = hal_pin_new_si32(hm2->llio->comp_id, HAL_OUT, &(hm2->encoder.instance[i].hal.pin.count),
+                                 0, "%s.encoder.%02d.count", hm2->llio->name, i);
             if (r < 0) {
-                HM2_ERR("error adding pin '%s', aborting\n", name);
+                HM2_ERR("error %d adding pin '%s.encoder.%02d.count', aborting\n", r, hm2->llio->name, i);
                 goto fail1;
             }
 
-            rtapi_snprintf(name, sizeof(name), "%s.encoder.%02d.count-latched", hm2->llio->name, i);
-            r = hal_pin_s32_new(name, HAL_OUT, &(hm2->encoder.instance[i].hal.pin.count_latch), hm2->llio->comp_id);
+            r = hal_pin_new_si32(hm2->llio->comp_id, HAL_OUT, &(hm2->encoder.instance[i].hal.pin.count_latch),
+                                 0, "%s.encoder.%02d.count-latched", hm2->llio->name, i);
             if (r < 0) {
-                HM2_ERR("error adding pin '%s', aborting\n", name);
+                HM2_ERR("error %d adding pin '%s.encoder.%02d.count-latched', aborting\n", r, hm2->llio->name, i);
                 goto fail1;
             }
 
-            rtapi_snprintf(name, sizeof(name), "%s.encoder.%02d.position", hm2->llio->name, i);
-            r = hal_pin_float_new(name, HAL_OUT, &(hm2->encoder.instance[i].hal.pin.position), hm2->llio->comp_id);
+            r = hal_pin_new_real(hm2->llio->comp_id, HAL_OUT, &(hm2->encoder.instance[i].hal.pin.position),
+                                 0.0, "%s.encoder.%02d.position", hm2->llio->name, i);
             if (r < 0) {
-                HM2_ERR("error adding pin '%s', aborting\n", name);
+                HM2_ERR("error %d adding pin '%s.encoder.%02d.position', aborting\n", r, hm2->llio->name, i);
                 goto fail1;
             }
 
-            rtapi_snprintf(name, sizeof(name), "%s.encoder.%02d.position-interpolated", hm2->llio->name, i);
-            r = hal_pin_float_new(name, HAL_OUT, &(hm2->encoder.instance[i].hal.pin.position_interpolated), hm2->llio->comp_id);
+            r = hal_pin_new_real(hm2->llio->comp_id, HAL_OUT, &(hm2->encoder.instance[i].hal.pin.position_interpolated),
+                                 0.0, "%s.encoder.%02d.position-interpolated", hm2->llio->name, i);
             if (r < 0) {
-                HM2_ERR("error adding pin '%s', aborting\n", name);
+                HM2_ERR("error %d adding pin '%s.encoder.%02d.position-interpolated', aborting\n", r, hm2->llio->name, i);
                 goto fail1;
             }
 
-            rtapi_snprintf(name, sizeof(name), "%s.encoder.%02d.position-latched", hm2->llio->name, i);
-            r = hal_pin_float_new(name, HAL_OUT, &(hm2->encoder.instance[i].hal.pin.position_latch), hm2->llio->comp_id);
+            r = hal_pin_new_real(hm2->llio->comp_id, HAL_OUT, &(hm2->encoder.instance[i].hal.pin.position_latch),
+                                 0.0, "%s.encoder.%02d.position-latched", hm2->llio->name, i);
             if (r < 0) {
-                HM2_ERR("error adding pin '%s', aborting\n", name);
+                HM2_ERR("error %d adding pin '%s.encoder.%02d.position-latched', aborting\n", r, hm2->llio->name, i);
                 goto fail1;
             }
 
-            rtapi_snprintf(name, sizeof(name), "%s.encoder.%02d.velocity", hm2->llio->name, i);
-            r = hal_pin_float_new(name, HAL_OUT, &(hm2->encoder.instance[i].hal.pin.velocity), hm2->llio->comp_id);
+            r = hal_pin_new_real(hm2->llio->comp_id, HAL_OUT, &(hm2->encoder.instance[i].hal.pin.velocity),
+                                 0.0, "%s.encoder.%02d.velocity", hm2->llio->name, i);
             if (r < 0) {
-                HM2_ERR("error adding pin '%s', aborting\n", name);
+                HM2_ERR("error %d adding pin '%s.encoder.%02d.velocity', aborting\n", r, hm2->llio->name, i);
                 goto fail1;
             }
 
-            rtapi_snprintf(name, sizeof(name), "%s.encoder.%02d.velocity-rpm", hm2->llio->name, i);
-            r = hal_pin_float_new(name, HAL_OUT, &(hm2->encoder.instance[i].hal.pin.velocity_rpm), hm2->llio->comp_id);
+            r = hal_pin_new_real(hm2->llio->comp_id, HAL_OUT, &(hm2->encoder.instance[i].hal.pin.velocity_rpm),
+                                 0.0, "%s.encoder.%02d.velocity-rpm", hm2->llio->name, i);
             if (r < 0) {
-                HM2_ERR("error adding pin '%s', aborting\n", name);
+                HM2_ERR("error %d adding pin '%s.encoder.%02d.velocity-rpm', aborting\n", r, hm2->llio->name, i);
                 goto fail1;
             }
 
-            rtapi_snprintf(name, sizeof(name), "%s.encoder.%02d.reset", hm2->llio->name, i);
-            r = hal_pin_bit_new(name, HAL_IN, &(hm2->encoder.instance[i].hal.pin.reset), hm2->llio->comp_id);
+            r = hal_pin_new_bool(hm2->llio->comp_id, HAL_IN, &(hm2->encoder.instance[i].hal.pin.reset),
+                                 0, "%s.encoder.%02d.reset", hm2->llio->name, i);
             if (r < 0) {
-                HM2_ERR("error adding pin '%s', aborting\n", name);
+                HM2_ERR("error %d adding pin '%s.encoder.%02d.reset', aborting\n", r, hm2->llio->name, i);
                 goto fail1;
             }
 
-            rtapi_snprintf(name, sizeof(name), "%s.encoder.%02d.index-enable", hm2->llio->name, i);
-            r = hal_pin_bit_new(name, HAL_IO, &(hm2->encoder.instance[i].hal.pin.index_enable), hm2->llio->comp_id);
+            r = hal_pin_new_bool(hm2->llio->comp_id, HAL_IO, &(hm2->encoder.instance[i].hal.pin.index_enable),
+                                 0, "%s.encoder.%02d.index-enable", hm2->llio->name, i);
             if (r < 0) {
-                HM2_ERR("error adding pin '%s', aborting\n", name);
+                HM2_ERR("error %d adding pin '%s.encoder.%02d.index-enable', aborting\n", r, hm2->llio->name, i);
                 goto fail1;
             }
 
-          rtapi_snprintf(name, sizeof(name), "%s.encoder.%02d.no_clear_on_index", hm2->llio->name, i);
-            r = hal_pin_bit_new(name, HAL_IN, &(hm2->encoder.instance[i].hal.pin.no_clear_on_index), hm2->llio->comp_id);
+            r = hal_pin_new_bool(hm2->llio->comp_id, HAL_IN, &(hm2->encoder.instance[i].hal.pin.no_clear_on_index),
+                                 0, "%s.encoder.%02d.no_clear_on_index", hm2->llio->name, i);
             if (r < 0) {
-                HM2_ERR("error adding pin '%s', aborting\n", name);
+                HM2_ERR("error %d adding pin '%s.encoder.%02d.no_clear_on_index', aborting\n", r, hm2->llio->name, i);
                 goto fail1;
             }
- 
+
             if (hm2->encoder.firmware_supports_probe) {
-                rtapi_snprintf(name, sizeof(name), "%s.encoder.%02d.probe-enable", hm2->llio->name, i);
-                r = hal_pin_bit_new(name, HAL_IN, &(hm2->encoder.instance[i].hal.pin.latch_enable), hm2->llio->comp_id);
+                r = hal_pin_new_bool(hm2->llio->comp_id, HAL_IN, &(hm2->encoder.instance[i].hal.pin.latch_enable),
+                                     0, "%s.encoder.%02d.probe-enable", hm2->llio->name, i);
                 if (r < 0) {
-                    HM2_ERR("error adding pin '%s', aborting\n", name);
+                    HM2_ERR("error %d adding pin '%s.encoder.%02d.probe-enable', aborting\n", r, hm2->llio->name, i);
                     goto fail1;
                 }
-    
-                rtapi_snprintf(name, sizeof(name), "%s.encoder.%02d.probe-invert", hm2->llio->name, i);
-                r = hal_pin_bit_new(name, HAL_IN, &(hm2->encoder.instance[i].hal.pin.latch_polarity), hm2->llio->comp_id);
+
+                r = hal_pin_new_bool(hm2->llio->comp_id, HAL_IN, &(hm2->encoder.instance[i].hal.pin.latch_polarity),
+                                     0, "%s.encoder.%02d.probe-invert", hm2->llio->name, i);
                 if (r < 0) {
-                    HM2_ERR("error adding pin '%s', aborting\n", name);
+                    HM2_ERR("error %d adding pin '%s.encoder.%02d.probe-invert', aborting\n", r, hm2->llio->name, i);
                     goto fail1;
                 }
             }
 
-            rtapi_snprintf(name, sizeof(name), "%s.encoder.%02d.quad-error", hm2->llio->name, i);
-            r = hal_pin_bit_new(name, HAL_OUT, &(hm2->encoder.instance[i].hal.pin.quadrature_error), hm2->llio->comp_id);
+            r = hal_pin_new_bool(hm2->llio->comp_id, HAL_OUT, &(hm2->encoder.instance[i].hal.pin.quadrature_error),
+                                 0, "%s.encoder.%02d.quad-error", hm2->llio->name, i);
             if (r < 0) {
-                HM2_ERR("error adding pin '%s', aborting\n", name);
+                HM2_ERR("error %d adding pin '%s.encoder.%02d.quad-error', aborting\n", r, hm2->llio->name, i);
                 goto fail1;
             }
 
-
-          rtapi_snprintf(name, sizeof(name), "%s.encoder.%02d.quad-error-enable", hm2->llio->name, i);
-            r = hal_pin_bit_new(name, HAL_IN, &(hm2->encoder.instance[i].hal.pin.quadrature_error_enable), hm2->llio->comp_id);
+            r = hal_pin_new_bool(hm2->llio->comp_id, HAL_IN, &(hm2->encoder.instance[i].hal.pin.quadrature_error_enable),
+                                 0, "%s.encoder.%02d.quad-error-enable", hm2->llio->name, i);
             if (r < 0) {
-                HM2_ERR("error adding pin '%s', aborting\n", name);
+                HM2_ERR("error %d adding pin '%s.encoder.%02d.quad-error-enable', aborting\n", r, hm2->llio->name, i);
                 goto fail1;
             }
 
-            rtapi_snprintf(name, sizeof(name), "%s.encoder.%02d.input-a", hm2->llio->name, i);
-            r = hal_pin_bit_new(name, HAL_OUT, &(hm2->encoder.instance[i].hal.pin.input_a), hm2->llio->comp_id);
+            r = hal_pin_new_bool(hm2->llio->comp_id, HAL_OUT, &(hm2->encoder.instance[i].hal.pin.input_a),
+                                 0, "%s.encoder.%02d.input-a", hm2->llio->name, i);
             if (r < 0) {
-                HM2_ERR("error adding pin '%s', aborting\n", name);
+                HM2_ERR("error %d adding pin '%s.encoder.%02d.input-a', aborting\n", r, hm2->llio->name, i);
                 goto fail1;
             }
 
-            rtapi_snprintf(name, sizeof(name), "%s.encoder.%02d.input-b", hm2->llio->name, i);
-            r = hal_pin_bit_new(name, HAL_OUT, &(hm2->encoder.instance[i].hal.pin.input_b), hm2->llio->comp_id);
+            r = hal_pin_new_bool(hm2->llio->comp_id, HAL_OUT, &(hm2->encoder.instance[i].hal.pin.input_b),
+                                 0, "%s.encoder.%02d.input-b", hm2->llio->name, i);
             if (r < 0) {
-                HM2_ERR("error adding pin '%s', aborting\n", name);
+                HM2_ERR("error %d adding pin '%s.encoder.%02d.input-b', aborting\n", r, hm2->llio->name, i);
                 goto fail1;
             }
 
-            rtapi_snprintf(name, sizeof(name), "%s.encoder.%02d.input-index", hm2->llio->name, i);
-            r = hal_pin_bit_new(name, HAL_OUT, &(hm2->encoder.instance[i].hal.pin.input_idx), hm2->llio->comp_id);
+            r = hal_pin_new_bool(hm2->llio->comp_id, HAL_OUT, &(hm2->encoder.instance[i].hal.pin.input_idx),
+                                 0, "%s.encoder.%02d.input-index", hm2->llio->name, i);
             if (r < 0) {
-                HM2_ERR("error adding pin '%s', aborting\n", name);
+                HM2_ERR("error %d adding pin '%s.encoder.%02d.input-index', aborting\n", r, hm2->llio->name, i);
                 goto fail1;
             }
 
             // parameters
-            rtapi_snprintf(name, sizeof(name), "%s.encoder.%02d.scale", hm2->llio->name, i);
-            r = hal_param_float_new(name, HAL_RW, &(hm2->encoder.instance[i].hal.param.scale), hm2->llio->comp_id);
+            r = hal_param_new_real(hm2->llio->comp_id, HAL_RW, &(hm2->encoder.instance[i].hal.param.scale),
+                                   1.0, "%s.encoder.%02d.scale", hm2->llio->name, i);
             if (r < 0) {
-                HM2_ERR("error adding param '%s', aborting\n", name);
+                HM2_ERR("error %d adding param '%s.encoder.%02d.scale', aborting\n", r, hm2->llio->name, i);
                 goto fail1;
             }
 
-            rtapi_snprintf(name, sizeof(name), "%s.encoder.%02d.index-invert", hm2->llio->name, i);
-            r = hal_param_bit_new(name, HAL_RW, &(hm2->encoder.instance[i].hal.param.index_invert), hm2->llio->comp_id);
+            r = hal_param_new_bool(hm2->llio->comp_id, HAL_RW, &(hm2->encoder.instance[i].hal.param.index_invert),
+                                   0, "%s.encoder.%02d.index-invert", hm2->llio->name, i);
             if (r < 0) {
-                HM2_ERR("error adding param '%s', aborting\n", name);
+                HM2_ERR("error %d adding param '%s.encoder.%02d.index-invert', aborting\n", r, hm2->llio->name, i);
                 goto fail1;
             }
 
-            rtapi_snprintf(name, sizeof(name), "%s.encoder.%02d.index-mask", hm2->llio->name, i);
-            r = hal_param_bit_new(name, HAL_RW, &(hm2->encoder.instance[i].hal.param.index_mask), hm2->llio->comp_id);
+            r = hal_param_new_bool(hm2->llio->comp_id, HAL_RW, &(hm2->encoder.instance[i].hal.param.index_mask),
+                                   0, "%s.encoder.%02d.index-mask", hm2->llio->name, i);
             if (r < 0) {
-                HM2_ERR("error adding param '%s', aborting\n", name);
+                HM2_ERR("error %d adding param '%s.encoder.%02d.index-mask', aborting\n", r, hm2->llio->name, i);
                 goto fail1;
             }
 
-            rtapi_snprintf(name, sizeof(name), "%s.encoder.%02d.index-mask-invert", hm2->llio->name, i);
-            r = hal_param_bit_new(name, HAL_RW, &(hm2->encoder.instance[i].hal.param.index_mask_invert), hm2->llio->comp_id);
+            r = hal_param_new_bool(hm2->llio->comp_id, HAL_RW, &(hm2->encoder.instance[i].hal.param.index_mask_invert),
+                                   0, "%s.encoder.%02d.index-mask-invert", hm2->llio->name, i);
             if (r < 0) {
-                HM2_ERR("error adding param '%s', aborting\n", name);
+                HM2_ERR("error %d adding param '%s.encoder.%02d.index-mask-invert', aborting\n", r, hm2->llio->name, i);
                 goto fail1;
             }
 
-            rtapi_snprintf(name, sizeof(name), "%s.encoder.%02d.counter-mode", hm2->llio->name, i);
-            r = hal_param_bit_new(name, HAL_RW, &(hm2->encoder.instance[i].hal.param.counter_mode), hm2->llio->comp_id);
+            r = hal_param_new_bool(hm2->llio->comp_id, HAL_RW, &(hm2->encoder.instance[i].hal.param.counter_mode),
+                                   0, "%s.encoder.%02d.counter-mode", hm2->llio->name, i);
             if (r < 0) {
-                HM2_ERR("error adding param '%s', aborting\n", name);
+                HM2_ERR("error %d adding param '%s.encoder.%02d.counter-mode', aborting\n", r, hm2->llio->name, i);
                 goto fail1;
             }
 
-            rtapi_snprintf(name, sizeof(name), "%s.encoder.%02d.filter", hm2->llio->name, i);
-            r = hal_param_bit_new(name, HAL_RW, &(hm2->encoder.instance[i].hal.param.filter), hm2->llio->comp_id);
+            r = hal_param_new_bool(hm2->llio->comp_id, HAL_RW, &(hm2->encoder.instance[i].hal.param.filter),
+                                   1, "%s.encoder.%02d.filter", hm2->llio->name, i);
             if (r < 0) {
-                HM2_ERR("error adding param '%s', aborting\n", name);
+                HM2_ERR("error %d adding param '%s.encoder.%02d.filter', aborting\n", r, hm2->llio->name, i);
                 goto fail1;
             }
 
-            rtapi_snprintf(name, sizeof(name), "%s.encoder.%02d.vel-timeout", hm2->llio->name, i);
-            r = hal_param_float_new(name, HAL_RW, &(hm2->encoder.instance[i].hal.param.vel_timeout), hm2->llio->comp_id);
+            r = hal_param_new_real(hm2->llio->comp_id, HAL_RW, &(hm2->encoder.instance[i].hal.param.vel_timeout),
+                                   0.5, "%s.encoder.%02d.vel-timeout", hm2->llio->name, i);
             if (r < 0) {
-                HM2_ERR("error adding param '%s', aborting\n", name);
+                HM2_ERR("error %d adding param '%s.encoder.%02d.vel-timeout', aborting\n", r, hm2->llio->name, i);
                 goto fail1;
             }
-
 
             //
-            // init the hal objects that need it
             // the things not initialized here will be set by hm2_encoder_tram_init()
             //
-
-            *hm2->encoder.instance[i].hal.pin.reset = 0;
-            *hm2->encoder.instance[i].hal.pin.index_enable = 0;
-            *hm2->encoder.instance[i].hal.pin.no_clear_on_index = 0;
-
-            hm2->encoder.instance[i].hal.param.scale = 1.0;
-            hm2->encoder.instance[i].hal.param.index_invert = 0;
-            hm2->encoder.instance[i].hal.param.index_mask = 0;
-            hm2->encoder.instance[i].hal.param.index_mask_invert = 0;
-            hm2->encoder.instance[i].hal.param.counter_mode = 0;
-            hm2->encoder.instance[i].hal.param.filter = 1;
-            hm2->encoder.instance[i].hal.param.vel_timeout = 0.5;
-
             hm2->encoder.instance[i].state = HM2_ENCODER_STOPPED;
-
         }
     }
 
-    // initialize with hires off and force update 
+    // initialize with hires off and force update
     // (with somewhat shady trick to force update if set true in halfile)
-    *hm2->encoder.hal->pin.hires_timestamp = 0;    
-     hm2->encoder.written_hires_timestamp = 666; 
+     hm2->encoder.written_hires_timestamp = 666;
 
 
     if (md->gtag == HM2_GTAG_ENCODER) {
-        *hm2->encoder.hal->pin.sample_frequency = 25000000;
+        hal_set_ui32(hm2->encoder.hal->pin.sample_frequency, 25000000);
     } else {
-        *hm2->encoder.hal->pin.sample_frequency = 8000000;
+        hal_set_ui32(hm2->encoder.hal->pin.sample_frequency, 8000000);
     }
 
     return hm2->encoder.num_instances;
@@ -749,20 +728,20 @@ void hm2_encoder_tram_init(hostmot2_t *hm2) {
 
         count = hm2_encoder_get_reg_count(hm2, i);
 
-        *hm2->encoder.instance[i].hal.pin.rawcounts = count;
-        *hm2->encoder.instance[i].hal.pin.rawlatch = count;
+        hal_set_si32(hm2->encoder.instance[i].hal.pin.rawcounts, count);
+        hal_set_si32(hm2->encoder.instance[i].hal.pin.rawlatch, count);
         hm2->encoder.instance[i].rawcounts_64 = count;
         hm2->encoder.instance[i].rawlatch_64 = count;
 
-        *hm2->encoder.instance[i].hal.pin.count = 0;
-        *hm2->encoder.instance[i].hal.pin.count_latch = 0;
+        hal_set_si32(hm2->encoder.instance[i].hal.pin.count, 0);
+        hal_set_si32(hm2->encoder.instance[i].hal.pin.count_latch, 0);
         hm2->encoder.instance[i].count_64 = 0;
         hm2->encoder.instance[i].count_latch_64 = 0;
-        *hm2->encoder.instance[i].hal.pin.position = 0.0;
-        *hm2->encoder.instance[i].hal.pin.position_latch = 0.0;
-        *hm2->encoder.instance[i].hal.pin.velocity = 0.0;
-        *hm2->encoder.instance[i].hal.pin.velocity_rpm = 0.0;
-        *hm2->encoder.instance[i].hal.pin.quadrature_error = 0;
+        hal_set_real(hm2->encoder.instance[i].hal.pin.position, 0.0);
+        hal_set_real(hm2->encoder.instance[i].hal.pin.position_latch, 0.0);
+        hal_set_real(hm2->encoder.instance[i].hal.pin.velocity, 0.0);
+        hal_set_real(hm2->encoder.instance[i].hal.pin.velocity_rpm, 0.0);
+        hal_set_bool(hm2->encoder.instance[i].hal.pin.quadrature_error, 0);
  
         hm2->encoder.instance[i].zero_offset = count;
 
@@ -818,7 +797,7 @@ static void hm2_encoder_instance_update_rawcounts_and_handle_index(hostmot2_t *h
     reg_count = hm2_encoder_get_reg_count(hm2, instance);
 
     e->rawcounts_64 = hal_extend_counter(e->rawcounts_64, reg_count, 16);
-    *e->hal.pin.rawcounts = (rtapi_s32)e->rawcounts_64;
+    hal_set_si32(e->hal.pin.rawcounts, (rtapi_s32)e->rawcounts_64);
 
 
     //
@@ -840,13 +819,13 @@ static void hm2_encoder_instance_update_rawcounts_and_handle_index(hostmot2_t *h
             latched_count = (latch_ctrl >> 16) & 0xffff;
 
             latched_64 = hal_extend_counter(prev_rawcounts_64, latched_count, 16);
-            if (!*(e->hal.pin.no_clear_on_index)) {
+            if (!hal_get_bool(e->hal.pin.no_clear_on_index)) {
               e->zero_offset_64 = latched_64;
               e->zero_offset = (rtapi_s32)latched_64;
             }
             e->rawlatch_64 = latched_64;
-            *(e->hal.pin.rawlatch) = (rtapi_s32)latched_64;
-            *e->hal.pin.index_enable = 0;
+            hal_set_si32(e->hal.pin.rawlatch, (rtapi_s32)latched_64);
+            hal_set_bool(e->hal.pin.index_enable, 0);
             // may need to update interpolated position after index event because
             // this _may_ happen without a count but its pretty ugly...
             // *e->hal.pin.count = *e->hal.pin.rawcounts - e->zero_offset;
@@ -867,8 +846,8 @@ static void hm2_encoder_instance_update_rawcounts_and_handle_index(hostmot2_t *h
 
                 latched_64 = hal_extend_counter(prev_rawcounts_64, latched_count, 16);
                 e->rawlatch_64 = latched_64;
-                *(e->hal.pin.rawlatch) = (rtapi_s32)latched_64;
-                *e->hal.pin.latch_enable = 0;
+                hal_set_si32(e->hal.pin.rawlatch, (rtapi_s32)latched_64);
+                hal_set_bool(e->hal.pin.latch_enable, 0);
             }
         }
     }
@@ -913,12 +892,12 @@ static void hm2_encoder_instance_update_position(hostmot2_t *hm2, int instance) 
     // reset count if the user wants us to (by just setting the zero offset to the current rawcounts)
     //
 
-    if (*e->hal.pin.reset) {
-        e->zero_offset = *e->hal.pin.rawcounts;
+    if (hal_get_bool(e->hal.pin.reset)) {
+        e->zero_offset = hal_get_si32(e->hal.pin.rawcounts);
         e->zero_offset_64 = e->rawcounts_64;
-        *e->hal.pin.rawlatch = e->zero_offset;
+        hal_set_si32(e->hal.pin.rawlatch, e->zero_offset);
         e->rawlatch_64 = e->zero_offset_64;
-        *e->hal.pin.position_interpolated = *e->hal.pin.position;
+        hal_set_real(e->hal.pin.position_interpolated, hal_get_real(e->hal.pin.position));
 
     }
 
@@ -930,9 +909,9 @@ static void hm2_encoder_instance_update_position(hostmot2_t *hm2, int instance) 
     // From that we easily compute count and scaled position.
     //
 
-    *e->hal.pin.count = *e->hal.pin.rawcounts - e->zero_offset;
+    hal_set_si32(e->hal.pin.count, hal_get_si32(e->hal.pin.rawcounts) - e->zero_offset);
     e->count_64 = e->rawcounts_64 - e->zero_offset_64;
-    *e->hal.pin.count_latch = *e->hal.pin.rawlatch - e->zero_offset;
+    hal_set_si32(e->hal.pin.count_latch, hal_get_si32(e->hal.pin.rawlatch) - e->zero_offset);
     e->count_latch_64 = e->rawlatch_64 - e->zero_offset_64;
 
 
@@ -942,8 +921,8 @@ static void hm2_encoder_instance_update_position(hostmot2_t *hm2, int instance) 
     // to avoid wrap on high-resolution encoders.
     //
 
-    *e->hal.pin.position = e->count_64 / e->hal.param.scale;
-    *e->hal.pin.position_latch = e->count_latch_64 / e->hal.param.scale;
+    hal_set_real(e->hal.pin.position, e->count_64 / hal_get_real(e->hal.param.scale));
+    hal_set_real(e->hal.pin.position_latch, e->count_latch_64 / hal_get_real(e->hal.param.scale));
 }
 
 
@@ -960,9 +939,9 @@ static void hm2_encoder_instance_process_tram_read(hostmot2_t *hm2, int instance
     e = &hm2->encoder.instance[instance];
 
     // sanity check
-    if (e->hal.param.scale == 0.0) {
+    if (hal_get_real(e->hal.param.scale) == 0.0) {
         HM2_ERR("encoder.%02d.scale == 0.0, bogus, setting to 1.0\n", instance);
-        e->hal.param.scale = 1.0;
+        hal_set_real(e->hal.param.scale, 1.0);
     }
 
 
@@ -985,7 +964,7 @@ static void hm2_encoder_instance_process_tram_read(hostmot2_t *hm2, int instance
             hm2_encoder_instance_update_rawcounts_and_handle_index(hm2, instance);
             hm2_encoder_instance_update_position(hm2, instance);
 
-            e->prev_event_rawcounts = *e->hal.pin.rawcounts;
+            e->prev_event_rawcounts = hal_get_si32(e->hal.pin.rawcounts);
             e->prev_event_reg_timestamp = hm2_encoder_get_reg_timestamp(hm2, instance);
             e->prev_dS_counts = 0;
 
@@ -1031,31 +1010,31 @@ static void hm2_encoder_instance_process_tram_read(hostmot2_t *hm2, int instance
                 dT_clocks = (time_of_interest - e->prev_event_reg_timestamp) + (e->tsc_num_rollovers << 16);
                 dT_s = (double)dT_clocks * hm2->encoder.seconds_per_tsdiv_clock;
 
-                if (dT_s >= e->hal.param.vel_timeout) {
-                    *e->hal.pin.velocity = 0.0;
-                    *e->hal.pin.velocity_rpm = 0.0;
-                    *e->hal.pin.position_interpolated = *e->hal.pin.position;
+                if (dT_s >= hal_get_real(e->hal.param.vel_timeout)) {
+                    hal_set_real(e->hal.pin.velocity, 0.0);
+                    hal_set_real(e->hal.pin.velocity_rpm, 0.0);
+                    hal_set_real(e->hal.pin.position_interpolated, hal_get_real(e->hal.pin.position));
                     e->state = HM2_ENCODER_STOPPED;
                     break;
                 }
 
-                if ((*e->hal.pin.velocity * e->hal.param.scale) > 0.0) {
+                if ((hal_get_real(e->hal.pin.velocity) * hal_get_real(e->hal.param.scale)) > 0.0) {
                     dS_counts = 1;
                 } else {
                     dS_counts = -1;
                 }
                 // if no counts, calculate interpolated position
-                *e->hal.pin.position_interpolated = *e->hal.pin.position + (dT_s * *e->hal.pin.velocity);
+                hal_set_real(e->hal.pin.position_interpolated, hal_get_real(e->hal.pin.position) + (dT_s * hal_get_real(e->hal.pin.velocity)));
 
-                dS_pos_units = dS_counts / e->hal.param.scale;
+                dS_pos_units = dS_counts / hal_get_real(e->hal.param.scale);
 
                 // we can calculate velocity only if timestamp changed along with counts
                 if (dT_clocks > 0) {
                     // we know the encoder velocity is not faster than this
                     vel = dS_pos_units / dT_s;
-                    if (fabs(vel) < fabs(*e->hal.pin.velocity)) {
-                        *e->hal.pin.velocity = vel;
-                        *e->hal.pin.velocity_rpm = vel * 60.0;
+                    if (fabs(vel) < fabs(hal_get_real(e->hal.pin.velocity))) {
+                        hal_set_real(e->hal.pin.velocity, vel);
+                        hal_set_real(e->hal.pin.velocity_rpm, vel * 60.0);
                     }
                 }
 
@@ -1076,14 +1055,14 @@ static void hm2_encoder_instance_process_tram_read(hostmot2_t *hm2, int instance
 
                 hm2_encoder_instance_update_rawcounts_and_handle_index(hm2, instance);
                 hm2_encoder_instance_update_position(hm2, instance);
-                *e->hal.pin.position_interpolated = *e->hal.pin.position;
+                hal_set_real(e->hal.pin.position_interpolated, hal_get_real(e->hal.pin.position));
                 time_of_interest = hm2_encoder_get_reg_timestamp(hm2, instance);
                 if (time_of_interest < e->prev_time_of_interest) {
                     // tsc rollover!
                     e->tsc_num_rollovers ++;
                 }
 
-                dS_counts = *e->hal.pin.rawcounts - e->prev_event_rawcounts;
+                dS_counts = hal_get_si32(e->hal.pin.rawcounts) - e->prev_event_rawcounts;
 
                 // If we reversed direction and moved exactly one edge,
                 // we can't reliably estimate velocity.  The encoder might
@@ -1091,24 +1070,24 @@ static void hm2_encoder_instance_process_tram_read(hostmot2_t *hm2, int instance
                 // small dT between adjacent edges, leading to misleadingly
                 // large velocity estimates.  So we just call it 0.
                 if (
-                    (((*e->hal.pin.rawcounts - e->prev_event_rawcounts) == 1) && (e->prev_dS_counts < 0))
-                    || (((*e->hal.pin.rawcounts - e->prev_event_rawcounts) == -1) && (e->prev_dS_counts > 0))
+                    (((hal_get_si32(e->hal.pin.rawcounts) - e->prev_event_rawcounts) == 1) && (e->prev_dS_counts < 0))
+                    || (((hal_get_si32(e->hal.pin.rawcounts) - e->prev_event_rawcounts) == -1) && (e->prev_dS_counts > 0))
                 ) {
-                    *e->hal.pin.velocity = 0.0;
-                    *e->hal.pin.velocity_rpm = 0.0;
-                    *e->hal.pin.position_interpolated = *e->hal.pin.position;
+                    hal_set_real(e->hal.pin.velocity, 0.0);
+                    hal_set_real(e->hal.pin.velocity_rpm, 0.0);
+                    hal_set_real(e->hal.pin.position_interpolated, hal_get_real(e->hal.pin.position));
 
                 } else {
                     dT_clocks = (time_of_interest - e->prev_event_reg_timestamp) + (e->tsc_num_rollovers << 16);
                     dT_s = (double)dT_clocks * hm2->encoder.seconds_per_tsdiv_clock;
 
-                    dS_pos_units = dS_counts / e->hal.param.scale;
+                    dS_pos_units = dS_counts / hal_get_real(e->hal.param.scale);
 
                     // we can calculate velocity only if timestamp changed along with counts
                     if (dT_clocks > 0) {
                         // finally time to do Relative-Time Velocity Estimation
-                        *e->hal.pin.velocity = dS_pos_units / dT_s;
-                        *e->hal.pin.velocity_rpm = *e->hal.pin.velocity  * 60.0;
+                        hal_set_real(e->hal.pin.velocity, dS_pos_units / dT_s);
+                        hal_set_real(e->hal.pin.velocity_rpm, hal_get_real(e->hal.pin.velocity) * 60.0);
                     }
                 }
 
@@ -1116,7 +1095,7 @@ static void hm2_encoder_instance_process_tram_read(hostmot2_t *hm2, int instance
 
                 e->prev_dS_counts = dS_counts;
 
-                e->prev_event_rawcounts = *e->hal.pin.rawcounts;
+                e->prev_event_rawcounts = hal_get_si32(e->hal.pin.rawcounts);
                 e->prev_event_reg_timestamp = time_of_interest;
 
                 e->prev_time_of_interest = time_of_interest;

--- a/src/hal/drivers/mesa-hostmot2/hm2_7i43.c
+++ b/src/hal/drivers/mesa-hostmot2/hm2_7i43.c
@@ -215,7 +215,7 @@ int hm2_7i43_read(hm2_lowlevel_io_t *this, rtapi_u32 addr, void *buffer, int siz
 
     if (hm2_7i43_epp_check_for_timeout(board)) {
         THIS_PRINT("EPP timeout on data cycle of read(addr=0x%04x, size=%d)\n", addr, size);
-        (*this->io_error) = 1;
+        hal_set_bool(*this->io_error, 1);
         this->needs_reset = 1;
         hm2_7i43_epp_clear_timeout(board);
         return 0;  // fail
@@ -246,7 +246,7 @@ int hm2_7i43_write(hm2_lowlevel_io_t *this, rtapi_u32 addr, const void *buffer, 
 
     if (hm2_7i43_epp_check_for_timeout(board)) {
         THIS_PRINT("EPP timeout on data cycle of write(addr=0x%04x, size=%d)\n", addr, size);
-        (*this->io_error) = 1;
+        hal_set_bool(*this->io_error, 1);
         this->needs_reset = 1;
         hm2_7i43_epp_clear_timeout(board);
         return 0;

--- a/src/hal/drivers/mesa-hostmot2/hm2_7i90.c
+++ b/src/hal/drivers/mesa-hostmot2/hm2_7i90.c
@@ -211,7 +211,7 @@ int hm2_7i90_read(hm2_lowlevel_io_t *this, rtapi_u32 addr, void *buffer, int siz
 
     if (hm2_7i90_epp_check_for_timeout(board)) {
         THIS_PRINT("EPP timeout on data cycle of read(addr=0x%04x, size=%d)\n", addr, size);
-        (*this->io_error) = 1;
+        hal_set_bool(*this->io_error, 1);
         this->needs_reset = 1;
         hm2_7i90_epp_clear_timeout(board);
         return 0;  // fail
@@ -242,7 +242,7 @@ int hm2_7i90_write(hm2_lowlevel_io_t *this, rtapi_u32 addr, const void *buffer, 
 
     if (hm2_7i90_epp_check_for_timeout(board)) {
         THIS_PRINT("EPP timeout on data cycle of write(addr=0x%04x, size=%d)\n", addr, size);
-        (*this->io_error) = 1;
+        hal_set_bool(*this->io_error, 1);
         this->needs_reset = 1;
         hm2_7i90_epp_clear_timeout(board);
         return 0;

--- a/src/hal/drivers/mesa-hostmot2/hm2_eth.c
+++ b/src/hal/drivers/mesa-hostmot2/hm2_eth.c
@@ -107,7 +107,7 @@ RTAPI_MP_ARRAY_STRING(config, MAX_ETH_BOARDS, "config string for the AnyIO board
 int debug = 0;
 RTAPI_MP_INT(debug, "Developer/debug use only!  Enable debug logging.");
 
-static char *firewall = 0;
+static char *firewall = NULL;
 RTAPI_MP_STRING(firewall, "Firewall backend for traffic isolation: auto (default), iptables, nft, or none.");
 
 static int boards_count = 0;
@@ -973,29 +973,29 @@ static int hm2_eth_send_queued_reads(hm2_lowlevel_io_t *this) {
 static bool record_soft_error(hm2_eth_t *board) {
     if(!board->hal) return 1; // still early in hm2_eth_probe
     board->llio.needs_soft_reset = 1;
-    *board->hal->packet_error = 1;
-    *board->hal->packet_error_total += 1;
-    int32_t increment = board->hal->packet_error_increment;
+    hal_set_bool(board->hal->packet_error, 1);
+    hal_set_ui32(board->hal->packet_error_total, hal_get_ui32(board->hal->packet_error_total) + 1);
+    int32_t increment = hal_get_si32(board->hal->packet_error_increment);
     if(increment < 1) increment = 1;
     board->comm_error_counter += increment;
-    if(board->comm_error_counter < 0 || board->comm_error_counter > board->hal->packet_error_limit)
-        board->comm_error_counter = board->hal->packet_error_limit;
-    *board->hal->packet_error_level = board->comm_error_counter;
-    bool result = board->comm_error_counter < board->hal->packet_error_limit;
-    if(!result) *board->llio.io_error = true;
-    *board->hal->packet_error_exceeded = !result;
+    if(board->comm_error_counter < 0 || board->comm_error_counter > hal_get_si32(board->hal->packet_error_limit))
+        board->comm_error_counter = hal_get_si32(board->hal->packet_error_limit);
+    hal_set_si32(board->hal->packet_error_level, board->comm_error_counter);
+    bool result = board->comm_error_counter < hal_get_si32(board->hal->packet_error_limit);
+    if(!result) hal_set_bool(*board->llio.io_error, true);
+    hal_set_bool(board->hal->packet_error_exceeded, !result);
     return result;
 }
 
 static void decrement_soft_error(hm2_eth_t *board) {
     if(!board->hal) return; // still early in hm2_eth_probe
-    int32_t decrement = board->hal->packet_error_decrement;
+    int32_t decrement = hal_get_si32(board->hal->packet_error_decrement);
     if(decrement < 1) decrement = 1;
     board->comm_error_counter -= decrement;
     if(board->comm_error_counter < 0) board->comm_error_counter = 0;
-    *board->hal->packet_error_level = board->comm_error_counter;
-    *board->hal->packet_error = 0;
-    *board->hal->packet_error_exceeded = 0;
+    hal_set_si32(board->hal->packet_error_level, board->comm_error_counter);
+    hal_set_bool(board->hal->packet_error, 0);
+    hal_set_bool(board->hal->packet_error_exceeded, 0);
 }
 
 static int hm2_eth_receive_queued_reads(hm2_lowlevel_io_t *this) {
@@ -1009,11 +1009,11 @@ static int hm2_eth_receive_queued_reads(hm2_lowlevel_io_t *this) {
     // pin (or they did something else like fiddle with the error limit
     // during a run, in which case we don't care if we reset the counter
     // or not)
-    if(board->hal && board->comm_error_counter == board->hal->packet_error_limit && !*board->llio.io_error) {
+    if(board->hal && board->comm_error_counter == hal_get_si32(board->hal->packet_error_limit) && !hal_get_bool(*board->llio.io_error)) {
         board->comm_error_counter = 0;
     }
 
-    long read_timeout = board->hal ? board->hal->read_timeout : 1600000;
+    long read_timeout = board->hal ? hal_get_si32(board->hal->read_timeout) : 1600000;
     if(read_timeout <= 0)//less than or equal to 0, use 80% of the thread period.
         read_timeout = 80;
     if(read_timeout < 100)//less than 100 is interpreted as a percentage of the thread period.
@@ -1618,69 +1618,37 @@ static int hm2_eth_items(hm2_eth_t *board) {
     board->hal = hal_malloc(sizeof(*board->hal));
     if(!board->hal) return -ENOMEM;
 
-    if((r = hal_param_s32_newf(HAL_RW,
-            &board->hal->read_timeout,
-            board->llio.comp_id,
-            "%s.packet-read-timeout",
-            board->llio.name)) < 0)
+    if((r = hal_param_new_si32(board->llio.comp_id, HAL_RW, &board->hal->read_timeout,
+            80, "%s.packet-read-timeout", board->llio.name)) < 0)
         return r;
-    board->hal->read_timeout = 80;
 
-    if((r = hal_param_s32_newf(HAL_RW,
-            &board->hal->packet_error_limit,
-            board->llio.comp_id,
-            "%s.packet-error-limit",
-            board->llio.name)) < 0)
+    if((r = hal_param_new_si32(board->llio.comp_id, HAL_RW, &board->hal->packet_error_limit,
+            10, "%s.packet-error-limit", board->llio.name)) < 0)
         return r;
-    board->hal->packet_error_limit = 10;
 
-    if((r = hal_param_s32_newf(HAL_RW,
-            &board->hal->packet_error_increment,
-            board->llio.comp_id,
-            "%s.packet-error-increment",
-            board->llio.name)) < 0)
+    if((r = hal_param_new_si32(board->llio.comp_id, HAL_RW, &board->hal->packet_error_increment,
+            2, "%s.packet-error-increment", board->llio.name)) < 0)
         return r;
-    board->hal->packet_error_increment = 2;
 
-    if((r = hal_param_s32_newf(HAL_RO,
-            &board->hal->packet_error_decrement,
-            board->llio.comp_id,
-            "%s.packet-error-decrement",
-            board->llio.name)) < 0)
+    if((r = hal_param_new_si32(board->llio.comp_id, HAL_RO, &board->hal->packet_error_decrement,
+            1, "%s.packet-error-decrement", board->llio.name)) < 0)
         return r;
-    board->hal->packet_error_decrement = 1;
 
-    if((r = hal_pin_bit_newf(HAL_OUT,
-            &board->hal->packet_error,
-            board->llio.comp_id,
-            "%s.packet-error",
-            board->llio.name)) < 0)
+    if((r = hal_pin_new_bool(board->llio.comp_id, HAL_OUT, &board->hal->packet_error,
+            0, "%s.packet-error", board->llio.name)) < 0)
         return r;
-    *board->hal->packet_error = 0;
 
-    if((r = hal_pin_u32_newf(HAL_IO,
-            &board->hal->packet_error_total,
-            board->llio.comp_id,
-            "%s.packet-error-total",
-            board->llio.name)) < 0)
+    if((r = hal_pin_new_ui32(board->llio.comp_id, HAL_IO, &board->hal->packet_error_total,
+            0, "%s.packet-error-total", board->llio.name)) < 0)
         return r;
-    *board->hal->packet_error_total = 0;
 
-    if((r = hal_pin_s32_newf(HAL_OUT,
-            &board->hal->packet_error_level,
-            board->llio.comp_id,
-            "%s.packet-error-level",
-            board->llio.name)) < 0)
+    if((r = hal_pin_new_si32(board->llio.comp_id, HAL_OUT, &board->hal->packet_error_level,
+            0, "%s.packet-error-level", board->llio.name)) < 0)
         return r;
-    *board->hal->packet_error_level = 0;
 
-    if((r = hal_pin_bit_newf(HAL_OUT,
-            &board->hal->packet_error_exceeded,
-            board->llio.comp_id,
-            "%s.packet-error-exceeded",
-            board->llio.name)) < 0)
+    if((r = hal_pin_new_bool(board->llio.comp_id, HAL_OUT, &board->hal->packet_error_exceeded,
+            0, "%s.packet-error-exceeded", board->llio.name)) < 0)
         return r;
-    *board->hal->packet_error_exceeded = 0;
 
     return 0;
 }
@@ -1711,7 +1679,7 @@ int rtapi_app_main(void) {
 
     for(i = 0, ret = 0; ret == 0 && i<MAX_ETH_BOARDS && board_ip[i] && *board_ip[i]; i++) {
         ret = init_board(&boards[i], board_ip[i], board_rtnet[i]);
-        if(ret < 0) board_ip[i] = 0;
+        if(ret < 0) board_ip[i] = NULL;
     }
 
     if (ret < 0)

--- a/src/hal/drivers/mesa-hostmot2/hm2_eth.h
+++ b/src/hal/drivers/mesa-hostmot2/hm2_eth.h
@@ -83,14 +83,14 @@ struct hm2_eth_t {
     struct arpreq req;
 
     struct {
-        hal_s32_t read_timeout;
-        hal_s32_t packet_error_limit;
-        hal_s32_t packet_error_increment;
-        hal_s32_t packet_error_decrement;
-        hal_bit_t *packet_error;
-        hal_u32_t *packet_error_total;
-        hal_s32_t *packet_error_level;
-        hal_bit_t *packet_error_exceeded;
+        hal_sint_t read_timeout;
+        hal_sint_t packet_error_limit;
+        hal_sint_t packet_error_increment;
+        hal_sint_t packet_error_decrement;
+        hal_bool_t packet_error;
+        hal_uint_t packet_error_total;
+        hal_sint_t packet_error_level;
+        hal_bool_t packet_error_exceeded;
     } *hal;
 };
 

--- a/src/hal/drivers/mesa-hostmot2/hm2_modbus.c
+++ b/src/hal/drivers/mesa-hostmot2/hm2_modbus.c
@@ -196,35 +196,35 @@ typedef union {
 } mb_types64_u;
 
 typedef struct {
-	hal_data_u	*pin;		// Modbus data pin
-	hal_data_u	*offset;	// Pin offset input
-	hal_float_t *scale;		// Pin scale input
-	hal_float_t	*scaled;	// Pin scaled output
+	hal_refs_u pin;			// Modbus data pin
+	hal_refs_u offset;		// Pin offset input
+	hal_real_t scale;		// Pin scale input
+	hal_real_t scaled;		// Pin scaled output
 } mbt_pin_hal_t;
 
 typedef struct {
-	hal_bit_t *disable;		// Command disable input
-	hal_bit_t *disabled;	// Command disable output
-	hal_bit_t *reset;		// Reset errors and re-enable on rising edge
-	hal_u32_t *error;		// Command error counter
-	hal_u32_t *errorcode;	// Last error code
+	hal_bool_t disable;		// Command disable input
+	hal_bool_t disabled;	// Command disable output
+	hal_bool_t reset;		// Reset errors and re-enable on rising edge
+	hal_uint_t error;		// Command error counter
+	hal_uint_t errorcode;	// Last error code
 } mbt_cmd_hal_t;
 
 typedef struct {
 	mbt_pin_hal_t *pins;	// All data pins
 	mbt_cmd_hal_t *cmds;	// Per command pins
-	hal_bit_t *suspend;		// Suspend running commands
-	hal_bit_t *reset;		// Reset command errors and re-enable on rising edge
-	hal_bit_t *fault;
-	hal_u32_t *faultcmd;
-	hal_u32_t *lasterror;
-	hal_u32_t baudrate;	// RO
-	hal_u32_t parity;	// RO
-	hal_u32_t stopbits;	// RO
-	hal_u32_t icdelay;	// RO Inter character delay
-	hal_u32_t txdelay;	// RO Inter frame delay for packets sent
-	hal_u32_t rxdelay;	// RO Inter frame delay for packet end detection in receive
-	hal_u32_t drvdelay;	// RO Delay before sending data (in bit times)
+	hal_bool_t suspend;		// Suspend running commands
+	hal_bool_t reset;		// Reset command errors and re-enable on rising edge
+	hal_bool_t fault;
+	hal_uint_t faultcmd;
+	hal_uint_t lasterror;
+	hal_uint_t baudrate;	// RO
+	hal_uint_t parity;		// RO
+	hal_uint_t stopbits;	// RO
+	hal_uint_t icdelay;		// RO Inter character delay
+	hal_uint_t txdelay;		// RO Inter frame delay for packets sent
+	hal_uint_t rxdelay;		// RO Inter frame delay for packet end detection in receive
+	hal_uint_t drvdelay;	// RO Delay before sending data (in bit times)
 } hm2_modbus_hal_t;
 
 // The command structure and data buffer.
@@ -371,7 +371,7 @@ static void setup_icdelay(hm2_modbus_inst_t *inst, unsigned baudrate, unsigned p
 	} else {
 		inst->maxicharbits = 0;
 	}
-	inst->hal->icdelay = inst->maxicharbits;
+	hal_set_ui32(inst->hal->icdelay, inst->maxicharbits);
 }
 
 //
@@ -440,12 +440,12 @@ static int send_comms_change(hm2_modbus_inst_t *inst)
 	inst->cfg_tx.drivedelay = cc->cmd.idrvdelay ? cc->cmd.idrvdelay : 1;
 
 	// Expose to HAL
-	inst->hal->baudrate = baudrate;
-	inst->hal->parity   = parity;
-	inst->hal->stopbits = stopbits;
-	inst->hal->rxdelay  = inst->cfg_rx.ifdelay;
-	inst->hal->txdelay  = inst->cfg_tx.ifdelay;
-	inst->hal->drvdelay = inst->cfg_tx.drivedelay;
+	hal_set_ui32(inst->hal->baudrate, baudrate);
+	hal_set_ui32(inst->hal->parity,   parity);
+	hal_set_ui32(inst->hal->stopbits, stopbits);
+	hal_set_ui32(inst->hal->rxdelay,  inst->cfg_rx.ifdelay);
+	hal_set_ui32(inst->hal->txdelay,  inst->cfg_tx.ifdelay);
+	hal_set_ui32(inst->hal->drvdelay, inst->cfg_tx.drivedelay);
 	// Redo the inter-character delay settings
 	setup_icdelay(inst, baudrate, parity, stopbits, cc->cmd.iicdelay);
 
@@ -460,18 +460,18 @@ static void set_error(hm2_modbus_inst_t *inst, int errcode)
 {
 	if(handling_inits(inst)) {
 		// No individual pins for init commands, use global
-		*(inst->hal->fault) = 1;
-		*(inst->hal->faultcmd) = inst->cmdidx;
-		*(inst->hal->lasterror) = errcode;
+		hal_set_bool(inst->hal->fault, 1);
+		hal_set_ui32(inst->hal->faultcmd, inst->cmdidx);
+		hal_set_ui32(inst->hal->lasterror, errcode);
 		return;
 	}
 	hm2_modbus_cmd_t *cc = current_cmd(inst);
 	if(++cc->errors >= MAX_ERRORS || cc->disabled) {
 		cc->disabled = 1;
-		*(inst->hal->cmds[inst->cmdidx].disabled)  = 1;
-		*(inst->hal->cmds[inst->cmdidx].errorcode) = errcode;
+		hal_set_bool(inst->hal->cmds[inst->cmdidx].disabled, 1);
+		hal_set_ui32(inst->hal->cmds[inst->cmdidx].errorcode, errcode);
 	}
-	*(inst->hal->cmds[inst->cmdidx].error) = cc->errors;
+	hal_set_ui32(inst->hal->cmds[inst->cmdidx].error, cc->errors);
 }
 
 //
@@ -612,15 +612,15 @@ static inline int next_command(hm2_modbus_inst_t *inst)
 		// Reset the individual commands on request.
 		// Using modulo index ensures we also reset index zero when we wrap.
 		unsigned i = inst->cmdidx % inst->ncmds;
-		bool b = !!*(inst->hal->cmds[i].reset);
+		bool b = hal_get_bool(inst->hal->cmds[i].reset);
 		if(inst->cmds[i].prevreset != b) {
 			inst->cmds[i].prevreset = !inst->cmds[i].prevreset;
 			if(inst->cmds[i].prevreset) {
 				inst->cmds[i].disabled = 0;
 				inst->cmds[i].errors   = 0;
-				*(inst->hal->cmds[i].disabled)  = 0;
-				*(inst->hal->cmds[i].error)     = 0;
-				*(inst->hal->cmds[i].errorcode) = 0;
+				hal_set_bool(inst->hal->cmds[i].disabled, 0);
+				hal_set_ui32(inst->hal->cmds[i].error, 0);
+				hal_set_ui32(inst->hal->cmds[i].errorcode, 0);
 				// Honor the writeflush flag when coming out of disable.
 				write_flush_cmd(inst, i);
 			}
@@ -628,15 +628,15 @@ static inline int next_command(hm2_modbus_inst_t *inst)
 
 		// The run-time disabling of a command takes precedens over reset.
 		// Set it on the rising edge of the 'disable' pin
-		b = !!*(inst->hal->cmds[i].disable);
+		b = hal_get_bool(inst->hal->cmds[i].disable);
 		if(inst->cmds[i].prevdisable != b) {
 			inst->cmds[i].prevdisable = !inst->cmds[i].prevdisable;
 			if(inst->cmds[i].prevdisable) {
 				inst->cmds[i].disabled = 1;
 				inst->cmds[i].errors   = 0;
-				*(inst->hal->cmds[i].disabled)  = 1;
-				*(inst->hal->cmds[i].error)     = 0;
-				*(inst->hal->cmds[i].errorcode) = EAGAIN;
+				hal_set_bool(inst->hal->cmds[i].disabled, 1);
+				hal_set_ui32(inst->hal->cmds[i].error, 0);
+				hal_set_ui32(inst->hal->cmds[i].errorcode, EAGAIN);
 			}
 		}
 	} while(inst->cmdidx < inst->ncmds && inst->cmds[inst->cmdidx].disabled);
@@ -689,7 +689,7 @@ static inline void set_state(hm2_modbus_inst_t *inst, int newstate)
 		inst->timeout = 25000000;	// 25 milliseconds
 		break;
 	case STATE_START:
-		if(*(inst->hal->suspend)) {
+		if(hal_get_bool(inst->hal->suspend)) {
 			inst->suspended = 1;
 		}
 		inst->ignoredata = 0;	// Re-enable data handling
@@ -721,9 +721,9 @@ static void do_timeout(hm2_modbus_inst_t *inst)
 		MSG_DBG("Timeout reset cmd=%u %s(%d)\n", inst->cmdidx, state_names[inst->state], inst->state);
 		force_resend(inst);
 		queue_reset(inst);
-		*(inst->hal->lasterror) = ETIMEDOUT;
-		*(inst->hal->fault) = 1;
-		*(inst->hal->faultcmd) = inst->cmdidx;
+		hal_set_ui32(inst->hal->lasterror, ETIMEDOUT);
+		hal_set_bool(inst->hal->fault, 1);
+		hal_set_ui32(inst->hal->faultcmd, inst->cmdidx);
 		set_error(inst, ETIMEDOUT);
 		set_state(inst, STATE_START);
 	}
@@ -749,7 +749,7 @@ static void process(void *arg, long period)
 	hm2_modbus_inst_t *inst = (hm2_modbus_inst_t *)arg;
 
 	if(inst->suspended) {
-		if(!*(inst->hal->suspend)) {
+		if(!hal_get_bool(inst->hal->suspend)) {
 			inst->suspended = 0;
 			// When coming out of suspend, see if we want to suppress writes
 			// because our local data will most likely not match the pin data.
@@ -772,18 +772,18 @@ static void process(void *arg, long period)
 		}
 
 		// Re-enable all commands on rising edge of global reset pin
-		bool b = !!*(inst->hal->reset);	// Make sure its value is bool-worthy
+		bool b = hal_get_bool(inst->hal->reset);
 		if(inst->prevreset != b) {
 			inst->prevreset = !inst->prevreset;
 			if(inst->prevreset) {
 				for(unsigned i = 0; i < inst->ncmds; i++) {
 					if(inst->cmds[i].disabled) {
 						inst->cmds[i].disabled = 0;
-						*(inst->hal->cmds[i].disabled) = 0;
+						hal_set_bool(inst->hal->cmds[i].disabled, 0);
 						write_flush_cmd(inst, i);
 					}
-					*(inst->hal->cmds[i].errorcode) = 0;
-					*(inst->hal->cmds[i].error)     = 0;
+					hal_set_ui32(inst->hal->cmds[i].errorcode, 0);
+					hal_set_ui32(inst->hal->cmds[i].error, 0);
 					inst->cmds[i].errors = 0;
 				}
 			}
@@ -864,9 +864,9 @@ retry_next_init:
 				// If the next command is again the first, then we have no
 				// messages we can send.
 				if(next_command(inst)) {
-					*(inst->hal->lasterror) = ENODATA;
-					*(inst->hal->fault) = 1;
-					*(inst->hal->faultcmd) = 0;
+					hal_set_ui32(inst->hal->lasterror, ENODATA);
+					hal_set_bool(inst->hal->fault, 1);
+					hal_set_ui32(inst->hal->faultcmd, 0);
 					break;
 				}
 			}
@@ -962,7 +962,7 @@ retry_next_init:
 		if(inst->timeout < 0) {
 			// Timeout of delay, proceed to next command
 			set_state(inst, STATE_START);
-			*(inst->hal->fault) = 0;
+			hal_set_bool(inst->hal->fault, 0);
 		}
 		break;
 
@@ -1086,7 +1086,7 @@ fetch_more_data:
 			// more (new) data is pending, then that will also be out-of-band.
 			// We can go to the start state and sort it out there.
 			set_state(inst, STATE_START);
-			*(inst->hal->fault) = 0;
+			hal_set_bool(inst->hal->fault, 0);
 		}
 		break;
 
@@ -1097,9 +1097,9 @@ fetch_more_data:
 
 	default:
 		MSG_ERR("%s: error: Unknown state (%d) in process(), setting START state\n", inst->name, inst->state);
-		*(inst->hal->fault) = 1;
-		*(inst->hal->lasterror) = EINVAL;
-		*(inst->hal->faultcmd) = inst->cmdidx;
+		hal_set_bool(inst->hal->fault, 1);
+		hal_set_ui32(inst->hal->lasterror, EINVAL);
+		hal_set_ui32(inst->hal->faultcmd, inst->cmdidx);
 		set_state(inst, STATE_START);
 		break;
 	}
@@ -1450,38 +1450,38 @@ static int build_data_frame(hm2_modbus_inst_t *inst)
 		break;
 	case MBCMD_W_COIL: // Write single coil
 		CHK_RV(ch_append16(cc, cc->cmd.caddr));
-		CHK_RV(ch_append16(cc, hal->pins[p].pin->b ? 0xFF00 : 0x0000));
+		CHK_RV(ch_append16(cc, hal_get_bool(hal->pins[p].pin.b) ? 0xFF00 : 0x0000));
 		break;
 	case MBCMD_W_REGISTER: // Write single register
 		// The target mtype can only be MBT_AB or MBT_BA (single reg write)
 		CHK_RV(ch_append16(cc, cc->cmd.caddr));
 		switch(cc->typeptr[0].htype) {
-		case HAL_BIT:
-			CHK_RV(map_u(cc, hal->pins[p].pin->b ? 1 : 0, 0));
+		case HAL_BOOL:
+			CHK_RV(map_u(cc, hal_get_bool(hal->pins[p].pin.b) ? 1 : 0, 0));
 			break;
 		case HAL_U32:
 			switch(mtypetype(cc->typeptr[0].mtype)) {
-			case MBT_U: CHK_RV(map_u(cc, hal->pins[p].pin->u, 0)); break;
-			case MBT_S: CHK_RV(map_s(cc, map_us(hal->pins[p].pin->u), 0)); break;
-			case MBT_F: CHK_RV(map_f(cc, map_uf(hal->pins[p].pin->u), 0)); break;
+			case MBT_U: CHK_RV(map_u(cc, hal_get_ui32(hal->pins[p].pin.u), 0)); break;
+			case MBT_S: CHK_RV(map_s(cc, map_us(hal_get_ui32(hal->pins[p].pin.u)), 0)); break;
+			case MBT_F: CHK_RV(map_f(cc, map_uf(hal_get_ui32(hal->pins[p].pin.u)), 0)); break;
 			}
 			break;
-		case HAL_U64:
+		case HAL_UINT:
 			switch(mtypetype(cc->typeptr[0].mtype)) {
-			case MBT_U: CHK_RV(map_u(cc, hal->pins[p].pin->lu, 0)); break;
-			case MBT_S: CHK_RV(map_s(cc, map_us(hal->pins[p].pin->lu), 0)); break;
-			case MBT_F: CHK_RV(map_f(cc, map_uf(hal->pins[p].pin->lu), 0)); break;
+			case MBT_U: CHK_RV(map_u(cc, hal_get_uint(hal->pins[p].pin.u), 0)); break;
+			case MBT_S: CHK_RV(map_s(cc, map_us(hal_get_uint(hal->pins[p].pin.u)), 0)); break;
+			case MBT_F: CHK_RV(map_f(cc, map_uf(hal_get_uint(hal->pins[p].pin.u)), 0)); break;
 			}
 			break;
 		case HAL_S32:
 			if(!haspinscale(&cc->typeptr[0])) {
 				switch(mtypetype(cc->typeptr[0].mtype)) {
-				case MBT_U: CHK_RV(map_u(cc, map_su(hal->pins[p].pin->s), 0)); break;
-				case MBT_S: CHK_RV(map_s(cc, hal->pins[p].pin->s, 0)); break;
-				case MBT_F: CHK_RV(map_f(cc, map_sf(hal->pins[p].pin->s), 0)); break;
+				case MBT_U: CHK_RV(map_u(cc, map_su(hal_get_si32(hal->pins[p].pin.s)), 0)); break;
+				case MBT_S: CHK_RV(map_s(cc, hal_get_si32(hal->pins[p].pin.s), 0)); break;
+				case MBT_F: CHK_RV(map_f(cc, map_sf(hal_get_si32(hal->pins[p].pin.s)), 0)); break;
 				}
 			} else {
-				val64.f = (real_t)((rtapi_s64)hal->pins[p].pin->s - hal->pins[p].offset->s) * *(hal->pins[p].scale);
+				val64.f = (rtapi_real)((rtapi_s64)hal_get_si32(hal->pins[p].pin.s) - hal_get_si32(hal->pins[p].offset.s)) * hal_get_real(hal->pins[p].scale);
 				switch(mtypetype(cc->typeptr[0].mtype)) {
 				case MBT_U: CHK_RV(map_u(cc, map_fu(val64.f), 0)); break;
 				case MBT_S: CHK_RV(map_s(cc, map_fs(val64.f), 0)); break;
@@ -1489,15 +1489,15 @@ static int build_data_frame(hm2_modbus_inst_t *inst)
 				}
 			}
 			break;
-		case HAL_S64:
+		case HAL_SINT:
 			if(!haspinscale(&cc->typeptr[0])) {
 				switch(mtypetype(cc->typeptr[0].mtype)) {
-				case MBT_U: CHK_RV(map_u(cc, map_su(hal->pins[p].pin->ls), 0)); break;
-				case MBT_S: CHK_RV(map_s(cc, hal->pins[p].pin->ls, 0)); break;
-				case MBT_F: CHK_RV(map_f(cc, map_sf(hal->pins[p].pin->ls), 0)); break;
+				case MBT_U: CHK_RV(map_u(cc, map_su(hal_get_sint(hal->pins[p].pin.s)), 0)); break;
+				case MBT_S: CHK_RV(map_s(cc, hal_get_sint(hal->pins[p].pin.s), 0)); break;
+				case MBT_F: CHK_RV(map_f(cc, map_sf(hal_get_sint(hal->pins[p].pin.s)), 0)); break;
 				}
 			} else {
-				val64.f = (real_t)(hal->pins[p].pin->ls - hal->pins[p].offset->ls) * *(hal->pins[p].scale);
+				val64.f = (rtapi_real)(hal_get_sint(hal->pins[p].pin.s) - hal_get_sint(hal->pins[p].offset.s)) * hal_get_real(hal->pins[p].scale);
 				switch(mtypetype(cc->typeptr[0].mtype)) {
 				case MBT_U: CHK_RV(map_u(cc, map_fu(val64.f), 0)); break;
 				case MBT_S: CHK_RV(map_s(cc, map_fs(val64.f), 0)); break;
@@ -1505,15 +1505,15 @@ static int build_data_frame(hm2_modbus_inst_t *inst)
 				}
 			}
 			break;
-		case HAL_FLOAT:
+		case HAL_REAL:
 			if(!haspinscale(&cc->typeptr[0])) {
 				switch(mtypetype(cc->typeptr[0].mtype)) {
-				case MBT_U: CHK_RV(map_u(cc, map_fu(hal->pins[p].pin->f), 0)); break;
-				case MBT_S: CHK_RV(map_s(cc, map_fs(hal->pins[p].pin->f), 0)); break;
-				case MBT_F: CHK_RV(map_f(cc, hal->pins[p].pin->f, 0)); break;
+				case MBT_U: CHK_RV(map_u(cc, map_fu(hal_get_real(hal->pins[p].pin.r)), 0)); break;
+				case MBT_S: CHK_RV(map_s(cc, map_fs(hal_get_real(hal->pins[p].pin.r)), 0)); break;
+				case MBT_F: CHK_RV(map_f(cc, hal_get_real(hal->pins[p].pin.r), 0)); break;
 				}
 			} else {
-				val64.f = (hal->pins[p].pin->f - hal->pins[p].offset->f) * *(hal->pins[p].scale);
+				val64.f = (hal_get_real(hal->pins[p].pin.r) - hal_get_real(hal->pins[p].offset.r)) * hal_get_real(hal->pins[p].scale);
 				switch(mtypetype(cc->typeptr[0].mtype)) {
 				case MBT_U: CHK_RV(map_u(cc, map_fu(val64.f), 0)); break;
 				case MBT_S: CHK_RV(map_s(cc, map_fs(val64.f), 0)); break;
@@ -1531,7 +1531,7 @@ static int build_data_frame(hm2_modbus_inst_t *inst)
 		CHK_RV(ch_append16(cc, cc->cmd.cpincnt));
 		CHK_RV(ch_append8(cc, (cc->cmd.cpincnt + 7) / 8));
 		for(unsigned i = 0; i < cc->cmd.cpincnt; i++) {
-			if(hal->pins[p++].pin->b)
+			if(hal_get_bool(hal->pins[p++].pin.b))
 				acc |= 1u << (i % 8);
 			if((i % 8) == 7 || i == cc->cmd.cpincnt - 1u) { // time for the next byte
 				CHK_RV(ch_append8(cc, acc));
@@ -1552,32 +1552,32 @@ static int build_data_frame(hm2_modbus_inst_t *inst)
 				regpos++;
 			}
 			switch(cc->typeptr[i].htype) {
-			case HAL_BIT:
-				CHK_RV(map_u(cc, hal->pins[p].pin->b ? 1 : 0, i));
+			case HAL_BOOL:
+				CHK_RV(map_u(cc, hal_get_bool(hal->pins[p].pin.b) ? 1 : 0, i));
 				break;
 			case HAL_U32:
 				switch(mtypetype(cc->typeptr[i].mtype)) {
-				case MBT_U: CHK_RV(map_u(cc, hal->pins[p].pin->u, i)); break;
-				case MBT_S: CHK_RV(map_s(cc, map_us(hal->pins[p].pin->u), i)); break;
-				case MBT_F: CHK_RV(map_f(cc, map_uf(hal->pins[p].pin->u), i)); break;
+				case MBT_U: CHK_RV(map_u(cc, hal_get_ui32(hal->pins[p].pin.u), i)); break;
+				case MBT_S: CHK_RV(map_s(cc, map_us(hal_get_ui32(hal->pins[p].pin.u)), i)); break;
+				case MBT_F: CHK_RV(map_f(cc, map_uf(hal_get_ui32(hal->pins[p].pin.u)), i)); break;
 				}
 				break;
-			case HAL_U64:
+			case HAL_UINT:
 				switch(mtypetype(cc->typeptr[i].mtype)) {
-				case MBT_U: CHK_RV(map_u(cc, hal->pins[p].pin->lu, i)); break;
-				case MBT_S: CHK_RV(map_s(cc, map_us(hal->pins[p].pin->lu), i)); break;
-				case MBT_F: CHK_RV(map_f(cc, map_uf(hal->pins[p].pin->lu), i)); break;
+				case MBT_U: CHK_RV(map_u(cc, hal_get_uint(hal->pins[p].pin.u), i)); break;
+				case MBT_S: CHK_RV(map_s(cc, map_us(hal_get_uint(hal->pins[p].pin.u)), i)); break;
+				case MBT_F: CHK_RV(map_f(cc, map_uf(hal_get_uint(hal->pins[p].pin.u)), i)); break;
 				}
 				break;
 			case HAL_S32:
 				if(!haspinscale(&cc->typeptr[i])) {
 					switch(mtypetype(cc->typeptr[i].mtype)) {
-					case MBT_U: CHK_RV(map_u(cc, map_su(hal->pins[p].pin->s), i)); break;
-					case MBT_S: CHK_RV(map_s(cc, hal->pins[p].pin->s, i)); break;
-					case MBT_F: CHK_RV(map_f(cc, map_sf(hal->pins[p].pin->s), i)); break;
+					case MBT_U: CHK_RV(map_u(cc, map_su(hal_get_si32(hal->pins[p].pin.s)), i)); break;
+					case MBT_S: CHK_RV(map_s(cc, hal_get_si32(hal->pins[p].pin.s), i)); break;
+					case MBT_F: CHK_RV(map_f(cc, map_sf(hal_get_si32(hal->pins[p].pin.s)), i)); break;
 					}
 				} else {
-					val64.f = (real_t)((rtapi_s64)hal->pins[p].pin->s - hal->pins[p].offset->s) * *(hal->pins[p].scale);
+					val64.f = (rtapi_real)((rtapi_s64)hal_get_si32(hal->pins[p].pin.s) - hal_get_si32(hal->pins[p].offset.s)) * hal_get_real(hal->pins[p].scale);
 					switch(mtypetype(cc->typeptr[i].mtype)) {
 					case MBT_U: CHK_RV(map_u(cc, map_fu(val64.f), i)); break;
 					case MBT_S: CHK_RV(map_s(cc, map_fs(val64.f), i)); break;
@@ -1585,15 +1585,15 @@ static int build_data_frame(hm2_modbus_inst_t *inst)
 					}
 				}
 				break;
-			case HAL_S64:
+			case HAL_SINT:
 				if(!haspinscale(&cc->typeptr[i])) {
 					switch(mtypetype(cc->typeptr[i].mtype)) {
-					case MBT_U: CHK_RV(map_u(cc, map_su(hal->pins[p].pin->ls), i)); break;
-					case MBT_S: CHK_RV(map_s(cc, hal->pins[p].pin->ls, i)); break;
-					case MBT_F: CHK_RV(map_f(cc, map_sf(hal->pins[p].pin->ls), i)); break;
+					case MBT_U: CHK_RV(map_u(cc, map_su(hal_get_sint(hal->pins[p].pin.s)), i)); break;
+					case MBT_S: CHK_RV(map_s(cc, hal_get_sint(hal->pins[p].pin.s), i)); break;
+					case MBT_F: CHK_RV(map_f(cc, map_sf(hal_get_sint(hal->pins[p].pin.s)), i)); break;
 					}
 				} else {
-					val64.f = (real_t)(hal->pins[p].pin->ls - hal->pins[p].offset->ls) * *(hal->pins[p].scale);
+					val64.f = (rtapi_real)(hal_get_sint(hal->pins[p].pin.s) - hal_get_sint(hal->pins[p].offset.s)) * hal_get_real(hal->pins[p].scale);
 					switch(mtypetype(cc->typeptr[i].mtype)) {
 					case MBT_U: CHK_RV(map_u(cc, map_fu(val64.f), i)); break;
 					case MBT_S: CHK_RV(map_s(cc, map_fs(val64.f), i)); break;
@@ -1601,15 +1601,15 @@ static int build_data_frame(hm2_modbus_inst_t *inst)
 					}
 				}
 				break;
-			case HAL_FLOAT:
+			case HAL_REAL:
 				if(!haspinscale(&cc->typeptr[i])) {
 					switch(mtypetype(cc->typeptr[i].mtype)) {
-					case MBT_U: CHK_RV(map_u(cc, map_fu(hal->pins[p].pin->f), i)); break;
-					case MBT_S: CHK_RV(map_s(cc, map_fs(hal->pins[p].pin->f), i)); break;
-					case MBT_F: CHK_RV(map_f(cc, hal->pins[p].pin->f, i)); break;
+					case MBT_U: CHK_RV(map_u(cc, map_fu(hal_get_real(hal->pins[p].pin.r)), i)); break;
+					case MBT_S: CHK_RV(map_s(cc, map_fs(hal_get_real(hal->pins[p].pin.r)), i)); break;
+					case MBT_F: CHK_RV(map_f(cc, hal_get_real(hal->pins[p].pin.r), i)); break;
 					}
 				} else {
-					val64.f = (hal->pins[p].pin->f - hal->pins[p].offset->f) * *(hal->pins[p].scale);
+					val64.f = (hal_get_real(hal->pins[p].pin.r) - hal_get_real(hal->pins[p].offset.r)) * hal_get_real(hal->pins[p].scale);
 					switch(mtypetype(cc->typeptr[i].mtype)) {
 					case MBT_U: CHK_RV(map_u(cc, map_fu(val64.f), i)); break;
 					case MBT_S: CHK_RV(map_s(cc, map_fs(val64.f), i)); break;
@@ -1861,7 +1861,7 @@ static int parse_data_frame(hm2_modbus_inst_t *inst)
 		w = 3;	// First data return byte {mbid, func, bytecount, ...}
 		b = 0;
 		for(unsigned i = 0; i < cc->cmd.cpincnt; i++) {
-			hal->pins[p++].pin->b = !!(bytes[w] & (1u << b));
+			hal_set_bool(hal->pins[p++].pin.b, !!(bytes[w] & (1u << b)));
 			if(++b >= 8) { b = 0; w++; }
 		}
 		break;
@@ -1970,62 +1970,62 @@ static int parse_data_frame(hm2_modbus_inst_t *inst)
 			}
 
 			switch(cc->typeptr[i].htype) {
-			case HAL_BIT:
-				hal->pins[p].pin->b = 0 != val64.u;	// Zero maps to false, anything else to true
+			case HAL_BOOL:
+				hal_set_bool(hal->pins[p].pin.b, 0 != val64.u);	// Zero maps to false, anything else to true
 				break;
 			case HAL_U32:
 				switch(mtypetype(cc->typeptr[i].mtype)) {
-				case MBT_U:	hal->pins[p].pin->u = unmap32_uu(cc, val64.u, i); break;
-				case MBT_S:	hal->pins[p].pin->u = unmap32_us(cc, val64.s, i); break;
-				case MBT_F:	hal->pins[p].pin->u = unmap32_uf(cc, val64.f, i); break;
+				case MBT_U:	hal_set_ui32(hal->pins[p].pin.u, unmap32_uu(cc, val64.u, i)); break;
+				case MBT_S:	hal_set_ui32(hal->pins[p].pin.u, unmap32_us(cc, val64.s, i)); break;
+				case MBT_F:	hal_set_ui32(hal->pins[p].pin.u, unmap32_uf(cc, val64.f, i)); break;
 				}
 				break;
 			case HAL_S32:
 				switch(mtypetype(cc->typeptr[i].mtype)) {
-				case MBT_U:	hal->pins[p].pin->s = unmap32_su(cc, val64.u, i); break;
-				case MBT_S:	hal->pins[p].pin->s = unmap32_ss(cc, val64.s, i); break;
-				case MBT_F:	hal->pins[p].pin->s = unmap32_sf(cc, val64.f, i); break;
+				case MBT_U:	hal_set_si32(hal->pins[p].pin.s, unmap32_su(cc, val64.u, i)); break;
+				case MBT_S:	hal_set_si32(hal->pins[p].pin.s, unmap32_ss(cc, val64.s, i)); break;
+				case MBT_F:	hal_set_si32(hal->pins[p].pin.s, unmap32_sf(cc, val64.f, i)); break;
 				}
 				if(haspinscale(&cc->typeptr[i])) {
 					switch(mtypetype(cc->typeptr[i].mtype)) {
-					case MBT_U:	*(hal->pins[p].scaled) = (real_t)(rtapi_s64)(val64.u - hal->pins[p].offset->lu) * *(hal->pins[p].scale); break;
-					case MBT_S:	*(hal->pins[p].scaled) = (real_t)(val64.s - hal->pins[p].offset->ls) * *(hal->pins[p].scale); break;
-					case MBT_F:	*(hal->pins[p].scaled) = (val64.f - hal->pins[p].offset->f) * *(hal->pins[p].scale); break;
+					case MBT_U:	hal_set_real(hal->pins[p].scaled, (rtapi_real)(rtapi_s64)(val64.u - hal_get_uint(hal->pins[p].offset.u)) * hal_get_real(hal->pins[p].scale)); break;
+					case MBT_S:	hal_set_real(hal->pins[p].scaled, (rtapi_real)(val64.s - hal_get_sint(hal->pins[p].offset.s)) * hal_get_real(hal->pins[p].scale)); break;
+					case MBT_F:	hal_set_real(hal->pins[p].scaled, (val64.f - hal_get_real(hal->pins[p].offset.r)) * hal_get_real(hal->pins[p].scale)); break;
 					}
 				}
 				break;
-			case HAL_U64:
+			case HAL_UINT:
 				switch(mtypetype(cc->typeptr[i].mtype)) {
-				case MBT_U:	hal->pins[p].pin->lu = val64.u; break;
-				case MBT_S:	hal->pins[p].pin->lu = unmap64_us(cc, val64.s, i); break;
-				case MBT_F:	hal->pins[p].pin->lu = unmap64_uf(cc, val64.f, i); break;
+				case MBT_U:	hal_set_uint(hal->pins[p].pin.u, val64.u); break;
+				case MBT_S:	hal_set_uint(hal->pins[p].pin.u, unmap64_us(cc, val64.s, i)); break;
+				case MBT_F:	hal_set_uint(hal->pins[p].pin.u, unmap64_uf(cc, val64.f, i)); break;
 				}
 				break;
-			case HAL_S64:
+			case HAL_SINT:
 				switch(mtypetype(cc->typeptr[i].mtype)) {
-				case MBT_U:	hal->pins[p].pin->ls = unmap64_su(cc, val64.u, i); break;
-				case MBT_S:	hal->pins[p].pin->ls = val64.s; break;
-				case MBT_F:	hal->pins[p].pin->ls = unmap64_sf(cc, val64.f, i); break;
+				case MBT_U:	hal_set_sint(hal->pins[p].pin.s, unmap64_su(cc, val64.u, i)); break;
+				case MBT_S:	hal_set_sint(hal->pins[p].pin.s, val64.s); break;
+				case MBT_F:	hal_set_sint(hal->pins[p].pin.s, unmap64_sf(cc, val64.f, i)); break;
 				}
 				if(haspinscale(&cc->typeptr[i])) {
 					switch(mtypetype(cc->typeptr[i].mtype)) {
-					case MBT_U:	*(hal->pins[p].scaled) = (real_t)(rtapi_s64)(val64.u - hal->pins[p].offset->lu) * *(hal->pins[p].scale); break;
-					case MBT_S:	*(hal->pins[p].scaled) = (real_t)(val64.s - hal->pins[p].offset->ls) * *(hal->pins[p].scale); break;
-					case MBT_F:	*(hal->pins[p].scaled) = (val64.f - hal->pins[p].offset->f) * *(hal->pins[p].scale); break;
+					case MBT_U:	hal_set_real(hal->pins[p].scaled, (rtapi_real)(rtapi_s64)(val64.u - hal_get_uint(hal->pins[p].offset.u)) * hal_get_real(hal->pins[p].scale)); break;
+					case MBT_S:	hal_set_real(hal->pins[p].scaled, (rtapi_real)(val64.s - hal_get_sint(hal->pins[p].offset.s)) * hal_get_real(hal->pins[p].scale)); break;
+					case MBT_F:	hal_set_real(hal->pins[p].scaled, (val64.f - hal_get_real(hal->pins[p].offset.r)) * hal_get_real(hal->pins[p].scale)); break;
 					}
 				}
 				break;
-			case HAL_FLOAT:
+			case HAL_REAL:
 				switch(mtypetype(cc->typeptr[i].mtype)) {
-				case MBT_U:	hal->pins[p].pin->f = val64.u; break;
-				case MBT_S:	hal->pins[p].pin->f = val64.s; break;
-				case MBT_F:	hal->pins[p].pin->f = val64.f; break;
+				case MBT_U:	hal_set_real(hal->pins[p].pin.r, val64.u); break;
+				case MBT_S:	hal_set_real(hal->pins[p].pin.r, val64.s); break;
+				case MBT_F:	hal_set_real(hal->pins[p].pin.r, val64.f); break;
 				}
 				if(haspinscale(&cc->typeptr[i])) {
 					switch(mtypetype(cc->typeptr[i].mtype)) {
-					case MBT_U:	*(hal->pins[p].scaled) = (real_t)(rtapi_s64)(val64.u - hal->pins[p].offset->lu) * *(hal->pins[p].scale); break;
-					case MBT_S:	*(hal->pins[p].scaled) = (real_t)(val64.s - hal->pins[p].offset->ls) * *(hal->pins[p].scale); break;
-					case MBT_F:	*(hal->pins[p].scaled) = (val64.f - hal->pins[p].offset->f) * *(hal->pins[p].scale); break;
+					case MBT_U:	hal_set_real(hal->pins[p].scaled, (rtapi_real)(rtapi_s64)(val64.u - hal_get_uint(hal->pins[p].offset.u)) * hal_get_real(hal->pins[p].scale)); break;
+					case MBT_S:	hal_set_real(hal->pins[p].scaled, (rtapi_real)(val64.s - hal_get_sint(hal->pins[p].offset.s)) * hal_get_real(hal->pins[p].scale)); break;
+					case MBT_F:	hal_set_real(hal->pins[p].scaled, (val64.f - hal_get_real(hal->pins[p].offset.r)) * hal_get_real(hal->pins[p].scale)); break;
 					}
 				}
 				break;
@@ -2259,12 +2259,12 @@ static ssize_t read_mbccb(const hm2_modbus_inst_t *inst, const char *fname, hm2_
 static int check_htype(unsigned type)
 {
 	switch(type) {
-	case HAL_BIT:	// not valid in register read/write
+	case HAL_BOOL:	// not valid in register read/write
 	case HAL_U32:
 	case HAL_S32:
-	case HAL_U64:
-	case HAL_S64:
-	case HAL_FLOAT:
+	case HAL_UINT:
+	case HAL_SINT:
+	case HAL_REAL:
 		return 0;
 	}
 	return -1;
@@ -2546,7 +2546,7 @@ static int load_mbccb(hm2_modbus_inst_t *inst, const char *fname)
 						inst->name, c, cmdsptr[c].func, cmdsptr[c].cpincnt);
 				goto errout;
 			}
-			// These are implicit HAL_BIT
+			// These are implicit HAL_BOOL
 			break;
 		case MBCMD_R_REGISTERS:
 		case MBCMD_R_INPUTREGS:
@@ -2820,21 +2820,21 @@ int rtapi_app_main(void)
 						goto errout; \
 					} \
 				} while(0)
-		CHECK(hal_param_u32_newf(HAL_RO, &(inst->hal->baudrate), comp_id, "%s.baudrate", inst->name));
-		CHECK(hal_param_u32_newf(HAL_RO, &(inst->hal->parity),   comp_id, "%s.parity", inst->name));
-		CHECK(hal_param_u32_newf(HAL_RO, &(inst->hal->stopbits), comp_id, "%s.stopbits", inst->name));
-		CHECK(hal_param_u32_newf(HAL_RO, &(inst->hal->icdelay),  comp_id, "%s.icdelay", inst->name));
-		CHECK(hal_param_u32_newf(HAL_RO, &(inst->hal->txdelay),  comp_id, "%s.txdelay", inst->name));
-		CHECK(hal_param_u32_newf(HAL_RO, &(inst->hal->rxdelay),  comp_id, "%s.rxdelay", inst->name));
-		CHECK(hal_param_u32_newf(HAL_RO, &(inst->hal->drvdelay), comp_id, "%s.drivedelay", inst->name));
+		CHECK(hal_param_new_ui32(comp_id, HAL_RO, &(inst->hal->baudrate), 0, "%s.baudrate", inst->name));
+		CHECK(hal_param_new_ui32(comp_id, HAL_RO, &(inst->hal->parity),   0, "%s.parity", inst->name));
+		CHECK(hal_param_new_ui32(comp_id, HAL_RO, &(inst->hal->stopbits), 0, "%s.stopbits", inst->name));
+		CHECK(hal_param_new_ui32(comp_id, HAL_RO, &(inst->hal->icdelay),  0, "%s.icdelay", inst->name));
+		CHECK(hal_param_new_ui32(comp_id, HAL_RO, &(inst->hal->txdelay),  0, "%s.txdelay", inst->name));
+		CHECK(hal_param_new_ui32(comp_id, HAL_RO, &(inst->hal->rxdelay),  0, "%s.rxdelay", inst->name));
+		CHECK(hal_param_new_ui32(comp_id, HAL_RO, &(inst->hal->drvdelay), 0, "%s.drivedelay", inst->name));
 
-		CHECK(hal_pin_bit_newf(HAL_IN,  &(inst->hal->suspend),   comp_id, "%s.suspend", inst->name));
-		CHECK(hal_pin_bit_newf(HAL_IN,  &(inst->hal->reset),     comp_id, "%s.reset", inst->name));
-		CHECK(hal_pin_bit_newf(HAL_OUT, &(inst->hal->fault),     comp_id, "%s.fault", inst->name));
-		CHECK(hal_pin_u32_newf(HAL_OUT, &(inst->hal->faultcmd),  comp_id, "%s.fault-command", inst->name));
-		CHECK(hal_pin_u32_newf(HAL_OUT, &(inst->hal->lasterror), comp_id, "%s.last-error-code", inst->name));
+		CHECK(hal_pin_new_bool(comp_id, HAL_IN,  &(inst->hal->suspend),   0, "%s.suspend", inst->name));
+		CHECK(hal_pin_new_bool(comp_id, HAL_IN,  &(inst->hal->reset),     0, "%s.reset", inst->name));
+		CHECK(hal_pin_new_bool(comp_id, HAL_OUT, &(inst->hal->fault),     0, "%s.fault", inst->name));
+		CHECK(hal_pin_new_ui32(comp_id, HAL_OUT, &(inst->hal->faultcmd),  0, "%s.fault-command", inst->name));
+		CHECK(hal_pin_new_ui32(comp_id, HAL_OUT, &(inst->hal->lasterror), 0, "%s.last-error-code", inst->name));
 
-		inst->hal->baudrate = inst->cfg_rx.baudrate = inst->cfg_tx.baudrate = inst->mbccb->baudrate;
+		hal_set_ui32(inst->hal->baudrate, inst->cfg_rx.baudrate = inst->cfg_tx.baudrate = inst->mbccb->baudrate);
 		unsigned parity = 0;
 		if(inst->mbccb->format & MBCCB_FORMAT_PARITYEN) {
 			inst->cfg_rx.flags |= HM2_PKTUART_CONFIG_PARITYEN;
@@ -2852,22 +2852,22 @@ int rtapi_app_main(void)
 			inst->cfg_tx.flags |= HM2_PKTUART_CONFIG_STOPBITS2;
 			stopbits = 2;
 		}
-		inst->hal->parity   = parity;
-		inst->hal->stopbits = stopbits;
+		hal_set_ui32(inst->hal->parity, parity);
+		hal_set_ui32(inst->hal->stopbits, stopbits);
 		if(!inst->mbccb->rxdelay)	// Auto
-			inst->hal->rxdelay = inst->cfg_rx.ifdelay = calc_ifdelay(inst, inst->mbccb->baudrate, parity, stopbits) - 1;
+			inst->cfg_rx.ifdelay = hal_set_ui32(inst->hal->rxdelay, calc_ifdelay(inst, inst->mbccb->baudrate, parity, stopbits) - 1);
 		else	// Manual
-			inst->hal->rxdelay = inst->cfg_rx.ifdelay = inst->mbccb->rxdelay;
+			inst->cfg_rx.ifdelay = hal_set_ui32(inst->hal->rxdelay, inst->mbccb->rxdelay);
 
 		if(!inst->mbccb->txdelay)	// Auto
-			inst->hal->txdelay = inst->cfg_tx.ifdelay = calc_ifdelay(inst, inst->mbccb->baudrate, parity, stopbits) + 1;
+			inst->cfg_tx.ifdelay = hal_set_ui32(inst->hal->txdelay, calc_ifdelay(inst, inst->mbccb->baudrate, parity, stopbits) + 1);
 		else	// Manual
-			inst->hal->txdelay = inst->cfg_tx.ifdelay = inst->mbccb->txdelay;
+			inst->cfg_tx.ifdelay = hal_set_ui32(inst->hal->txdelay, inst->mbccb->txdelay);
 
 		if(!inst->mbccb->drvdelay)	// Auto
-			inst->hal->drvdelay = inst->cfg_tx.drivedelay = 1;
+			inst->cfg_tx.drivedelay = hal_set_ui32(inst->hal->drvdelay, 1);
 		else	// Manual
-			inst->hal->drvdelay = inst->cfg_tx.drivedelay = inst->mbccb->drvdelay;
+			inst->cfg_tx.drivedelay = hal_set_ui32(inst->hal->drvdelay, inst->mbccb->drvdelay);
 
 		inst->cfg_rx.filterrate = 0;	// Zero means 2 times baudrate
 		inst->cfg_rx.flags |= HM2_PKTUART_CONFIG_RXEN;
@@ -2938,10 +2938,7 @@ int rtapi_app_main(void)
 					stopbits > 1 ? '2' : '1',
 					inst->cfg_rx.baudrate);
 
-		*(inst->hal->fault)     = 0;
-		*(inst->hal->faultcmd)  = 0;
-		*(inst->hal->lasterror) = 0;
-		*(inst->hal->suspend)   = 0 != (inst->mbccb->format & MBCCB_FORMAT_SUSPEND);
+		hal_set_bool(inst->hal->suspend, 0 != (inst->mbccb->format & MBCCB_FORMAT_SUSPEND));
 		// Start with internal suspended bit set. The HAL pin will dictate to
 		// move to the active state in the process() function. This enables to
 		// use the WFLUSH setting each time we come out of suspend and,
@@ -2954,24 +2951,24 @@ int rtapi_app_main(void)
 #define CPTR(x)	((const char *)((x) + 1))
 		for(unsigned c = 0; c < inst->ncmds; c++) {
 			// First create command status pins
-			CHECK(hal_pin_bit_newf(HAL_IN, &(inst->hal->cmds[c].disable),
-					comp_id, "%s.command.%02d.disable", inst->name, c));
-			CHECK(hal_pin_bit_newf(HAL_OUT, &(inst->hal->cmds[c].disabled),
-					comp_id, "%s.command.%02d.disabled", inst->name, c));
-			CHECK(hal_pin_u32_newf(HAL_OUT, &(inst->hal->cmds[c].error),
-					comp_id, "%s.command.%02d.errors", inst->name, c));
-			CHECK(hal_pin_u32_newf(HAL_OUT, &(inst->hal->cmds[c].errorcode),
-					comp_id, "%s.command.%02d.error-code", inst->name, c));
-			CHECK(hal_pin_bit_newf(HAL_IN, &(inst->hal->cmds[c].reset),
-					comp_id, "%s.command.%02d.reset", inst->name, c));
+			CHECK(hal_pin_new_bool(comp_id, HAL_IN, &(inst->hal->cmds[c].disable),
+					0, "%s.command.%02d.disable", inst->name, c));
+			CHECK(hal_pin_new_bool(comp_id, HAL_OUT, &(inst->hal->cmds[c].disabled),
+					0, "%s.command.%02d.disabled", inst->name, c));
+			CHECK(hal_pin_new_ui32(comp_id, HAL_OUT, &(inst->hal->cmds[c].error),
+					0, "%s.command.%02d.errors", inst->name, c));
+			CHECK(hal_pin_new_ui32(comp_id, HAL_OUT, &(inst->hal->cmds[c].errorcode),
+					0, "%s.command.%02d.error-code", inst->name, c));
+			CHECK(hal_pin_new_bool(comp_id, HAL_IN, &(inst->hal->cmds[c].reset),
+					0, "%s.command.%02d.reset", inst->name, c));
 
 			hm2_modbus_cmd_t *cc = &inst->_cmds[c];
 
 			// If the command is disabled, set it so
 			if(hasdisabled(cc)) {
 				cc->disabled = 1;
-				*(inst->hal->cmds[c].disabled)  = 1;
-				*(inst->hal->cmds[c].errorcode) = EAGAIN;
+				hal_set_bool(inst->hal->cmds[c].disabled, 1);
+				hal_set_ui32(inst->hal->cmds[c].errorcode, EAGAIN);
 			}
 
 			// Now create the pins associated with the command
@@ -2986,8 +2983,8 @@ int rtapi_app_main(void)
 					/* Fallthrough */
 				case MBCMD_W_COIL:
 				case MBCMD_W_COILS:
-					CHECK(hal_pin_bit_newf(dir, (hal_bit_t**)&(inst->hal->pins[p++]),
-							comp_id, "%s.%s", inst->name, CPTR(dptr)));
+					CHECK(hal_pin_new_bool(comp_id, dir, &(inst->hal->pins[p++].pin.b),
+							0, "%s.%s", inst->name, CPTR(dptr)));
 					break;
 
 				case MBCMD_R_INPUTREGS:
@@ -2998,112 +2995,108 @@ int rtapi_app_main(void)
 				case MBCMD_W_REGISTERS:
 					switch(cc->typeptr[j].htype) {
 					default:
-					case HAL_BIT:
-						CHECK(hal_pin_bit_newf(dir, (hal_bit_t**)&(inst->hal->pins[p++]),
-								comp_id, "%s.%s", inst->name, CPTR(dptr)));
+					case HAL_BOOL:
+						CHECK(hal_pin_new_bool(comp_id, dir, &(inst->hal->pins[p++].pin.b),
+								0, "%s.%s", inst->name, CPTR(dptr)));
 						break;
 
 					case HAL_U32:
-						CHECK(hal_pin_u32_newf(dir, (hal_u32_t**)&(inst->hal->pins[p++]),
-								comp_id, "%s.%s", inst->name, CPTR(dptr)));
+						CHECK(hal_pin_new_ui32(comp_id, dir, &(inst->hal->pins[p++].pin.u),
+								0, "%s.%s", inst->name, CPTR(dptr)));
 						break;
 
-					case HAL_U64:
-						CHECK(hal_pin_u64_newf(dir, (hal_u64_t**)&(inst->hal->pins[p++]),
-								comp_id, "%s.%s", inst->name, CPTR(dptr)));
+					case HAL_UINT:
+						CHECK(hal_pin_new_uint(comp_id, dir, &(inst->hal->pins[p++].pin.u),
+								0, "%s.%s", inst->name, CPTR(dptr)));
 						break;
 
 					case HAL_S32:
-						CHECK(hal_pin_s32_newf(dir, (hal_s32_t**)&(inst->hal->pins[p]),
-								comp_id, "%s.%s", inst->name, CPTR(dptr)));
+						CHECK(hal_pin_new_si32(comp_id, dir, &(inst->hal->pins[p].pin.s),
+								0, "%s.%s", inst->name, CPTR(dptr)));
 						if(haspinscale(&cc->typeptr[j])) {
-							CHECK(hal_pin_float_newf(HAL_IN, &(inst->hal->pins[p].scale),
-									comp_id, "%s.%s.scale", inst->name, CPTR(dptr)));
-							*(inst->hal->pins[p].scale) = 1.0;
+							CHECK(hal_pin_new_real(comp_id, HAL_IN, &(inst->hal->pins[p].scale),
+									1.0, "%s.%s.scale", inst->name, CPTR(dptr)));
 							if(HAL_OUT == dir) {
-								CHECK(hal_pin_float_newf(HAL_OUT, &(inst->hal->pins[p].scaled),
-										comp_id, "%s.%s.scaled", inst->name, CPTR(dptr)));
+								CHECK(hal_pin_new_real(comp_id, HAL_OUT, &(inst->hal->pins[p].scaled),
+										0.0, "%s.%s.scaled", inst->name, CPTR(dptr)));
 								switch(mtypetype(cc->typeptr[j].mtype)) {
 								case MBT_U:
-									CHECK(hal_pin_u64_newf(HAL_IN, (hal_u64_t**)&(inst->hal->pins[p].offset),
-											comp_id, "%s.%s.offset", inst->name, CPTR(dptr)));
+									CHECK(hal_pin_new_uint(comp_id, HAL_IN, &(inst->hal->pins[p].offset.u),
+											0, "%s.%s.offset", inst->name, CPTR(dptr)));
 									break;
 								case MBT_S:
-									CHECK(hal_pin_s64_newf(HAL_IN, (hal_s64_t**)&(inst->hal->pins[p].offset),
-											comp_id, "%s.%s.offset", inst->name, CPTR(dptr)));
+									CHECK(hal_pin_new_sint(comp_id, HAL_IN, &(inst->hal->pins[p].offset.s),
+											0, "%s.%s.offset", inst->name, CPTR(dptr)));
 									break;
 								case MBT_F:
-									CHECK(hal_pin_float_newf(HAL_IN, (hal_float_t**)&(inst->hal->pins[p].offset),
-											comp_id, "%s.%s.offset", inst->name, CPTR(dptr)));
+									CHECK(hal_pin_new_real(comp_id, HAL_IN, &(inst->hal->pins[p].offset.r),
+											0.0, "%s.%s.offset", inst->name, CPTR(dptr)));
 									break;
 								}
 							} else {
-								CHECK(hal_pin_s32_newf(HAL_IN, (hal_s32_t**)&(inst->hal->pins[p].offset),
-										comp_id, "%s.%s.offset", inst->name, CPTR(dptr)));
+								CHECK(hal_pin_new_si32(comp_id, HAL_IN, &(inst->hal->pins[p].offset.s),
+										0, "%s.%s.offset", inst->name, CPTR(dptr)));
 							}
 						}
 						p++;
 						break;
-					case HAL_S64:
-						CHECK(hal_pin_s64_newf(dir, (hal_s64_t**)&(inst->hal->pins[p]),
-								comp_id, "%s.%s", inst->name, CPTR(dptr)));
+					case HAL_SINT:
+						CHECK(hal_pin_new_sint(comp_id, dir, &(inst->hal->pins[p].pin.s),
+								0, "%s.%s", inst->name, CPTR(dptr)));
 						if(haspinscale(&cc->typeptr[j])) {
-							CHECK(hal_pin_float_newf(HAL_IN, &(inst->hal->pins[p].scale),
-									comp_id, "%s.%s.scale", inst->name, CPTR(dptr)));
-							*(inst->hal->pins[p].scale) = 1.0;
+							CHECK(hal_pin_new_real(comp_id, HAL_IN, &(inst->hal->pins[p].scale),
+									1.0, "%s.%s.scale", inst->name, CPTR(dptr)));
 							if(HAL_OUT == dir) {
-								CHECK(hal_pin_float_newf(HAL_OUT, &(inst->hal->pins[p].scaled),
-										comp_id, "%s.%s.scaled", inst->name, CPTR(dptr)));
+								CHECK(hal_pin_new_real(comp_id, HAL_OUT, &(inst->hal->pins[p].scaled),
+										0.0, "%s.%s.scaled", inst->name, CPTR(dptr)));
 								switch(mtypetype(cc->typeptr[j].mtype)) {
 								case MBT_U:
-									CHECK(hal_pin_u64_newf(HAL_IN, (hal_u64_t**)&(inst->hal->pins[p].offset),
-											comp_id, "%s.%s.offset", inst->name, CPTR(dptr)));
+									CHECK(hal_pin_new_uint(comp_id, HAL_IN, &(inst->hal->pins[p].offset.u),
+											0, "%s.%s.offset", inst->name, CPTR(dptr)));
 									break;
 								case MBT_S:
-									CHECK(hal_pin_s64_newf(HAL_IN, (hal_s64_t**)&(inst->hal->pins[p].offset),
-											comp_id, "%s.%s.offset", inst->name, CPTR(dptr)));
+									CHECK(hal_pin_new_sint(comp_id, HAL_IN, &(inst->hal->pins[p].offset.s),
+											0, "%s.%s.offset", inst->name, CPTR(dptr)));
 									break;
 								case MBT_F:
-									CHECK(hal_pin_float_newf(HAL_IN, (hal_float_t**)&(inst->hal->pins[p].offset),
-											comp_id, "%s.%s.offset", inst->name, CPTR(dptr)));
+									CHECK(hal_pin_new_real(comp_id, HAL_IN, &(inst->hal->pins[p].offset.r),
+											0.0, "%s.%s.offset", inst->name, CPTR(dptr)));
 									break;
 								}
 							} else {
-								CHECK(hal_pin_s64_newf(HAL_IN, (hal_s64_t**)&(inst->hal->pins[p].offset),
-										comp_id, "%s.%s.offset", inst->name, CPTR(dptr)));
+								CHECK(hal_pin_new_sint(comp_id, HAL_IN, &(inst->hal->pins[p].offset.s),
+										0, "%s.%s.offset", inst->name, CPTR(dptr)));
 							}
 						}
 						p++;
 						break;
-					case HAL_FLOAT:
-						CHECK(hal_pin_float_newf(dir, (hal_float_t**)&(inst->hal->pins[p]),
-								comp_id, "%s.%s", inst->name, CPTR(dptr)));
+					case HAL_REAL:
+						CHECK(hal_pin_new_real(comp_id, dir, &(inst->hal->pins[p].pin.r),
+								0.0, "%s.%s", inst->name, CPTR(dptr)));
 						if(haspinscale(&cc->typeptr[j])) {
-							CHECK(hal_pin_float_newf(HAL_IN, &(inst->hal->pins[p].scale),
-									comp_id, "%s.%s.scale", inst->name, CPTR(dptr)));
-							*(inst->hal->pins[p].scale) = 1.0;
+							CHECK(hal_pin_new_real(comp_id, HAL_IN, &(inst->hal->pins[p].scale),
+									1.0, "%s.%s.scale", inst->name, CPTR(dptr)));
 							if(HAL_OUT == dir) {
-								CHECK(hal_pin_float_newf(HAL_OUT, &(inst->hal->pins[p].scaled),
-										comp_id, "%s.%s.scaled", inst->name, CPTR(dptr)));
+								CHECK(hal_pin_new_real(comp_id, HAL_OUT, &(inst->hal->pins[p].scaled),
+										0.0, "%s.%s.scaled", inst->name, CPTR(dptr)));
 								switch(mtypetype(cc->typeptr[j].mtype)) {
 								case MBT_U:
-									CHECK(hal_pin_u64_newf(HAL_IN, (hal_u64_t**)&(inst->hal->pins[p].offset),
-											comp_id, "%s.%s.offset", inst->name, CPTR(dptr)));
+									CHECK(hal_pin_new_uint(comp_id, HAL_IN, &(inst->hal->pins[p].offset.u),
+											0, "%s.%s.offset", inst->name, CPTR(dptr)));
 									break;
 								case MBT_S:
-									CHECK(hal_pin_s64_newf(HAL_IN, (hal_s64_t**)&(inst->hal->pins[p].offset),
-											comp_id, "%s.%s.offset", inst->name, CPTR(dptr)));
+									CHECK(hal_pin_new_sint(comp_id, HAL_IN, &(inst->hal->pins[p].offset.s),
+											0, "%s.%s.offset", inst->name, CPTR(dptr)));
 									break;
 								case MBT_F:
-									CHECK(hal_pin_float_newf(HAL_IN, (hal_float_t**)&(inst->hal->pins[p].offset),
-											comp_id, "%s.%s.offset", inst->name, CPTR(dptr)));
+									CHECK(hal_pin_new_real(comp_id, HAL_IN, &(inst->hal->pins[p].offset.r),
+											0.0, "%s.%s.offset", inst->name, CPTR(dptr)));
 									break;
 								}
 							} else {
-								CHECK(hal_pin_float_newf(HAL_IN, (hal_float_t**)&(inst->hal->pins[p].offset),
-										comp_id, "%s.%s.offset", inst->name, CPTR(dptr)));
+								CHECK(hal_pin_new_real(comp_id, HAL_IN, &(inst->hal->pins[p].offset.r),
+										0.0, "%s.%s.offset", inst->name, CPTR(dptr)));
 							}
-							inst->hal->pins[p].offset->f = 0.0;
 						}
 						p++;
 						break;

--- a/src/hal/drivers/mesa-hostmot2/hm2_spi.c
+++ b/src/hal/drivers/mesa-hostmot2/hm2_spi.c
@@ -152,12 +152,12 @@ static int queue_write(hm2_lowlevel_io_t *llio, rtapi_u32 addr, const void *buff
         if(r < 0) return r;
     }
 
-    PUT(write_command(addr, wsize), 0);
+    PUT(write_command(addr, wsize), NULL);
 
     const uint32_t *wbuffer = buffer;
     int i=0;
     for(i=0; i<wsize; i++)
-        PUT(wbuffer[i], 0);
+        PUT(wbuffer[i], NULL);
 
     return 1;
 }
@@ -180,7 +180,7 @@ static int queue_read(hm2_lowlevel_io_t *llio, rtapi_u32 addr, void *buffer, int
 
     uint32_t *wbuffer = buffer;
     int i=0;
-    PUT(read_command(addr, wsize), 0);
+    PUT(read_command(addr, wsize), NULL);
     for(i=0; i<wsize; i++)
         PUT(0, &wbuffer[i]);
 

--- a/src/hal/drivers/mesa-hostmot2/hostmot2-lowlevel.h
+++ b/src/hal/drivers/mesa-hostmot2/hostmot2-lowlevel.h
@@ -122,7 +122,7 @@ struct hm2_lowlevel_io_struct {
     //   hostmot2 driver call into llio to reset the hardware and start
     //   driving it again.
     // 
-    hal_bit_t *io_error;
+    hal_bool_t *io_error;
 
     // this gets set to TRUE by .read-request and cleared by .read, in order
     // to amortize latency on multiple ethernet devices

--- a/src/hal/drivers/mesa-hostmot2/hostmot2.c
+++ b/src/hal/drivers/mesa-hostmot2/hostmot2.c
@@ -79,13 +79,13 @@ static void hm2_read_request(void *void_hm2, long period) {
     hm2->llio->period = period;
 
     // if there are comm problems, wait for the user to fix it
-    if ((*hm2->llio->io_error) != 0) return;
+    if (hal_get_bool(*hm2->llio->io_error)) return;
 
     hm2_tram_read(hm2);
-    if ((*hm2->llio->io_error) != 0) return;
+    if (hal_get_bool(*hm2->llio->io_error)) return;
     hm2_raw_queue_read(hm2);
     hm2_tp_pwmgen_queue_read(hm2);
-    if ((*hm2->llio->io_error) != 0) return;
+    if (hal_get_bool(*hm2->llio->io_error)) return;
     hm2_queue_read(hm2);
     hm2->llio->read_requested = true;
     hm2->llio->read_time = rtapi_get_time();
@@ -98,10 +98,10 @@ static void hm2_read(void *void_hm2, long period) {
     hm2->llio->read_requested = false;
 
     // if there are comm problems, wait for the user to fix it
-    if ((*hm2->llio->io_error) != 0) return;
+    if (hal_get_bool(*hm2->llio->io_error)) return;
     // if there's a temporary read failure, don't sweat it
     if(hm2_finish_read(hm2) == -EAGAIN) return;
-    if ((*hm2->llio->io_error) != 0) return;
+    if (hal_get_bool(*hm2->llio->io_error)) return;
 
     hm2_watchdog_process_tram_read(hm2);
     hm2_ioport_gpio_process_tram_read(hm2);
@@ -127,7 +127,7 @@ static void hm2_write(void *void_hm2, long period) {
     hostmot2_t *hm2 = void_hm2;
 
     // if there are comm problems, wait for the user to fix it
-    if ((*hm2->llio->io_error) != 0) return;
+    if (hal_get_bool(*hm2->llio->io_error)) return;
 
     if (!hm2->ddr_initialized) {
         hm2_ioport_initialize_ddr(hm2);
@@ -183,7 +183,7 @@ static void hm2_read_gpio(void *void_hm2, long period) {
     hostmot2_t *hm2 = void_hm2;
 
     // if there are comm problems, wait for the user to fix it
-    if ((*hm2->llio->io_error) != 0) return;
+    if (hal_get_bool(*hm2->llio->io_error)) return;
 
     hm2_ioport_gpio_read(hm2);
 }
@@ -193,7 +193,7 @@ static void hm2_write_gpio(void *void_hm2, long period) {
     hostmot2_t *hm2 = void_hm2;
 
     // if there are comm problems, wait for the user to fix it
-    if ((*hm2->llio->io_error) != 0) return;
+    if (hal_get_bool(*hm2->llio->io_error)) return;
 
     hm2_ioport_gpio_write(hm2);
     hm2_watchdog_write(hm2, period);
@@ -957,7 +957,7 @@ static int hm2_parse_module_descriptors(hostmot2_t *hm2) {
 
         md_accepted = hm2_ioport_parse_md(hm2, md_index);
 
-        if ((*hm2->llio->io_error) != 0) {
+        if (hal_get_bool(*hm2->llio->io_error)) {
             HM2_ERR("IO error while parsing Module Descriptor %d\n", md_index);
             return -EIO;
         }
@@ -1097,7 +1097,7 @@ static int hm2_parse_module_descriptors(hostmot2_t *hm2) {
 
         }
 
-        if ((*hm2->llio->io_error) != 0) {
+        if (hal_get_bool(*hm2->llio->io_error)) {
             HM2_ERR("IO error while parsing Module Descriptor %d\n", md_index);
             return -EIO;
         }
@@ -1450,22 +1450,16 @@ int hm2_register(hm2_lowlevel_io_t *llio, char *config_string) {
     //
 
     {
-        int r;
-        char name[HAL_NAME_LEN + 1];
-
-        llio->io_error = (hal_bit_t *)hal_malloc(sizeof(hal_bit_t));
+        llio->io_error = hal_malloc(sizeof(*llio->io_error));
         if (llio->io_error == NULL) {
             HM2_ERR("out of memory!\n");
             r = -ENOMEM;
             goto fail0;
         }
 
-        (*llio->io_error) = 0;
-
-        rtapi_snprintf(name, sizeof(name), "%s.io_error", llio->name);
-        r = hal_param_bit_new(name, HAL_RW, llio->io_error, llio->comp_id);
+        r = hal_param_new_bool(llio->comp_id, HAL_RW, llio->io_error, 0, "%s.io_error", llio->name);
         if (r < 0) {
-            HM2_ERR("error adding param '%s', aborting\n", name);
+            HM2_ERR("error adding param '%s.io_error', aborting\n", llio->name);
             r = -EINVAL;
             goto fail0;
         }
@@ -1676,7 +1670,7 @@ int hm2_register(hm2_lowlevel_io_t *llio, char *config_string) {
     // final check for comm errors
     //
 
-    if ((*hm2->llio->io_error) != 0) {
+    if (hal_get_bool(*hm2->llio->io_error)) {
         HM2_ERR("comm errors while initializing firmware!\n");
         goto fail1;
     }
@@ -1776,7 +1770,7 @@ void hm2_unregister(hm2_lowlevel_io_t *llio) {
         // if there's a watchdog, set it to safe the board right away
         if (hm2->watchdog.num_instances > 0) {
             hm2->watchdog.instance[0].enable = 1;
-            hm2->watchdog.instance[0].hal.param.timeout_ns = 1;
+            hal_set_ui32(hm2->watchdog.instance[0].hal.param.timeout_ns, 1);
             hm2_watchdog_force_write(hm2);
         }
 

--- a/src/hal/drivers/mesa-hostmot2/hostmot2.h
+++ b/src/hal/drivers/mesa-hostmot2/hostmot2.h
@@ -194,15 +194,15 @@ typedef struct {
     struct {
 
         struct {
-            hal_bit_t *in;
-            hal_bit_t *in_not;
-            hal_bit_t *out;
+            hal_bool_t in;
+            hal_bool_t in_not;
+            hal_bool_t out;
         } pin;
 
         struct {
-            hal_bit_t is_output;
-            hal_bit_t is_opendrain;
-            hal_bit_t invert_output;
+            hal_bool_t is_output;
+            hal_bool_t is_opendrain;
+            hal_bool_t invert_output;
         } param;
 
     } hal;
@@ -281,35 +281,35 @@ typedef struct {
     struct {
 
         struct {
-            hal_s32_t *rawcounts;       // raw encoder counts (truncated view of 64-bit internal)
-            hal_s32_t *rawlatch;        // raw encoder of latch (truncated view)
-            hal_s32_t *count;           // (rawcounts - zero_offset), truncated view
-            hal_s32_t *count_latch;     // (rawlatch - zero_offset), truncated view
-            hal_float_t *position;
-            hal_float_t *position_latch;
-            hal_float_t *position_interpolated;
-            hal_float_t *velocity;
-            hal_float_t *velocity_rpm;
-            hal_bit_t *reset;
-            hal_bit_t *index_enable;
-            hal_bit_t *latch_enable;
-            hal_bit_t *latch_polarity;
-            hal_bit_t *no_clear_on_index;
-            hal_bit_t *quadrature_error;
-            hal_bit_t *quadrature_error_enable;
-            hal_bit_t *input_a;
-            hal_bit_t *input_b;
-            hal_bit_t *input_idx;
+            hal_sint_t rawcounts;       // raw encoder counts (truncated view of 64-bit internal)
+            hal_sint_t rawlatch;        // raw encoder of latch (truncated view)
+            hal_sint_t count;           // (rawcounts - zero_offset), truncated view
+            hal_sint_t count_latch;     // (rawlatch - zero_offset), truncated view
+            hal_real_t position;
+            hal_real_t position_latch;
+            hal_real_t position_interpolated;
+            hal_real_t velocity;
+            hal_real_t velocity_rpm;
+            hal_bool_t reset;
+            hal_bool_t index_enable;
+            hal_bool_t latch_enable;
+            hal_bool_t latch_polarity;
+            hal_bool_t no_clear_on_index;
+            hal_bool_t quadrature_error;
+            hal_bool_t quadrature_error_enable;
+            hal_bool_t input_a;
+            hal_bool_t input_b;
+            hal_bool_t input_idx;
         } pin;
 
         struct {
-            hal_float_t scale;
-            hal_bit_t index_invert;
-            hal_bit_t index_mask;
-            hal_bit_t index_mask_invert;
-            hal_bit_t counter_mode;
-            hal_bit_t filter;
-            hal_float_t vel_timeout;
+            hal_real_t scale;
+            hal_bool_t index_invert;
+            hal_bool_t index_mask;
+            hal_bool_t index_mask_invert;
+            hal_bool_t counter_mode;
+            hal_bool_t filter;
+            hal_real_t vel_timeout;
 
 
         } param;
@@ -331,8 +331,8 @@ typedef struct {
 
     rtapi_u32 prev_control;
 
-    hal_bit_t prev_quadrature_error_enable; // shadow for detecting rising edge on the quadrature_error_enable
-    hal_bit_t reset_quadrature_error; // bit to indicate if we want to reset the quadrature error
+    rtapi_bool prev_quadrature_error_enable; // shadow for detecting rising edge on the quadrature_error_enable
+    rtapi_bool reset_quadrature_error; // bit to indicate if we want to reset the quadrature error
 
 
     // these two are the datapoint last time we moved (only valid if state == HM2_ENCODER_MOVING)
@@ -350,10 +350,10 @@ typedef struct {
 // these hal pins affect all encoder instances
 typedef struct {
     struct {
-        hal_u32_t *sample_frequency;
-        hal_u32_t *skew;
-        hal_s32_t *dpll_timer_num;
-        hal_bit_t *hires_timestamp;
+        hal_uint_t sample_frequency;
+        hal_uint_t skew;
+        hal_sint_t dpll_timer_num;
+        hal_bool_t hires_timestamp;
 
     } pin;
 } hm2_encoder_module_global_t;
@@ -374,7 +374,7 @@ typedef struct {
     int has_skew;
     rtapi_u32 written_skew;
     rtapi_u32 written_hires_timestamp;
-    uint32_t desired_dpll_timer_reg, written_dpll_timer_reg;
+    rtapi_u32 desired_dpll_timer_reg, written_dpll_timer_reg;
 
     // hw registers
     rtapi_u32 counter_addr;
@@ -386,7 +386,7 @@ typedef struct {
 
     rtapi_u32 timestamp_div_addr;
     rtapi_u32 timestamp_div_reg;  // one register for the whole Function
-    hal_float_t seconds_per_tsdiv_clock;
+    rtapi_real seconds_per_tsdiv_clock;
 
     rtapi_u32 timestamp_count_addr;
     rtapi_u32 *timestamp_count_reg;
@@ -442,23 +442,23 @@ typedef struct {
     struct {
 
         struct {
-            hal_s32_t *rawcounts;
-            hal_s32_t *count;
-            hal_float_t *angle;
-            hal_float_t *position;
-            hal_float_t *velocity;
-            hal_float_t *velocity_rpm;
-            hal_bit_t *reset;
-            hal_bit_t *index_enable;
-            hal_bit_t *error;
-            hal_float_t *joint_pos_fb;
+            hal_sint_t rawcounts;
+            hal_sint_t count;
+            hal_real_t angle;
+            hal_real_t position;
+            hal_real_t velocity;
+            hal_real_t velocity_rpm;
+            hal_bool_t reset;
+            hal_bool_t index_enable;
+            hal_bool_t error;
+            hal_real_t joint_pos_fb;
         } pin;
 
         struct {
-            hal_float_t scale;
-            hal_float_t vel_scale;
-            hal_u32_t index_div;
-            hal_bit_t use_abs;
+            hal_real_t scale;
+            hal_real_t vel_scale;
+            hal_uint_t index_div;
+            hal_bool_t use_abs;
         } param;
 
     } hal;
@@ -472,7 +472,7 @@ typedef struct {
 
 typedef struct {
     struct {
-        hal_float_t excitation_khz;
+        hal_real_t excitation_khz;
     } param;
 } hm2_resolver_global_t;
 
@@ -501,8 +501,8 @@ typedef struct {
     rtapi_u32 velocity_addr;
     rtapi_s32 *velocity_reg;
     
-    hal_float_t written_khz;
-    hal_float_t kHz;
+    rtapi_real written_khz;
+    rtapi_real kHz;
     
 } hm2_resolver_t;
 
@@ -521,15 +521,15 @@ typedef struct {
     struct {
 
         struct {
-            hal_float_t *value;
-            hal_bit_t *enable;
+            hal_real_t value;
+            hal_bool_t enable;
         } pin;
 
         struct {
-            hal_float_t scale;
-            hal_bit_t offset_mode;
-            hal_s32_t output_type; 
-            hal_bit_t dither;            
+            hal_real_t scale;
+            hal_bool_t offset_mode;
+            hal_sint_t output_type;
+            hal_bool_t dither;
         } param;
 
     } hal;
@@ -556,8 +556,8 @@ typedef struct {
 // these hal params affect all pwmgen instances
 typedef struct {
     struct {
-        hal_u32_t pwm_frequency;
-        hal_u32_t pdm_frequency;
+        hal_uint_t pwm_frequency;
+        hal_uint_t pdm_frequency;
     } param;
 } hm2_pwmgen_module_global_t;
 
@@ -609,31 +609,31 @@ typedef struct {
     struct {
 
         struct {
-            hal_float_t *width1;
-            hal_float_t *width2; 
-            hal_float_t *filter1;
-            hal_float_t *filter2;
-            hal_float_t *rate;
-            hal_u32_t *trigselect1;
-            hal_u32_t *trigselect2;
-            hal_bit_t *trigrise1;
-            hal_bit_t *trigrise2;
-            hal_bit_t *trigfall1;
-            hal_bit_t *trigfall2;
-            hal_bit_t *retrig1;
-            hal_bit_t *retrig2;
-            hal_bit_t *enable1;
-            hal_bit_t *enable2;
-            hal_bit_t *reset1;
-            hal_bit_t *reset2;
-            hal_bit_t *swtrig1;
-            hal_bit_t *swtrig2;
-            hal_bit_t *exttrig1;
-            hal_bit_t *exttrig2;
-            hal_bit_t *out1;
-            hal_bit_t *out2;
+            hal_real_t width1;
+            hal_real_t width2;
+            hal_real_t filter1;
+            hal_real_t filter2;
+            hal_real_t rate;
+            hal_uint_t trigselect1;
+            hal_uint_t trigselect2;
+            hal_bool_t trigrise1;
+            hal_bool_t trigrise2;
+            hal_bool_t trigfall1;
+            hal_bool_t trigfall2;
+            hal_bool_t retrig1;
+            hal_bool_t retrig2;
+            hal_bool_t enable1;
+            hal_bool_t enable2;
+            hal_bool_t reset1;
+            hal_bool_t reset2;
+            hal_bool_t swtrig1;
+            hal_bool_t swtrig2;
+            hal_bool_t exttrig1;
+            hal_bool_t exttrig2;
+            hal_bool_t out1;
+            hal_bool_t out2;
             
-            hal_s32_t *dpll_timer_num;
+            hal_sint_t dpll_timer_num;
         } pin;
 
     } hal;
@@ -682,18 +682,18 @@ typedef struct {
     struct {
 
         struct {
-            hal_float_t *period;
-            hal_float_t *width;
-            hal_float_t *dutycycle;
-            hal_float_t *frequency;
-            hal_float_t *filtertc;
-            hal_float_t *dutyscale;
-            hal_float_t *dutyoffset;
-            hal_float_t *minfreq;
-            hal_u32_t *averages;
-            hal_bit_t *polarity;
-            hal_bit_t *valid;
-            hal_bit_t *input;
+            hal_real_t period;
+            hal_real_t width;
+            hal_real_t dutycycle;
+            hal_real_t frequency;
+            hal_real_t filtertc;
+            hal_real_t dutyscale;
+            hal_real_t dutyoffset;
+            hal_real_t minfreq;
+            hal_uint_t averages;
+            hal_bool_t polarity;
+            hal_bool_t valid;
+            hal_bool_t input;
         } pin;
 
     } hal;
@@ -735,9 +735,9 @@ typedef struct {
     struct {
 
         struct {
-            hal_float_t *width;
-            hal_float_t *scale;
-            hal_float_t *offset;
+            hal_real_t width;
+            hal_real_t scale;
+            hal_real_t offset;
         } pin;
 
     } hal;
@@ -747,7 +747,7 @@ typedef struct {
 // this hal pin affects all rcpwmgen instances
 typedef struct {
     struct {
-        hal_float_t *rate;
+        hal_real_t rate;
     } pin;
 } hm2_rcpwmgen_module_global_t;
 
@@ -784,31 +784,30 @@ typedef struct {
     struct {
 
         struct {
-            hal_bit_t *filt_data[32];
-            hal_bit_t *raw_data[32];
-            hal_bit_t *filt_data_not[32];
-            hal_bit_t *raw_data_not[32];
-            hal_bit_t *slow[32] ;
-            hal_s32_t *enc0_count; 
-            hal_s32_t *enc1_count; 
-            hal_s32_t *enc2_count; 
-            hal_s32_t *enc3_count;
-            hal_bit_t *enc0_reset; 
-            hal_bit_t *enc1_reset; 
-            hal_bit_t *enc2_reset; 
-            hal_bit_t *enc3_reset; 
-             		
+            hal_bool_t filt_data[32];
+            hal_bool_t raw_data[32];
+            hal_bool_t filt_data_not[32];
+            hal_bool_t raw_data_not[32];
+            hal_bool_t slow[32];
+            hal_sint_t enc0_count;
+            hal_sint_t enc1_count;
+            hal_sint_t enc2_count;
+            hal_sint_t enc3_count;
+            hal_bool_t enc0_reset;
+            hal_bool_t enc1_reset;
+            hal_bool_t enc2_reset;
+            hal_bool_t enc3_reset;
         } pin;
 
         struct {
-            hal_u32_t scan_rate;
-            hal_u32_t slow_scans; 
-            hal_u32_t fast_scans; 		
-            hal_bit_t enc0_mode; 
-            hal_bit_t enc1_mode; 
-            hal_bit_t enc2_mode; 
-            hal_bit_t enc3_mode; 
-            hal_u32_t scan_width; 	    	
+            hal_uint_t scan_rate;
+            hal_uint_t slow_scans;
+            hal_uint_t fast_scans;
+            hal_bool_t enc0_mode;
+            hal_bool_t enc1_mode;
+            hal_bool_t enc2_mode;
+            hal_bool_t enc3_mode;
+            hal_uint_t scan_width;
         } param;
 
     } hal;
@@ -879,30 +878,30 @@ typedef struct {
     struct {
 
         struct {
-            hal_bit_t *filt_data[32];
-            hal_bit_t *raw_data[32];
-            hal_bit_t *filt_data_not[32];
-            hal_bit_t *raw_data_not[32];
-            hal_bit_t *slow[32] ;
-            hal_s32_t *enc0_count; 
-            hal_s32_t *enc1_count; 
-            hal_s32_t *enc2_count; 
-            hal_s32_t *enc3_count; 		
-            hal_bit_t *enc0_reset; 
-            hal_bit_t *enc1_reset; 
-            hal_bit_t *enc2_reset; 
-            hal_bit_t *enc3_reset; 
+            hal_bool_t filt_data[32];
+            hal_bool_t raw_data[32];
+            hal_bool_t filt_data_not[32];
+            hal_bool_t raw_data_not[32];
+            hal_bool_t slow[32];
+            hal_sint_t enc0_count;
+            hal_sint_t enc1_count;
+            hal_sint_t enc2_count;
+            hal_sint_t enc3_count;
+            hal_bool_t enc0_reset;
+            hal_bool_t enc1_reset;
+            hal_bool_t enc2_reset;
+            hal_bool_t enc3_reset;
         } pin;
 
         struct {
-            hal_u32_t scan_rate;
-            hal_u32_t slow_scans; 
-            hal_u32_t fast_scans; 		
-            hal_bit_t enc0_mode; 
-            hal_bit_t enc1_mode; 
-            hal_bit_t enc2_mode; 
-            hal_bit_t enc3_mode; 
-            hal_u32_t scan_width; 	    	
+            hal_uint_t scan_rate;
+            hal_uint_t slow_scans;
+            hal_uint_t fast_scans;
+            hal_bool_t enc0_mode;
+            hal_bool_t enc1_mode;
+            hal_bool_t enc2_mode;
+            hal_bool_t enc3_mode;
+            hal_uint_t scan_width;
         } param;
 
     } hal;
@@ -979,53 +978,53 @@ typedef struct {
     struct {
 
         struct {
-            hal_float_t *accx_cmd;
-            hal_float_t *accy_cmd;
-            hal_float_t *velx_cmd;
-            hal_float_t *vely_cmd;
-            hal_float_t *posx_cmd;
-            hal_float_t *posy_cmd;
-            hal_float_t *velx_fb;
-            hal_float_t *vely_fb;
-            hal_float_t *posx_fb;
-            hal_float_t *posy_fb;
-            hal_float_t *posx_scale;
-            hal_float_t *posy_scale;
-            hal_bit_t 	*enable;
-            hal_u32_t 	*controlx;
-            hal_u32_t 	*controly;
-            hal_u32_t 	*commandx;
-            hal_u32_t 	*commandy;
-            hal_bit_t 	*mode18bitx;
-            hal_bit_t 	*mode18bity;
-            hal_bit_t 	*commandmodex;
-            hal_bit_t 	*commandmodey;
-            hal_u32_t 	*status;
-            hal_bit_t 	*posx_overflow;
-            hal_bit_t 	*posy_overflow;
-            hal_bit_t 	*velx_overflow;
-            hal_bit_t 	*vely_overflow;
+            hal_real_t accx_cmd;
+            hal_real_t accy_cmd;
+            hal_real_t velx_cmd;
+            hal_real_t vely_cmd;
+            hal_real_t posx_cmd;
+            hal_real_t posy_cmd;
+            hal_real_t velx_fb;
+            hal_real_t vely_fb;
+            hal_real_t posx_fb;
+            hal_real_t posy_fb;
+            hal_real_t posx_scale;
+            hal_real_t posy_scale;
+            hal_bool_t enable;
+            hal_uint_t controlx;
+            hal_uint_t controly;
+            hal_uint_t commandx;
+            hal_uint_t commandy;
+            hal_bool_t mode18bitx;
+            hal_bool_t mode18bity;
+            hal_bool_t commandmodex;
+            hal_bool_t commandmodey;
+            hal_uint_t status;
+            hal_bool_t posx_overflow;
+            hal_bool_t posy_overflow;
+            hal_bool_t velx_overflow;
+            hal_bool_t vely_overflow;
         } pin;
 
     } hal;
 
 
     //previous MPG counts for this instance	
-    hal_float_t prev_accx_cmd;	
-    hal_float_t prev_accy_cmd;	
-    hal_float_t prev_velx_cmd;	
-    hal_float_t prev_vely_cmd;	
-    hal_float_t prev_posx_cmd;	
-    hal_float_t prev_posy_cmd;	
+    rtapi_real prev_accx_cmd;
+    rtapi_real prev_accy_cmd;
+    rtapi_real prev_velx_cmd;
+    rtapi_real prev_vely_cmd;
+    rtapi_real prev_posx_cmd;
+    rtapi_real prev_posy_cmd;
 
  
 } hm2_xy2mod_instance_t;
 
-// these hal params affect all xy2mod instances
+// these hal pins affect all xy2mod instances
 typedef struct {
     struct {
-        hal_s32_t *dpll_rtimer_num;
-        hal_s32_t *dpll_wtimer_num;
+        hal_sint_t dpll_rtimer_num;
+        hal_sint_t dpll_wtimer_num;
     } pin;
 } hm2_xy2mod_module_global_t;
 
@@ -1041,8 +1040,8 @@ typedef struct {
     // module-global HAL objects...
 
     hm2_xy2mod_module_global_t *hal;
-    rtapi_u32 written_dpll_rtimer_num;
-    rtapi_u32 written_dpll_wtimer_num;
+    rtapi_s32 written_dpll_rtimer_num;
+    rtapi_s32 written_dpll_wtimer_num;
 
 
     rtapi_u32 accx_addr;
@@ -1092,18 +1091,18 @@ typedef struct {
     struct {
 
         struct {
-            hal_float_t *Avalue;
-            hal_float_t *Bvalue;
-            hal_float_t *Cvalue;
-            hal_bit_t *fault;
-            hal_bit_t *enable;
+            hal_real_t Avalue;
+            hal_real_t Bvalue;
+            hal_real_t Cvalue;
+            hal_bool_t fault;
+            hal_bool_t enable;
         } pin;
 
         struct {
-            hal_float_t scale;
-            hal_float_t deadzone;
-            hal_bit_t faultpolarity;
-            hal_float_t sampletime;
+            hal_real_t scale;
+            hal_real_t deadzone;
+            hal_bool_t faultpolarity;
+            hal_real_t sampletime;
         } param;
 
     } hal;
@@ -1112,14 +1111,14 @@ typedef struct {
     // know if an update-write is needed
     // enable is a little more complicated and is based on the read-back
     // of the fault/enable register
-    double written_deadzone;
-    int written_faultpolarity;
-    double written_sampletime;
+    rtapi_real written_deadzone;
+    rtapi_bool written_faultpolarity;
+    rtapi_real written_sampletime;
 } hm2_tp_pwmgen_instance_t;
 
 typedef struct {
     struct {
-        hal_u32_t pwm_frequency; // One PWM rate for all instances
+        hal_uint_t pwm_frequency; // One PWM rate for all instances
     } param;
 } hm2_tp_pwmgen_global_hal_t;
 
@@ -1205,49 +1204,55 @@ typedef struct {
     struct {
 
         struct {
-            hal_float_t *position_cmd;
-            hal_float_t *velocity_cmd;
-            hal_s32_t *counts;
-            hal_float_t *position_fb;
-            hal_float_t *position_latch;
-            hal_float_t *velocity_fb;
-            hal_bit_t *enable;
-            hal_bit_t *control_type;   // 0="position control", 1="velocity control"
-            hal_bit_t *position_reset; // reset position when true
-            hal_bit_t *index_enable;	
-            hal_bit_t *index_polarity;
-            hal_bit_t *latch_enable;
-            hal_bit_t *latch_polarity;
+            hal_real_t position_cmd;
+            hal_real_t velocity_cmd;
+            hal_sint_t counts;
+            hal_real_t position_fb;
+            hal_real_t position_latch;
+            hal_real_t velocity_fb;
+            hal_bool_t enable;
+            hal_bool_t control_type;   // 0="position control", 1="velocity control"
+            hal_bool_t position_reset; // reset position when true
+            hal_bool_t index_enable;	
+            hal_bool_t index_polarity;
+            hal_bool_t latch_enable;
+            hal_bool_t latch_polarity;
 
             // debug pins
-            hal_float_t *dbg_ff_vel;
-            hal_float_t *dbg_vel_error;
-            hal_float_t *dbg_s_to_match;
-            hal_float_t *dbg_err_at_match;
-            hal_s32_t *dbg_step_rate;
-            hal_float_t *dbg_pos_minus_prev_cmd;
+            hal_real_t dbg_ff_vel;
+            hal_real_t dbg_vel_error;
+            hal_real_t dbg_s_to_match;
+            hal_real_t dbg_err_at_match;
+            hal_sint_t dbg_step_rate;
+            hal_real_t dbg_pos_minus_prev_cmd;
         } pin;
 
         struct {
-            hal_float_t position_scale;
-            hal_float_t maxvel;
-            hal_float_t maxaccel;
+            hal_real_t position_scale;
+            hal_real_t maxvel;
+            hal_real_t maxaccel;
 
-            hal_u32_t steplen;
-            hal_u32_t stepspace;
-            hal_u32_t dirsetup;
-            hal_u32_t dirhold;
+            hal_uint_t steplen;
+            hal_uint_t stepspace;
+            hal_uint_t dirsetup;
+            hal_uint_t dirhold;
 
-            hal_u32_t step_type;
-            hal_bit_t swap_step_dir;
-            hal_u32_t table[5]; // the Fifth Element is used as a very crude hash
+            hal_uint_t step_type;
+            hal_bool_t swap_step_dir;
+            hal_uint_t table[4];
+            // the Fifth Element was moved below (used as a very crude hash)
         } param;
 
     } hal;
 
+    // This was originally the fifth parameter element in 'table'. It was moved
+    // here because there was no parameter allocated and is an instance value.
+    // Parameters work like pins now and cannot be used as local storage.
+    rtapi_u32 tablehash;
+
     // this variable holds the previous position command, for
     // computing the feedforward velocity
-    hal_float_t old_position_cmd;
+    rtapi_real old_position_cmd;
 
     rtapi_u32 prev_accumulator;
 
@@ -1275,7 +1280,7 @@ typedef struct {
 // these hal params affect all stepgen instances
 typedef struct {
     struct {
-        hal_s32_t *dpll_timer_num;
+        hal_sint_t dpll_timer_num;
     } pin;
 } hm2_stepgen_module_global_t;
 
@@ -1335,7 +1340,6 @@ typedef struct {
     int conf_flag[16];
     rtapi_u16 cd_addr;
     rtapi_u16 count_addr;
-    hal_u32_t *count;
     int num_frames;
     rtapi_u32 clock_freq;
     rtapi_u16 base_address;
@@ -1426,16 +1430,16 @@ typedef struct {
 //
 
 typedef struct {
-    hal_float_t *time1_us;
-    hal_float_t *time2_us;
-    hal_float_t *time3_us;
-    hal_float_t *time4_us;
-    hal_float_t *base_freq;
-    hal_float_t *phase_error;
-    hal_u32_t *plimit;
-    hal_u32_t *ddssize;
-    hal_u32_t *time_const;
-    hal_u32_t *prescale;
+    hal_real_t time1_us;
+    hal_real_t time2_us;
+    hal_real_t time3_us;
+    hal_real_t time4_us;
+    hal_real_t base_freq;
+    hal_real_t phase_error;
+    hal_uint_t plimit;
+    hal_uint_t ddssize;
+    hal_uint_t time_const;
+    hal_uint_t prescale;
 } hm2_dpll_pins_t ;
 
 typedef struct {
@@ -1470,11 +1474,11 @@ typedef struct {
     struct {
 
         struct {
-            hal_bit_t *has_bit;
+            hal_bool_t has_bit;
         } pin;
 
         struct {
-            hal_u32_t timeout_ns;
+            hal_uint_t timeout_ns;
         } param;
 
     } hal;
@@ -1508,7 +1512,7 @@ typedef struct {
 //
 
 typedef struct {
-        hal_bit_t *led;
+        hal_bool_t led;
     } hm2_led_instance_t ;
 
 typedef struct {
@@ -1533,9 +1537,9 @@ typedef struct {
     struct {
 
         struct {
-            hal_u32_t *rate;
-            hal_bit_t *out[32];
-            hal_bit_t *invert[32];
+            hal_uint_t rate;
+            hal_bool_t out[32];
+            hal_bool_t invert[32];
         } pin;
 
     } hal;
@@ -1566,8 +1570,8 @@ typedef struct {
     struct {
 
         struct {
-            hal_bit_t *out[32];
-            hal_bit_t *invert[32];
+            hal_bool_t out[32];
+            hal_bool_t invert[32];
         } pin;
 
     } hal;
@@ -1596,14 +1600,14 @@ typedef struct {
 typedef struct {
     struct {
         struct {
-            hal_u32_t *read_address;
-            hal_u32_t *read_data;
+            hal_uint_t read_address;
+            hal_uint_t read_data;
 
-            hal_u32_t *write_address;
-            hal_u32_t *write_data;
-            hal_bit_t *write_strobe;
+            hal_uint_t write_address;
+            hal_uint_t write_data;
+            hal_bool_t write_strobe;
 
-            hal_bit_t *dump_state;
+            hal_bool_t dump_state;
         } pin;
     } hal;
 } hm2_raw_t;

--- a/src/hal/drivers/mesa-hostmot2/inm.c
+++ b/src/hal/drivers/mesa-hostmot2/inm.c
@@ -96,7 +96,7 @@ int hm2_inm_parse_md(hostmot2_t *hm2, int md_index) {
     hm2->inm.clock_frequency = md->clock_freq;
     hm2->inm.version = md->version;
 
-    hm2->inm.instance = (hm2_inm_instance_t *)hal_malloc(hm2->inm.num_instances * sizeof(hm2_inm_instance_t));
+    hm2->inm.instance = hal_malloc(hm2->inm.num_instances * sizeof(*hm2->inm.instance));
     if (hm2->inm.instance == NULL) {
         HM2_ERR("out of memory!\n");
         r = -ENOMEM;
@@ -153,247 +153,244 @@ int hm2_inm_parse_md(hostmot2_t *hm2, int md_index) {
     // Export to HAL.
     //
 
-    {
-        int i;
-        int j;
-        int inm_number;
-	     int temp;
-        char name[HAL_NAME_LEN + 1];
+    for (int i = 0; i < hm2->inm.num_instances; i ++) {
+        hm2_inm_instance_t *inst = &hm2->inm.instance[i];
+        inst->enc0_present = false;
+        inst->enc1_present = false;
+        inst->enc2_present = false;
+        inst->enc3_present = false;
+        rtapi_u32 temp = 0;
+        // Determine which MPG encoders have both pins so are useable
+        for (int j = 0; j < hm2->num_pins; j++){
+            if (hm2->pin[j].sec_tag == HM2_GTAG_INM && hm2->pin[j].sec_unit == i) {
+                int inm_number = (hm2->pin[j].sec_pin & 0x7f) - 1;
+                if (inm_number < 8) {
+                    temp = temp | (1  << inm_number);
+                }
+            }
+        }
+        if ((temp & 0x03) == 0x03) {
+            inst->enc0_present = true;
+        }
+        if ((temp & 0x0C) == 0x0C) {
+            inst->enc1_present = true;
+        }
+        if ((temp & 0x30) == 0x30) {
+            inst->enc2_present = true;
+        }
+        if ((temp & 0xC0) == 0xC0) {
+            inst->enc3_present = true;
+        }
+        // Do a low level read to determine the per instance scanwidth
+        hm2->llio->read(hm2->llio,hm2->inm.control_addr + (i * md->instance_stride),&temp, sizeof(rtapi_u32));
+        temp  = (temp & 0x0000001f) +1;
+        inst->scanwidth = temp;
+        // init 20000: 20 KHz = 50 usec/scan
+        r = hal_param_new_ui32(hm2->llio->comp_id, HAL_RW, &(inst->hal.param.scan_rate),
+                               20000, "%s.inm.%02d.scan_rate", hm2->llio->name, i);
+        if (r < 0) {
+            HM2_ERR("error %d adding param '%s.inm.%02d.scan_rate', aborting\n", r, hm2->llio->name, i);
+            goto fail1;
+        }
+        // init 500: 500*50 usec = 25 ms
+        r = hal_param_new_ui32(hm2->llio->comp_id, HAL_RW, &(inst->hal.param.slow_scans),
+                               500, "%s.inm.%02d.slow_scans", hm2->llio->name, i);
+        if (r < 0) {
+            HM2_ERR("error %d adding param '%s.inm.%02d.slow_scans', aborting\n", r, hm2->llio->name, i);
+            goto fail1;
+        }
+        // init 5: 5*50 usec = 250 usec
+        r = hal_param_new_ui32(hm2->llio->comp_id, HAL_RW, &(inst->hal.param.fast_scans),
+                               5, "%s.inm.%02d.fast_scans", hm2->llio->name, i);
+        if (r < 0) {
+            HM2_ERR("error %d adding param '%s.inm.%02d.fast_scans', aborting\n", r, hm2->llio->name, i);
+            goto fail1;
+        }
 
-        for (i = 0; i < hm2->inm.num_instances; i ++) {
-            hm2->inm.instance[i].enc0_present = false;
-            hm2->inm.instance[i].enc1_present = false;
-            hm2->inm.instance[i].enc2_present = false;
-            hm2->inm.instance[i].enc3_present = false;
-            temp = 0;
-            // Determine which MPG encoders have both pins so are useable
-            for (j = 0; j < hm2->num_pins; j++){
-                if (hm2->pin[j].sec_tag == HM2_GTAG_INM && hm2->pin[j].sec_unit == i) {
-                    inm_number = (hm2->pin[j].sec_pin & 0x7f) - 1;
-                    if (inm_number < 8) {
-                        temp = temp | (1  << inm_number);
-                    }    
-                }
-            }
-            if ((temp & 0x03) == 0x03)  {    
-                hm2->inm.instance[i].enc0_present = true;
-            }          
-            if ((temp & 0x0C) == 0x0C)  {    
-                hm2->inm.instance[i].enc1_present = true;
-            }          
-            if ((temp & 0x30) == 0x30)  {    
-                hm2->inm.instance[i].enc2_present = true;
-            }          
-            if ((temp & 0xC0) == 0xC0)  {    
-                hm2->inm.instance[i].enc3_present = true;
-            }          
-            // Do a low level read to determine the per instance scanwidth
-            hm2->llio->read(hm2->llio,hm2->inm.control_addr + (i * md->instance_stride),&temp, sizeof(rtapi_u32));
-            temp  = (temp & 0x0000001f) +1;
-	    		hm2->inm.instance[i].scanwidth = temp;         
-	    		hm2->inm.instance[i].hal.param.scan_width = temp;
-            rtapi_snprintf(name, sizeof(name), "%s.inm.%02d.scan_rate", hm2->llio->name, i);
-            r = hal_param_u32_new(name, HAL_RW, &(hm2->inm.instance[i].hal.param.scan_rate), hm2->llio->comp_id);
+        if (inst->enc0_present) {
+            r = hal_param_new_bool(hm2->llio->comp_id, HAL_RW, &(inst->hal.param.enc0_mode),
+                                   0, "%s.inm.%02d.enc0_4xmode", hm2->llio->name, i);
             if (r < 0) {
-                HM2_ERR("error adding param '%s', aborting\n", name);
+                HM2_ERR("error %d adding param '%s.inm.%02d.enc0_4xmode', aborting\n", r, hm2->llio->name, i);
                 goto fail1;
             }
-            rtapi_snprintf(name, sizeof(name), "%s.inm.%02d.slow_scans", hm2->llio->name, i);
-            r = hal_param_u32_new(name, HAL_RW, &(hm2->inm.instance[i].hal.param.slow_scans), hm2->llio->comp_id);
+        } else {
+            r = hal_param_new_fake(hm2->llio->comp_id, (hal_refs_u *)&(inst->hal.param.enc0_mode));
             if (r < 0) {
-                HM2_ERR("error adding param '%s', aborting\n", name);
+                HM2_ERR("error %d allocating fake param '%s.inm.%02d.enc0_4xmode', aborting\n", r, hm2->llio->name, i);
                 goto fail1;
-            } 
-            rtapi_snprintf(name, sizeof(name), "%s.inm.%02d.fast_scans", hm2->llio->name, i);
-            r = hal_param_u32_new(name, HAL_RW, &(hm2->inm.instance[i].hal.param.fast_scans), hm2->llio->comp_id);
-            if (r < 0) {
-                HM2_ERR("error adding param '%s', aborting\n", name);
-                goto fail1;
-            }  
+            }
+        }
 
-            if (hm2->inm.instance[i].enc0_present)  {
-            	rtapi_snprintf(name, sizeof(name), "%s.inm.%02d.enc0_4xmode", hm2->llio->name, i);
-            	r = hal_param_bit_new(name, HAL_RW, &(hm2->inm.instance[i].hal.param.enc0_mode), hm2->llio->comp_id);
-            	if (r < 0) {
-                	HM2_ERR("error adding param '%s', aborting\n", name);
-                	goto fail1;
-            	}
-            }
-            
-				if (hm2->inm.instance[i].enc1_present)  {
-					rtapi_snprintf(name, sizeof(name), "%s.inm.%02d.enc1_4xmode", hm2->llio->name, i);
-            	r = hal_param_bit_new(name, HAL_RW, &(hm2->inm.instance[i].hal.param.enc1_mode), hm2->llio->comp_id);
-            	if (r < 0) {
-                	HM2_ERR("error adding param '%s', aborting\n", name);
-                	goto fail1;
-            	}
-            }
-            	
-				if (hm2->inm.instance[i].enc2_present)  {
-					rtapi_snprintf(name, sizeof(name), "%s.inm.%02d.enc2_4xmode", hm2->llio->name, i);
-            	r = hal_param_bit_new(name, HAL_RW, &(hm2->inm.instance[i].hal.param.enc2_mode), hm2->llio->comp_id);
-            	if (r < 0) {
-                	HM2_ERR("error adding param '%s', aborting\n", name);
-                	goto fail1;
-            	}
-            }
-             
-				if (hm2->inm.instance[i].enc3_present)  {
-					rtapi_snprintf(name, sizeof(name), "%s.inm.%02d.enc3_4xmode", hm2->llio->name, i);
-            	r = hal_param_bit_new(name, HAL_RW, &(hm2->inm.instance[i].hal.param.enc3_mode), hm2->llio->comp_id);
-            	if (r < 0) {
-                	HM2_ERR("error adding param '%s', aborting\n", name);
-                	goto fail1;
-            	}
-            }
-            
-            rtapi_snprintf(name, sizeof(name), "%s.inm.%02d.scan_width", hm2->llio->name, i);
-            r = hal_param_u32_new(name, HAL_RO, &(hm2->inm.instance[i].hal.param.scan_width), hm2->llio->comp_id);
+        if (inst->enc1_present) {
+            r = hal_param_new_bool(hm2->llio->comp_id, HAL_RW, &(inst->hal.param.enc1_mode),
+                                   0, "%s.inm.%02d.enc1_4xmode", hm2->llio->name, i);
             if (r < 0) {
-                HM2_ERR("error adding param '%s', aborting\n", name);
+                HM2_ERR("error %d adding param '%s.inm.%02d.enc1_4xmode', aborting\n", r, hm2->llio->name, i);
                 goto fail1;
             }
+        } else {
+            r = hal_param_new_fake(hm2->llio->comp_id, (hal_refs_u *)&(inst->hal.param.enc1_mode));
+            if (r < 0) {
+                HM2_ERR("error %d allocating fake param '%s.inm.%02d.enc1_4xmode', aborting\n", r, hm2->llio->name, i);
+                goto fail1;
+            }
+        }
 
-            int j = 0;
-            int inm_number;
-            for (j = 0; j < hm2->num_pins; j++){
-                if (hm2->pin[j].sec_tag == HM2_GTAG_INM && hm2->pin[j].sec_unit == i) {
-                    if ((hm2->pin[j].sec_pin & 0x80) != 00) {
-                        HM2_ERR("Pin Descriptor %d has an inm pin that's not an input!\n", j);
-                        r = -EINVAL;
-                        goto fail0;
-                    }
-                    inm_number = (hm2->pin[j].sec_pin & 0x7f) - 1;
-                    if (inm_number >= 32) {
-                        HM2_ERR("Pin Descriptor %d has invalid secondary pin number %d for inm module!\n", j, inm_number);
-                        r = -EINVAL;
-                        goto fail0;
-                    }                     
-                    rtapi_snprintf(name, sizeof(name), "%s.inm.%02d.input-%02d", hm2->llio->name, i, inm_number);
-                    r = hal_pin_bit_new(name, HAL_OUT, &(hm2->inm.instance[i].hal.pin.filt_data[inm_number]), hm2->llio->comp_id);
-                    if (r < 0) {
-                        HM2_ERR("error adding pin '%s', aborting\n", name);
-                        r = -ENOMEM;
-                    goto fail1;
-                    }                         
-                    rtapi_snprintf(name, sizeof(name), "%s.inm.%02d.raw-input-%02d", hm2->llio->name, i, inm_number);
-                    r = hal_pin_bit_new(name, HAL_OUT, &(hm2->inm.instance[i].hal.pin.raw_data[inm_number]), hm2->llio->comp_id);
-                    if (r < 0) {
-                        HM2_ERR("error adding pin '%s', aborting\n", name);
-                        r = -ENOMEM;
-                        goto fail1;
-                    }
-                    rtapi_snprintf(name, sizeof(name), "%s.inm.%02d.input-%02d-not", hm2->llio->name, i, inm_number);
-                    r = hal_pin_bit_new(name, HAL_OUT, &(hm2->inm.instance[i].hal.pin.filt_data_not[inm_number]), hm2->llio->comp_id);
-                    if (r < 0) {
-                        HM2_ERR("error adding pin '%s', aborting\n", name);
-                        r = -ENOMEM;
-                        goto fail1;
-                    }
-                    rtapi_snprintf(name, sizeof(name), "%s.inm.%02d.raw-input-%02d-not", hm2->llio->name, i, inm_number);
-                    r = hal_pin_bit_new(name, HAL_OUT, &(hm2->inm.instance[i].hal.pin.raw_data_not[inm_number]), hm2->llio->comp_id);
-                    if (r < 0) {
-                        HM2_ERR("error adding pin '%s', aborting\n", name);
-                        r = -ENOMEM;
-                        goto fail1;
-                    }
-                    rtapi_snprintf(name, sizeof(name), "%s.inm.%02d.input-%02d-slow", hm2->llio->name, i, inm_number);
-                    r = hal_pin_bit_new(name, HAL_IN, &(hm2->inm.instance[i].hal.pin.slow[inm_number]), hm2->llio->comp_id);
-                    if (r < 0) {
-                        HM2_ERR("error adding pin '%s', aborting\n", name);
-                        r = -ENOMEM;
-                        goto fail1;
-                    }
+        if (inst->enc2_present) {
+            r = hal_param_new_bool(hm2->llio->comp_id, HAL_RW, &(inst->hal.param.enc2_mode),
+                                   0, "%s.inm.%02d.enc2_4xmode", hm2->llio->name, i);
+            if (r < 0) {
+                HM2_ERR("error %d adding param '%s.inm.%02d.enc2_4xmode', aborting\n", r, hm2->llio->name, i);
+                goto fail1;
+            }
+        } else {
+            r = hal_param_new_fake(hm2->llio->comp_id, (hal_refs_u *)&(inst->hal.param.enc2_mode));
+            if (r < 0) {
+                HM2_ERR("error %d allocating fake param '%s.inm.%02d.enc2_4xmode', aborting\n", r, hm2->llio->name, i);
+                goto fail1;
+            }
+        }
+
+        if (inst->enc3_present) {
+            r = hal_param_new_bool(hm2->llio->comp_id, HAL_RW, &(inst->hal.param.enc3_mode),
+                                   0, "%s.inm.%02d.enc3_4xmode", hm2->llio->name, i);
+            if (r < 0) {
+                HM2_ERR("error %d adding param '%s.inm.%02d.enc3_4xmode', aborting\n", r, hm2->llio->name, i);
+                goto fail1;
+            }
+        } else {
+            r = hal_param_new_fake(hm2->llio->comp_id, (hal_refs_u *)&(inst->hal.param.enc3_mode));
+            if (r < 0) {
+                HM2_ERR("error %d allocating fake param '%s.inm.%02d.enc3_4xmode', aborting\n", r, hm2->llio->name, i);
+                goto fail1;
+            }
+        }
+
+        r = hal_param_new_ui32(hm2->llio->comp_id, HAL_RO, &(inst->hal.param.scan_width),
+                               temp, "%s.inm.%02d.scan_width", hm2->llio->name, i);
+        if (r < 0) {
+            HM2_ERR("error %d adding param '%s.inm.%02d.scan_width', aborting\n", r, hm2->llio->name, i);
+            goto fail1;
+        }
+
+        for (int j = 0; j < hm2->num_pins; j++) {
+            if (hm2->pin[j].sec_tag == HM2_GTAG_INM && hm2->pin[j].sec_unit == i) {
+                if ((hm2->pin[j].sec_pin & 0x80) != 00) {
+                    HM2_ERR("Pin Descriptor %d has an inm pin that's not an input!\n", j);
+                    r = -EINVAL;
+                    goto fail0;
                 }
-            }    
-				if (hm2->inm.instance[i].enc0_present) {
-                rtapi_snprintf(name, sizeof(name), "%s.inm.%02d.enc0-count", hm2->llio->name, i);
-                r = hal_pin_s32_new(name, HAL_OUT, &(hm2->inm.instance[i].hal.pin.enc0_count), hm2->llio->comp_id);
-                if (r < 0) {
-                    HM2_ERR("error adding pin '%s', aborting\n", name);
-                	  r = -ENOMEM;
-                	  goto fail1;
+                int inm_number = (hm2->pin[j].sec_pin & 0x7f) - 1;
+                if (inm_number >= 32) {
+                    HM2_ERR("Pin Descriptor %d has invalid secondary pin number %d for inm module!\n", j, inm_number);
+                    r = -EINVAL;
+                    goto fail0;
                 }
-                rtapi_snprintf(name, sizeof(name), "%s.inm.%02d.enc0-reset", hm2->llio->name, i);
-                r = hal_pin_bit_new(name, HAL_IN, &(hm2->inm.instance[i].hal.pin.enc0_reset), hm2->llio->comp_id);
+                r = hal_pin_new_bool(hm2->llio->comp_id, HAL_OUT, &(inst->hal.pin.filt_data[inm_number]),
+                                     0, "%s.inm.%02d.input-%02d", hm2->llio->name, i, inm_number);
                 if (r < 0) {
-                    HM2_ERR("error adding pin '%s', aborting\n", name);
-                    r = -ENOMEM;
+                    HM2_ERR("error %d adding pin '%s.inm.%02d.input-%02d', aborting\n", r, hm2->llio->name, i, inm_number);
                     goto fail1;
                 }
-				}
-					
-				if (hm2->inm.instance[i].enc1_present) {
-              	 rtapi_snprintf(name, sizeof(name), "%s.inm.%02d.enc1-count", hm2->llio->name, i);
-                r = hal_pin_s32_new(name, HAL_OUT, &(hm2->inm.instance[i].hal.pin.enc1_count), hm2->llio->comp_id);
+                r = hal_pin_new_bool(hm2->llio->comp_id, HAL_OUT, &(inst->hal.pin.raw_data[inm_number]),
+                                     0, "%s.inm.%02d.raw-input-%02d", hm2->llio->name, i, inm_number);
                 if (r < 0) {
-                    HM2_ERR("error adding pin '%s', aborting\n", name);
-                    r = -ENOMEM;
+                    HM2_ERR("error %d adding pin '%s.inm.%02d.raw-input-%02d', aborting\n", r, hm2->llio->name, i, inm_number);
                     goto fail1;
                 }
-                rtapi_snprintf(name, sizeof(name), "%s.inm.%02d.enc1-reset", hm2->llio->name, i);
-                r = hal_pin_bit_new(name, HAL_IN, &(hm2->inm.instance[i].hal.pin.enc1_reset), hm2->llio->comp_id);
+                r = hal_pin_new_bool(hm2->llio->comp_id, HAL_OUT, &(inst->hal.pin.filt_data_not[inm_number]),
+                                     0, "%s.inm.%02d.input-%02d-not", hm2->llio->name, i, inm_number);
                 if (r < 0) {
-                    HM2_ERR("error adding pin '%s', aborting\n", name);
-                    r = -ENOMEM;
+                    HM2_ERR("error %d adding pin '%s.inm.%02d.input-%02d-not', aborting\n", r, hm2->llio->name, i, inm_number);
                     goto fail1;
                 }
-					
-					 if (hm2->inm.instance[i].enc2_present)  { 					
-                    rtapi_snprintf(name, sizeof(name), "%s.inm.%02d.enc2-count", hm2->llio->name, i);
-                    r = hal_pin_s32_new(name, HAL_OUT, &(hm2->inm.instance[i].hal.pin.enc2_count), hm2->llio->comp_id);
-                    if (r < 0) {
-                        HM2_ERR("error adding pin '%s', aborting\n", name);
-                  	   r = -ENOMEM;
-                  	   goto fail1;
-                	  }
-                	  rtapi_snprintf(name, sizeof(name), "%s.inm.%02d.enc2-reset", hm2->llio->name, i);
-                	  r = hal_pin_bit_new(name, HAL_IN, &(hm2->inm.instance[i].hal.pin.enc2_reset), hm2->llio->comp_id);
-                    if (r < 0) {
-                        HM2_ERR("error adding pin '%s', aborting\n", name);
-                        r = -ENOMEM;
-                        goto fail1;
-                	  }
+                r = hal_pin_new_bool(hm2->llio->comp_id, HAL_OUT, &(inst->hal.pin.raw_data_not[inm_number]),
+                                     0, "%s.inm.%02d.raw-input-%02d-not", hm2->llio->name, i, inm_number);
+                if (r < 0) {
+                    HM2_ERR("error %d adding pin '%s.inm.%02d.raw-input-%02d-not', aborting\n", r, hm2->llio->name, i, inm_number);
+                    goto fail1;
                 }
-					 if (hm2->inm.instance[i].enc3_present) {					
-                    rtapi_snprintf(name, sizeof(name), "%s.inm.%02d.enc3-count", hm2->llio->name, i);
-                    r = hal_pin_s32_new(name, HAL_OUT, &(hm2->inm.instance[i].hal.pin.enc3_count), hm2->llio->comp_id);
-                    if (r < 0) {
-                        HM2_ERR("error adding pin '%s', aborting\n", name);
-                        r = -ENOMEM;
-                        goto fail1;
-                    }
-                    rtapi_snprintf(name, sizeof(name), "%s.inm.%02d.enc3-reset", hm2->llio->name, i);
-                	  r = hal_pin_bit_new(name, HAL_IN, &(hm2->inm.instance[i].hal.pin.enc3_reset), hm2->llio->comp_id);
-                	  if (r < 0) {
-                        HM2_ERR("error adding pin '%s', aborting\n", name);
-                    	   r = -ENOMEM;
-                        goto fail1;
-                	  }
-					 }	
+                r = hal_pin_new_bool(hm2->llio->comp_id, HAL_IN, &(inst->hal.pin.slow[inm_number]),
+                                     0, "%s.inm.%02d.input-%02d-slow", hm2->llio->name, i, inm_number);
+                if (r < 0) {
+                    HM2_ERR("error %d adding pin '%s.inm.%02d.input-%02d-slow', aborting\n", r, hm2->llio->name, i, inm_number);
+                    goto fail1;
+                }
+            }
+        }
+        if (inst->enc0_present) {
+            r = hal_pin_new_si32(hm2->llio->comp_id, HAL_OUT, &(inst->hal.pin.enc0_count),
+                                 0, "%s.inm.%02d.enc0-count", hm2->llio->name, i);
+            if (r < 0) {
+                HM2_ERR("error %d adding pin '%s.inm.%02d.enc0-count', aborting\n", r, hm2->llio->name, i);
+                  goto fail1;
+            }
+            r = hal_pin_new_bool(hm2->llio->comp_id, HAL_IN, &(inst->hal.pin.enc0_reset),
+                                 0, "%s.inm.%02d.enc0-reset", hm2->llio->name, i);
+            if (r < 0) {
+                HM2_ERR("error %d adding pin '%s.inm.%02d.enc0-reset', aborting\n", r, hm2->llio->name, i);
+                goto fail1;
+            }
+        }
+
+        if (inst->enc1_present) {
+            r = hal_pin_new_si32(hm2->llio->comp_id, HAL_OUT, &(inst->hal.pin.enc1_count),
+                                 0, "%s.inm.%02d.enc1-count", hm2->llio->name, i);
+            if (r < 0) {
+                HM2_ERR("error %d adding pin '%s.inm.%02d.enc1-count', aborting\n", r, hm2->llio->name, i);
+                goto fail1;
+            }
+            r = hal_pin_new_bool(hm2->llio->comp_id, HAL_IN, &(inst->hal.pin.enc1_reset),
+                                 0, "%s.inm.%02d.enc1-reset", hm2->llio->name, i);
+            if (r < 0) {
+                HM2_ERR("error %d adding pin '%s.inm.%02d.enc1-reset', aborting\n", r, hm2->llio->name, i);
+                goto fail1;
+            }
+        }
+
+        if (inst->enc2_present) {
+            r = hal_pin_new_si32(hm2->llio->comp_id, HAL_OUT, &(inst->hal.pin.enc2_count),
+                                 0, "%s.inm.%02d.enc2-count", hm2->llio->name, i);
+            if (r < 0) {
+                HM2_ERR("error %d adding pin '%s.inm.%02d.enc2-count', aborting\n", r, hm2->llio->name, i);
+                goto fail1;
+            }
+            r = hal_pin_new_bool(hm2->llio->comp_id, HAL_IN, &(inst->hal.pin.enc2_reset),
+                                 0, "%s.inm.%02d.enc2-reset", hm2->llio->name, i);
+            if (r < 0) {
+                HM2_ERR("error %d adding pin '%s.inm.%02d.enc2-reset', aborting\n", r, hm2->llio->name, i);
+                goto fail1;
+              }
+        }
+        if (inst->enc3_present) {
+            r = hal_pin_new_si32(hm2->llio->comp_id, HAL_OUT, &(inst->hal.pin.enc3_count),
+                                 0, "%s.inm.%02d.enc3-count", hm2->llio->name, i);
+            if (r < 0) {
+                HM2_ERR("error %d adding pin '%s.inm.%02d.enc3-count', aborting\n", r, hm2->llio->name, i);
+                goto fail1;
+            }
+            r = hal_pin_new_bool(hm2->llio->comp_id, HAL_IN, &(inst->hal.pin.enc3_reset),
+                                 0, "%s.inm.%02d.enc3-reset", hm2->llio->name, i);
+            if (r < 0) {
+                HM2_ERR("error %d adding pin '%s.inm.%02d.enc3-reset', aborting\n", r, hm2->llio->name, i);
+                goto fail1;
             }
         }
     }
 
     //
-    // Set inm default scanrate and filter values 
+    // Set inm default scanrate and filter values
     // and remove initial MPG offset
 
-    {
-        int i;
-        int rawmpgs;
-        for (i = 0; i < hm2->inm.num_instances; i ++) {
-            hm2->inm.instance[i].hal.param.scan_rate = 20000; // 20 KHz = 50 usec/scan
-            hm2->inm.instance[i].hal.param.slow_scans = 500;  // 500*50 usec = 25 ms
-            hm2->inm.instance[i].hal.param.fast_scans = 5;   //  5*50 usec = 250 usec
-            hm2->llio->read(hm2->llio,hm2->inm.mpg_read_addr + (i * md->instance_stride),&rawmpgs, sizeof(rtapi_u32));
-            if (hm2->inm.instance[i].enc0_present)   { hm2->inm.instance[i].prev_enc0_count = (rtapi_s32)((rawmpgs >>  0) & 0x000000FF); } 
-            if (hm2->inm.instance[i].enc1_present)   { hm2->inm.instance[i].prev_enc1_count = (rtapi_s32)((rawmpgs >>  8) & 0x000000FF); } 
-            if (hm2->inm.instance[i].enc2_present)   { hm2->inm.instance[i].prev_enc2_count = (rtapi_s32)((rawmpgs >> 16) & 0x000000FF); } 
-            if (hm2->inm.instance[i].enc3_present)   { hm2->inm.instance[i].prev_enc3_count = (rtapi_s32)((rawmpgs >> 24) & 0x000000FF); } 
-
-        }
-
+    for (int i = 0; i < hm2->inm.num_instances; i ++) {
+        hm2_inm_instance_t *inst = &hm2->inm.instance[i];
+        rtapi_u32 rawmpgs;
+        hm2->llio->read(hm2->llio,hm2->inm.mpg_read_addr + (i * md->instance_stride),&rawmpgs, sizeof(rtapi_u32));
+        if (inst->enc0_present)   { inst->prev_enc0_count = (rtapi_s32)((rawmpgs >>  0) & 0x000000FF); }
+        if (inst->enc1_present)   { inst->prev_enc1_count = (rtapi_s32)((rawmpgs >>  8) & 0x000000FF); }
+        if (inst->enc2_present)   { inst->prev_enc2_count = (rtapi_s32)((rawmpgs >> 16) & 0x000000FF); }
+        if (inst->enc3_present)   { inst->prev_enc3_count = (rtapi_s32)((rawmpgs >> 24) & 0x000000FF); }
     }
 
     return hm2->inm.num_instances;
@@ -420,24 +417,24 @@ void hm2_inm_force_write(hostmot2_t *hm2) {
 
     // setup control register and mpg_write
     for (i = 0; i < hm2->inm.num_instances; i ++) {
-        scanrate = hm2->inm.instance[i].scanwidth * hm2->inm.instance[i].hal.param.scan_rate;
+        hm2_inm_instance_t *inst = &hm2->inm.instance[i];
+        scanrate = inst->scanwidth * hal_get_ui32(inst->hal.param.scan_rate);
 	if (scanrate > 10000000) {
             scanrate = 10000000;
-	    hm2->inm.instance[i].hal.param.scan_rate = scanrate/hm2->inm.instance[i].scanwidth;
+	    hal_set_ui32(inst->hal.param.scan_rate, scanrate/inst->scanwidth);
         }
         divisor = (hm2->inm.clock_frequency / (4 * scanrate)) - 1;
-	if (hm2->inm.instance[i].hal.param.fast_scans > 63) {
-            hm2->inm.instance[i].hal.param.fast_scans = 63;
+        rtapi_u32 fast_scans = hal_get_ui32(inst->hal.param.fast_scans);
+	if (fast_scans > 63) {
+            fast_scans = hal_set_ui32(inst->hal.param.fast_scans, 63);
         }
-        if (hm2->inm.instance[i].hal.param.slow_scans > 1023) {
-            hm2->inm.instance[i].hal.param.slow_scans = 1023;
+        rtapi_u32 slow_scans = hal_get_ui32(inst->hal.param.slow_scans);
+        if (slow_scans > 1023) {
+            slow_scans = hal_set_ui32(inst->hal.param.slow_scans, 1023);
         }
 
-         hm2->inm.control_reg[i] = (1 << 5) +  
-//       global invert bit(5) fixed to true for now as this matches all existing hardware
-	(divisor << 6) +
-        (hm2->inm.instance[i].hal.param.fast_scans  << 16) +
-        (hm2->inm.instance[i].hal.param.slow_scans  << 22);
+        // global invert bit(5) fixed to true for now as this matches all existing hardware
+        hm2->inm.control_reg[i] = (1 << 5) + (divisor << 6) + (fast_scans << 16) + (slow_scans << 22);
     }
 
     size = hm2->inm.num_instances * sizeof(rtapi_u32);
@@ -467,69 +464,69 @@ void hm2_inm_write(hostmot2_t *hm2) {
 
 
     for (i = 0; i < hm2->inm.num_instances; i ++) {
-        scanrate = hm2->inm.instance[i].scanwidth * hm2->inm.instance[i].hal.param.scan_rate;
+        hm2_inm_instance_t *inst = &hm2->inm.instance[i];
+        scanrate = inst->scanwidth * hal_get_ui32(inst->hal.param.scan_rate);
 //      bound scanrate maximum frequency
 	if (scanrate > 10000000) {
             scanrate = 10000000;
-	    hm2->inm.instance[i].hal.param.scan_rate = scanrate/hm2->inm.instance[i].scanwidth;
-            HM2_ERR("inm %d scanrate too high, resetting to %d \n", i,hm2->inm.instance[i].hal.param.scan_rate);
+	    hal_set_ui32(inst->hal.param.scan_rate, scanrate/inst->scanwidth);
+            HM2_ERR("inm %d scanrate too high, resetting to %d \n", i, hal_get_ui32(inst->hal.param.scan_rate));
         }
         divisor = (hm2->inm.clock_frequency / (4 * scanrate)) - 1;
 //      bound divisor so we dont splatter into other fields
 	if ((divisor > 1023 ) | (scanrate == 0 )) {
             divisor = 1023;
-	    hm2->inm.instance[i].hal.param.scan_rate = (hm2->inm.clock_frequency/4)/(divisor +1)
-            /hm2->inm.instance[i].scanwidth;
-            HM2_ERR("inm %d scanrate too low, resetting to %d \n", i,hm2->inm.instance[i].hal.param.scan_rate);
+	    hal_set_ui32(inst->hal.param.scan_rate, (hm2->inm.clock_frequency/4)/(divisor +1)
+            /inst->scanwidth);
+            HM2_ERR("inm %d scanrate too low, resetting to %d \n", i, hal_get_ui32(inst->hal.param.scan_rate));
         }
-	if (hm2->inm.instance[i].hal.param.fast_scans > 63) {
-            hm2->inm.instance[i].hal.param.fast_scans = 63;
+        rtapi_u32 fast_scans = hal_get_ui32(inst->hal.param.fast_scans);
+	if (fast_scans > 63) {
+            fast_scans = hal_set_ui32(inst->hal.param.fast_scans, 63);
             HM2_ERR("inm %d fastscans must be less than 63, resetting to %d \n", i,63);
         }
-        if (hm2->inm.instance[i].hal.param.slow_scans > 1023) {
-            hm2->inm.instance[i].hal.param.slow_scans = 1023;
+        rtapi_u32 slow_scans = hal_get_ui32(inst->hal.param.slow_scans);
+        if (slow_scans > 1023) {
+            slow_scans = hal_set_ui32(inst->hal.param.slow_scans, 1023);
             HM2_ERR("inm %d slowscans  must be less than 1023, resetting to %d \n", i,1023);
         }
-        if (hm2->inm.instance[i].hal.param.fast_scans < 1 ) {
-            hm2->inm.instance[i].hal.param.fast_scans = 1;
+        if (fast_scans < 1 ) {
+            fast_scans = hal_set_ui32(inst->hal.param.fast_scans, 1);
             HM2_ERR("inm %d fastscans must be greater than 0, resetting to %d \n", i,1);
         }
-        if (hm2->inm.instance[i].hal.param.slow_scans < 1) {
-            hm2->inm.instance[i].hal.param.slow_scans = 1;
+        if (slow_scans < 1) {
+            slow_scans = hal_set_ui32(inst->hal.param.slow_scans, 1);
             HM2_ERR("inm %d slowscans must be greater than 0, resetting to %d \n", i,1);
         }
 
-         hm2->inm.control_reg[i] = (1 << 5) +  
-//       global invert bit(5) fixed to true for now as this matches all existing hardware)
-        (divisor << 6) +
-        (hm2->inm.instance[i].hal.param.fast_scans  << 16) +
-        (hm2->inm.instance[i].hal.param.slow_scans  << 22);
-        if (hm2->inm.control_reg[i] != hm2->inm.instance[i].written_control_reg) {
+        // global invert bit(5) fixed to true for now as this matches all existing hardware)
+        hm2->inm.control_reg[i] = (1 << 5) + (divisor << 6) + (fast_scans << 16) + (slow_scans  << 22);
+        if (hm2->inm.control_reg[i] != inst->written_control_reg) {
             hm2->llio->write(hm2->llio, hm2->inm.control_addr, hm2->inm.control_reg, size);
-            hm2->inm.instance[i].written_control_reg = hm2->inm.control_reg[i];
+            inst->written_control_reg = hm2->inm.control_reg[i];
 //            HM2_PRINT(" Debug: updating inm control reg to = 0x%08X\n", hm2->inm.control_reg[i]);
         }
         hm2->inm.filter_reg[i] = 0;
         for (j = 0; j < hm2->num_pins; j++){
             if (hm2->pin[j].sec_tag == HM2_GTAG_INM && hm2->pin[j].sec_unit == i) {
                 inm_number = (hm2->pin[j].sec_pin & 0x7f) - 1;
-                hm2->inm.filter_reg[i] |= (*hm2->inm.instance[i].hal.pin.slow[inm_number] << inm_number);
+                hm2->inm.filter_reg[i] |= (hal_get_bool(inst->hal.pin.slow[inm_number]) << inm_number);
             }
         }
-        if (hm2->inm.filter_reg[i] != hm2->inm.instance[i].written_filter_reg) {
+        if (hm2->inm.filter_reg[i] != inst->written_filter_reg) {
             hm2->llio->write(hm2->llio, hm2->inm.filter_addr, hm2->inm.filter_reg, size);
-            hm2->inm.instance[i].written_filter_reg = hm2->inm.filter_reg[i];
+            inst->written_filter_reg = hm2->inm.filter_reg[i];
 //            HM2_PRINT(" Debug: updating inm filter reg to = 0x%08X\n", hm2->inm.filter_reg[i]);
         }
  
         hm2->inm.mpg_mode_reg[i] =   0;             
-        if (hm2->inm.instance[i].enc0_present) { hm2->inm.mpg_mode_reg[i]   =  hm2->inm.instance[i].hal.param.enc0_mode << 0; }
-        if (hm2->inm.instance[i].enc1_present) { hm2->inm.mpg_mode_reg[i]  |=  hm2->inm.instance[i].hal.param.enc1_mode << 8; }
-        if (hm2->inm.instance[i].enc2_present) { hm2->inm.mpg_mode_reg[i]  |=  hm2->inm.instance[i].hal.param.enc2_mode << 16; }
-        if (hm2->inm.instance[i].enc3_present) { hm2->inm.mpg_mode_reg[i]  |=  hm2->inm.instance[i].hal.param.enc3_mode << 24; }
-        if (hm2->inm.mpg_mode_reg[i] != hm2->inm.instance[i].written_mpg_mode_reg) {
+        if (inst->enc0_present) { hm2->inm.mpg_mode_reg[i]   =  hal_get_bool(inst->hal.param.enc0_mode) << 0; }
+        if (inst->enc1_present) { hm2->inm.mpg_mode_reg[i]  |=  hal_get_bool(inst->hal.param.enc1_mode) << 8; }
+        if (inst->enc2_present) { hm2->inm.mpg_mode_reg[i]  |=  hal_get_bool(inst->hal.param.enc2_mode) << 16; }
+        if (inst->enc3_present) { hm2->inm.mpg_mode_reg[i]  |=  hal_get_bool(inst->hal.param.enc3_mode) << 24; }
+        if (hm2->inm.mpg_mode_reg[i] != inst->written_mpg_mode_reg) {
             hm2->llio->write(hm2->llio, hm2->inm.mpg_mode_addr, hm2->inm.mpg_mode_reg, size);
-            hm2->inm.instance[i].written_mpg_mode_reg = hm2->inm.mpg_mode_reg[i];
+            inst->written_mpg_mode_reg = hm2->inm.mpg_mode_reg[i];
 //            HM2_PRINT(" Debug: updating inm mpg mode reg to = 0x%08X\n", hm2->inm.mpg_mode_reg[i]);
         }       
     }
@@ -547,7 +544,7 @@ void hm2_inm_prepare_tram_write(hostmot2_t *hm2) {
         for (j = 0; j < hm2->num_pins; j++){
             if (hm2->pin[j].sec_tag == HM2_GTAG_INM && hm2->pin[j].sec_unit == i) {
                 inm_number = (hm2->pin[j].sec_pin & 0x7f) - 1;
-                hm2->inm.filter_reg[i] |= (*hm2->inm.instance[i].hal.pin.slow[inm_number] << inm_number);
+                hm2->inm.filter_reg[i] |= (hal_get_bool(hm2->inm.instance[i].hal.pin.slow[inm_number]) << inm_number);
             }        
         }
     }
@@ -564,60 +561,69 @@ void hm2_inm_process_tram_read(hostmot2_t *hm2) {
         return;
     }
     for (i = 0; i < hm2->inm.num_instances; i ++) {
+        hm2_inm_instance_t *inst = &hm2->inm.instance[i];
         for (j = 0; j < hm2->num_pins; j++){
             if (hm2->pin[j].sec_tag == HM2_GTAG_INM && hm2->pin[j].sec_unit == i) {
                 inm_number = (hm2->pin[j].sec_pin & 0x7f) - 1;
-                *hm2->inm.instance[i].hal.pin.filt_data[inm_number] = (hm2->inm.filt_data_reg[i] >> inm_number) &1;
-                *hm2->inm.instance[i].hal.pin.raw_data[inm_number] = (hm2->inm.raw_data_reg[i] >> inm_number) &1;
-                *hm2->inm.instance[i].hal.pin.filt_data_not[inm_number] = !((hm2->inm.filt_data_reg[i] >> inm_number) &1);
-                *hm2->inm.instance[i].hal.pin.raw_data_not[inm_number] = !((hm2->inm.raw_data_reg[i] >> inm_number) &1);
+                hal_set_bool(inst->hal.pin.filt_data[inm_number],       (hm2->inm.filt_data_reg[i] >> inm_number) & 1);
+                hal_set_bool(inst->hal.pin.raw_data[inm_number],        (hm2->inm.raw_data_reg[i]  >> inm_number) & 1);
+                hal_set_bool(inst->hal.pin.filt_data_not[inm_number], !((hm2->inm.filt_data_reg[i] >> inm_number) & 1));
+                hal_set_bool(inst->hal.pin.raw_data_not[inm_number],  !((hm2->inm.raw_data_reg[i]  >> inm_number) & 1));
             }
         }
 
-		if (hm2->inm.instance[i].enc0_present)  {
-			raw_count = hm2->inm.mpg_read_reg[i] & 0x000000FF;	
-      	count_diff = (rtapi_s32)raw_count - hm2->inm.instance[i].prev_enc0_count;
-      	hm2->inm.instance[i].prev_enc0_count = hm2->inm.instance[i].prev_enc0_count + count_diff;
-			if (count_diff >  128) count_diff -= 256;
-      	if (count_diff < -128) count_diff += 256;
-			if (*hm2->inm.instance[i].hal.pin.enc0_reset == 0) {
-	   	*hm2->inm.instance[i].hal.pin.enc0_count = *hm2->inm.instance[i].hal.pin.enc0_count + count_diff;
-	   	} else { *hm2->inm.instance[i].hal.pin.enc0_count = 0;}
-		}
-	
-		if (hm2->inm.instance[i].enc1_present)  {
-			raw_count = (hm2->inm.mpg_read_reg[i] >> 8) & 0x000000FF;	
-   	   count_diff = (rtapi_s32)raw_count - hm2->inm.instance[i].prev_enc1_count;
-      	hm2->inm.instance[i].prev_enc1_count = hm2->inm.instance[i].prev_enc1_count + count_diff;
-      	if (count_diff >  128) count_diff -= 256;
-      	if (count_diff < -128) count_diff += 256;
-			if (*hm2->inm.instance[i].hal.pin.enc1_reset == 0) {
-			*hm2->inm.instance[i].hal.pin.enc1_count = *hm2->inm.instance[i].hal.pin.enc1_count + count_diff;
-	   	} else { *hm2->inm.instance[i].hal.pin.enc1_count = 0;}
-		}
-	
-		if (hm2->inm.instance[i].enc2_present)  {
-			raw_count = (hm2->inm.mpg_read_reg[i] >> 16) & 0x000000FF;	
-			count_diff = (rtapi_s32)raw_count - hm2->inm.instance[i].prev_enc2_count;
-			hm2->inm.instance[i].prev_enc2_count = hm2->inm.instance[i].prev_enc2_count + count_diff;
-   		if (count_diff >  128) count_diff -= 256;
-    		if (count_diff < -128) count_diff += 256;
-			if (*hm2->inm.instance[i].hal.pin.enc2_reset == 0) {
-			*hm2->inm.instance[i].hal.pin.enc2_count = *hm2->inm.instance[i].hal.pin.enc2_count + count_diff;
-	 	  } else { *hm2->inm.instance[i].hal.pin.enc2_count = 0;}
-		}
-		   
-		if (hm2->inm.instance[i].enc3_present)  {
-			raw_count = (hm2->inm.mpg_read_reg[i] >> 24) & 0x000000FF;	
-     	 	count_diff = (rtapi_s32)raw_count - hm2->inm.instance[i].prev_enc3_count;
-      	hm2->inm.instance[i].prev_enc3_count = hm2->inm.instance[i].prev_enc3_count + count_diff;
-      	if (count_diff >  128) count_diff -= 256;
-      	if (count_diff < -128) count_diff += 256;
-			if (*hm2->inm.instance[i].hal.pin.enc3_reset == 0) {
-			*hm2->inm.instance[i].hal.pin.enc3_count = *hm2->inm.instance[i].hal.pin.enc3_count + count_diff;
-	   	} else { *hm2->inm.instance[i].hal.pin.enc3_count = 0;}
-		}
-	}
+        if (inst->enc0_present)  {
+            raw_count = hm2->inm.mpg_read_reg[i] & 0x000000FF;
+            count_diff = (rtapi_s32)raw_count - inst->prev_enc0_count;
+            inst->prev_enc0_count = inst->prev_enc0_count + count_diff;
+            if (count_diff >  128) count_diff -= 256;
+            if (count_diff < -128) count_diff += 256;
+            if (!hal_get_bool(inst->hal.pin.enc0_reset)) {
+                hal_set_si32(inst->hal.pin.enc0_count, hal_get_si32(inst->hal.pin.enc0_count) + count_diff);
+            } else {
+                hal_set_si32(inst->hal.pin.enc0_count, 0);
+            }
+        }
+
+        if (inst->enc1_present)  {
+            raw_count = (hm2->inm.mpg_read_reg[i] >> 8) & 0x000000FF;
+            count_diff = (rtapi_s32)raw_count - inst->prev_enc1_count;
+            inst->prev_enc1_count = inst->prev_enc1_count + count_diff;
+            if (count_diff >  128) count_diff -= 256;
+            if (count_diff < -128) count_diff += 256;
+            if (!hal_get_bool(inst->hal.pin.enc1_reset)) {
+                hal_set_si32(inst->hal.pin.enc1_count, hal_get_si32(inst->hal.pin.enc1_count) + count_diff);
+            } else {
+                hal_set_si32(inst->hal.pin.enc1_count, 0);
+            }
+        }
+
+        if (inst->enc2_present)  {
+            raw_count = (hm2->inm.mpg_read_reg[i] >> 16) & 0x000000FF;
+            count_diff = (rtapi_s32)raw_count - inst->prev_enc2_count;
+            inst->prev_enc2_count = inst->prev_enc2_count + count_diff;
+            if (count_diff >  128) count_diff -= 256;
+            if (count_diff < -128) count_diff += 256;
+            if (!hal_get_bool(inst->hal.pin.enc2_reset)) {
+                hal_set_si32(inst->hal.pin.enc2_count, hal_get_si32(inst->hal.pin.enc2_count) + count_diff);
+            } else {
+                hal_set_si32(inst->hal.pin.enc2_count, 0);
+            }
+        }
+
+        if (inst->enc3_present)  {
+            raw_count = (hm2->inm.mpg_read_reg[i] >> 24) & 0x000000FF;
+            count_diff = (rtapi_s32)raw_count - inst->prev_enc3_count;
+            inst->prev_enc3_count = inst->prev_enc3_count + count_diff;
+            if (count_diff >  128) count_diff -= 256;
+            if (count_diff < -128) count_diff += 256;
+            if (!hal_get_bool(inst->hal.pin.enc3_reset)) {
+                hal_set_si32(inst->hal.pin.enc3_count, hal_get_si32(inst->hal.pin.enc3_count) + count_diff);
+            } else {
+                hal_set_si32(inst->hal.pin.enc3_count, 0);
+            }
+        }
+    }
 }
 
 void hm2_inm_cleanup(hostmot2_t *hm2) {

--- a/src/hal/drivers/mesa-hostmot2/inmux.c
+++ b/src/hal/drivers/mesa-hostmot2/inmux.c
@@ -96,7 +96,7 @@ int hm2_inmux_parse_md(hostmot2_t *hm2, int md_index) {
     hm2->inmux.clock_frequency = md->clock_freq;
     hm2->inmux.version = md->version;
 
-    hm2->inmux.instance = (hm2_inmux_instance_t *)hal_malloc(hm2->inmux.num_instances * sizeof(hm2_inmux_instance_t));
+    hm2->inmux.instance = hal_malloc(hm2->inmux.num_instances * sizeof(*hm2->inmux.instance));
     if (hm2->inmux.instance == NULL) {
         HM2_ERR("out of memory!\n");
         r = -ENOMEM;
@@ -154,199 +154,168 @@ int hm2_inmux_parse_md(hostmot2_t *hm2, int md_index) {
     //
 
     {
-        int i;
-	int temp;
-        char name[HAL_NAME_LEN + 1];
-
-        for (i = 0; i < hm2->inmux.num_instances; i ++) {
-            
-
+        for (int i = 0; i < hm2->inmux.num_instances; i ++) {
+            hm2_inmux_instance_t *inst = &hm2->inmux.instance[i];
             // first do a low level read to determine the per instance scanwidth
+            rtapi_u32 temp;
             hm2->llio->read(hm2->llio,hm2->inmux.control_addr + (i * md->instance_stride),&temp, sizeof(rtapi_u32));
             temp  = (temp & 0x0000001f) +1;
-	    hm2->inmux.instance[i].scanwidth = temp;         
-	    hm2->inmux.instance[i].hal.param.scan_width = temp;
+	    inst->scanwidth = temp;
 
-            rtapi_snprintf(name, sizeof(name), "%s.inmux.%02d.scan_rate", hm2->llio->name, i);
-            r = hal_param_u32_new(name, HAL_RW, &(hm2->inmux.instance[i].hal.param.scan_rate), hm2->llio->comp_id);
+            // init=20000: 20 KHz = 50 usec/scan
+            r = hal_param_new_ui32(hm2->llio->comp_id, HAL_RW, &(inst->hal.param.scan_rate),
+                                  20000, "%s.inmux.%02d.scan_rate", hm2->llio->name, i);
             if (r < 0) {
-                HM2_ERR("error adding param '%s', aborting\n", name);
+                HM2_ERR("error %d adding param '%s.inmux.%02d.scan_rate', aborting\n", r, hm2->llio->name, i);
                 goto fail1;
             }
-            rtapi_snprintf(name, sizeof(name), "%s.inmux.%02d.slow_scans", hm2->llio->name, i);
-            r = hal_param_u32_new(name, HAL_RW, &(hm2->inmux.instance[i].hal.param.slow_scans), hm2->llio->comp_id);
+            // init=500: 500*50 usec = 25 ms
+            r = hal_param_new_ui32(hm2->llio->comp_id, HAL_RW, &(inst->hal.param.slow_scans),
+                                  500, "%s.inmux.%02d.slow_scans", hm2->llio->name, i);
             if (r < 0) {
-                HM2_ERR("error adding param '%s', aborting\n", name);
+                HM2_ERR("error %d adding param '%s.inmux.%02d.slow_scans', aborting\n", r, hm2->llio->name, i);
                 goto fail1;
             } 
-            rtapi_snprintf(name, sizeof(name), "%s.inmux.%02d.fast_scans", hm2->llio->name, i);
-            r = hal_param_u32_new(name, HAL_RW, &(hm2->inmux.instance[i].hal.param.fast_scans), hm2->llio->comp_id);
+            // init=5: 5*50 usec = 250 usec
+            r = hal_param_new_ui32(hm2->llio->comp_id, HAL_RW, &(inst->hal.param.fast_scans),
+                                   5, "%s.inmux.%02d.fast_scans", hm2->llio->name, i);
             if (r < 0) {
-                HM2_ERR("error adding param '%s', aborting\n", name);
+                HM2_ERR("error %d adding param '%s.inmux.%02d.fast_scans', aborting\n", r, hm2->llio->name, i);
                 goto fail1;
             }  
-           rtapi_snprintf(name, sizeof(name), "%s.inmux.%02d.enc0_4xmode", hm2->llio->name, i);
-            r = hal_param_bit_new(name, HAL_RW, &(hm2->inmux.instance[i].hal.param.enc0_mode), hm2->llio->comp_id);
+            r = hal_param_new_bool(hm2->llio->comp_id, HAL_RW, &(inst->hal.param.enc0_mode),
+                                   0, "%s.inmux.%02d.enc0_4xmode", hm2->llio->name, i);
             if (r < 0) {
-                HM2_ERR("error adding param '%s', aborting\n", name);
+                HM2_ERR("error %d adding param '%s.inmux.%02d.enc0_4xmode', aborting\n", r, hm2->llio->name, i);
                 goto fail1;
             }
-            rtapi_snprintf(name, sizeof(name), "%s.inmux.%02d.enc1_4xmode", hm2->llio->name, i);
-            r = hal_param_bit_new(name, HAL_RW, &(hm2->inmux.instance[i].hal.param.enc1_mode), hm2->llio->comp_id);
+            r = hal_param_new_bool(hm2->llio->comp_id, HAL_RW, &(inst->hal.param.enc1_mode),
+                                   0, "%s.inmux.%02d.enc1_4xmode", hm2->llio->name, i);
             if (r < 0) {
-                HM2_ERR("error adding param '%s', aborting\n", name);
+                HM2_ERR("error %d adding param '%s.inmux.%02d.enc1_4xmode', aborting\n", r, hm2->llio->name, i);
                 goto fail1;
             }
-            rtapi_snprintf(name, sizeof(name), "%s.inmux.%02d.enc2_4xmode", hm2->llio->name, i);
-            r = hal_param_bit_new(name, HAL_RW, &(hm2->inmux.instance[i].hal.param.enc2_mode), hm2->llio->comp_id);
+            r = hal_param_new_bool(hm2->llio->comp_id, HAL_RW, &(inst->hal.param.enc2_mode),
+                                   0, "%s.inmux.%02d.enc2_4xmode", hm2->llio->name, i);
             if (r < 0) {
-                HM2_ERR("error adding param '%s', aborting\n", name);
+                HM2_ERR("error %d adding param '%s.inmux.%02d.enc2_4xmode', aborting\n", r, hm2->llio->name, i);
                 goto fail1;
             } 
-            rtapi_snprintf(name, sizeof(name), "%s.inmux.%02d.enc3_4xmode", hm2->llio->name, i);
-            r = hal_param_bit_new(name, HAL_RW, &(hm2->inmux.instance[i].hal.param.enc3_mode), hm2->llio->comp_id);
+            r = hal_param_new_bool(hm2->llio->comp_id, HAL_RW, &(inst->hal.param.enc3_mode),
+                                   0, "%s.inmux.%02d.enc3_4xmode", hm2->llio->name, i);
             if (r < 0) {
-                HM2_ERR("error adding param '%s', aborting\n", name);
+                HM2_ERR("error %d adding param '%s.inmux.%02d.enc3_4xmode', aborting\n", r, hm2->llio->name, i);
                 goto fail1;
             }
-            rtapi_snprintf(name, sizeof(name), "%s.inmux.%02d.scan_width", hm2->llio->name, i);
-            r = hal_param_u32_new(name, HAL_RO, &(hm2->inmux.instance[i].hal.param.scan_width), hm2->llio->comp_id);
+            r = hal_param_new_ui32(hm2->llio->comp_id, HAL_RO, &(inst->hal.param.scan_width),
+                                  temp, "%s.inmux.%02d.scan_width", hm2->llio->name, i);
             if (r < 0) {
-                HM2_ERR("error adding param '%s', aborting\n", name);
+                HM2_ERR("error %d adding param '%s.inmux.%02d.scan_width', aborting\n", r, hm2->llio->name, i);
                 goto fail1;
             }
 
-            {
-                unsigned j = 0;
-                for (j = 0; j < hm2->inmux.instance[i].scanwidth; j++){
-  
-
-                        rtapi_snprintf(name, sizeof(name), "%s.inmux.%02d.input-%02u", hm2->llio->name, i, j);
-                        r = hal_pin_bit_new(name, HAL_OUT, &(hm2->inmux.instance[i].hal.pin.filt_data[j]), hm2->llio->comp_id);
-                        if (r < 0) {
-                            HM2_ERR("error adding pin '%s', aborting\n", name);
-                            r = -ENOMEM;
-                            goto fail1;
-                        }
-                         rtapi_snprintf(name, sizeof(name), "%s.inmux.%02d.raw-input-%02u", hm2->llio->name, i, j);
-                        r = hal_pin_bit_new(name, HAL_OUT, &(hm2->inmux.instance[i].hal.pin.raw_data[j]), hm2->llio->comp_id);
-                        if (r < 0) {
-                            HM2_ERR("error adding pin '%s', aborting\n", name);
-                            r = -ENOMEM;
-                            goto fail1;
-                        }
-                        rtapi_snprintf(name, sizeof(name), "%s.inmux.%02d.input-%02u-not", hm2->llio->name, i, j);
-                        r = hal_pin_bit_new(name, HAL_OUT, &(hm2->inmux.instance[i].hal.pin.filt_data_not[j]), hm2->llio->comp_id);
-                        if (r < 0) {
-                            HM2_ERR("error adding pin '%s', aborting\n", name);
-                            r = -ENOMEM;
-                            goto fail1;
-                        }
-                         rtapi_snprintf(name, sizeof(name), "%s.inmux.%02d.raw-input-%02u-not", hm2->llio->name, i, j);
-                        r = hal_pin_bit_new(name, HAL_OUT, &(hm2->inmux.instance[i].hal.pin.raw_data_not[j]), hm2->llio->comp_id);
-                        if (r < 0) {
-                            HM2_ERR("error adding pin '%s', aborting\n", name);
-                            r = -ENOMEM;
-                            goto fail1;
-                        }
-                        rtapi_snprintf(name, sizeof(name), "%s.inmux.%02d.input-%02u-slow", hm2->llio->name, i, j);
-                        r = hal_pin_bit_new(name, HAL_IN, &(hm2->inmux.instance[i].hal.pin.slow[j]), hm2->llio->comp_id);
-                        if (r < 0) {
-                            HM2_ERR("error adding pin '%s', aborting\n", name);
-                            r = -ENOMEM;
-                            goto fail1;
-                        }
-                   }
-
-                rtapi_snprintf(name, sizeof(name), "%s.inmux.%02d.enc0-count", hm2->llio->name, i);
-                r = hal_pin_s32_new(name, HAL_OUT, &(hm2->inmux.instance[i].hal.pin.enc0_count), hm2->llio->comp_id);
+            for (unsigned j = 0; j < inst->scanwidth; j++) {
+                r = hal_pin_new_bool(hm2->llio->comp_id, HAL_OUT, &(inst->hal.pin.filt_data[j]),
+                                     0, "%s.inmux.%02d.input-%02u", hm2->llio->name, i, j);
                 if (r < 0) {
-                    HM2_ERR("error adding pin '%s', aborting\n", name);
-                    r = -ENOMEM;
+                    HM2_ERR("error %d adding pin '%s.inmux.%02d.input-%02u', aborting\n", r, hm2->llio->name, i, j);
                     goto fail1;
                 }
-
-                rtapi_snprintf(name, sizeof(name), "%s.inmux.%02d.enc1-count", hm2->llio->name, i);
-                r = hal_pin_s32_new(name, HAL_OUT, &(hm2->inmux.instance[i].hal.pin.enc1_count), hm2->llio->comp_id);
+                r = hal_pin_new_bool(hm2->llio->comp_id, HAL_OUT, &(inst->hal.pin.raw_data[j]),
+                                     0, "%s.inmux.%02d.raw-input-%02u", hm2->llio->name, i, j);
                 if (r < 0) {
-                    HM2_ERR("error adding pin '%s', aborting\n", name);
-                    r = -ENOMEM;
+                    HM2_ERR("error %d adding pin '%s.inmux.%02d.raw-input-%02u', aborting\n", r, hm2->llio->name, i, j);
                     goto fail1;
                 }
-
-                rtapi_snprintf(name, sizeof(name), "%s.inmux.%02d.enc2-count", hm2->llio->name, i);
-                r = hal_pin_s32_new(name, HAL_OUT, &(hm2->inmux.instance[i].hal.pin.enc2_count), hm2->llio->comp_id);
+                r = hal_pin_new_bool(hm2->llio->comp_id, HAL_OUT, &(inst->hal.pin.filt_data_not[j]),
+                                     0, "%s.inmux.%02d.input-%02u-not", hm2->llio->name, i, j);
                 if (r < 0) {
-                    HM2_ERR("error adding pin '%s', aborting\n", name);
-                    r = -ENOMEM;
+                    HM2_ERR("error %d adding pin '%s.inmux.%02d.input-%02u-not', aborting\n", r, hm2->llio->name, i, j);
                     goto fail1;
                 }
-
-                rtapi_snprintf(name, sizeof(name), "%s.inmux.%02d.enc3-count", hm2->llio->name, i);
-                r = hal_pin_s32_new(name, HAL_OUT, &(hm2->inmux.instance[i].hal.pin.enc3_count), hm2->llio->comp_id);
+                r = hal_pin_new_bool(hm2->llio->comp_id, HAL_OUT, &(inst->hal.pin.raw_data_not[j]),
+                                     0, "%s.inmux.%02d.raw-input-%02u-not", hm2->llio->name, i, j);
                 if (r < 0) {
-                    HM2_ERR("error adding pin '%s', aborting\n", name);
-                    r = -ENOMEM;
+                    HM2_ERR("error %d adding pin '%s.inmux.%02d.raw-input-%02u-not', aborting\n", r, hm2->llio->name, i, j);
                     goto fail1;
                 }
-
-                rtapi_snprintf(name, sizeof(name), "%s.inmux.%02d.enc0-reset", hm2->llio->name, i);
-                r = hal_pin_bit_new(name, HAL_IN, &(hm2->inmux.instance[i].hal.pin.enc0_reset), hm2->llio->comp_id);
+                r = hal_pin_new_bool(hm2->llio->comp_id, HAL_IN, &(inst->hal.pin.slow[j]),
+                                     0, "%s.inmux.%02d.input-%02u-slow", hm2->llio->name, i, j);
                 if (r < 0) {
-                    HM2_ERR("error adding pin '%s', aborting\n", name);
-                    r = -ENOMEM;
+                    HM2_ERR("error %d adding pin '%s.inmux.%02d.input-%02u-slow', aborting\n", r, hm2->llio->name, i, j);
                     goto fail1;
                 }
-
-                rtapi_snprintf(name, sizeof(name), "%s.inmux.%02d.enc1-reset", hm2->llio->name, i);
-                r = hal_pin_bit_new(name, HAL_IN, &(hm2->inmux.instance[i].hal.pin.enc1_reset), hm2->llio->comp_id);
-                if (r < 0) {
-                    HM2_ERR("error adding pin '%s', aborting\n", name);
-                    r = -ENOMEM;
-                    goto fail1;
-                }
-
-                rtapi_snprintf(name, sizeof(name), "%s.inmux.%02d.enc2-reset", hm2->llio->name, i);
-                r = hal_pin_bit_new(name, HAL_IN, &(hm2->inmux.instance[i].hal.pin.enc2_reset), hm2->llio->comp_id);
-                if (r < 0) {
-                    HM2_ERR("error adding pin '%s', aborting\n", name);
-                    r = -ENOMEM;
-                    goto fail1;
-                }
-
-                rtapi_snprintf(name, sizeof(name), "%s.inmux.%02d.enc3-reset", hm2->llio->name, i);
-                r = hal_pin_bit_new(name, HAL_IN, &(hm2->inmux.instance[i].hal.pin.enc3_reset), hm2->llio->comp_id);
-                if (r < 0) {
-                    HM2_ERR("error adding pin '%s', aborting\n", name);
-                    r = -ENOMEM;
-                    goto fail1;
-                }
-
             }
 
+            r = hal_pin_new_si32(hm2->llio->comp_id, HAL_OUT, &(inst->hal.pin.enc0_count),
+                                0, "%s.inmux.%02d.enc0-count", hm2->llio->name, i);
+            if (r < 0) {
+                HM2_ERR("error %d adding pin '%s.inmux.%02d.enc0-count', aborting\n", r, hm2->llio->name, i);
+                goto fail1;
+            }
+
+            r = hal_pin_new_si32(hm2->llio->comp_id, HAL_OUT, &(inst->hal.pin.enc1_count),
+                                0, "%s.inmux.%02d.enc1-count", hm2->llio->name, i);
+            if (r < 0) {
+                HM2_ERR("error %d adding pin '%s.inmux.%02d.enc1-count', aborting\n", r, hm2->llio->name, i);
+                goto fail1;
+            }
+
+            r = hal_pin_new_si32(hm2->llio->comp_id, HAL_OUT, &(inst->hal.pin.enc2_count),
+                                0, "%s.inmux.%02d.enc2-count", hm2->llio->name, i);
+            if (r < 0) {
+                HM2_ERR("error %d adding pin '%s.inmux.%02d.enc2-count', aborting\n", r, hm2->llio->name, i);
+                goto fail1;
+            }
+
+            r = hal_pin_new_si32(hm2->llio->comp_id, HAL_OUT, &(inst->hal.pin.enc3_count),
+                                0, "%s.inmux.%02d.enc3-count", hm2->llio->name, i);
+            if (r < 0) {
+                HM2_ERR("error %d adding pin '%s.inmux.%02d.enc3-count', aborting\n", r, hm2->llio->name, i);
+                goto fail1;
+            }
+
+            r = hal_pin_new_bool(hm2->llio->comp_id, HAL_IN, &(inst->hal.pin.enc0_reset),
+                                 0, "%s.inmux.%02d.enc0-reset", hm2->llio->name, i);
+            if (r < 0) {
+                HM2_ERR("error %d adding pin '%s.inmux.%02d.enc0-reset', aborting\n", r, hm2->llio->name, i);
+                goto fail1;
+            }
+
+            r = hal_pin_new_bool(hm2->llio->comp_id, HAL_IN, &(inst->hal.pin.enc1_reset),
+                                 0, "%s.inmux.%02d.enc1-reset", hm2->llio->name, i);
+            if (r < 0) {
+                HM2_ERR("error %d adding pin '%s.inmux.%02d.enc1-reset', aborting\n", r, hm2->llio->name, i);
+                goto fail1;
+            }
+
+            r = hal_pin_new_bool(hm2->llio->comp_id, HAL_IN, &(inst->hal.pin.enc2_reset),
+                                 0, "%s.inmux.%02d.enc2-reset", hm2->llio->name, i);
+            if (r < 0) {
+                HM2_ERR("error %d adding pin '%s.inmux.%02d.enc2-reset', aborting\n", r, hm2->llio->name, i);
+                goto fail1;
+            }
+
+            r = hal_pin_new_bool(hm2->llio->comp_id, HAL_IN, &(inst->hal.pin.enc3_reset),
+                                 0, "%s.inmux.%02d.enc3-reset", hm2->llio->name, i);
+            if (r < 0) {
+                HM2_ERR("error %d adding pin '%s.inmux.%02d.enc3-reset', aborting\n", r, hm2->llio->name, i);
+                goto fail1;
+            }
         }
-
     }
 
     //
     // Set inmux default scanrate and filter values 
     // and remove initial MPG offset
 
-    {
-        int i;
-        int rawmpgs;
-        for (i = 0; i < hm2->inmux.num_instances; i ++) {
-            hm2->inmux.instance[i].hal.param.scan_rate = 20000; // 20 KHz = 50 usec/scan
-            hm2->inmux.instance[i].hal.param.slow_scans = 500;  // 500*50 usec = 25 ms
-            hm2->inmux.instance[i].hal.param.fast_scans = 5;   //  5*50 usec = 250 usec
-            hm2->llio->read(hm2->llio,hm2->inmux.mpg_read_addr + (i * md->instance_stride),&rawmpgs, sizeof(rtapi_u32));
-            hm2->inmux.instance[i].prev_enc0_count = (rtapi_s32)((rawmpgs >>  0) & 0x000000FF); 
-            hm2->inmux.instance[i].prev_enc1_count = (rtapi_s32)((rawmpgs >>  8) & 0x000000FF); 
-            hm2->inmux.instance[i].prev_enc2_count = (rtapi_s32)((rawmpgs >> 16) & 0x000000FF); 
-            hm2->inmux.instance[i].prev_enc3_count = (rtapi_s32)((rawmpgs >> 24) & 0x000000FF); 
-
-        }
-
+    for (int i = 0; i < hm2->inmux.num_instances; i ++) {
+        rtapi_u32 rawmpgs;
+        hm2->llio->read(hm2->llio,hm2->inmux.mpg_read_addr + (i * md->instance_stride), &rawmpgs, sizeof(rtapi_u32));
+        hm2->inmux.instance[i].prev_enc0_count = (rtapi_s32)((rawmpgs >>  0) & 0x000000FF);
+        hm2->inmux.instance[i].prev_enc1_count = (rtapi_s32)((rawmpgs >>  8) & 0x000000FF);
+        hm2->inmux.instance[i].prev_enc2_count = (rtapi_s32)((rawmpgs >> 16) & 0x000000FF);
+        hm2->inmux.instance[i].prev_enc3_count = (rtapi_s32)((rawmpgs >> 24) & 0x000000FF);
     }
 
     return hm2->inmux.num_instances;
@@ -373,24 +342,24 @@ void hm2_inmux_force_write(hostmot2_t *hm2) {
 
     // setup control register and mpg_write
     for (i = 0; i < hm2->inmux.num_instances; i ++) {
-        muxrate = hm2->inmux.instance[i].scanwidth * hm2->inmux.instance[i].hal.param.scan_rate;
+        hm2_inmux_instance_t *inst = &hm2->inmux.instance[i];
+        muxrate = inst->scanwidth * hal_get_ui32(inst->hal.param.scan_rate);
 	if (muxrate > 5000000) {
             muxrate = 5000000;
-	    hm2->inmux.instance[i].hal.param.scan_rate = muxrate/hm2->inmux.instance[i].scanwidth;
+	    hal_set_ui32(inst->hal.param.scan_rate, muxrate/inst->scanwidth);
         }
         divisor = (hm2->inmux.clock_frequency / (4 * muxrate)) - 1;
-	if (hm2->inmux.instance[i].hal.param.fast_scans > 63) {
-            hm2->inmux.instance[i].hal.param.fast_scans = 63;
+        rtapi_u32 fast_scans = hal_get_ui32(inst->hal.param.fast_scans);
+	if (fast_scans > 63) {
+            fast_scans = hal_set_ui32(inst->hal.param.fast_scans, 63);
         }
-        if (hm2->inmux.instance[i].hal.param.slow_scans > 1023) {
-            hm2->inmux.instance[i].hal.param.slow_scans = 1023;
+        rtapi_u32 slow_scans = hal_get_ui32(inst->hal.param.slow_scans);
+        if (slow_scans > 1023) {
+            slow_scans = hal_set_ui32(inst->hal.param.slow_scans, 1023);
         }
 
-         hm2->inmux.control_reg[i] = (1 << 5) +  
-//       global invert bit(5) fixed to true for now as this matches all existing hardware
-	(divisor << 6) +
-        (hm2->inmux.instance[i].hal.param.fast_scans  << 16) +
-        (hm2->inmux.instance[i].hal.param.slow_scans  << 22);
+         // global invert bit(5) fixed to true for now as this matches all existing hardware
+         hm2->inmux.control_reg[i] = (1 << 5) + (divisor << 6) + (fast_scans << 16) + (slow_scans << 22);
     }
 
     size = hm2->inmux.num_instances * sizeof(rtapi_u32);
@@ -404,7 +373,6 @@ void hm2_inmux_force_write(hostmot2_t *hm2) {
     for (i = 0; i < hm2->inmux.num_instances; i ++) {
         hm2->inmux.instance[i].written_control_reg = hm2->inmux.control_reg[i];
         hm2->inmux.instance[i].written_mpg_mode_reg = hm2->inmux.mpg_mode_reg[i];
-
     }
 }
 
@@ -418,66 +386,66 @@ void hm2_inmux_write(hostmot2_t *hm2) {
 
 
     for (i = 0; i < hm2->inmux.num_instances; i ++) {
-        muxrate = hm2->inmux.instance[i].scanwidth * hm2->inmux.instance[i].hal.param.scan_rate;
+        hm2_inmux_instance_t *inst = &hm2->inmux.instance[i];
+        muxrate = inst->scanwidth * hal_get_ui32(inst->hal.param.scan_rate);
 //      bound muxrate maximum frequency
 	if (muxrate > 5000000) {
             muxrate = 5000000;
-	    hm2->inmux.instance[i].hal.param.scan_rate = muxrate/hm2->inmux.instance[i].scanwidth;
-            HM2_ERR("InMux %d scanrate too high, resetting to %d \n", i,hm2->inmux.instance[i].hal.param.scan_rate);
+	    hal_set_ui32(inst->hal.param.scan_rate, muxrate/inst->scanwidth);
+            HM2_ERR("InMux %d scanrate too high, resetting to %d \n", i, hal_get_ui32(inst->hal.param.scan_rate));
         }
         divisor = (hm2->inmux.clock_frequency / (4 * muxrate)) - 1;
 //      bound divisor so we dont splatter into other fields
 	if ((divisor > 1023 ) | (muxrate == 0 )) {
             divisor = 1023;
-	    hm2->inmux.instance[i].hal.param.scan_rate = (hm2->inmux.clock_frequency/4)/(divisor +1)
-            /hm2->inmux.instance[i].scanwidth;
-            HM2_ERR("InMux %d scanrate too low, resetting to %d \n", i,hm2->inmux.instance[i].hal.param.scan_rate);
+	    hal_set_ui32(inst->hal.param.scan_rate,
+                (hm2->inmux.clock_frequency/4) / (divisor +1) / inst->scanwidth);
+            HM2_ERR("InMux %d scanrate too low, resetting to %d \n", i, hal_get_ui32(inst->hal.param.scan_rate));
         }
-	if (hm2->inmux.instance[i].hal.param.fast_scans > 63) {
-            hm2->inmux.instance[i].hal.param.fast_scans = 63;
+        rtapi_u32 fast_scans = hal_get_ui32(inst->hal.param.fast_scans);
+	if (fast_scans > 63) {
+            fast_scans = hal_set_ui32(inst->hal.param.fast_scans, 63);
             HM2_ERR("InMux %d fastscans must be less than 63, resetting to %d \n", i,63);
         }
-        if (hm2->inmux.instance[i].hal.param.slow_scans > 1023) {
-            hm2->inmux.instance[i].hal.param.slow_scans = 1023;
+        rtapi_u32 slow_scans = hal_get_ui32(inst->hal.param.slow_scans);
+        if (slow_scans > 1023) {
+            slow_scans = hal_set_ui32(inst->hal.param.slow_scans, 1023);
             HM2_ERR("InMux %d slowscans  must be less than 1023, resetting to %d \n", i,1023);
         }
-	if (hm2->inmux.instance[i].hal.param.fast_scans < 1 ) {
-            hm2->inmux.instance[i].hal.param.fast_scans = 1;
+	if (fast_scans < 1 ) {
+            fast_scans = hal_set_ui32(inst->hal.param.fast_scans, 1);
             HM2_ERR("InMux %d fastscans must be greater than 0, resetting to %d \n", i,1);
         }
-        if (hm2->inmux.instance[i].hal.param.slow_scans < 1) {
-            hm2->inmux.instance[i].hal.param.slow_scans = 1;
+        if (slow_scans < 1) {
+            slow_scans = hal_set_ui32(inst->hal.param.slow_scans, 1);
             HM2_ERR("InMux %d slowscans must be greater than 0, resetting to %d \n", i,1);
         }
 
-         hm2->inmux.control_reg[i] = (1 << 5) +  
-//       global invert bit(5) fixed to true for now as this matches all existing hardware)
-	(divisor << 6) +
-        (hm2->inmux.instance[i].hal.param.fast_scans  << 16) +
-        (hm2->inmux.instance[i].hal.param.slow_scans  << 22);
-        if (hm2->inmux.control_reg[i] != hm2->inmux.instance[i].written_control_reg) {
+        // global invert bit(5) fixed to true for now as this matches all existing hardware)
+        hm2->inmux.control_reg[i] = (1 << 5) +  (divisor << 6) + (fast_scans << 16) + (slow_scans << 22);
+        if (hm2->inmux.control_reg[i] != inst->written_control_reg) {
             hm2->llio->write(hm2->llio, hm2->inmux.control_addr, hm2->inmux.control_reg, size);
-            hm2->inmux.instance[i].written_control_reg = hm2->inmux.control_reg[i];
+            inst->written_control_reg = hm2->inmux.control_reg[i];
 //            HM2_PRINT(" Debug: updating inmux control reg to = 0x%08X\n", hm2->inmux.control_reg[i]);
         }
         hm2->inmux.filter_reg[i] = 0;
-	for (unsigned j = 0; j < hm2->inmux.instance[i].scanwidth; j ++) {
-            hm2->inmux.filter_reg[i] |= (*hm2->inmux.instance[i].hal.pin.slow[j] << j);
+	for (unsigned j = 0; j < inst->scanwidth; j ++) {
+            hm2->inmux.filter_reg[i] |= (hal_get_bool(inst->hal.pin.slow[j]) << j);
         }
-        if (hm2->inmux.filter_reg[i] != hm2->inmux.instance[i].written_filter_reg) {
+        if (hm2->inmux.filter_reg[i] != inst->written_filter_reg) {
             hm2->llio->write(hm2->llio, hm2->inmux.filter_addr, hm2->inmux.filter_reg, size);
-            hm2->inmux.instance[i].written_filter_reg = hm2->inmux.filter_reg[i];
+            inst->written_filter_reg = hm2->inmux.filter_reg[i];
 //            HM2_PRINT(" Debug: updating inmux filter reg to = 0x%08X\n", hm2->inmux.filter_reg[i]);
         }
         
 	hm2->inmux.mpg_mode_reg[i] =        
-	hm2->inmux.instance[i].hal.param.enc0_mode << 0  |
-        hm2->inmux.instance[i].hal.param.enc1_mode << 8  |
-        hm2->inmux.instance[i].hal.param.enc2_mode << 16 |
-        hm2->inmux.instance[i].hal.param.enc3_mode << 24;
-        if (hm2->inmux.mpg_mode_reg[i] != hm2->inmux.instance[i].written_mpg_mode_reg) {
+	hal_get_bool(inst->hal.param.enc0_mode) << 0  |
+        hal_get_bool(inst->hal.param.enc1_mode) << 8  |
+        hal_get_bool(inst->hal.param.enc2_mode) << 16 |
+        hal_get_bool(inst->hal.param.enc3_mode) << 24;
+        if (hm2->inmux.mpg_mode_reg[i] != inst->written_mpg_mode_reg) {
             hm2->llio->write(hm2->llio, hm2->inmux.mpg_mode_addr, hm2->inmux.mpg_mode_reg, size);
-            hm2->inmux.instance[i].written_mpg_mode_reg = hm2->inmux.mpg_mode_reg[i];
+            inst->written_mpg_mode_reg = hm2->inmux.mpg_mode_reg[i];
 //            HM2_PRINT(" Debug: updating inmux mpg mode reg to = 0x%08X\n", hm2->inmux.mpg_mode_reg[i]);
         }       
     }
@@ -491,7 +459,7 @@ void hm2_inmux_prepare_tram_write(hostmot2_t *hm2) {
     for (i = 0; i < hm2->inmux.num_instances; i ++) {
         hm2->inmux.filter_reg[i] = 0;
         for (unsigned j = 0; j < hm2->inmux.instance[i].scanwidth; j ++) {
-            hm2->inmux.filter_reg[i] |= (*hm2->inmux.instance[i].hal.pin.slow[j] << j);
+            hm2->inmux.filter_reg[i] |= (hal_get_bool(hm2->inmux.instance[i].hal.pin.slow[j]) << j);
         }
     }
 }
@@ -505,45 +473,54 @@ void hm2_inmux_process_tram_read(hostmot2_t *hm2) {
         return;
     }
     for (i = 0; i < hm2->inmux.num_instances; i ++) {
-        for (unsigned j = 0; j < hm2->inmux.instance[i].scanwidth; j ++) {
-           *hm2->inmux.instance[i].hal.pin.filt_data[j] = (hm2->inmux.filt_data_reg[i] >> j) &1;
-           *hm2->inmux.instance[i].hal.pin.raw_data[j] = (hm2->inmux.raw_data_reg[i] >> j) &1;
-           *hm2->inmux.instance[i].hal.pin.filt_data_not[j] = !((hm2->inmux.filt_data_reg[i] >> j) &1);
-           *hm2->inmux.instance[i].hal.pin.raw_data_not[j] = !((hm2->inmux.raw_data_reg[i] >> j) &1);
+        hm2_inmux_instance_t *inst = &hm2->inmux.instance[i];
+        for (unsigned j = 0; j < inst->scanwidth; j ++) {
+           hal_set_bool(inst->hal.pin.filt_data[j],       (hm2->inmux.filt_data_reg[i] >> j) & 1);
+           hal_set_bool(inst->hal.pin.raw_data[j],        (hm2->inmux.raw_data_reg[i]  >> j) & 1);
+           hal_set_bool(inst->hal.pin.filt_data_not[j], !((hm2->inmux.filt_data_reg[i] >> j) & 1));
+           hal_set_bool(inst->hal.pin.raw_data_not[j],  !((hm2->inmux.raw_data_reg[i]  >> j) & 1));
         }
 
-	raw_count = hm2->inmux.mpg_read_reg[i] & 0x000000FF;	
-        count_diff = (rtapi_s32)raw_count - hm2->inmux.instance[i].prev_enc0_count;
-        hm2->inmux.instance[i].prev_enc0_count = hm2->inmux.instance[i].prev_enc0_count + count_diff;
+        raw_count = hm2->inmux.mpg_read_reg[i] & 0x000000FF;
+        count_diff = (rtapi_s32)raw_count - inst->prev_enc0_count;
+        inst->prev_enc0_count = inst->prev_enc0_count + count_diff;
         if (count_diff >  128) count_diff -= 256;
         if (count_diff < -128) count_diff += 256;
-	if (*hm2->inmux.instance[i].hal.pin.enc0_reset == 0) {
-	    *hm2->inmux.instance[i].hal.pin.enc0_count = *hm2->inmux.instance[i].hal.pin.enc0_count + count_diff;
-	    } else { *hm2->inmux.instance[i].hal.pin.enc0_count = 0;}
-	raw_count = (hm2->inmux.mpg_read_reg[i] >> 8) & 0x000000FF;	
-        count_diff = (rtapi_s32)raw_count - hm2->inmux.instance[i].prev_enc1_count;
-        hm2->inmux.instance[i].prev_enc1_count = hm2->inmux.instance[i].prev_enc1_count + count_diff;
+        if (!hal_get_bool(inst->hal.pin.enc0_reset)) {
+            hal_set_si32(inst->hal.pin.enc0_count, hal_get_si32(inst->hal.pin.enc0_count) + count_diff);
+        } else {
+            hal_set_si32(inst->hal.pin.enc0_count, 0);
+        }
+        raw_count = (hm2->inmux.mpg_read_reg[i] >> 8) & 0x000000FF;
+        count_diff = (rtapi_s32)raw_count - inst->prev_enc1_count;
+        inst->prev_enc1_count = inst->prev_enc1_count + count_diff;
         if (count_diff >  128) count_diff -= 256;
         if (count_diff < -128) count_diff += 256;
-	if (*hm2->inmux.instance[i].hal.pin.enc1_reset == 0) {
-	    *hm2->inmux.instance[i].hal.pin.enc1_count = *hm2->inmux.instance[i].hal.pin.enc1_count + count_diff;
-	    } else { *hm2->inmux.instance[i].hal.pin.enc1_count = 0;}
-	raw_count = (hm2->inmux.mpg_read_reg[i] >> 16) & 0x000000FF;	
-        count_diff = (rtapi_s32)raw_count - hm2->inmux.instance[i].prev_enc2_count;
-        hm2->inmux.instance[i].prev_enc2_count = hm2->inmux.instance[i].prev_enc2_count + count_diff;
+        if (!hal_get_bool(inst->hal.pin.enc1_reset)) {
+            hal_set_si32(inst->hal.pin.enc1_count, hal_get_si32(inst->hal.pin.enc1_count) + count_diff);
+        } else {
+            hal_set_si32(inst->hal.pin.enc1_count, 0);
+        }
+        raw_count = (hm2->inmux.mpg_read_reg[i] >> 16) & 0x000000FF;
+        count_diff = (rtapi_s32)raw_count - inst->prev_enc2_count;
+        inst->prev_enc2_count = inst->prev_enc2_count + count_diff;
         if (count_diff >  128) count_diff -= 256;
         if (count_diff < -128) count_diff += 256;
-	if (*hm2->inmux.instance[i].hal.pin.enc2_reset == 0) {
-	    *hm2->inmux.instance[i].hal.pin.enc2_count = *hm2->inmux.instance[i].hal.pin.enc2_count + count_diff;
-	    } else { *hm2->inmux.instance[i].hal.pin.enc2_count = 0;}
-	raw_count = (hm2->inmux.mpg_read_reg[i] >> 24) & 0x000000FF;	
-        count_diff = (rtapi_s32)raw_count - hm2->inmux.instance[i].prev_enc3_count;
-        hm2->inmux.instance[i].prev_enc3_count = hm2->inmux.instance[i].prev_enc3_count + count_diff;
+        if (!hal_get_bool(inst->hal.pin.enc2_reset)) {
+            hal_set_si32(inst->hal.pin.enc2_count, hal_get_si32(inst->hal.pin.enc2_count) + count_diff);
+        } else {
+            hal_set_si32(inst->hal.pin.enc2_count, 0);
+        }
+        raw_count = (hm2->inmux.mpg_read_reg[i] >> 24) & 0x000000FF;
+        count_diff = (rtapi_s32)raw_count - inst->prev_enc3_count;
+        inst->prev_enc3_count = inst->prev_enc3_count + count_diff;
         if (count_diff >  128) count_diff -= 256;
         if (count_diff < -128) count_diff += 256;
-	if (*hm2->inmux.instance[i].hal.pin.enc3_reset == 0) {
-	    *hm2->inmux.instance[i].hal.pin.enc3_count = *hm2->inmux.instance[i].hal.pin.enc3_count + count_diff;
-	    } else { *hm2->inmux.instance[i].hal.pin.enc3_count = 0;}
+        if (!hal_get_bool(inst->hal.pin.enc3_reset)) {
+            hal_set_si32(inst->hal.pin.enc3_count, hal_get_si32(inst->hal.pin.enc3_count) + count_diff);
+        } else {
+            hal_set_si32(inst->hal.pin.enc3_count, 0);
+        }
     }
 }
 

--- a/src/hal/drivers/mesa-hostmot2/ioport.c
+++ b/src/hal/drivers/mesa-hostmot2/ioport.c
@@ -246,7 +246,7 @@ int hm2_ioport_gpio_export_hal(hostmot2_t *hm2) {
 
     for (i = 0; i < hm2->num_pins; i ++) {
         // all pins get *some* gpio HAL presence
-        hm2->pin[i].instance = (hm2_gpio_instance_t *)hal_malloc(sizeof(hm2_gpio_instance_t));
+        hm2->pin[i].instance = hal_malloc(sizeof(*hm2->pin[i].instance));
         if (hm2->pin[i].instance == NULL) {
             HM2_ERR("out of memory!\n");
             return -ENOMEM;
@@ -259,29 +259,17 @@ int hm2_ioport_gpio_export_hal(hostmot2_t *hm2) {
         //
 
         // pins
-        r = hal_pin_bit_newf(
-            HAL_OUT,
-            &(hm2->pin[i].instance->hal.pin.in),
-            hm2->llio->comp_id,
-            "%s.gpio.%03d.in",
-            hm2->llio->name,
-            i
-        );
+        r = hal_pin_new_bool(hm2->llio->comp_id, HAL_OUT, &(hm2->pin[i].instance->hal.pin.in),
+                             0, "%s.gpio.%03d.in", hm2->llio->name, i);
         if (r < 0) {
-            HM2_ERR("error %d adding gpio pin, aborting\n", r);
+            HM2_ERR("error %d adding pin '%s.gpio.%03d.in', aborting\n", r, hm2->llio->name, i);
             return -EINVAL;
         }
 
-        r = hal_pin_bit_newf(
-            HAL_OUT,
-            &(hm2->pin[i].instance->hal.pin.in_not),
-            hm2->llio->comp_id,
-            "%s.gpio.%03d.in_not",
-            hm2->llio->name,
-            i
-        );
+        r = hal_pin_new_bool(hm2->llio->comp_id, HAL_OUT, &(hm2->pin[i].instance->hal.pin.in_not),
+                             0, "%s.gpio.%03d.in_not", hm2->llio->name, i);
         if (r < 0) {
-            HM2_ERR("error %d adding gpio pin, aborting\n", r);
+            HM2_ERR("error %d adding pin '%s.gpio.%03d.in_not', aborting\n", r, hm2->llio->name, i);
             return -EINVAL;
         }
 
@@ -295,34 +283,31 @@ int hm2_ioport_gpio_export_hal(hostmot2_t *hm2) {
             || (hm2->pin[i].direction_at_start == HM2_PIN_DIR_IS_OUTPUT)
         ) {
 
-            r = hal_param_bit_newf(
-                HAL_RW,
-                &(hm2->pin[i].instance->hal.param.invert_output),
-                hm2->llio->comp_id,
-                "%s.gpio.%03d.invert_output",
-                hm2->llio->name,
-                i
-            );
+            r = hal_param_new_bool(hm2->llio->comp_id, HAL_RW, &(hm2->pin[i].instance->hal.param.invert_output),
+                                   0, "%s.gpio.%03d.invert_output", hm2->llio->name, i);
             if (r < 0) {
-                HM2_ERR("error %d adding gpio param, aborting\n", r);
+                HM2_ERR("error %d adding param '%s.gpio.%03d.invert_output', aborting\n", r, hm2->llio->name, i);
                 return -EINVAL;
             }
 
-            r = hal_param_bit_newf(
-                HAL_RW,
-                &(hm2->pin[i].instance->hal.param.is_opendrain),
-                hm2->llio->comp_id,
-                "%s.gpio.%03d.is_opendrain",
-                hm2->llio->name,
-                i
-            );
+            r = hal_param_new_bool(hm2->llio->comp_id, HAL_RW, &(hm2->pin[i].instance->hal.param.is_opendrain),
+                                   0, "%s.gpio.%03d.is_opendrain", hm2->llio->name, i);
             if (r < 0) {
-                HM2_ERR("error %d adding gpio param, aborting\n", r);
+                HM2_ERR("error %d adding param '%s.gpio.%03d.is_opendrain', aborting\n", r, hm2->llio->name, i);
                 return -EINVAL;
             }
-
-            hm2->pin[i].instance->hal.param.invert_output = 0;
-            hm2->pin[i].instance->hal.param.is_opendrain = 0;
+        } else {
+            // Parameters allocated in conditional, make sure their memory is available
+            r = hal_param_new_fake(hm2->llio->comp_id, (hal_refs_u *)&(hm2->pin[i].instance->hal.param.invert_output));
+            if (r < 0) {
+                HM2_ERR("error %d allocating fake param '%s.gpio.%03d.invert_output', aborting\n", r, hm2->llio->name, i);
+                return -EINVAL;
+            }
+            r = hal_param_new_fake(hm2->llio->comp_id, (hal_refs_u *)&(hm2->pin[i].instance->hal.param.is_opendrain));
+            if (r < 0) {
+                HM2_ERR("error %d allocating fake param '%s.gpio.%03d.is_opendrain', aborting\n", r, hm2->llio->name, i);
+                return -EINVAL;
+            }
         }
 
 
@@ -332,36 +317,27 @@ int hm2_ioport_gpio_export_hal(hostmot2_t *hm2) {
 
         if (hm2->pin[i].gtag == HM2_GTAG_IOPORT) {
 
-            r = hal_pin_bit_newf(
-                HAL_IN,
-                &(hm2->pin[i].instance->hal.pin.out),
-                hm2->llio->comp_id,
-                "%s.gpio.%03d.out",
-                hm2->llio->name,
-                i
-            );
+            r = hal_pin_new_bool(hm2->llio->comp_id, HAL_IN, &(hm2->pin[i].instance->hal.pin.out),
+                                 0, "%s.gpio.%03d.out", hm2->llio->name, i);
             if (r < 0) {
-                HM2_ERR("error %d adding gpio pin, aborting\n", r);
+                HM2_ERR("error %d adding pin '%s.gpio.%03d.out', aborting\n", r, hm2->llio->name, i);
                 return -EINVAL;
             }
-
-            *(hm2->pin[i].instance->hal.pin.out) = 0;
 
             // parameters
-            r = hal_param_bit_newf(
-                HAL_RW,
-                &(hm2->pin[i].instance->hal.param.is_output),
-                hm2->llio->comp_id,
-                "%s.gpio.%03d.is_output",
-                hm2->llio->name,
-                i
-            );
+            r = hal_param_new_bool(hm2->llio->comp_id, HAL_RW, &(hm2->pin[i].instance->hal.param.is_output),
+                                   0, "%s.gpio.%03d.is_output", hm2->llio->name, i);
             if (r < 0) {
-                HM2_ERR("error %d adding gpio param, aborting\n", r);
+                HM2_ERR("error %d adding param '%s.gpio.%03d.is_output', aborting\n", r, hm2->llio->name, i);
                 return -EINVAL;
             }
-
-            hm2->pin[i].instance->hal.param.is_output = 0;
+        } else {
+            // Parameter allocated in conditional, make sure its memory is available
+            r = hal_param_new_fake(hm2->llio->comp_id, (hal_refs_u *)&(hm2->pin[i].instance->hal.param.is_output));
+            if (r < 0) {
+                HM2_ERR("error %d allocating fake param '%s.gpio.%03d.is_output', aborting\n", r, hm2->llio->name, i);
+                return -EINVAL;
+            }
         }
 
         // it's an output of some other module
@@ -492,7 +468,7 @@ void hm2_ioport_update(hostmot2_t *hm2) {
             int io_pin = (port * hm2->idrom.port_width) + port_pin;
 
             if (hm2->pin[io_pin].gtag == HM2_GTAG_IOPORT) {
-                if (hm2->pin[io_pin].instance->hal.param.is_output) {
+                if (hal_get_bool(hm2->pin[io_pin].instance->hal.param.is_output)) {
                     hm2->pin[io_pin].direction = HM2_PIN_DIR_IS_OUTPUT;
                 } else {
                     hm2->pin[io_pin].direction = HM2_PIN_DIR_IS_INPUT;
@@ -503,14 +479,14 @@ void hm2_ioport_update(hostmot2_t *hm2) {
                 hm2->ioport.ddr_reg[port] |= (1 << port_pin);  // set the bit in the ddr register
 
                 // Open Drain Register
-                if (hm2->pin[io_pin].instance->hal.param.is_opendrain) {
+                if (hal_get_bool(hm2->pin[io_pin].instance->hal.param.is_opendrain)) {
                     hm2->ioport.open_drain_reg[port] |= (1 << port_pin);  // set the bit in the open drain register
                 } else {
                     hm2->ioport.open_drain_reg[port] &= ~(1 << port_pin);  // clear the bit in the open drain register
                 }
 
                 // Invert Output Register
-                if (hm2->pin[io_pin].instance->hal.param.invert_output) {
+                if (hal_get_bool(hm2->pin[io_pin].instance->hal.param.invert_output)) {
                     hm2->ioport.output_invert_reg[port] |= (1 << port_pin);  // set the bit in the output invert register
                 } else {
                     hm2->ioport.output_invert_reg[port] &= ~(1 << port_pin);  // clear the bit in the output invert register
@@ -598,11 +574,9 @@ void hm2_ioport_gpio_process_tram_read(hostmot2_t *hm2) {
     for (port = 0; port < hm2->ioport.num_instances; port ++) {
         for (unsigned port_pin = 0; port_pin < hm2->idrom.port_width; port_pin ++) {
             int io_pin = (port * hm2->idrom.port_width) + port_pin;
-            hal_bit_t bit;
-
-            bit = (hm2->ioport.data_read_reg[port] >> port_pin) & 0x1;
-            *hm2->pin[io_pin].instance->hal.pin.in = bit;
-            *hm2->pin[io_pin].instance->hal.pin.in_not = !bit;
+            rtapi_bool bit = (hm2->ioport.data_read_reg[port] >> port_pin) & 0x1;
+            hal_set_bool(hm2->pin[io_pin].instance->hal.pin.in, bit);
+            hal_set_bool(hm2->pin[io_pin].instance->hal.pin.in_not, !bit);
         }
     }
 }
@@ -629,7 +603,7 @@ void hm2_ioport_gpio_prepare_tram_write(hostmot2_t *hm2) {
             if (hm2->pin[io_pin].gtag != HM2_GTAG_IOPORT) continue;
 
             hm2->ioport.data_write_reg[port] &= ~(1 << port_pin);   // zero the bit
-            if(*(hm2->pin[io_pin].instance->hal.pin.out))
+            if(hal_get_bool(hm2->pin[io_pin].instance->hal.pin.out))
                 hm2->ioport.data_write_reg[port] |= (1 << port_pin);  // and set if appropriate
         }
     }
@@ -654,13 +628,12 @@ void hm2_ioport_gpio_read(hostmot2_t *hm2) {
     for (port = 0; port < hm2->ioport.num_instances; port ++) {
         for (unsigned port_pin = 0; port_pin < hm2->idrom.port_width; port_pin ++) {
             int io_pin = (port * hm2->idrom.port_width) + port_pin;
-            hal_bit_t bit;
 
             if (hm2->pin[io_pin].direction != HM2_PIN_DIR_IS_INPUT) continue;
 
-            bit = (hm2->ioport.data_read_reg[port] >> port_pin) & 0x1;
-            *hm2->pin[io_pin].instance->hal.pin.in = bit;
-            *hm2->pin[io_pin].instance->hal.pin.in_not = !bit;
+            rtapi_bool bit = (hm2->ioport.data_read_reg[port] >> port_pin) & 0x1;
+            hal_set_bool(hm2->pin[io_pin].instance->hal.pin.in, bit);
+            hal_set_bool(hm2->pin[io_pin].instance->hal.pin.in_not, !bit);
         }
     }
 }
@@ -682,7 +655,7 @@ void hm2_ioport_gpio_write(hostmot2_t *hm2) {
             if (hm2->pin[io_pin].gtag != HM2_GTAG_IOPORT) continue;
 
             hm2->ioport.data_write_reg[port] &= ~(1 << port_pin);   // zero the bit
-            hm2->ioport.data_write_reg[port] |= (*(hm2->pin[io_pin].instance->hal.pin.out) << port_pin);  // and set it as appropriate
+            hm2->ioport.data_write_reg[port] |= (hal_get_bool(hm2->pin[io_pin].instance->hal.pin.out) << port_pin);  // and set it as appropriate
         }
     }
 

--- a/src/hal/drivers/mesa-hostmot2/led.c
+++ b/src/hal/drivers/mesa-hostmot2/led.c
@@ -64,7 +64,7 @@ int hm2_led_parse_md(hostmot2_t *hm2, int md_index) {
 
 
     // allocate the module-global HAL shared memory
-    hm2->led.instance = (hm2_led_instance_t *)hal_malloc(hm2->config.num_leds * sizeof(hm2_led_instance_t));
+    hm2->led.instance = hal_malloc(hm2->config.num_leds * sizeof(*hm2->led.instance));
     if (hm2->led.instance == NULL) {
         HM2_ERR("out of memory!\n");
         r = -ENOMEM;
@@ -84,13 +84,11 @@ int hm2_led_parse_md(hostmot2_t *hm2, int md_index) {
 
     // export to HAL
     {
-        int i;
-        char name[HAL_NAME_LEN+1];
-        for (i = 0 ; i < hm2->config.num_leds ; i++) {
-            rtapi_snprintf(name, sizeof(name), "%s.led.CR%02d", hm2->llio->name, i + 1 );
-            r = hal_pin_bit_new(name, HAL_IN, &(hm2->led.instance[i].led), hm2->llio->comp_id);
+        for (int i = 0 ; i < hm2->config.num_leds ; i++) {
+            r = hal_pin_new_bool(hm2->llio->comp_id, HAL_IN, &(hm2->led.instance[i].led),
+                                 0, "%s.led.CR%02d", hm2->llio->name, i + 1);
             if (r < 0) {
-                HM2_ERR("error adding pin '%s', aborting\n", name);
+                HM2_ERR("error %d adding pin '%s.led.CR%02d', aborting\n", r, hm2->llio->name, i + 1);
                 goto fail1;
             }
         }
@@ -111,7 +109,7 @@ void hm2_led_write(hostmot2_t *hm2) {
     int i;
 
     for (i = 0 ; i < hm2->config.num_leds; i++ ) {
-        if (*hm2->led.instance[i].led) {
+        if (hal_get_bool(hm2->led.instance[i].led)) {
             regval |= 1 << (31 - i);
         }
     }

--- a/src/hal/drivers/mesa-hostmot2/modbus/mesa_modbus.c.tmpl
+++ b/src/hal/drivers/mesa-hostmot2/modbus/mesa_modbus.c.tmpl
@@ -114,19 +114,19 @@ enum {
 };
 
 typedef struct {
-    hal_data_u **pins;
-    hal_float_t **scale;
-    hal_data_u **pin2;
+    hal_refs_u *pins;
+    hal_real_t *scale;
+    hal_refs_u *pin2;
     rtapi_s64 *buff;
-    hal_bit_t *fault;
-    hal_u32_t *last_err;
-    hal_s32_t address;
-    hal_s32_t baudrate;
-    hal_s32_t parity;
-    hal_s32_t txdelay;
-    hal_s32_t rxdelay;
-    hal_s32_t drive_delay;
-    hal_float_t rate;
+    hal_bool_t fault;
+    hal_uint_t last_err;
+    hal_sint_t address;
+    hal_sint_t baudrate;
+    hal_sint_t parity;
+    hal_sint_t txdelay;
+    hal_sint_t rxdelay;
+    hal_sint_t drive_delay;
+    hal_real_t rate;
 } hm2_modbus_hal_t;
 
 typedef struct {
@@ -219,12 +219,12 @@ int rtapi_app_main(void){
             inst->num_pins += channels[c].count;
         }
         // Malloc structs and pins, some in main or kernel memory, some in HAL
-        inst->chans = (hm2_modbus_channel_t *)rtapi_kmalloc(inst->num_chans * sizeof(hm2_modbus_channel_t), RTAPI_GFP_KERNEL);
-        inst->hal =   (hm2_modbus_hal_t *) hal_malloc(sizeof(hm2_modbus_hal_t));
-        inst->hal->pins =  (hal_data_u **) hal_malloc(inst->num_pins * sizeof(hal_data_u));
-        inst->hal->scale = (hal_float_t **)hal_malloc(inst->num_pins * sizeof(hal_float_t));
-        inst->hal->pin2 =  (hal_data_u **) hal_malloc(inst->num_pins * sizeof(hal_data_u));
-        inst->hal->buff =  (rtapi_s64 *) hal_malloc(inst->num_pins * sizeof(rtapi_s64));
+        inst->chans = (hm2_modbus_channel_t *)rtapi_kmalloc(inst->num_chans * sizeof(*inst->chans), RTAPI_GFP_KERNEL);
+        inst->hal = hal_malloc(sizeof(*inst->hal));
+        inst->hal->pins  = hal_malloc(inst->num_pins * sizeof(*inst->hal->pins));
+        inst->hal->scale = hal_malloc(inst->num_pins * sizeof(*inst->hal->scale));
+        inst->hal->pin2  = hal_malloc(inst->num_pins * sizeof(*inst->hal->pin2));
+        inst->hal->buff  = hal_malloc(inst->num_pins * sizeof(*inst->hal->buff));
         
         rtapi_strlcpy(inst->port, ports[i], HAL_NAME_LEN);
 
@@ -234,28 +234,19 @@ int rtapi_app_main(void){
             goto fail0;
         }
 
-        retval =  hal_param_s32_newf(HAL_RW, &(inst->hal->address), comp_id, COMP_NAME".%02i.address", i);
-        retval += hal_param_s32_newf(HAL_RW, &(inst->hal->baudrate), comp_id, COMP_NAME".%02i.baudrate", i);
-        retval += hal_param_s32_newf(HAL_RW, &(inst->hal->parity), comp_id, COMP_NAME".%02i.parity", i);
-        retval += hal_param_s32_newf(HAL_RW, &(inst->hal->txdelay), comp_id, COMP_NAME".%02i.txdelay", i);
-        retval += hal_param_s32_newf(HAL_RW, &(inst->hal->rxdelay), comp_id, COMP_NAME".%02i.rxdelay", i);
-        retval += hal_param_s32_newf(HAL_RW, &(inst->hal->drive_delay), comp_id, COMP_NAME".%02i.drive-delay", i);
-        retval += hal_param_float_newf(HAL_RW, &(inst->hal->rate), comp_id, COMP_NAME".%02i.update-hz", i);
-        retval += hal_pin_bit_newf(HAL_OUT, &(inst->hal->fault), comp_id, COMP_NAME".%02i.fault", i);
-        retval += hal_pin_u32_newf(HAL_OUT, &(inst->hal->last_err), comp_id, COMP_NAME".%02i.last-error", i);
+        retval =  hal_param_new_si32(comp_id, HAL_RW, &(inst->hal->address), 0x01, COMP_NAME".%02i.address", i);
+        retval += hal_param_new_si32(comp_id, HAL_RW, &(inst->hal->baudrate), 9600, COMP_NAME".%02i.baudrate", i);
+        retval += hal_param_new_si32(comp_id, HAL_RW, &(inst->hal->parity), 0, COMP_NAME".%02i.parity", i);
+        retval += hal_param_new_si32(comp_id, HAL_RW, &(inst->hal->txdelay), 20, COMP_NAME".%02i.txdelay", i);
+        retval += hal_param_new_si32(comp_id, HAL_RW, &(inst->hal->rxdelay), 15, COMP_NAME".%02i.rxdelay", i);
+        retval += hal_param_new_si32(comp_id, HAL_RW, &(inst->hal->drive_delay), 0, COMP_NAME".%02i.drive-delay", i);
+        retval += hal_param_new_real(comp_id, HAL_RW, &(inst->hal->rate), 0.0, COMP_NAME".%02i.update-hz", i);
+        retval += hal_pin_new_bool(comp_id, HAL_OUT, &(inst->hal->fault), 0, COMP_NAME".%02i.fault", i);
+        retval += hal_pin_new_ui32(comp_id, HAL_OUT, &(inst->hal->last_err), 0, COMP_NAME".%02i.last-error", i);
         if (retval < 0) {
             rtapi_print_msg(RTAPI_MSG_ERR, COMP_NAME" ERROR: failed to create one or more pins/parameters\n");
             goto fail0;
         }
-
-        inst->hal->address = 0x01;
-        inst->hal->baudrate = 9600;
-        inst->hal->parity = 0;
-        inst->hal->txdelay = 20;      // should generally be larger than Rx Delay
-        inst->hal->rxdelay = 15;
-        inst->hal->drive_delay = 0;   // delay between setting drive enable and sending data
-        *(inst->hal->fault) = 0;
-        *(inst->hal->last_err) = 0;
 
         inst->state = START;
                     
@@ -295,15 +286,15 @@ int rtapi_app_main(void){
                 case 2: // read inputs
                     if (ch->count > 1){
                         for (j = 0; j < ch->count; j++){
-                            retval = hal_pin_bit_newf(dir,
-                                    (hal_bit_t**)&(inst->hal->pins[p++]),
-                                    comp_id, COMP_NAME".%02i.%s-%02i",
+                            retval = hal_pin_new_bool(comp_id, dir,
+                                    &(inst->hal->pins[p++].b),
+                                    0, COMP_NAME".%02i.%s-%02i",
                                     i, channels[c].name, j);
                         }
                     } else {
-                        retval = hal_pin_bit_newf(dir,
-                                    (hal_bit_t**)&(inst->hal->pins[p++]),
-                                            comp_id, COMP_NAME".%02i.%s",
+                        retval = hal_pin_new_bool(comp_id, dir,
+                                    &(inst->hal->pins[p++].b),
+                                            0, COMP_NAME".%02i.%s",
                                             i, channels[c].name);
                     }
                     break;
@@ -331,79 +322,77 @@ int rtapi_app_main(void){
                         switch (ch->type){
                         case HAL_U32:
                             if (ch->count > 1) {
-                                retval = hal_pin_u32_newf(dir,
-                                    (hal_u32_t**)&(inst->hal->pins[p]),
-                                    comp_id, COMP_NAME".%02i.%s-%02i",
+                                retval = hal_pin_new_ui32(comp_id, dir,
+                                    &(inst->hal->pins[p].u),
+                                    0, COMP_NAME".%02i.%s-%02i",
                                     i, channels[c].name, j);
                             } else {
-                                retval = hal_pin_u32_newf(dir,
-                                    (hal_u32_t**)&(inst->hal->pins[p]),
-                                    comp_id, COMP_NAME".%02i.%s",
+                                retval = hal_pin_new_ui32(comp_id, dir,
+                                    &(inst->hal->pins[p].u),
+                                    0, COMP_NAME".%02i.%s",
                                     i, channels[c].name);
                             }
                             p++;
                             break;
                         case HAL_S32:
                             if (ch->count > 1) {
-                                retval = hal_pin_s32_newf(dir,
-                                    (hal_s32_t**)&(inst->hal->pins[p]),
-                                    comp_id, COMP_NAME".%02i.%s-%02i",
+                                retval = hal_pin_new_si32(comp_id, dir,
+                                    &(inst->hal->pins[p].s),
+                                    0, COMP_NAME".%02i.%s-%02i",
                                     i, channels[c].name, j);
-                                retval = hal_pin_float_newf(HAL_IN,
-                                    (hal_float_t**)&(inst->hal->scale[p]),
-                                    comp_id, COMP_NAME".%02i.%s-%02i-scale",
+                                retval = hal_pin_new_real(comp_id, HAL_IN,
+                                    &(inst->hal->scale[p]),
+                                    1.0, COMP_NAME".%02i.%s-%02i-scale",
                                     i, channels[c].name, j);
-                                retval = hal_pin_float_newf(dir,
-                                    (hal_float_t**)&(inst->hal->pin2[p]),
-                                    comp_id, COMP_NAME".%02i.%s-%02i-scaled",
+                                retval = hal_pin_new_real(comp_id, dir,
+                                    &(inst->hal->pin2[p].r),
+                                    0.0, COMP_NAME".%02i.%s-%02i-scaled",
                                     i, channels[c].name, j);
                             } else {
-                                retval = hal_pin_s32_newf(dir,
-                                    (hal_s32_t**)&(inst->hal->pins[p]),
-                                    comp_id, COMP_NAME".%02i.%s",
+                                retval = hal_pin_new_si32(comp_id, dir,
+                                    &(inst->hal->pins[p].s),
+                                    0, COMP_NAME".%02i.%s",
                                     i, channels[c].name);
-                                retval = hal_pin_float_newf(HAL_IN,
-                                    (hal_float_t**)&(inst->hal->scale[p]),
-                                    comp_id, COMP_NAME".%02i.%s-scale",
+                                retval = hal_pin_new_real(comp_id, HAL_IN,
+                                    &(inst->hal->scale[p]),
+                                    1.0, COMP_NAME".%02i.%s-scale",
                                     i, channels[c].name);
-                                retval = hal_pin_float_newf(dir,
-                                    (hal_float_t**)&(inst->hal->pin2[p]),
-                                    comp_id, COMP_NAME".%02i.%s-scaled",
+                                retval = hal_pin_new_real(comp_id, dir,
+                                    &(inst->hal->pin2[p].r),
+                                    0.0, COMP_NAME".%02i.%s-scaled",
                                     i, channels[c].name);
                             }
-                            *inst->hal->scale[p] = 1.0;
                             inst->hal->buff[p] = 0;
                             p++;
                             break;
                         case HAL_FLOAT:
                             if (ch->count > 1) {
-                                retval = hal_pin_float_newf(dir,
-                                    (hal_float_t**)&(inst->hal->pins[p]),
-                                    comp_id, COMP_NAME".%02i.%s-%02i",
+                                retval = hal_pin_new_real(comp_id, dir,
+                                    &(inst->hal->pins[p].r),
+                                    0.0, COMP_NAME".%02i.%s-%02i",
                                     i, channels[c].name, j);
-                                retval = hal_pin_float_newf(HAL_IN,
-                                    (hal_float_t**)&(inst->hal->scale[p]),
-                                    comp_id, COMP_NAME".%02i.%s-%02i-scale",
+                                retval = hal_pin_new_real(comp_id, HAL_IN,
+                                    &(inst->hal->scale[p]),
+                                    1.0, COMP_NAME".%02i.%s-%02i-scale",
                                     i, channels[c].name, j);
-                                retval = hal_pin_float_newf(HAL_IN,
-                                    (hal_float_t**)&(inst->hal->pin2[p]),
-                                    comp_id, COMP_NAME".%02i.%s-%02i-offset",
+                                retval = hal_pin_new_real(comp_id, HAL_IN,
+                                    &(inst->hal->pin2[p].r),
+                                    0.0, COMP_NAME".%02i.%s-%02i-offset",
                                     i, channels[c].name, j);
                             } else {
-                                retval = hal_pin_float_newf(dir,
-                                    (hal_float_t**)&(inst->hal->pins[p]),
-                                    comp_id, COMP_NAME".%02i.%s",
+                                retval = hal_pin_new_real(comp_id, dir,
+                                    &(inst->hal->pins[p].r),
+                                    0.0, COMP_NAME".%02i.%s",
                                     i, channels[c].name);
-                                retval = hal_pin_float_newf(HAL_IN,
-                                    (hal_float_t**)&(inst->hal->scale[p]),
-                                    comp_id, COMP_NAME".%02i.%s-scale",
+                                retval = hal_pin_new_real(comp_id, HAL_IN,
+                                    &(inst->hal->scale[p]),
+                                    1.0, COMP_NAME".%02i.%s-scale",
                                     i, channels[c].name);
-                                retval = hal_pin_float_newf(HAL_IN,
-                                    (hal_float_t**)&(inst->hal->pin2[p]),
-                                    comp_id, COMP_NAME".%02i.%s-offset",
+                                retval = hal_pin_new_real(comp_id, HAL_IN,
+                                    &(inst->hal->pin2[p].r),
+                                    0.0, COMP_NAME".%02i.%s-offset",
                                     i, channels[c].name);
                             }
-                            *(inst->hal->scale[p]) = 1;
                             p++;
                             break;
                         default:
@@ -435,19 +424,19 @@ static int do_setup(hm2_modbus_inst_t *inst){
     
     int retval;
     
-    if    (inst->baudrate    == inst->hal->baudrate
-        && inst->parity      == inst->hal->parity
-        && inst->txdelay     == inst->hal->txdelay
-        && inst->rxdelay     == inst->hal->rxdelay
-        && inst->drive_delay == inst->hal->drive_delay) return 0;
+    if    (inst->baudrate    == hal_get_si32(inst->hal->baudrate)
+        && inst->parity      == hal_get_si32(inst->hal->parity)
+        && inst->txdelay     == hal_get_si32(inst->hal->txdelay)
+        && inst->rxdelay     == hal_get_si32(inst->hal->rxdelay)
+        && inst->drive_delay == hal_get_si32(inst->hal->drive_delay)) return 0;
 
-    if (inst->hal->txdelay > 0xFF) inst->hal->txdelay = 0xFF;
-    if (inst->hal->rxdelay > 0xFF) inst->hal->rxdelay = 0xFF;
-    inst->baudrate    = inst->hal->baudrate;
-    inst->parity      = inst->hal->parity;
-    inst->txdelay     = inst->hal->txdelay;
-    inst->rxdelay     = inst->hal->rxdelay;
-    inst->drive_delay = inst->hal->drive_delay;
+    if (hal_get_si32(inst->hal->txdelay) > 0xFF) hal_set_si32(inst->hal->txdelay, 0xFF);
+    if (hal_get_si32(inst->hal->rxdelay) > 0xFF) hal_set_si32(inst->hal->rxdelay, 0xFF);
+    inst->baudrate    = hal_get_si32(inst->hal->baudrate);
+    inst->parity      = hal_get_si32(inst->hal->parity);
+    inst->txdelay     = hal_get_si32(inst->hal->txdelay);
+    inst->rxdelay     = hal_get_si32(inst->hal->rxdelay);
+    inst->drive_delay = hal_get_si32(inst->hal->drive_delay);
 
     unsigned flg;
     flg  = inst->parity != 0 ? HM2_PKTUART_CONFIG_PARITYEN : 0;
@@ -508,8 +497,8 @@ static void do_timeout(hm2_modbus_inst_t *inst){
         hm2_pktuart_reset(inst->port);
         inst->state = RESET_WAIT;
         inst->iter = 0;
-        *(inst->hal->last_err) = 11;
-        *(inst->hal->fault) = 1;
+        hal_set_ui32(inst->hal->last_err, 11);
+        hal_set_bool(inst->hal->fault, 1);
         inst->chans[inst->index].data[1] = 0xFF; // Write invalid data to force re-send
     }
     rtapi_print_msg(RTAPI_MSG_INFO, "%i timeout %i\r", inst->iter, inst->state);
@@ -518,7 +507,7 @@ static void do_timeout(hm2_modbus_inst_t *inst){
 static void process(void *arg, long period) {
     static long timer = 0;
     hm2_modbus_inst_t *inst = arg;
-    real_t rate;
+    rtapi_real rate;
     int r;
 
     rtapi_u32 rxstatus = hm2_pktuart_get_rx_status(inst->port);
@@ -527,7 +516,7 @@ static void process(void *arg, long period) {
     switch (inst->state) {
         case START:
 
-            rate = inst->hal->rate;
+            rate = hal_get_real(inst->hal->rate);
             if (rate >= RATE_MIN && rate <= RATE_MAX && (timer -= period) > 0) break;
 
             rtapi_print_msg(RTAPI_MSG_INFO, "START txstatus = %08X rxstatus = %08X\n", txstatus, rxstatus);
@@ -619,7 +608,7 @@ static void process(void *arg, long period) {
             rtapi_print_msg(RTAPI_MSG_INFO, "\r");
             if (rxstatus & 0x200000) break;
             inst->state = START;
-            *(inst->hal->fault) = 0;
+            hal_set_bool(inst->hal->fault, 0);
             break;
             
         case RESET_WAIT:
@@ -648,17 +637,17 @@ static int ch_append16(hm2_modbus_channel_t *ch, rtapi_u16 v){
     return r;
 }
     
-static int ch_init(hm2_modbus_channel_t *ch, hm2_modbus_hal_t hal){
+static int ch_init(hm2_modbus_channel_t *ch, hm2_modbus_hal_t *hal){
     int r;
     ch->ptr = -1;
-    r = ch_append8(ch, hal.address);
+    r = ch_append8(ch, hal_get_si32(hal->address));
     r = ch_append8(ch, ch->func);
     return r;
 }
 
 static int build_data_frame(hm2_modbus_inst_t *inst){
     hm2_modbus_channel_t *ch = &(inst->chans[inst->index]);
-    hm2_modbus_hal_t hal = *inst->hal;
+    hm2_modbus_hal_t *hal = inst->hal;
     rtapi_u8 acc = 0;
     int r = 0;
     int p = ch->start_pin;
@@ -679,7 +668,7 @@ static int build_data_frame(hm2_modbus_inst_t *inst){
             break;
         case 5: // Write single coil
             r += ch_append16(ch, ch->addr);
-            if (hal.pins[p]->b){
+            if (hal_get_bool(hal->pins[p].b)){
                 r += ch_append16(ch, 0xFF00);
             } else {
                 r += ch_append16(ch, 0x0000);
@@ -689,15 +678,15 @@ static int build_data_frame(hm2_modbus_inst_t *inst){
             r += ch_append16(ch, ch->addr);
             switch (ch->type){
             case HAL_U32:
-                r += ch_append16(ch, (rtapi_u16)hal.pins[p]->u);
+                r += ch_append16(ch, (rtapi_u16)hal_get_ui32(hal->pins[p].u));
                 break;
             case HAL_S32:
-                r += ch_append16(ch, (rtapi_s16)hal.pins[p]->s);
+                r += ch_append16(ch, (rtapi_s16)hal_get_si32(hal->pins[p].s));
                 break;
             case HAL_FLOAT:
-                rtapi_print_msg(RTAPI_MSG_INFO, "671 %f %f %f \n", hal.pins[p]->f, hal.pin2[p]->f, *hal.scale[p]);
-                if (*hal.scale[p] <= -EPSILON || *hal.scale[p] >= +EPSILON){
-                    r+= ch_append16(ch, (rtapi_u16)((hal.pins[p]->f - hal.pin2[p]->f) / *hal.scale[p])) ;
+                rtapi_print_msg(RTAPI_MSG_INFO, "671 %f %f %f \n", hal_get_real(hal->pins[p].r), hal_get_real(hal->pin2[p].r), hal_get_real(hal->scale[p]));
+                if (hal_get_real(hal->scale[p]) <= -EPSILON || hal_get_real(hal->scale[p]) >= +EPSILON){
+                    r+= ch_append16(ch, (rtapi_u16)((hal_get_real(hal->pins[p].r) - hal_get_real(hal->pin2[p].r)) / hal_get_real(hal->scale[p]))) ;
                 }
                 rtapi_print_msg(RTAPI_MSG_INFO, "678\n");
                 break;
@@ -710,7 +699,7 @@ static int build_data_frame(hm2_modbus_inst_t *inst){
             r += ch_append16(ch, ch->count);
             r += ch_append8(ch, ( ch->count + 8 - 1) / 8);
             for (i = 0; i < ch->count; i++){
-                if (hal.pins[p++]->b) acc += 1 << (i % 8);
+                if (hal_get_bool(hal->pins[p++].b)) acc += 1 << (i % 8);
                 if (i % 8 == 7 || i == (ch->count -1)) { // time for the next byte
                     r += ch_append8(ch, acc);
                     acc = 0;
@@ -724,17 +713,17 @@ static int build_data_frame(hm2_modbus_inst_t *inst){
             for (i = 0; i < ch->count; i++){
                 switch (ch->type){
                 case HAL_U32:
-                    r += ch_append16(ch, (rtapi_u16)hal.pins[p]->u);
+                    r += ch_append16(ch, (rtapi_u16)hal_get_ui32(hal->pins[p].u));
                     break;
                 case HAL_S32:
-                    r += ch_append16(ch, (rtapi_s16)hal.pins[p]->s);
+                    r += ch_append16(ch, (rtapi_s16)hal_get_si32(hal->pins[p].s));
                     break;
                 case HAL_FLOAT:
-                    if (*hal.scale[p] <= -EPSILON  || *hal.scale[p] >= +EPSILON){
-                        r+= ch_append16(ch, (rtapi_u16)((hal.pins[p]->f - hal.pin2[p]->f) / *hal.scale[p])) ;
+                    if (hal_get_real(hal->scale[p]) <= -EPSILON  || hal_get_real(hal->scale[p]) >= +EPSILON){
+                        r+= ch_append16(ch, (rtapi_u16)((hal_get_real(hal->pins[p].r) - hal_get_real(hal->pin2[p].r)) / hal_get_real(hal->scale[p]))) ;
                     } else {
                         // Prevent (near) divide-by-zero and assume scale 1.0
-                        r+= ch_append16(ch, (rtapi_u16)(hal.pins[p]->f - hal.pin2[p]->f));
+                        r+= ch_append16(ch, (rtapi_u16)(hal_get_real(hal->pins[p].r) - hal_get_real(hal->pin2[p].r)));
                     }
                     break;
                 default:
@@ -751,7 +740,7 @@ static int build_data_frame(hm2_modbus_inst_t *inst){
 
 static int parse_data_frame(hm2_modbus_inst_t *inst){
     hm2_modbus_channel_t *ch = &(inst->chans[inst->index]);
-    hm2_modbus_hal_t hal = *inst->hal;
+    hm2_modbus_hal_t *hal = inst->hal;
     rtapi_u32 *data = inst->rxdata;
     int count = inst->fsizes[inst->frame_index] & 0x3FF;
     int i;
@@ -791,7 +780,7 @@ static int parse_data_frame(hm2_modbus_inst_t *inst){
             w = 3;
             b = 0;
             for (i = 0; i < ch->count; i++){
-                hal.pins[p++]->b = (bytes[w] & 1 << b);
+                hal_set_bool(hal->pins[p++].b, (bytes[w] & 1 << b));
                 if (++b >= 8) { b = 0; w++;}
             }
             break;
@@ -801,24 +790,24 @@ static int parse_data_frame(hm2_modbus_inst_t *inst){
             for (i = 0; i < bytes[2] / 2; i++){
                 switch (ch->type){
                 case HAL_U32:
-                    hal.pins[p]->u = 256 * bytes[w] + bytes[w + 1];
+                    hal_set_ui32(hal->pins[p].u, 256 * bytes[w] + bytes[w + 1]);
                     w += 2;
                     p++;
                     break;
                 case HAL_S32: // wrap the result into the (s32) offset too
-                    tmp = hal.pins[p]->s;
-                    hal.pins[p]->s = bytes[w] * 256 + bytes[w + 1];
+                    tmp = hal_get_si32(hal->pins[p].s);
+                    hal_set_si32(hal->pins[p].s, bytes[w] * 256 + bytes[w + 1]);
                     w += 2;
-                    tmp = hal.pins[p]->s - tmp;
+                    tmp = hal_get_si32(hal->pins[p].s) - tmp;
                     if (tmp > 32768) tmp -= 65536;
                     if (tmp < -32768) tmp += 65536;
-                    hal.buff[p] += tmp;
-                    hal.pin2[p]->f = hal.buff[p] * *hal.scale[p];
+                    hal->buff[p] += tmp;
+                    hal_set_real(hal->pin2[p].r, hal->buff[p] * hal_get_real(hal->scale[p]));
                     p++;
                     break;
                 case HAL_FLOAT:
-                    hal.pins[p]->f = (256 * bytes[w] + bytes[w + 1])
-                                    * *(hal.scale[p]) + hal.pin2[p]->f;
+                    hal_set_real(hal->pins[p].r, (256 * bytes[w] + bytes[w + 1])
+                                    * hal_get_real(hal->scale[p]) + hal_get_real(hal->pin2[p].r));
                     w += 2;
                     p++;
                     break;

--- a/src/hal/drivers/mesa-hostmot2/oneshot.c
+++ b/src/hal/drivers/mesa-hostmot2/oneshot.c
@@ -32,74 +32,74 @@
 
 void hm2_oneshot_update_width1(hostmot2_t *hm2, int i) {
     // widths are in ms
-    hm2->oneshot.width1_reg[i] = (double)*hm2->oneshot.instance[i].hal.pin.width1 * ((double)hm2->oneshot.clock_frequency / (double)1e3);
+    hm2->oneshot.width1_reg[i] = hal_get_real(hm2->oneshot.instance[i].hal.pin.width1) * ((double)hm2->oneshot.clock_frequency / (double)1e3);
     if (hm2->oneshot.width1_reg[i] > 0x7FFFFFFF) {
         HM2_ERR("oneshot %d has invalid width1, resetting to max\n", i);
         hm2->oneshot.width1_reg[i] = 0x7FFFFFFF;
-        *hm2->oneshot.instance[i].hal.pin.width1 = (double)hm2->oneshot.width1_reg[i] * ((double)1e3 / (double)hm2->oneshot.clock_frequency);
+        hal_set_real(hm2->oneshot.instance[i].hal.pin.width1, (double)hm2->oneshot.width1_reg[i] * ((double)1e3 / (double)hm2->oneshot.clock_frequency));
     }
 }
 
 void hm2_oneshot_update_width2(hostmot2_t *hm2, int i) {
     // widths are in ms
-    hm2->oneshot.width2_reg[i] = (double)*hm2->oneshot.instance[i].hal.pin.width2 * ((double)hm2->oneshot.clock_frequency / (double)1e3);
+    hm2->oneshot.width2_reg[i] = hal_get_real(hm2->oneshot.instance[i].hal.pin.width2) * ((double)hm2->oneshot.clock_frequency / (double)1e3);
     if (hm2->oneshot.width2_reg[i] > 0x7FFFFFFF) {
         HM2_ERR("oneshot %d has invalid width1, resetting to max\n", i);
         hm2->oneshot.width2_reg[i] = 0x7FFFFFFF;
-        *hm2->oneshot.instance[i].hal.pin.width2 = (double)hm2->oneshot.width2_reg[i] * ((double)1e3 / (double)hm2->oneshot.clock_frequency);
+        hal_set_real(hm2->oneshot.instance[i].hal.pin.width2, (double)hm2->oneshot.width2_reg[i] * ((double)1e3 / (double)hm2->oneshot.clock_frequency));
     }
 }
 
 void hm2_oneshot_update_filter1(hostmot2_t *hm2, int i) {
     // widths are in ms
-    hm2->oneshot.filter1_reg[i] = (double)*hm2->oneshot.instance[i].hal.pin.filter1 * ((double)hm2->oneshot.clock_frequency / (double)1e3);
+    hm2->oneshot.filter1_reg[i] = hal_get_real(hm2->oneshot.instance[i].hal.pin.filter1) * ((double)hm2->oneshot.clock_frequency / (double)1e3);
     if (hm2->oneshot.filter1_reg[i] > 0xFFFFFF) {
         HM2_ERR("oneshot %d has invalid filter1 time, resetting to max\n", i);
         hm2->oneshot.width1_reg[i] = 0xFFFFFF;
-        *hm2->oneshot.instance[i].hal.pin.filter1 = (double)hm2->oneshot.filter1_reg[i] * ((double)1e3 / (double)hm2->oneshot.clock_frequency);
+        hal_set_real(hm2->oneshot.instance[i].hal.pin.filter1, (double)hm2->oneshot.filter1_reg[i] * ((double)1e3 / (double)hm2->oneshot.clock_frequency));
     }
 }
 
 void hm2_oneshot_update_filter2(hostmot2_t *hm2, int i) {
     // widths are in ms
-    hm2->oneshot.filter2_reg[i] = (double)*hm2->oneshot.instance[i].hal.pin.filter2 * ((double)hm2->oneshot.clock_frequency / (double)1e3);
+    hm2->oneshot.filter2_reg[i] = hal_get_real(hm2->oneshot.instance[i].hal.pin.filter2) * ((double)hm2->oneshot.clock_frequency / (double)1e3);
     if (hm2->oneshot.filter2_reg[i] > 0xFFFFFF) {
         HM2_ERR("oneshot %d has invalid filter2 time, resetting to max\n", i);
         hm2->oneshot.width2_reg[i] = 0xFFFFFF;
-        *hm2->oneshot.instance[i].hal.pin.filter2 = (double)hm2->oneshot.filter2_reg[i] * ((double)1e3 / (double)hm2->oneshot.clock_frequency);
+        hal_set_real(hm2->oneshot.instance[i].hal.pin.filter2, (double)hm2->oneshot.filter2_reg[i] * ((double)1e3 / (double)hm2->oneshot.clock_frequency));
     }
 } 
 
 void hm2_oneshot_update_rate(hostmot2_t *hm2, int i) {
-       hm2->oneshot.rate_reg[i] = (uint32_t)(*hm2->oneshot.instance[i].hal.pin.rate * (4294967296.0 / (double)hm2->oneshot.clock_frequency));
+       hm2->oneshot.rate_reg[i] = (uint32_t)(hal_get_real(hm2->oneshot.instance[i].hal.pin.rate) * (4294967296.0 / (double)hm2->oneshot.clock_frequency));
 }
 
 void hm2_oneshot_update_control(hostmot2_t *hm2, int i) {
     rtapi_u32 controlbuff;
-    if(*hm2->oneshot.instance[i].hal.pin.trigselect1 > 7) {
+    if(hal_get_ui32(hm2->oneshot.instance[i].hal.pin.trigselect1) > 7) {
         HM2_ERR("oneshot %d has invalid trigger 1 select value , resetting to 0\n", i);
-		  *hm2->oneshot.instance[i].hal.pin.trigselect1 = 0;
+		  hal_set_ui32(hm2->oneshot.instance[i].hal.pin.trigselect1, 0);
     }     
-	 if(*hm2->oneshot.instance[i].hal.pin.trigselect2 > 7) {
+	 if(hal_get_ui32(hm2->oneshot.instance[i].hal.pin.trigselect2) > 7) {
 	     HM2_ERR("oneshot %d has invalid trigger 2 select value , resetting to 0\n", i);
-		  *hm2->oneshot.instance[i].hal.pin.trigselect2 = 0;
+		  hal_set_ui32(hm2->oneshot.instance[i].hal.pin.trigselect2, 0);
     }     
     controlbuff = 0;
-    controlbuff |= (*hm2->oneshot.instance[i].hal.pin.trigselect1 << 0);
-    controlbuff |= (*hm2->oneshot.instance[i].hal.pin.trigrise1 << 3);
-    controlbuff |= (*hm2->oneshot.instance[i].hal.pin.trigfall1 << 4);
-    controlbuff |= (*hm2->oneshot.instance[i].hal.pin.retrig1 << 5);
-    controlbuff |= (*hm2->oneshot.instance[i].hal.pin.enable1 << 6);
-    controlbuff |= (*hm2->oneshot.instance[i].hal.pin.reset1 << 7);
-    controlbuff |= (*hm2->oneshot.instance[i].hal.pin.swtrig1 << 10);
-    controlbuff |= ((*hm2->oneshot.instance[i].hal.pin.dpll_timer_num & 7) << 12);
-    controlbuff |= (*hm2->oneshot.instance[i].hal.pin.trigselect2 << 16);
-    controlbuff |= (*hm2->oneshot.instance[i].hal.pin.trigrise2 << 19);
-    controlbuff |= (*hm2->oneshot.instance[i].hal.pin.trigfall2 << 20);
-    controlbuff |= (*hm2->oneshot.instance[i].hal.pin.retrig2 << 21);
-    controlbuff |= (*hm2->oneshot.instance[i].hal.pin.enable2 << 22);
-    controlbuff |= (*hm2->oneshot.instance[i].hal.pin.reset2 << 23);
-    controlbuff |= (*hm2->oneshot.instance[i].hal.pin.swtrig2 << 26);
+    controlbuff |= (hal_get_ui32(hm2->oneshot.instance[i].hal.pin.trigselect1) << 0);
+    controlbuff |= (hal_get_bool(hm2->oneshot.instance[i].hal.pin.trigrise1) << 3);
+    controlbuff |= (hal_get_bool(hm2->oneshot.instance[i].hal.pin.trigfall1) << 4);
+    controlbuff |= (hal_get_bool(hm2->oneshot.instance[i].hal.pin.retrig1) << 5);
+    controlbuff |= (hal_get_bool(hm2->oneshot.instance[i].hal.pin.enable1) << 6);
+    controlbuff |= (hal_get_bool(hm2->oneshot.instance[i].hal.pin.reset1) << 7);
+    controlbuff |= (hal_get_bool(hm2->oneshot.instance[i].hal.pin.swtrig1) << 10);
+    controlbuff |= ((hal_get_si32(hm2->oneshot.instance[i].hal.pin.dpll_timer_num) & 7) << 12);
+    controlbuff |= (hal_get_ui32(hm2->oneshot.instance[i].hal.pin.trigselect2) << 16);
+    controlbuff |= (hal_get_bool(hm2->oneshot.instance[i].hal.pin.trigrise2) << 19);
+    controlbuff |= (hal_get_bool(hm2->oneshot.instance[i].hal.pin.trigfall2) << 20);
+    controlbuff |= (hal_get_bool(hm2->oneshot.instance[i].hal.pin.retrig2) << 21);
+    controlbuff |= (hal_get_bool(hm2->oneshot.instance[i].hal.pin.enable2) << 22);
+    controlbuff |= (hal_get_bool(hm2->oneshot.instance[i].hal.pin.reset2) << 23);
+    controlbuff |= (hal_get_bool(hm2->oneshot.instance[i].hal.pin.swtrig2) << 26);
 
 	 hm2->oneshot.control_reg[i] = controlbuff;
 }
@@ -132,7 +132,7 @@ void hm2_oneshot_force_write(hostmot2_t *hm2) {
     hm2->llio->write(hm2->llio, hm2->oneshot.control_addr, hm2->oneshot.control_reg, (hm2->oneshot.num_instances * sizeof(rtapi_u32)));
 
     
-    if ((*hm2->llio->io_error) != 0) return;
+    if (hal_get_bool(*hm2->llio->io_error)) return;
 
 }
 
@@ -201,7 +201,7 @@ int hm2_oneshot_parse_md(hostmot2_t *hm2, int md_index) {
 
 
 
-    hm2->oneshot.instance = (hm2_oneshot_instance_t *)hal_malloc(hm2->oneshot.num_instances * sizeof(hm2_oneshot_instance_t));
+    hm2->oneshot.instance = hal_malloc(hm2->oneshot.num_instances * sizeof(*hm2->oneshot.instance));
     if (hm2->oneshot.instance == NULL) {
         HM2_ERR("out of memory!\n");
         r = -ENOMEM;
@@ -263,204 +263,176 @@ int hm2_oneshot_parse_md(hostmot2_t *hm2, int md_index) {
 
 
     // export to HAL
-    // FIXME: r hides the r in enclosing function, and it returns the wrong thing
     {
-        int i;
-        int r;
-        char name[HAL_NAME_LEN + 1];
-
-
-        for (i = 0; i < hm2->oneshot.num_instances; i ++) {
+        for (int i = 0; i < hm2->oneshot.num_instances; i ++) {
             // pins
-            rtapi_snprintf(name, sizeof(name), "%s.oneshot.%02d.width1", hm2->llio->name, i);
-            r = hal_pin_float_new(name, HAL_IN, &(hm2->oneshot.instance[i].hal.pin.width1), hm2->llio->comp_id);
+            r = hal_pin_new_real(hm2->llio->comp_id, HAL_IN, &(hm2->oneshot.instance[i].hal.pin.width1),
+                                 1.0, "%s.oneshot.%02d.width1", hm2->llio->name, i);
             if (r < 0) {
-                HM2_ERR("error adding pin '%s', aborting\n", name);
+                HM2_ERR("error %d adding pin '%s.oneshot.%02d.width1', aborting\n", r, hm2->llio->name, i);
                 goto fail1;
             }
 
-            rtapi_snprintf(name, sizeof(name), "%s.oneshot.%02d.width2", hm2->llio->name, i);
-            r = hal_pin_float_new(name, HAL_IN, &(hm2->oneshot.instance[i].hal.pin.width2), hm2->llio->comp_id);
+            r = hal_pin_new_real(hm2->llio->comp_id, HAL_IN, &(hm2->oneshot.instance[i].hal.pin.width2),
+                                 1.0, "%s.oneshot.%02d.width2", hm2->llio->name, i);
             if (r < 0) {
-                HM2_ERR("error adding pin '%s', aborting\n", name);
+                HM2_ERR("error %d adding pin '%s.oneshot.%02d.width2', aborting\n", r, hm2->llio->name, i);
                 goto fail1;
             }
 
-            rtapi_snprintf(name, sizeof(name), "%s.oneshot.%02d.filter1", hm2->llio->name, i);
-            r = hal_pin_float_new(name, HAL_IN, &(hm2->oneshot.instance[i].hal.pin.filter1), hm2->llio->comp_id);
+            r = hal_pin_new_real(hm2->llio->comp_id, HAL_IN, &(hm2->oneshot.instance[i].hal.pin.filter1),
+                                 0.1, "%s.oneshot.%02d.filter1", hm2->llio->name, i);
             if (r < 0) {
-                HM2_ERR("error adding pin '%s', aborting\n", name);
+                HM2_ERR("error %d adding pin '%s.oneshot.%02d.filter1', aborting\n", r, hm2->llio->name, i);
                 goto fail1;
             }
 
-            rtapi_snprintf(name, sizeof(name), "%s.oneshot.%02d.filter2", hm2->llio->name, i);
-            r = hal_pin_float_new(name, HAL_IN, &(hm2->oneshot.instance[i].hal.pin.filter2), hm2->llio->comp_id);
+            r = hal_pin_new_real(hm2->llio->comp_id, HAL_IN, &(hm2->oneshot.instance[i].hal.pin.filter2),
+                                 0.1, "%s.oneshot.%02d.filter2", hm2->llio->name, i);
             if (r < 0) {
-                HM2_ERR("error adding pin '%s', aborting\n", name);
+                HM2_ERR("error %d adding pin '%s.oneshot.%02d.filter2', aborting\n", r, hm2->llio->name, i);
                 goto fail1;
             }
 
-            rtapi_snprintf(name, sizeof(name), "%s.oneshot.%02d.rate", hm2->llio->name, i);
-            r = hal_pin_float_new(name, HAL_IN, &(hm2->oneshot.instance[i].hal.pin.rate), hm2->llio->comp_id);
+            r = hal_pin_new_real(hm2->llio->comp_id, HAL_IN, &(hm2->oneshot.instance[i].hal.pin.rate),
+                                 1000.0, "%s.oneshot.%02d.rate", hm2->llio->name, i);
             if (r < 0) {
-                HM2_ERR("error adding pin '%s', aborting\n", name);
+                HM2_ERR("error %d adding pin '%s.oneshot.%02d.rate', aborting\n", r, hm2->llio->name, i);
                 goto fail1;
             }
 
-            rtapi_snprintf(name, sizeof(name), "%s.oneshot.%02d.trigger_select1", hm2->llio->name, i);
-            r = hal_pin_u32_new(name, HAL_IN, &(hm2->oneshot.instance[i].hal.pin.trigselect1), hm2->llio->comp_id);
+            r = hal_pin_new_ui32(hm2->llio->comp_id, HAL_IN, &(hm2->oneshot.instance[i].hal.pin.trigselect1),
+                                 0, "%s.oneshot.%02d.trigger_select1", hm2->llio->name, i);
             if (r < 0) {
-                HM2_ERR("error adding pin '%s', aborting\n", name);
+                HM2_ERR("error %d adding pin '%s.oneshot.%02d.trigger_select1', aborting\n", r, hm2->llio->name, i);
                 goto fail1;
             }
 
-            rtapi_snprintf(name, sizeof(name), "%s.oneshot.%02d.trigger_select2", hm2->llio->name, i);
-            r = hal_pin_u32_new(name, HAL_IN, &(hm2->oneshot.instance[i].hal.pin.trigselect2), hm2->llio->comp_id);
+            r = hal_pin_new_ui32(hm2->llio->comp_id, HAL_IN, &(hm2->oneshot.instance[i].hal.pin.trigselect2),
+                                 0, "%s.oneshot.%02d.trigger_select2", hm2->llio->name, i);
             if (r < 0) {
-                HM2_ERR("error adding pin '%s', aborting\n", name);
+                HM2_ERR("error %d adding pin '%s.oneshot.%02d.trigger_select2', aborting\n", r, hm2->llio->name, i);
                 goto fail1;
             }
 
-            rtapi_snprintf(name, sizeof(name), "%s.oneshot.%02d.dpll_timer_number", hm2->llio->name, i);
-            r = hal_pin_s32_new(name, HAL_IN, &(hm2->oneshot.instance[i].hal.pin.dpll_timer_num), hm2->llio->comp_id);
+            r = hal_pin_new_si32(hm2->llio->comp_id, HAL_IN, &(hm2->oneshot.instance[i].hal.pin.dpll_timer_num),
+                                 0, "%s.oneshot.%02d.dpll_timer_number", hm2->llio->name, i);
             if (r < 0) {
-                HM2_ERR("error adding pin '%s', aborting\n", name);
+                HM2_ERR("error %d adding pin '%s.oneshot.%02d.dpll_timer_number', aborting\n", r, hm2->llio->name, i);
                 goto fail1;
             }
   
-            rtapi_snprintf(name, sizeof(name), "%s.oneshot.%02d.trigger_on_rise1", hm2->llio->name, i);
-            r = hal_pin_bit_new(name, HAL_IN, &(hm2->oneshot.instance[i].hal.pin.trigrise1), hm2->llio->comp_id);
+            r = hal_pin_new_bool(hm2->llio->comp_id, HAL_IN, &(hm2->oneshot.instance[i].hal.pin.trigrise1),
+                                 0, "%s.oneshot.%02d.trigger_on_rise1", hm2->llio->name, i);
             if (r < 0) {
-                HM2_ERR("error adding pin '%s', aborting\n", name);
+                HM2_ERR("error %d adding pin '%s.oneshot.%02d.trigger_on_rise1', aborting\n", r, hm2->llio->name, i);
                 goto fail1;
             }
 
-            rtapi_snprintf(name, sizeof(name), "%s.oneshot.%02d.trigger_on_rise2", hm2->llio->name, i);
-            r = hal_pin_bit_new(name, HAL_IN, &(hm2->oneshot.instance[i].hal.pin.trigrise2), hm2->llio->comp_id);
+            r = hal_pin_new_bool(hm2->llio->comp_id, HAL_IN, &(hm2->oneshot.instance[i].hal.pin.trigrise2),
+                                 0, "%s.oneshot.%02d.trigger_on_rise2", hm2->llio->name, i);
             if (r < 0) {
-                HM2_ERR("error adding pin '%s', aborting\n", name);
+                HM2_ERR("error %d adding pin '%s.oneshot.%02d.trigger_on_rise2', aborting\n", r, hm2->llio->name, i);
                 goto fail1;
             }
 
-            rtapi_snprintf(name, sizeof(name), "%s.oneshot.%02d.trigger_on_fall1", hm2->llio->name, i);
-            r = hal_pin_bit_new(name, HAL_IN, &(hm2->oneshot.instance[i].hal.pin.trigfall1), hm2->llio->comp_id);
+            r = hal_pin_new_bool(hm2->llio->comp_id, HAL_IN, &(hm2->oneshot.instance[i].hal.pin.trigfall1),
+                                 0, "%s.oneshot.%02d.trigger_on_fall1", hm2->llio->name, i);
             if (r < 0) {
-                HM2_ERR("error adding pin '%s', aborting\n", name);
+                HM2_ERR("error %d adding pin '%s.oneshot.%02d.trigger_on_fall1', aborting\n", r, hm2->llio->name, i);
                 goto fail1;
             }
 
-            rtapi_snprintf(name, sizeof(name), "%s.oneshot.%02d.trigger_on_fall2", hm2->llio->name, i);
-            r = hal_pin_bit_new(name, HAL_IN, &(hm2->oneshot.instance[i].hal.pin.trigfall2), hm2->llio->comp_id);
+            r = hal_pin_new_bool(hm2->llio->comp_id, HAL_IN, &(hm2->oneshot.instance[i].hal.pin.trigfall2),
+                                 0, "%s.oneshot.%02d.trigger_on_fall2", hm2->llio->name, i);
             if (r < 0) {
-                HM2_ERR("error adding pin '%s', aborting\n", name);
+                HM2_ERR("error %d adding pin '%s.oneshot.%02d.trigger_on_fall2', aborting\n", r, hm2->llio->name, i);
                 goto fail1;
             }
 
-            rtapi_snprintf(name, sizeof(name), "%s.oneshot.%02d.retriggerable1", hm2->llio->name, i);
-            r = hal_pin_bit_new(name, HAL_IN, &(hm2->oneshot.instance[i].hal.pin.retrig1), hm2->llio->comp_id);
+            r = hal_pin_new_bool(hm2->llio->comp_id, HAL_IN, &(hm2->oneshot.instance[i].hal.pin.retrig1),
+                                 0, "%s.oneshot.%02d.retriggerable1", hm2->llio->name, i);
             if (r < 0) {
-                HM2_ERR("error adding pin '%s', aborting\n", name);
+                HM2_ERR("error %d adding pin '%s.oneshot.%02d.retriggerable1', aborting\n", r, hm2->llio->name, i);
                 goto fail1;
             }
 
-            rtapi_snprintf(name, sizeof(name), "%s.oneshot.%02d.retriggerable2", hm2->llio->name, i);
-            r = hal_pin_bit_new(name, HAL_IN, &(hm2->oneshot.instance[i].hal.pin.retrig2), hm2->llio->comp_id);
+            r = hal_pin_new_bool(hm2->llio->comp_id, HAL_IN, &(hm2->oneshot.instance[i].hal.pin.retrig2),
+                                 0, "%s.oneshot.%02d.retriggerable2", hm2->llio->name, i);
             if (r < 0) {
-                HM2_ERR("error adding pin '%s', aborting\n", name);
+                HM2_ERR("error %d adding pin '%s.oneshot.%02d.retriggerable2', aborting\n", r, hm2->llio->name, i);
                 goto fail1;
             }
 
-            rtapi_snprintf(name, sizeof(name), "%s.oneshot.%02d.enable1", hm2->llio->name, i);
-            r = hal_pin_bit_new(name, HAL_IN, &(hm2->oneshot.instance[i].hal.pin.enable1), hm2->llio->comp_id);
+            r = hal_pin_new_bool(hm2->llio->comp_id, HAL_IN, &(hm2->oneshot.instance[i].hal.pin.enable1),
+                                 0, "%s.oneshot.%02d.enable1", hm2->llio->name, i);
             if (r < 0) {
-                HM2_ERR("error adding pin '%s', aborting\n", name);
+                HM2_ERR("error %d adding pin '%s.oneshot.%02d.enable1', aborting\n", r, hm2->llio->name, i);
                 goto fail1;
             }
 
-            rtapi_snprintf(name, sizeof(name), "%s.oneshot.%02d.enable2", hm2->llio->name, i);
-            r = hal_pin_bit_new(name, HAL_IN, &(hm2->oneshot.instance[i].hal.pin.enable2), hm2->llio->comp_id);
+            r = hal_pin_new_bool(hm2->llio->comp_id, HAL_IN, &(hm2->oneshot.instance[i].hal.pin.enable2),
+                                 0, "%s.oneshot.%02d.enable2", hm2->llio->name, i);
             if (r < 0) {
-                HM2_ERR("error adding pin '%s', aborting\n", name);
+                HM2_ERR("error %d adding pin '%s.oneshot.%02d.enable2', aborting\n", r, hm2->llio->name, i);
                 goto fail1;
             }
 
-            rtapi_snprintf(name, sizeof(name), "%s.oneshot.%02d.reset1", hm2->llio->name, i);
-            r = hal_pin_bit_new(name, HAL_IN, &(hm2->oneshot.instance[i].hal.pin.reset1), hm2->llio->comp_id);
+            r = hal_pin_new_bool(hm2->llio->comp_id, HAL_IN, &(hm2->oneshot.instance[i].hal.pin.reset1),
+                                 0, "%s.oneshot.%02d.reset1", hm2->llio->name, i);
             if (r < 0) {
-                HM2_ERR("error adding pin '%s', aborting\n", name);
+                HM2_ERR("error %d adding pin '%s.oneshot.%02d.reset1', aborting\n", r, hm2->llio->name, i);
                 goto fail1;
             }
 
-            rtapi_snprintf(name, sizeof(name), "%s.oneshot.%02d.reset2", hm2->llio->name, i);
-            r = hal_pin_bit_new(name, HAL_IN, &(hm2->oneshot.instance[i].hal.pin.reset2), hm2->llio->comp_id);
+            r = hal_pin_new_bool(hm2->llio->comp_id, HAL_IN, &(hm2->oneshot.instance[i].hal.pin.reset2),
+                                 0, "%s.oneshot.%02d.reset2", hm2->llio->name, i);
             if (r < 0) {
-                HM2_ERR("error adding pin '%s', aborting\n", name);
+                HM2_ERR("error %d adding pin '%s.oneshot.%02d.reset2', aborting\n", r, hm2->llio->name, i);
                 goto fail1;
             }
 
-            rtapi_snprintf(name, sizeof(name), "%s.oneshot.%02d.swtrigger1", hm2->llio->name, i);
-            r = hal_pin_bit_new(name, HAL_IN, &(hm2->oneshot.instance[i].hal.pin.swtrig1), hm2->llio->comp_id);
+            r = hal_pin_new_bool(hm2->llio->comp_id, HAL_IN, &(hm2->oneshot.instance[i].hal.pin.swtrig1),
+                                 0, "%s.oneshot.%02d.swtrigger1", hm2->llio->name, i);
             if (r < 0) {
-                HM2_ERR("error adding pin '%s', aborting\n", name);
+                HM2_ERR("error %d adding pin '%s.oneshot.%02d.swtrigger1', aborting\n", r, hm2->llio->name, i);
                 goto fail1;
             }
 
-            rtapi_snprintf(name, sizeof(name), "%s.oneshot.%02d.swtrigger2", hm2->llio->name, i);
-            r = hal_pin_bit_new(name, HAL_IN, &(hm2->oneshot.instance[i].hal.pin.swtrig2), hm2->llio->comp_id);
+            r = hal_pin_new_bool(hm2->llio->comp_id, HAL_IN, &(hm2->oneshot.instance[i].hal.pin.swtrig2),
+                                 0, "%s.oneshot.%02d.swtrigger2", hm2->llio->name, i);
             if (r < 0) {
-                HM2_ERR("error adding pin '%s', aborting\n", name);
+                HM2_ERR("error %d adding pin '%s.oneshot.%02d.swtrigger2', aborting\n", r, hm2->llio->name, i);
                 goto fail1;
             }
 
-            rtapi_snprintf(name, sizeof(name), "%s.oneshot.%02d.exttrigger1", hm2->llio->name, i);
-            r = hal_pin_bit_new(name, HAL_OUT, &(hm2->oneshot.instance[i].hal.pin.exttrig1), hm2->llio->comp_id);
+            r = hal_pin_new_bool(hm2->llio->comp_id, HAL_OUT, &(hm2->oneshot.instance[i].hal.pin.exttrig1),
+                                 0, "%s.oneshot.%02d.exttrigger1", hm2->llio->name, i);
             if (r < 0) {
-                HM2_ERR("error adding pin '%s', aborting\n", name);
+                HM2_ERR("error %d adding pin '%s.oneshot.%02d.exttrigger1', aborting\n", r, hm2->llio->name, i);
                 goto fail1;
             }
 
-            rtapi_snprintf(name, sizeof(name), "%s.oneshot.%02d.exttrigger2", hm2->llio->name, i);
-            r = hal_pin_bit_new(name, HAL_OUT, &(hm2->oneshot.instance[i].hal.pin.exttrig2), hm2->llio->comp_id);
+            r = hal_pin_new_bool(hm2->llio->comp_id, HAL_OUT, &(hm2->oneshot.instance[i].hal.pin.exttrig2),
+                                 0, "%s.oneshot.%02d.exttrigger2", hm2->llio->name, i);
             if (r < 0) {
-                HM2_ERR("error adding pin '%s', aborting\n", name);
+                HM2_ERR("error %d adding pin '%s.oneshot.%02d.exttrigger2', aborting\n", r, hm2->llio->name, i);
                 goto fail1;
             }
  
-            rtapi_snprintf(name, sizeof(name), "%s.oneshot.%02d.out1", hm2->llio->name, i);
-            r = hal_pin_bit_new(name, HAL_OUT, &(hm2->oneshot.instance[i].hal.pin.out1), hm2->llio->comp_id);
+            r = hal_pin_new_bool(hm2->llio->comp_id, HAL_OUT, &(hm2->oneshot.instance[i].hal.pin.out1),
+                                 0, "%s.oneshot.%02d.out1", hm2->llio->name, i);
             if (r < 0) {
-                HM2_ERR("error adding pin '%s', aborting\n", name);
+                HM2_ERR("error %d adding pin '%s.oneshot.%02d.out1', aborting\n", r, hm2->llio->name, i);
                 goto fail1;
             }
 
-            rtapi_snprintf(name, sizeof(name), "%s.oneshot.%02d.out2", hm2->llio->name, i);
-            r = hal_pin_bit_new(name, HAL_OUT, &(hm2->oneshot.instance[i].hal.pin.out2), hm2->llio->comp_id);
+            r = hal_pin_new_bool(hm2->llio->comp_id, HAL_OUT, &(hm2->oneshot.instance[i].hal.pin.out2),
+                                 0, "%s.oneshot.%02d.out2", hm2->llio->name, i);
             if (r < 0) {
-                HM2_ERR("error adding pin '%s', aborting\n", name);
+                HM2_ERR("error %d adding pin '%s.oneshot.%02d.out2', aborting\n", r, hm2->llio->name, i);
                 goto fail1;
             }
-
-
-            // init hal objects
-            *(hm2->oneshot.instance[i].hal.pin.width1) = 1.0;
-            *(hm2->oneshot.instance[i].hal.pin.width2) = 1.0;
-            *(hm2->oneshot.instance[i].hal.pin.filter1) = 0.1;
-            *(hm2->oneshot.instance[i].hal.pin.filter2) = 0.1;
-            *(hm2->oneshot.instance[i].hal.pin.rate) = 1000.0;
-            *(hm2->oneshot.instance[i].hal.pin.trigselect1) = 0;
-            *(hm2->oneshot.instance[i].hal.pin.trigselect2) = 0;
-            *(hm2->oneshot.instance[i].hal.pin.trigrise1) = 0;
-            *(hm2->oneshot.instance[i].hal.pin.trigrise2) = 0;
-            *(hm2->oneshot.instance[i].hal.pin.trigfall1) = 0;
-            *(hm2->oneshot.instance[i].hal.pin.trigfall2) = 0;
-            *(hm2->oneshot.instance[i].hal.pin.retrig1) = 0;
-            *(hm2->oneshot.instance[i].hal.pin.retrig2) = 0;
-            *(hm2->oneshot.instance[i].hal.pin.enable1) = 0;
-            *(hm2->oneshot.instance[i].hal.pin.enable2) = 0;
-            *(hm2->oneshot.instance[i].hal.pin.reset1) = 0;
-            *(hm2->oneshot.instance[i].hal.pin.reset2) = 0;
-            *(hm2->oneshot.instance[i].hal.pin.swtrig1) = 0;
-            *(hm2->oneshot.instance[i].hal.pin.swtrig2) = 0;
         }
     }
 
@@ -530,10 +502,10 @@ void hm2_oneshot_process_tram_read(hostmot2_t *hm2) {
     rtapi_u32 control = 0;
     for (i = 0; i < hm2->oneshot.num_instances; i ++) {
         control = hm2->oneshot.control_read_reg[i];
-        *hm2->oneshot.instance[i].hal.pin.out1 = ((control & (1 << 8)) != 0);
-        *hm2->oneshot.instance[i].hal.pin.out2 = ((control & (1 << 24)) != 0);
-        *hm2->oneshot.instance[i].hal.pin.exttrig1 = ((control & (1 << 9)) != 0);
-        *hm2->oneshot.instance[i].hal.pin.exttrig2 = ((control & (1 << 25)) != 0);
+        hal_set_bool(hm2->oneshot.instance[i].hal.pin.out1, ((control & (1 << 8)) != 0));
+        hal_set_bool(hm2->oneshot.instance[i].hal.pin.out2, ((control & (1 << 24)) != 0));
+        hal_set_bool(hm2->oneshot.instance[i].hal.pin.exttrig1, ((control & (1 << 9)) != 0));
+        hal_set_bool(hm2->oneshot.instance[i].hal.pin.exttrig2, ((control & (1 << 25)) != 0));
     }    
 }
 

--- a/src/hal/drivers/mesa-hostmot2/outm.c
+++ b/src/hal/drivers/mesa-hostmot2/outm.c
@@ -77,7 +77,7 @@ int hm2_outm_parse_md(hostmot2_t *hm2, int md_index) {
     hm2->outm.clock_freq = md->clock_freq;
     hm2->outm.version = md->version;
 
-    hm2->outm.instance = (hm2_outm_instance_t *)hal_malloc(hm2->outm.num_instances * sizeof(hm2_outm_instance_t));
+    hm2->outm.instance = hal_malloc(hm2->outm.num_instances * sizeof(*hm2->outm.instance));
     if (hm2->outm.instance == NULL) {
         HM2_ERR("out of memory!\n");
         r = -ENOMEM;
@@ -115,10 +115,7 @@ int hm2_outm_parse_md(hostmot2_t *hm2, int md_index) {
     //
 
     {
-        int i;
-        char name[HAL_NAME_LEN + 1];
-
-        for (i = 0; i < hm2->outm.num_instances; i ++) {
+        for (int i = 0; i < hm2->outm.num_instances; i ++) {
             int j = 0;
             int outm_number;
             for (j = 0; j < hm2->num_pins; j++){
@@ -134,17 +131,17 @@ int hm2_outm_parse_md(hostmot2_t *hm2, int md_index) {
                         r = -EINVAL;
                         goto fail0;
                     }
-                    rtapi_snprintf(name, sizeof(name), "%s.outm.%02d.out-%02d", hm2->llio->name, i, outm_number);
-                    r = hal_pin_bit_new(name, HAL_IN, &(hm2->outm.instance[i].hal.pin.out[outm_number]), hm2->llio->comp_id);
+                    r = hal_pin_new_bool(hm2->llio->comp_id, HAL_IN, &(hm2->outm.instance[i].hal.pin.out[outm_number]),
+                                         0, "%s.outm.%02d.out-%02d", hm2->llio->name, i, outm_number);
                     if (r < 0) {
-                        HM2_ERR("error adding pin '%s', aborting\n", name);
+                        HM2_ERR("error %d adding pin '%s.outm.%02d.out-%02d', aborting\n", r, hm2->llio->name, i, outm_number);
                         r = -ENOMEM;
                         goto fail0;
                     }
-                    rtapi_snprintf(name, sizeof(name), "%s.outm.%02d.invert-%02d", hm2->llio->name, i, outm_number);
-                    r = hal_pin_bit_new(name, HAL_IN, &(hm2->outm.instance[i].hal.pin.invert[outm_number]), hm2->llio->comp_id);
+                    r = hal_pin_new_bool(hm2->llio->comp_id, HAL_IN, &(hm2->outm.instance[i].hal.pin.invert[outm_number]),
+                                         0, "%s.outm.%02d.invert-%02d", hm2->llio->name, i, outm_number);
                     if (r < 0) {
-                        HM2_ERR("error adding pin '%s', aborting\n", name);
+                        HM2_ERR("error %d adding pin '%s.outm.%02d.invert-%02d', aborting\n", r, hm2->llio->name, i, outm_number);
                         r = -ENOMEM;
                         goto fail0;
                     }
@@ -164,16 +161,7 @@ int hm2_outm_parse_md(hostmot2_t *hm2, int md_index) {
     {
         int i;
         for (i = 0; i < hm2->outm.num_instances; i ++) {
-            int pin;
             rtapi_u32 zero = 0;
-
-
-            for (pin = 0; pin < 32; pin ++) {
-                if (hm2->outm.instance[i].hal.pin.out[pin] != NULL) {
-                    *hm2->outm.instance[i].hal.pin.out[pin] = 0;
-                    *hm2->outm.instance[i].hal.pin.invert[pin] = 0;
-                }
-            }		 
             hm2->llio->write(hm2->llio, hm2->outm.data_addr + (i * md->instance_stride), &zero, sizeof(zero));
         }
     }
@@ -207,8 +195,8 @@ void hm2_outm_force_write(hostmot2_t *hm2) {
         hm2->outm.data_reg[i] = 0;
         for (pin = 0; pin < 32; pin ++) {
             if (hm2->outm.instance[i].hal.pin.out[pin] != NULL) {
-                hm2->outm.data_reg[i] |= *hm2->outm.instance[i].hal.pin.out[pin] << pin;
-                hm2->outm.data_reg[i] ^= *hm2->outm.instance[i].hal.pin.invert[pin] << pin;
+                hm2->outm.data_reg[i] |= hal_get_bool(hm2->outm.instance[i].hal.pin.out[pin]) << pin;
+                hm2->outm.data_reg[i] ^= hal_get_bool(hm2->outm.instance[i].hal.pin.invert[pin]) << pin;
             }
         }
     }
@@ -238,8 +226,8 @@ void hm2_outm_prepare_tram_write(hostmot2_t *hm2) {
         hm2->outm.data_reg[i] = 0;
         for (pin = 0; pin < 32; pin ++) {
             if (hm2->outm.instance[i].hal.pin.out[pin] != NULL) {
-                hm2->outm.data_reg[i] |= *hm2->outm.instance[i].hal.pin.out[pin] << pin;
-                hm2->outm.data_reg[i] ^= *hm2->outm.instance[i].hal.pin.invert[pin] << pin;
+                hm2->outm.data_reg[i] |= hal_get_bool(hm2->outm.instance[i].hal.pin.out[pin]) << pin;
+                hm2->outm.data_reg[i] ^= hal_get_bool(hm2->outm.instance[i].hal.pin.invert[pin]) << pin;
             }
         }
         if (hm2->outm.data_reg[i] != hm2->outm.instance[i].written_data) {

--- a/src/hal/drivers/mesa-hostmot2/periodm.c
+++ b/src/hal/drivers/mesa-hostmot2/periodm.c
@@ -33,36 +33,37 @@
 
 
 void hm2_periodm_update_limit(hostmot2_t *hm2, int i) {
-    hm2->periodm.limit_reg[i] =  ((double)hm2->periodm.clock_frequency / (double)*hm2->periodm.instance[i].hal.pin.minfreq) * *hm2->periodm.instance[i].hal.pin.averages;
-    if ((((double)hm2->periodm.clock_frequency / (double)*hm2->periodm.instance[i].hal.pin.minfreq) * *hm2->periodm.instance[i].hal.pin.averages ) > 0xFFFFFFFF) {
+    rtapi_u32 averages = hal_get_ui32(hm2->periodm.instance[i].hal.pin.averages);
+    rtapi_real minfreq = hal_get_real(hm2->periodm.instance[i].hal.pin.minfreq);
+    hm2->periodm.limit_reg[i] =  ((double)hm2->periodm.clock_frequency / minfreq) * averages;
+    if ((((double)hm2->periodm.clock_frequency / minfreq) * averages ) > 0xFFFFFFFF) {
         HM2_ERR("periodm %d has invalid min freq time, resetting to min\n", i);
-        *hm2->periodm.instance[i].hal.pin.minfreq = (0.025 * *hm2->periodm.instance[i].hal.pin.averages);
-        hm2->periodm.limit_reg[i] =  ((double)hm2->periodm.clock_frequency / (double)*hm2->periodm.instance[i].hal.pin.minfreq) * *hm2->periodm.instance[i].hal.pin.averages; 
+        minfreq = hal_set_real(hm2->periodm.instance[i].hal.pin.minfreq, 0.025 * averages);
+        hm2->periodm.limit_reg[i] =  ((double)hm2->periodm.clock_frequency / minfreq) * averages;
     }
 }
 
 void hm2_periodm_update_mode(hostmot2_t *hm2, int i) {
     rtapi_u32 modebuff;
     rtapi_u32 filterclocks;
-    rtapi_u32  averages;
-    filterclocks = (double)*hm2->periodm.instance[i].hal.pin.filtertc * ((double)hm2->periodm.clock_frequency / (double)1e6);
+    rtapi_u32  averages = hal_get_ui32(hm2->periodm.instance[i].hal.pin.averages);
+    filterclocks = (double)hal_get_real(hm2->periodm.instance[i].hal.pin.filtertc) * ((double)hm2->periodm.clock_frequency / (double)1e6);
     if (filterclocks > 0xFFFF) {
         HM2_ERR("periodm %d has invalid filter time constant, resetting to max\n", i);
         filterclocks = 0xFFFF;
-        *hm2->periodm.instance[i].hal.pin.filtertc = (double)filterclocks * ((double)1e6 / (double)hm2->periodm.clock_frequency);
+        hal_set_real(hm2->periodm.instance[i].hal.pin.filtertc, (double)filterclocks * ((double)1e6 / (double)hm2->periodm.clock_frequency));
     }
-    if (*hm2->periodm.instance[i].hal.pin.averages > 0xFFF) {
+    if (averages > 0xFFF) {
         HM2_ERR("periodm %d has invalid averages number, resetting to max\n", i);
-        *hm2->periodm.instance[i].hal.pin.averages =  0xFFF;
+        averages = hal_set_ui32(hm2->periodm.instance[i].hal.pin.averages, 0xFFF);
     }    
-    if (*hm2->periodm.instance[i].hal.pin.averages < 1) {
+    if (averages < 1) {
         HM2_ERR("periodm %d has invalid averages number, resetting to min\n", i);
-        *hm2->periodm.instance[i].hal.pin.averages =  1;
+        averages = hal_set_ui32(hm2->periodm.instance[i].hal.pin.averages, 1);
     }    
-    averages =  *hm2->periodm.instance[i].hal.pin.averages -1;    
     modebuff = 0;
-    modebuff |= (*hm2->periodm.instance[i].hal.pin.polarity << 0);
-    modebuff |= (averages << 4);
+    modebuff |= (hal_get_bool(hm2->periodm.instance[i].hal.pin.polarity) << 0);
+    modebuff |= ((averages-1) << 4);
     modebuff |= (filterclocks << 16);
  
 	 hm2->periodm.mode_write_reg[i] = modebuff;
@@ -86,7 +87,7 @@ void hm2_periodm_force_write(hostmot2_t *hm2) {
     hm2->llio->write(hm2->llio, hm2->periodm.mode_write_addr, hm2->periodm.mode_write_reg, (hm2->periodm.num_instances * sizeof(rtapi_u32)));
     hm2->llio->write(hm2->llio, hm2->periodm.limit_addr, hm2->periodm.limit_reg, (hm2->periodm.num_instances * sizeof(rtapi_u32)));
     
-    if ((*hm2->llio->io_error) != 0) return;
+    if (hal_get_bool(*hm2->llio->io_error)) return;
 
 }
 
@@ -152,7 +153,7 @@ int hm2_periodm_parse_md(hostmot2_t *hm2, int md_index) {
 
 
 
-    hm2->periodm.instance = (hm2_periodm_instance_t *)hal_malloc(hm2->periodm.num_instances * sizeof(hm2_periodm_instance_t));
+    hm2->periodm.instance = hal_malloc(hm2->periodm.num_instances * sizeof(*hm2->periodm.instance));
     if (hm2->periodm.instance == NULL) {
         HM2_ERR("out of memory!\n");
         r = -ENOMEM;
@@ -200,107 +201,92 @@ int hm2_periodm_parse_md(hostmot2_t *hm2, int md_index) {
 
 
     // export to HAL
-    // FIXME: r hides the r in enclosing function, and it returns the wrong thing
     {
-        int i;
-        int r;
-        char name[HAL_NAME_LEN + 1];
-
-
-        for (i = 0; i < hm2->periodm.num_instances; i ++) {
+        for (int i = 0; i < hm2->periodm.num_instances; i ++) {
             // pins
-            rtapi_snprintf(name, sizeof(name), "%s.periodm.%02d.period_us", hm2->llio->name, i);
-            r = hal_pin_float_new(name, HAL_OUT, &(hm2->periodm.instance[i].hal.pin.period), hm2->llio->comp_id);
+            r = hal_pin_new_real(hm2->llio->comp_id, HAL_OUT, &(hm2->periodm.instance[i].hal.pin.period),
+                                 0.0, "%s.periodm.%02d.period_us", hm2->llio->name, i);
             if (r < 0) {
-                HM2_ERR("error adding pin '%s', aborting\n", name);
+                HM2_ERR("error %d adding pin '%s.periodm.%02d.period_us', aborting\n", r, hm2->llio->name, i);
                 goto fail1;
             }
 
-            rtapi_snprintf(name, sizeof(name), "%s.periodm.%02d.width_us", hm2->llio->name, i);
-            r = hal_pin_float_new(name, HAL_OUT, &(hm2->periodm.instance[i].hal.pin.width), hm2->llio->comp_id);
+            r = hal_pin_new_real(hm2->llio->comp_id, HAL_OUT, &(hm2->periodm.instance[i].hal.pin.width),
+                                 0.0, "%s.periodm.%02d.width_us", hm2->llio->name, i);
             if (r < 0) {
-                HM2_ERR("error adding pin '%s', aborting\n", name);
+                HM2_ERR("error %d adding pin '%s.periodm.%02d.width_us', aborting\n", r, hm2->llio->name, i);
                 goto fail1;
             }
  
-            rtapi_snprintf(name, sizeof(name), "%s.periodm.%02d.duty_cycle", hm2->llio->name, i);
-            r = hal_pin_float_new(name, HAL_OUT, &(hm2->periodm.instance[i].hal.pin.dutycycle), hm2->llio->comp_id);
+            r = hal_pin_new_real(hm2->llio->comp_id, HAL_OUT, &(hm2->periodm.instance[i].hal.pin.dutycycle),
+                                 0.0, "%s.periodm.%02d.duty_cycle", hm2->llio->name, i);
             if (r < 0) {
-                HM2_ERR("error adding pin '%s', aborting\n", name);
+                HM2_ERR("error %d adding pin '%s.periodm.%02d.duty_cycle', aborting\n", r, hm2->llio->name, i);
                 goto fail1;
             }
 
-            rtapi_snprintf(name, sizeof(name), "%s.periodm.%02d.duty_cycle_scale", hm2->llio->name, i);
-            r = hal_pin_float_new(name, HAL_IN, &(hm2->periodm.instance[i].hal.pin.dutyscale), hm2->llio->comp_id);
+            r = hal_pin_new_real(hm2->llio->comp_id, HAL_IN, &(hm2->periodm.instance[i].hal.pin.dutyscale),
+                                 100.0, "%s.periodm.%02d.duty_cycle_scale", hm2->llio->name, i);
             if (r < 0) {
-                HM2_ERR("error adding pin '%s', aborting\n", name);
+                HM2_ERR("error %d adding pin '%s.periodm.%02d.duty_cycle_scale', aborting\n", r, hm2->llio->name, i);
                 goto fail1;
             }
 
-            rtapi_snprintf(name, sizeof(name), "%s.periodm.%02d.duty_cycle_offset", hm2->llio->name, i);
-            r = hal_pin_float_new(name, HAL_IN, &(hm2->periodm.instance[i].hal.pin.dutyoffset), hm2->llio->comp_id);
+            r = hal_pin_new_real(hm2->llio->comp_id, HAL_IN, &(hm2->periodm.instance[i].hal.pin.dutyoffset),
+                                 0.0, "%s.periodm.%02d.duty_cycle_offset", hm2->llio->name, i);
             if (r < 0) {
-                HM2_ERR("error adding pin '%s', aborting\n", name);
+                HM2_ERR("error %d adding pin '%s.periodm.%02d.duty_cycle_offset', aborting\n", r, hm2->llio->name, i);
                 goto fail1;
             }
 
-            rtapi_snprintf(name, sizeof(name), "%s.periodm.%02d.frequency", hm2->llio->name, i);
-            r = hal_pin_float_new(name, HAL_OUT, &(hm2->periodm.instance[i].hal.pin.frequency), hm2->llio->comp_id);
+            r = hal_pin_new_real(hm2->llio->comp_id, HAL_OUT, &(hm2->periodm.instance[i].hal.pin.frequency),
+                                 0.0, "%s.periodm.%02d.frequency", hm2->llio->name, i);
             if (r < 0) {
-                HM2_ERR("error adding pin '%s', aborting\n", name);
+                HM2_ERR("error %d adding pin '%s.periodm.%02d.frequency', aborting\n", r, hm2->llio->name, i);
                 goto fail1;
             }
 
-            rtapi_snprintf(name, sizeof(name), "%s.periodm.%02d.filtertc_us", hm2->llio->name, i);
-            r = hal_pin_float_new(name, HAL_IN, &(hm2->periodm.instance[i].hal.pin.filtertc), hm2->llio->comp_id);
+            r = hal_pin_new_real(hm2->llio->comp_id, HAL_IN, &(hm2->periodm.instance[i].hal.pin.filtertc),
+                                 1.0, "%s.periodm.%02d.filtertc_us", hm2->llio->name, i);
             if (r < 0) {
-                HM2_ERR("error adding pin '%s', aborting\n", name);
+                HM2_ERR("error %d adding pin '%s.periodm.%02d.filtertc_us', aborting\n", r, hm2->llio->name, i);
                 goto fail1;
             }
 
-            rtapi_snprintf(name, sizeof(name), "%s.periodm.%02d.minimum_frequency", hm2->llio->name, i);
-            r = hal_pin_float_new(name, HAL_IN, &(hm2->periodm.instance[i].hal.pin.minfreq), hm2->llio->comp_id);
+            r = hal_pin_new_real(hm2->llio->comp_id, HAL_IN, &(hm2->periodm.instance[i].hal.pin.minfreq),
+                                 1.0, "%s.periodm.%02d.minimum_frequency", hm2->llio->name, i);
             if (r < 0) {
-                HM2_ERR("error adding pin '%s', aborting\n", name);
+                HM2_ERR("error %d adding pin '%s.periodm.%02d.minimum_frequency', aborting\n", r, hm2->llio->name, i);
                 goto fail1;
             }
 
-            rtapi_snprintf(name, sizeof(name), "%s.periodm.%02d.averages", hm2->llio->name, i);
-            r = hal_pin_u32_new(name, HAL_IO, &(hm2->periodm.instance[i].hal.pin.averages), hm2->llio->comp_id);
+            r = hal_pin_new_ui32(hm2->llio->comp_id, HAL_IO, &(hm2->periodm.instance[i].hal.pin.averages),
+                                 1, "%s.periodm.%02d.averages", hm2->llio->name, i);
             if (r < 0) {
-                HM2_ERR("error adding pin '%s', aborting\n", name);
+                HM2_ERR("error %d adding pin '%s.periodm.%02d.averages', aborting\n", r, hm2->llio->name, i);
                 goto fail1;
             }
 
-            rtapi_snprintf(name, sizeof(name), "%s.periodm.%02d.invert", hm2->llio->name, i);
-            r = hal_pin_bit_new(name, HAL_IO, &(hm2->periodm.instance[i].hal.pin.polarity), hm2->llio->comp_id);
+            r = hal_pin_new_bool(hm2->llio->comp_id, HAL_IO, &(hm2->periodm.instance[i].hal.pin.polarity),
+                                 0, "%s.periodm.%02d.invert", hm2->llio->name, i);
             if (r < 0) {
-                HM2_ERR("error adding pin '%s', aborting\n", name);
+                HM2_ERR("error %d adding pin '%s.periodm.%02d.invert', aborting\n", r, hm2->llio->name, i);
                 goto fail1;
             }
 
-            rtapi_snprintf(name, sizeof(name), "%s.periodm.%02d.valid", hm2->llio->name, i);
-            r = hal_pin_bit_new(name, HAL_OUT, &(hm2->periodm.instance[i].hal.pin.valid), hm2->llio->comp_id);
+            r = hal_pin_new_bool(hm2->llio->comp_id, HAL_OUT, &(hm2->periodm.instance[i].hal.pin.valid),
+                                 0, "%s.periodm.%02d.valid", hm2->llio->name, i);
             if (r < 0) {
-                HM2_ERR("error adding pin '%s', aborting\n", name);
+                HM2_ERR("error %d adding pin '%s.periodm.%02d.valid', aborting\n", r, hm2->llio->name, i);
                 goto fail1;
             }
 
-            rtapi_snprintf(name, sizeof(name), "%s.periodm.%02d.input_status", hm2->llio->name, i);
-            r = hal_pin_bit_new(name, HAL_OUT, &(hm2->periodm.instance[i].hal.pin.input), hm2->llio->comp_id);
+            r = hal_pin_new_bool(hm2->llio->comp_id, HAL_OUT, &(hm2->periodm.instance[i].hal.pin.input),
+                                 0, "%s.periodm.%02d.input_status", hm2->llio->name, i);
             if (r < 0) {
-                HM2_ERR("error adding pin '%s', aborting\n", name);
+                HM2_ERR("error %d adding pin '%s.periodm.%02d.input_status', aborting\n", r, hm2->llio->name, i);
                 goto fail1;
             }
-
-            // init hal objects
-            *(hm2->periodm.instance[i].hal.pin.polarity) = 0;            
-            *(hm2->periodm.instance[i].hal.pin.filtertc) = 1.0;
-            *(hm2->periodm.instance[i].hal.pin.averages) = 1;
-            *(hm2->periodm.instance[i].hal.pin.minfreq) = 1.0;
-            *(hm2->periodm.instance[i].hal.pin.dutyscale) = 100;
-            *(hm2->periodm.instance[i].hal.pin.dutyoffset) = 0;
-            
         }
     }
 
@@ -361,19 +347,23 @@ void hm2_periodm_process_tram_read(hostmot2_t *hm2) {
     int i;
     rtapi_u32 mode = 0;
     for (i = 0; i < hm2->periodm.num_instances; i ++) {
+        rtapi_u32 averages = hal_get_ui32(hm2->periodm.instance[i].hal.pin.averages);
         mode = hm2->periodm.mode_read_reg[i];
-//        *hm2->periodm.instance[i].hal.pin.polarity = ((mode & (1 << 0)) != 0);
-        *hm2->periodm.instance[i].hal.pin.valid = ((mode & (1 << 1)) != 0);
-        *hm2->periodm.instance[i].hal.pin.input = ((mode & (1 << 2)) != 0);
+//        hal_set_bool(hm2->periodm.instance[i].hal.pin.polarity, (mode & (1 << 0)) != 0);
+        hal_set_bool(hm2->periodm.instance[i].hal.pin.valid, (mode & (1 << 1)) != 0);
+        hal_set_bool(hm2->periodm.instance[i].hal.pin.input, (mode & (1 << 2)) != 0);
 
-        *hm2->periodm.instance[i].hal.pin.period = (hm2->periodm.period_reg[i] / ((double)hm2->periodm.clock_frequency)) * (double)1e6 / *hm2->periodm.instance[i].hal.pin.averages; 
-        *hm2->periodm.instance[i].hal.pin.width  = (hm2->periodm.width_reg[i]  / ((double)hm2->periodm.clock_frequency)) * (double)1e6 / *hm2->periodm.instance[i].hal.pin.averages; 
-			if (*hm2->periodm.instance[i].hal.pin.period !=  0) {
-			    *hm2->periodm.instance[i].hal.pin.dutycycle =  (((double)*hm2->periodm.instance[i].hal.pin.width
-			     / (double)*hm2->periodm.instance[i].hal.pin.period) * (double)*hm2->periodm.instance[i].hal.pin.dutyscale) + *hm2->periodm.instance[i].hal.pin.dutyoffset;
-			    *hm2->periodm.instance[i].hal.pin.frequency =  (1.0 / (hm2->periodm.period_reg[i] / (double)hm2->periodm.clock_frequency)) * *hm2->periodm.instance[i].hal.pin.averages;
-			}   
-
+        rtapi_real period = hal_set_real(hm2->periodm.instance[i].hal.pin.period,
+            (hm2->periodm.period_reg[i] / ((double)hm2->periodm.clock_frequency)) * (double)1e6 / averages);
+        rtapi_real width = hal_set_real(hm2->periodm.instance[i].hal.pin.width,
+            (hm2->periodm.width_reg[i]  / ((double)hm2->periodm.clock_frequency)) * (double)1e6 / averages);
+        if (period != 0) {
+            hal_set_real(hm2->periodm.instance[i].hal.pin.dutycycle,
+                ((width / period) * hal_get_real(hm2->periodm.instance[i].hal.pin.dutyscale))
+                + hal_get_real(hm2->periodm.instance[i].hal.pin.dutyoffset));
+            hal_set_real(hm2->periodm.instance[i].hal.pin.frequency,
+                (1.0 / (hm2->periodm.period_reg[i] / (double)hm2->periodm.clock_frequency)) * averages);
+        }
     }    
 }
 

--- a/src/hal/drivers/mesa-hostmot2/pktuart.c
+++ b/src/hal/drivers/mesa-hostmot2/pktuart.c
@@ -99,8 +99,7 @@ int hm2_pktuart_parse_md(hostmot2_t *hm2, int md_index)
 			hm2->pktuart.num_instances = hm2->config.num_pktuarts;
 		}
 
-		hm2->pktuart.instance = (hm2_pktuart_instance_t *)hal_malloc(hm2->pktuart.num_instances
-															* sizeof(hm2_pktuart_instance_t));
+		hm2->pktuart.instance = hal_malloc(hm2->pktuart.num_instances * sizeof(*hm2->pktuart.instance));
 		if(hm2->pktuart.instance == NULL) {
 			HM2_ERR("out of memory!\n");
 			r = -ENOMEM;
@@ -440,7 +439,7 @@ EXPORT_SYMBOL_GPL(hm2_pktuart_config);
 static void perform_reset(const char *name, int queue)
 {
 	hostmot2_t *hm2;
-	hm2_pktuart_instance_t *inst = 0;
+	hm2_pktuart_instance_t *inst = NULL;
 	rtapi_u32 buff = HM2_PKTUART_CLEAR;
 	int i = hm2_get_pktuart(&hm2, name);
 	if(i < 0) {
@@ -496,7 +495,7 @@ EXPORT_SYMBOL_GPL(hm2_pktuart_queue_reset);
 int hm2_pktuart_setup(const char *name, unsigned bitrate, rtapi_s32 tx_mode, rtapi_s32 rx_mode, int txclear, int rxclear)
 {
 	hostmot2_t *hm2;
-	hm2_pktuart_instance_t *inst = 0;
+	hm2_pktuart_instance_t *inst = NULL;
 	rtapi_u32 buff;
 	int i;
 	int r = 0;

--- a/src/hal/drivers/mesa-hostmot2/pwmgen.c
+++ b/src/hal/drivers/mesa-hostmot2/pwmgen.c
@@ -34,9 +34,9 @@ void hm2_pwmgen_handle_pwm_frequency(hostmot2_t *hm2) {
     rtapi_u32 dds;
 
 
-    if (hm2->pwmgen.hal->param.pwm_frequency < 1) {
-        HM2_ERR("pwmgen.pwm_frequency %d is too low, setting to 1\n", hm2->pwmgen.hal->param.pwm_frequency);
-        hm2->pwmgen.hal->param.pwm_frequency = 1;
+    if (hal_get_ui32(hm2->pwmgen.hal->param.pwm_frequency) < 1) {
+        HM2_ERR("pwmgen.pwm_frequency %d is too low, setting to 1\n", hal_get_ui32(hm2->pwmgen.hal->param.pwm_frequency));
+        hal_set_ui32(hm2->pwmgen.hal->param.pwm_frequency, 1);
     }
 
 
@@ -65,7 +65,7 @@ void hm2_pwmgen_handle_pwm_frequency(hostmot2_t *hm2) {
     //
 
     // can we do it with 12 bits?
-    dds = ((double)hm2->pwmgen.hal->param.pwm_frequency * 65536.0 * 4096.0) / (double)hm2->pwmgen.clock_frequency;
+    dds = ((double)hal_get_ui32(hm2->pwmgen.hal->param.pwm_frequency) * 65536.0 * 4096.0) / (double)hm2->pwmgen.clock_frequency;
     if (dds < 65536) {
         hm2->pwmgen.pwmgen_master_rate_dds_reg = dds;
         hm2->pwmgen.pwm_bits = 12;
@@ -73,7 +73,7 @@ void hm2_pwmgen_handle_pwm_frequency(hostmot2_t *hm2) {
     }
 
     // try 11 bits
-    dds = ((double)hm2->pwmgen.hal->param.pwm_frequency * 65536.0 * 2048.0) / (double)hm2->pwmgen.clock_frequency;
+    dds = ((double)hal_get_ui32(hm2->pwmgen.hal->param.pwm_frequency) * 65536.0 * 2048.0) / (double)hm2->pwmgen.clock_frequency;
     if (dds < 65536) {
         hm2->pwmgen.pwmgen_master_rate_dds_reg = dds;
         hm2->pwmgen.pwm_bits = 11;
@@ -81,7 +81,7 @@ void hm2_pwmgen_handle_pwm_frequency(hostmot2_t *hm2) {
     }
 
     // try 10 bits
-    dds = ((double)hm2->pwmgen.hal->param.pwm_frequency * 65536.0 * 1024.0) / (double)hm2->pwmgen.clock_frequency;
+    dds = ((double)hal_get_ui32(hm2->pwmgen.hal->param.pwm_frequency) * 65536.0 * 1024.0) / (double)hm2->pwmgen.clock_frequency;
     if (dds < 65536) {
         hm2->pwmgen.pwmgen_master_rate_dds_reg = dds;
         hm2->pwmgen.pwm_bits = 10;
@@ -89,7 +89,7 @@ void hm2_pwmgen_handle_pwm_frequency(hostmot2_t *hm2) {
     }
 
     // try 9 bits
-    dds = ((double)hm2->pwmgen.hal->param.pwm_frequency * 65536.0 * 512.0) / (double)hm2->pwmgen.clock_frequency;
+    dds = ((double)hal_get_ui32(hm2->pwmgen.hal->param.pwm_frequency) * 65536.0 * 512.0) / (double)hm2->pwmgen.clock_frequency;
     if (dds < 65536) {
         hm2->pwmgen.pwmgen_master_rate_dds_reg = dds;
         hm2->pwmgen.pwm_bits = 9;
@@ -99,8 +99,8 @@ void hm2_pwmgen_handle_pwm_frequency(hostmot2_t *hm2) {
     // no joy, lower frequency until it'll work with 9 bits
     // From above:
     //     PWMFreq = (ClockHigh * DDS) / (65536 * 2^PWMBits)
-    hm2->pwmgen.hal->param.pwm_frequency = ((double)hm2->pwmgen.clock_frequency * 65535.0) / (65536.0 * 512.0);
-    HM2_ERR("max PWM frequency is %d Hz\n", hm2->pwmgen.hal->param.pwm_frequency);
+    hal_set_ui32(hm2->pwmgen.hal->param.pwm_frequency, ((double)hm2->pwmgen.clock_frequency * 65535.0) / (65536.0 * 512.0));
+    HM2_ERR("max PWM frequency is %d Hz\n", hal_get_ui32(hm2->pwmgen.hal->param.pwm_frequency));
     hm2->pwmgen.pwmgen_master_rate_dds_reg = 65535;
     hm2->pwmgen.pwm_bits = 9;
 }
@@ -110,9 +110,9 @@ void hm2_pwmgen_handle_pdm_frequency(hostmot2_t *hm2) {
     rtapi_u32 dds;
 
 
-    if (hm2->pwmgen.hal->param.pdm_frequency < 1) {
-        HM2_ERR("pwmgen.pdm_frequency %d is too low, setting to 1\n", hm2->pwmgen.hal->param.pdm_frequency);
-        hm2->pwmgen.hal->param.pdm_frequency = 1;
+    if (hal_get_ui32(hm2->pwmgen.hal->param.pdm_frequency) < 1) {
+        HM2_ERR("pwmgen.pdm_frequency %d is too low, setting to 1\n", hal_get_ui32(hm2->pwmgen.hal->param.pdm_frequency));
+        hal_set_ui32(hm2->pwmgen.hal->param.pdm_frequency, 1);
     }
 
 
@@ -151,14 +151,14 @@ void hm2_pwmgen_handle_pdm_frequency(hostmot2_t *hm2) {
     //
 
     // can we do it with 12 bits?
-    dds = ((double)hm2->pwmgen.hal->param.pdm_frequency * 65536.0) / (double)hm2->pwmgen.clock_frequency;
+    dds = ((double)hal_get_ui32(hm2->pwmgen.hal->param.pdm_frequency) * 65536.0) / (double)hm2->pwmgen.clock_frequency;
     if (dds == 0) {
         // too slow, set frequency to minimum
         // From above:
         //     PulseFreq = (ClockHigh * DDS) / 65536
         dds = 1;
-        hm2->pwmgen.hal->param.pdm_frequency = ((double)hm2->pwmgen.clock_frequency * (double)dds) / 65536.0;
-        HM2_ERR("min PDM frequency is %d Hz\n", hm2->pwmgen.hal->param.pdm_frequency);
+        hal_set_ui32(hm2->pwmgen.hal->param.pdm_frequency, ((double)hm2->pwmgen.clock_frequency * (double)dds) / 65536.0);
+        HM2_ERR("min PDM frequency is %d Hz\n", hal_get_ui32(hm2->pwmgen.hal->param.pdm_frequency));
         hm2->pwmgen.pdmgen_master_rate_dds_reg = 1;
         return;
     }
@@ -172,8 +172,8 @@ void hm2_pwmgen_handle_pdm_frequency(hostmot2_t *hm2) {
     // user wants too much, lower frequency until it'll work with 12 bits
     // From above:
     //     PulseFreq = (ClockHigh * DDS) / 65536
-    hm2->pwmgen.hal->param.pdm_frequency = ((double)hm2->pwmgen.clock_frequency * 65535.0) / 65536.0;
-    HM2_ERR("max PDM frequency is %d Hz\n", hm2->pwmgen.hal->param.pdm_frequency);
+    hal_set_ui32(hm2->pwmgen.hal->param.pdm_frequency, ((double)hm2->pwmgen.clock_frequency * 65535.0) / 65536.0);
+    HM2_ERR("max PDM frequency is %d Hz\n", hal_get_ui32(hm2->pwmgen.hal->param.pdm_frequency));
     hm2->pwmgen.pdmgen_master_rate_dds_reg = 65535;
 }
 
@@ -219,7 +219,7 @@ void hm2_pwmgen_force_write(hostmot2_t *hm2) {
 
         hm2->pwmgen.pwm_mode_reg[i] = pwm_width;
 
-        switch (hm2->pwmgen.instance[i].hal.param.output_type) {
+        switch (hal_get_si32(hm2->pwmgen.instance[i].hal.param.output_type)) {
             case HM2_PWMGEN_OUTPUT_TYPE_PWM: {
                 // leave the Output Mode bits 0
                 double_buffered = 1;
@@ -247,7 +247,7 @@ void hm2_pwmgen_force_write(hostmot2_t *hm2) {
             default: {  // unknown pwm mode!  complain and switch to pwm/dir
                 HM2_ERR(
                     "invalid pwmgen output_type %d requested\n",
-                    hm2->pwmgen.instance[i].hal.param.output_type
+                    hal_get_si32(hm2->pwmgen.instance[i].hal.param.output_type)
                 ); 
                 HM2_ERR(
                     "supported .output-type values are: %d (PWM & Dir), %d (Up & Down), %d (PDM & Dir), and %d (Dir & PWM)\n",
@@ -257,7 +257,7 @@ void hm2_pwmgen_force_write(hostmot2_t *hm2) {
                     HM2_PWMGEN_OUTPUT_TYPE_PWM_SWAPPED
                 ); 
                 HM2_ERR("switching to 1 (PWM & Dir)\n"); 
-                hm2->pwmgen.instance[i].hal.param.output_type = HM2_PWMGEN_OUTPUT_TYPE_PWM;
+                hal_set_si32(hm2->pwmgen.instance[i].hal.param.output_type, HM2_PWMGEN_OUTPUT_TYPE_PWM);
                 double_buffered = 1;
                 // leave the Output Mode bits 0
                 break;
@@ -265,7 +265,7 @@ void hm2_pwmgen_force_write(hostmot2_t *hm2) {
         }
 
         hm2->pwmgen.pwm_mode_reg[i] |= (double_buffered << 5);
-        if (hm2->pwmgen.instance[i].hal.param.dither) { 
+        if (hal_get_bool(hm2->pwmgen.instance[i].hal.param.dither)) {
             hm2->pwmgen.pwm_mode_reg[i] |= (1 << 6);
         }    
          
@@ -276,7 +276,7 @@ void hm2_pwmgen_force_write(hostmot2_t *hm2) {
     // update enable register
     hm2->pwmgen.enable_reg = 0;
     for (i = 0; i < hm2->pwmgen.num_instances; i ++) {
-        if (*(hm2->pwmgen.instance[i].hal.pin.enable)) {
+        if (hal_get_bool(hm2->pwmgen.instance[i].hal.pin.enable)) {
             hm2->pwmgen.enable_reg |= (1 << i);
         }
     }
@@ -287,17 +287,17 @@ void hm2_pwmgen_force_write(hostmot2_t *hm2) {
     hm2->llio->write(hm2->llio, hm2->pwmgen.pwmgen_master_rate_dds_addr, &hm2->pwmgen.pwmgen_master_rate_dds_reg, sizeof(rtapi_u32));
     hm2->llio->write(hm2->llio, hm2->pwmgen.pdmgen_master_rate_dds_addr, &hm2->pwmgen.pdmgen_master_rate_dds_reg, sizeof(rtapi_u32));
 
-    if ((*hm2->llio->io_error) != 0) return;
+    if (hal_get_bool(*hm2->llio->io_error)) return;
 
     for (i = 0; i < hm2->pwmgen.num_instances; i ++) {
-        hm2->pwmgen.instance[i].written_output_type = hm2->pwmgen.instance[i].hal.param.output_type;
-        hm2->pwmgen.instance[i].written_offset_mode = hm2->pwmgen.instance[i].hal.param.offset_mode;
-        hm2->pwmgen.instance[i].written_dither = hm2->pwmgen.instance[i].hal.param.dither;
-        hm2->pwmgen.instance[i].written_enable = *hm2->pwmgen.instance[i].hal.pin.enable;
+        hm2->pwmgen.instance[i].written_output_type = hal_get_si32(hm2->pwmgen.instance[i].hal.param.output_type);
+        hm2->pwmgen.instance[i].written_offset_mode = hal_get_bool(hm2->pwmgen.instance[i].hal.param.offset_mode);
+        hm2->pwmgen.instance[i].written_dither = hal_get_bool(hm2->pwmgen.instance[i].hal.param.dither);
+        hm2->pwmgen.instance[i].written_enable = hal_get_bool(hm2->pwmgen.instance[i].hal.pin.enable);
     }
 
-    hm2->pwmgen.written_pwm_frequency = hm2->pwmgen.hal->param.pwm_frequency;
-    hm2->pwmgen.written_pdm_frequency = hm2->pwmgen.hal->param.pdm_frequency;
+    hm2->pwmgen.written_pwm_frequency = hal_get_ui32(hm2->pwmgen.hal->param.pwm_frequency);
+    hm2->pwmgen.written_pdm_frequency = hal_get_ui32(hm2->pwmgen.hal->param.pdm_frequency);
 }
 
 
@@ -314,35 +314,34 @@ void hm2_pwmgen_write(hostmot2_t *hm2) {
 
     // check output type
     for (i = 0; i < hm2->pwmgen.num_instances; i ++) {
-        if (hm2->pwmgen.instance[i].hal.param.output_type != hm2->pwmgen.instance[i].written_output_type) {
+        if (hal_get_si32(hm2->pwmgen.instance[i].hal.param.output_type) != hm2->pwmgen.instance[i].written_output_type) {
            goto force_write;
         }
     }	
     // check offset mode
     for (i = 0; i < hm2->pwmgen.num_instances; i ++) {
-        if (hm2->pwmgen.instance[i].hal.param.offset_mode != hm2->pwmgen.instance[i].written_offset_mode) {
+        if (hal_get_bool(hm2->pwmgen.instance[i].hal.param.offset_mode) != hm2->pwmgen.instance[i].written_offset_mode) {
             goto force_write;
         }
     } 
     
     // update dither?
     for (i = 0; i < hm2->pwmgen.num_instances; i ++) {
-        if (hm2->pwmgen.instance[i].hal.param.dither != hm2->pwmgen.instance[i].written_dither) {
-            goto force_write;
-        }
-
-    // check pwm & pdm frequency
-    if (hm2->pwmgen.hal->param.pwm_frequency != hm2->pwmgen.written_pwm_frequency) goto force_write;
-    if (hm2->pwmgen.hal->param.pdm_frequency != hm2->pwmgen.written_pdm_frequency) goto force_write;
-
-    // update enable register?
-    for (i = 0; i < hm2->pwmgen.num_instances; i ++) {
-        if (*(hm2->pwmgen.instance[i].hal.pin.enable) != hm2->pwmgen.instance[i].written_enable) {
+        if (hal_get_bool(hm2->pwmgen.instance[i].hal.param.dither) != hm2->pwmgen.instance[i].written_dither) {
             goto force_write;
         }
     }
 
-}
+    // check pwm & pdm frequency
+    if (hal_get_ui32(hm2->pwmgen.hal->param.pwm_frequency) != hm2->pwmgen.written_pwm_frequency) goto force_write;
+    if (hal_get_ui32(hm2->pwmgen.hal->param.pdm_frequency) != hm2->pwmgen.written_pdm_frequency) goto force_write;
+
+    // update enable register?
+    for (i = 0; i < hm2->pwmgen.num_instances; i ++) {
+        if (hal_get_bool(hm2->pwmgen.instance[i].hal.pin.enable) != hm2->pwmgen.instance[i].written_enable) {
+            goto force_write;
+        }
+    }
 
     return;
 
@@ -405,9 +404,13 @@ int hm2_pwmgen_parse_md(hostmot2_t *hm2, int md_index) {
         hm2->pwmgen.num_instances = hm2->config.num_pwmgens;
     }
 
+    if (hm2->pwmgen.num_instances == 0) {
+	// No pwmgens is not an error, quit here or hal_malloc will fail.
+        return 0;
+    }
 
     // allocate the module-global HAL shared memory
-    hm2->pwmgen.hal = (hm2_pwmgen_module_global_t *)hal_malloc(sizeof(hm2_pwmgen_module_global_t));
+    hm2->pwmgen.hal = hal_malloc(sizeof(*hm2->pwmgen.hal));
     if (hm2->pwmgen.hal == NULL) {
         HM2_ERR("out of memory!\n");
         r = -ENOMEM;
@@ -415,7 +418,7 @@ int hm2_pwmgen_parse_md(hostmot2_t *hm2, int md_index) {
     }
 
 
-    hm2->pwmgen.instance = (hm2_pwmgen_instance_t *)hal_malloc(hm2->pwmgen.num_instances * sizeof(hm2_pwmgen_instance_t));
+    hm2->pwmgen.instance = hal_malloc(hm2->pwmgen.num_instances * sizeof(*hm2->pwmgen.instance));
     if (hm2->pwmgen.instance == NULL) {
         HM2_ERR("out of memory!\n");
         r = -ENOMEM;
@@ -445,101 +448,78 @@ int hm2_pwmgen_parse_md(hostmot2_t *hm2, int md_index) {
     }
 
     // export to HAL
-    // FIXME: r hides the r in enclosing function, and it returns the wrong thing
     {
-        int i;
-        int r;
-        char name[HAL_NAME_LEN + 1];
-
-
         // these hal parameters affect all pwmgen instances
-        r = hal_param_u32_newf(
-            HAL_RW,
-            &(hm2->pwmgen.hal->param.pwm_frequency),
-            hm2->llio->comp_id,
-            "%s.pwmgen.pwm_frequency",
-            hm2->llio->name
-        );
+        r = hal_param_new_ui32(hm2->llio->comp_id, HAL_RW, &(hm2->pwmgen.hal->param.pwm_frequency),
+                               20000, "%s.pwmgen.pwm_frequency", hm2->llio->name);
         if (r < 0) {
-            HM2_ERR("error adding pwmgen.pwm_frequency param, aborting\n");
+            HM2_ERR("error %d adding '%s.pwmgen.pwm_frequency' param, aborting\n", r, hm2->llio->name);
             goto fail1;
         }
-        hm2->pwmgen.hal->param.pwm_frequency = 20000;
         hm2->pwmgen.written_pwm_frequency = 0;
 
-        r = hal_param_u32_newf(
-            HAL_RW,
-            &(hm2->pwmgen.hal->param.pdm_frequency),
-            hm2->llio->comp_id,
-            "%s.pwmgen.pdm_frequency",
-            hm2->llio->name
-        );
+        r = hal_param_new_ui32(hm2->llio->comp_id, HAL_RW, &(hm2->pwmgen.hal->param.pdm_frequency),
+                               20000, "%s.pwmgen.pdm_frequency", hm2->llio->name);
         if (r < 0) {
-            HM2_ERR("error adding pwmgen.pdm_frequency param, aborting\n");
+            HM2_ERR("error %d adding '%s.pwmgen.pdm_frequency' param, aborting\n", r, hm2->llio->name);
             goto fail1;
         }
-        hm2->pwmgen.hal->param.pdm_frequency = 20000;
         hm2->pwmgen.written_pdm_frequency = 0;
 
 
-        for (i = 0; i < hm2->pwmgen.num_instances; i ++) {
+        for (int i = 0; i < hm2->pwmgen.num_instances; i ++) {
             // pins
-            rtapi_snprintf(name, sizeof(name), "%s.pwmgen.%02d.value", hm2->llio->name, i);
-            r = hal_pin_float_new(name, HAL_IN, &(hm2->pwmgen.instance[i].hal.pin.value), hm2->llio->comp_id);
+            r = hal_pin_new_real(hm2->llio->comp_id, HAL_IN, &(hm2->pwmgen.instance[i].hal.pin.value),
+                                 0.0, "%s.pwmgen.%02d.value", hm2->llio->name, i);
             if (r < 0) {
-                HM2_ERR("error adding pin '%s', aborting\n", name);
+                HM2_ERR("error %d adding pin '%s.pwmgen.%02d.value', aborting\n", r, hm2->llio->name, i);
                 goto fail1;
             }
 
-            rtapi_snprintf(name, sizeof(name), "%s.pwmgen.%02d.enable", hm2->llio->name, i);
-            r = hal_pin_bit_new(name, HAL_IN, &(hm2->pwmgen.instance[i].hal.pin.enable), hm2->llio->comp_id);
+            r = hal_pin_new_bool(hm2->llio->comp_id, HAL_IN, &(hm2->pwmgen.instance[i].hal.pin.enable),
+                                 0, "%s.pwmgen.%02d.enable", hm2->llio->name, i);
             if (r < 0) {
-                HM2_ERR("error adding pin '%s', aborting\n", name);
+                HM2_ERR("error %d adding pin '%s.pwmgen.%02d.enable', aborting\n", r, hm2->llio->name, i);
                 goto fail1;
             }
  
             // parameters
-            rtapi_snprintf(name, sizeof(name), "%s.pwmgen.%02d.offset-mode", hm2->llio->name, i);
-            r = hal_param_bit_new(name, HAL_RW, &(hm2->pwmgen.instance[i].hal.param.offset_mode), hm2->llio->comp_id);
+            r = hal_param_new_bool(hm2->llio->comp_id, HAL_RW, &(hm2->pwmgen.instance[i].hal.param.offset_mode),
+                                   0, "%s.pwmgen.%02d.offset-mode", hm2->llio->name, i);
             if (r < 0) {
-                HM2_ERR("error adding param '%s', aborting\n", name);
+                HM2_ERR("error %d adding param '%s.pwmgen.%02d.offset-mode', aborting\n", r, hm2->llio->name, i);
                 goto fail1;
             }
             if (hm2->pwmgen.firmware_supports_dither) {
-                rtapi_snprintf(name, sizeof(name), "%s.pwmgen.%02d.dither", hm2->llio->name, i);
-                r = hal_param_bit_new(name, HAL_RW, &(hm2->pwmgen.instance[i].hal.param.dither), hm2->llio->comp_id);
+                r = hal_param_new_bool(hm2->llio->comp_id, HAL_RW, &(hm2->pwmgen.instance[i].hal.param.dither),
+                                       0, "%s.pwmgen.%02d.dither", hm2->llio->name, i);
                 if (r < 0) {
-                     HM2_ERR("error adding param '%s', aborting\n", name);
+                     HM2_ERR("error %d adding param '%s.pwmgen.%02d.dither', aborting\n", r, hm2->llio->name, i);
+                    goto fail1;
+                }
+            } else {
+                // Parameter allocated in conditional, make sure the memory is still available
+                r = hal_param_new_fake(hm2->llio->comp_id, (hal_refs_u *)&(hm2->pwmgen.instance[i].hal.param.dither));
+                if (r < 0) {
+                     HM2_ERR("error %d allocating fake param for '%s.pwmgen.%02d.dither', aborting\n", r, hm2->llio->name, i);
                     goto fail1;
                 }
             }
-            rtapi_snprintf(name, sizeof(name), "%s.pwmgen.%02d.scale", hm2->llio->name, i);
-            r = hal_param_float_new(name, HAL_RW, &(hm2->pwmgen.instance[i].hal.param.scale), hm2->llio->comp_id);
+            r = hal_param_new_real(hm2->llio->comp_id, HAL_RW, &(hm2->pwmgen.instance[i].hal.param.scale),
+                                   1.0, "%s.pwmgen.%02d.scale", hm2->llio->name, i);
             if (r < 0) {
-                HM2_ERR("error adding param '%s', aborting\n", name);
+                HM2_ERR("error %d adding param '%s.pwmgen.%02d.scale', aborting\n", r, hm2->llio->name, i);
                 goto fail1;
             }
 
-            r = hal_param_s32_newf(
-                HAL_RW,
-                &(hm2->pwmgen.instance[i].hal.param.output_type),
-                hm2->llio->comp_id,
-                "%s.pwmgen.%02d.output-type",
-                hm2->llio->name,
-                i
-            );
+            r = hal_param_new_si32(hm2->llio->comp_id, HAL_RW, &(hm2->pwmgen.instance[i].hal.param.output_type),
+                                   HM2_PWMGEN_OUTPUT_TYPE_PWM, "%s.pwmgen.%02d.output-type", hm2->llio->name, i);
             if (r < 0) {
-                HM2_ERR("error adding param, aborting\n");
+                HM2_ERR("error %d adding param '%s.pwmgen.%02d.output-type', aborting\n", r, hm2->llio->name, i);
                 goto fail1;
             }
 
             // init hal objects
-            *(hm2->pwmgen.instance[i].hal.pin.enable) = 0;
-            *(hm2->pwmgen.instance[i].hal.pin.value) = 0.0;
-            hm2->pwmgen.instance[i].hal.param.dither = 0;  
-            hm2->pwmgen.instance[i].hal.param.scale = 1.0;        
-            hm2->pwmgen.instance[i].hal.param.offset_mode = 0;
-            hm2->pwmgen.instance[i].hal.param.output_type = HM2_PWMGEN_OUTPUT_TYPE_PWM;
             hm2->pwmgen.instance[i].written_output_type = -666;  // force an update at the start
             hm2->pwmgen.instance[i].written_enable = -666;       // force an update at the start
             hm2->pwmgen.instance[i].written_dither = -666;       // force an update at the start
@@ -614,7 +594,7 @@ void hm2_pwmgen_prepare_tram_write(hostmot2_t *hm2) {
         double register_value;
         int bits;
 
-        scaled_value = *hm2->pwmgen.instance[i].hal.pin.value / hm2->pwmgen.instance[i].hal.param.scale;
+        scaled_value = hal_get_real(hm2->pwmgen.instance[i].hal.pin.value) / hal_get_real(hm2->pwmgen.instance[i].hal.param.scale);
         if (scaled_value > 1.0) scaled_value = 1.0;
 	if (scaled_value < -1.0) scaled_value = -1.0;
 
@@ -625,16 +605,16 @@ void hm2_pwmgen_prepare_tram_write(hostmot2_t *hm2) {
         // However, there apparently is equipment that does not behave this
         // way, and that benefits from having PWM & Dir go low when /Enable
         // goes high. (note that PWM will go to 50% when offset mode is enabled)
-        if (*hm2->pwmgen.instance[i].hal.pin.enable == 0) {
+        if (!hal_get_bool(hm2->pwmgen.instance[i].hal.pin.enable)) {
             scaled_value = 0.0;
         }
 	
         abs_duty_cycle = fabs(scaled_value);
 
         // duty_cycle goes from 0.0 to 1.0, and needs to be puffed out to pwm_bits (if it's pwm) or 12 (if it's pdm)
- 	if  (hm2->pwmgen.instance[i].hal.param.offset_mode == 0) {
+	if (!hal_get_bool(hm2->pwmgen.instance[i].hal.param.offset_mode)) {
 	     //normal PWM/PDM modes	
-	     if (hm2->pwmgen.instance[i].hal.param.output_type == HM2_PWMGEN_OUTPUT_TYPE_PDM) {
+	     if (hal_get_si32(hm2->pwmgen.instance[i].hal.param.output_type) == HM2_PWMGEN_OUTPUT_TYPE_PDM) {
 	            bits = 12;
 	        } else {
 	            bits = hm2->pwmgen.pwm_bits;
@@ -642,7 +622,7 @@ void hm2_pwmgen_prepare_tram_write(hostmot2_t *hm2) {
 	        // With normal PWM, the max PWM register value is 0xNFF.X 
 	        // but for dithered PWM the max value is 0xNFE.F
 	        // the topdrop value is chosen to generate these max values  	
-	        if (hm2->pwmgen.instance[i].hal.param.dither == 0) {
+	        if (!hal_get_bool(hm2->pwmgen.instance[i].hal.param.dither)) {
 	            topdrop = 1; 
 	        } else {
 	            topdrop = 1.0625; 
@@ -651,7 +631,7 @@ void hm2_pwmgen_prepare_tram_write(hostmot2_t *hm2) {
 
 	} else {
 	     // offset PWM/PDM modes where 0 PWM value = 50% duty cycle	also choose active low
-	     if (hm2->pwmgen.instance[i].hal.param.output_type == HM2_PWMGEN_OUTPUT_TYPE_PDM) {
+	     if (hal_get_si32(hm2->pwmgen.instance[i].hal.param.output_type) == HM2_PWMGEN_OUTPUT_TYPE_PDM) {
 	            bits = 11;
 	        } else {
 	            bits = hm2->pwmgen.pwm_bits -1;
@@ -659,7 +639,7 @@ void hm2_pwmgen_prepare_tram_write(hostmot2_t *hm2) {
 	        // With normal PWM, the max PWM register value is 0xNFF.X 
 	        // but for dithered PWM the max value is 0xNFE.F
 	        // the topdrop value is chosen to generate these max values  	
-	        if (hm2->pwmgen.instance[i].hal.param.dither == 0) {
+	        if (!hal_get_bool(hm2->pwmgen.instance[i].hal.param.dither)) {
 	            topdrop = 1; 
 	        } else {
 	            topdrop = 1.0625; 

--- a/src/hal/drivers/mesa-hostmot2/raw.c
+++ b/src/hal/drivers/mesa-hostmot2/raw.c
@@ -32,72 +32,60 @@
 
 int hm2_raw_setup(hostmot2_t *hm2) {
     int r;
-    char name[HAL_NAME_LEN + 1];
-
 
     if (hm2->config.enable_raw == 0) {
         return 0;
     }
 
 
-    hm2->raw = (hm2_raw_t *)hal_malloc(sizeof(hm2_raw_t));
+    hm2->raw = hal_malloc(sizeof(*hm2->raw));
     if (hm2->raw == NULL) {
         HM2_ERR("out of memory!\n");
         hm2->config.enable_raw = 0;
         return -ENOMEM;
     }
 
-    rtapi_snprintf(name, sizeof(name), "%s.raw.read_address", hm2->llio->name);
-    r = hal_pin_u32_new(name, HAL_IN, &(hm2->raw->hal.pin.read_address), hm2->llio->comp_id);
+    r = hal_pin_new_ui32(hm2->llio->comp_id, HAL_IN, &(hm2->raw->hal.pin.read_address),
+                         0, "%s.raw.read_address", hm2->llio->name);
     if (r < 0) {
-        HM2_ERR("error adding pin '%s', aborting\n", name);
+        HM2_ERR("error %d adding pin '%s.raw.read_address', aborting\n", r, hm2->llio->name);
         return -EINVAL;
     }
 
-    rtapi_snprintf(name, sizeof(name), "%s.raw.read_data", hm2->llio->name);
-    r = hal_pin_u32_new(name, HAL_OUT, &(hm2->raw->hal.pin.read_data), hm2->llio->comp_id);
+    r = hal_pin_new_ui32(hm2->llio->comp_id, HAL_OUT, &(hm2->raw->hal.pin.read_data),
+                         0, "%s.raw.read_data", hm2->llio->name);
     if (r < 0) {
-        HM2_ERR("error adding pin '%s', aborting\n", name);
+        HM2_ERR("error %d adding pin '%s.raw.read_data', aborting\n", r, hm2->llio->name);
         return -EINVAL;
     }
 
-    rtapi_snprintf(name, sizeof(name), "%s.raw.write_address", hm2->llio->name);
-    r = hal_pin_u32_new(name, HAL_IN, &(hm2->raw->hal.pin.write_address), hm2->llio->comp_id);
+    r = hal_pin_new_ui32(hm2->llio->comp_id, HAL_IN, &(hm2->raw->hal.pin.write_address),
+                         0, "%s.raw.write_address", hm2->llio->name);
     if (r < 0) {
-        HM2_ERR("error adding pin '%s', aborting\n", name);
+        HM2_ERR("error %d adding pin '%s.raw.write_address', aborting\n", r, hm2->llio->name);
         return -EINVAL;
     }
 
-    rtapi_snprintf(name, sizeof(name), "%s.raw.write_data", hm2->llio->name);
-    r = hal_pin_u32_new(name, HAL_IN, &(hm2->raw->hal.pin.write_data), hm2->llio->comp_id);
+    r = hal_pin_new_ui32(hm2->llio->comp_id, HAL_IN, &(hm2->raw->hal.pin.write_data),
+                         0, "%s.raw.write_data", hm2->llio->name);
     if (r < 0) {
-        HM2_ERR("error adding pin '%s', aborting\n", name);
+        HM2_ERR("error %d adding pin '%s.raw.write_data', aborting\n", r, hm2->llio->name);
         return -EINVAL;
     }
 
-    rtapi_snprintf(name, sizeof(name), "%s.raw.write_strobe", hm2->llio->name);
-    r = hal_pin_bit_new(name, HAL_IN, &(hm2->raw->hal.pin.write_strobe), hm2->llio->comp_id);
+    r = hal_pin_new_bool(hm2->llio->comp_id, HAL_IN, &(hm2->raw->hal.pin.write_strobe),
+                         0, "%s.raw.write_strobe", hm2->llio->name);
     if (r < 0) {
-        HM2_ERR("error adding pin '%s', aborting\n", name);
+        HM2_ERR("error %d adding pin '%s.raw.write_strobe', aborting\n", r, hm2->llio->name);
         return -EINVAL;
     }
 
-    rtapi_snprintf(name, sizeof(name), "%s.raw.dump_state", hm2->llio->name);
-    r = hal_pin_bit_new(name, HAL_IO, &(hm2->raw->hal.pin.dump_state), hm2->llio->comp_id);
+    r = hal_pin_new_bool(hm2->llio->comp_id, HAL_IO, &(hm2->raw->hal.pin.dump_state),
+                         0, "%s.raw.dump_state", hm2->llio->name);
     if (r < 0) {
-        HM2_ERR("error adding pin '%s', aborting\n", name);
+        HM2_ERR("error %d adding pin '%s.raw.dump_state', aborting\n", r, hm2->llio->name);
         return -EINVAL;
     }
-
-    // init hal objects
-    *(hm2->raw->hal.pin.read_address)  = 0;
-    *(hm2->raw->hal.pin.read_data) = 0;
-
-    *(hm2->raw->hal.pin.write_address) = 0;
-    *(hm2->raw->hal.pin.write_data) = 0;
-    *(hm2->raw->hal.pin.write_strobe) = 0;
-
-    *(hm2->raw->hal.pin.dump_state) = 0;
 
     return 0;
 }
@@ -110,14 +98,14 @@ void hm2_raw_queue_read(hostmot2_t *hm2) {
 
     hm2->llio->queue_read(
         hm2->llio,
-        *hm2->raw->hal.pin.read_address & 0xffff,
+        hal_get_ui32(hm2->raw->hal.pin.read_address) & 0xffff,
         (void *)hm2->raw->hal.pin.read_data,
         sizeof(rtapi_u32)
     );
 
-    if (*hm2->raw->hal.pin.dump_state != 0) {
+    if (hal_get_bool(hm2->raw->hal.pin.dump_state)) {
         hm2_print_modules(hm2);
-        *hm2->raw->hal.pin.dump_state = 0;
+        hal_set_bool(hm2->raw->hal.pin.dump_state, 0);
     }
 }
 
@@ -126,15 +114,15 @@ void hm2_raw_queue_read(hostmot2_t *hm2) {
 
 void hm2_raw_write(hostmot2_t *hm2) {
     if (hm2->config.enable_raw == 0) return;
-    if (*hm2->raw->hal.pin.write_strobe == 0) return;
+    if (!hal_get_bool(hm2->raw->hal.pin.write_strobe)) return;
 
     hm2->llio->write(
         hm2->llio,
-        *hm2->raw->hal.pin.write_address & 0xffff,
+        hal_get_ui32(hm2->raw->hal.pin.write_address) & 0xffff,
         (void *)hm2->raw->hal.pin.write_data,
         sizeof(rtapi_u32)
     );
 
-    *hm2->raw->hal.pin.write_strobe = 0;
+    hal_set_bool(hm2->raw->hal.pin.write_strobe, 0);
 }
 

--- a/src/hal/drivers/mesa-hostmot2/rcpwmgen.c
+++ b/src/hal/drivers/mesa-hostmot2/rcpwmgen.c
@@ -77,7 +77,7 @@ int hm2_rcpwmgen_parse_md(hostmot2_t *hm2, int md_index) {
     hm2->rcpwmgen.clock_frequency = md->clock_freq;
     hm2->rcpwmgen.version = md->version;
     // allocate the module-instance HAL shared memory
-    hm2->rcpwmgen.instance = (hm2_rcpwmgen_instance_t *)hal_malloc(hm2->rcpwmgen.num_instances * sizeof(hm2_rcpwmgen_instance_t));
+    hm2->rcpwmgen.instance = hal_malloc(hm2->rcpwmgen.num_instances * sizeof(*hm2->rcpwmgen.instance));
     if (hm2->rcpwmgen.instance == NULL) {
         HM2_ERR("out of memory!\n");
         r = -ENOMEM;
@@ -85,7 +85,7 @@ int hm2_rcpwmgen_parse_md(hostmot2_t *hm2, int md_index) {
     }
 
     // allocate the module-global HAL shared memory
-    hm2->rcpwmgen.hal = (hm2_rcpwmgen_module_global_t *)hal_malloc(sizeof(hm2_rcpwmgen_module_global_t));
+    hm2->rcpwmgen.hal = hal_malloc(sizeof(*hm2->rcpwmgen.hal));
     if (hm2->rcpwmgen.hal == NULL) {
         HM2_ERR("out of memory!\n");
         r = -ENOMEM;
@@ -113,51 +113,40 @@ int hm2_rcpwmgen_parse_md(hostmot2_t *hm2, int md_index) {
     //
     // Export to HAL.
     //
-
+    // initialize width to 0, scale to 1, offset 0 and rate to 50 Hz
     {
-        int i;
-        char name[HAL_NAME_LEN + 1];
-         for (i = 0; i < hm2->rcpwmgen.num_instances; i ++) {
- 
-            rtapi_snprintf(name, sizeof(name), "%s.rcpwmgen.%02d.width", hm2->llio->name, i);
-            r = hal_pin_float_new(name, HAL_IN, &(hm2->rcpwmgen.instance[i].hal.pin.width), hm2->llio->comp_id);
+         for (int i = 0; i < hm2->rcpwmgen.num_instances; i ++) {
+            r = hal_pin_new_real(hm2->llio->comp_id, HAL_IN, &(hm2->rcpwmgen.instance[i].hal.pin.width),
+                                 0.0, "%s.rcpwmgen.%02d.width", hm2->llio->name, i);
             if (r < 0) {
-                HM2_ERR("error adding pin '%s', aborting\n", name);
+                HM2_ERR("error %d adding pin '%s.rcpwmgen.%02d.width', aborting\n", r, hm2->llio->name, i);
                 r = -ENOMEM;
                 goto fail1;
             }
-            rtapi_snprintf(name, sizeof(name), "%s.rcpwmgen.%02d.scale", hm2->llio->name, i);
-            r = hal_pin_float_new(name, HAL_IN, &(hm2->rcpwmgen.instance[i].hal.pin.scale), hm2->llio->comp_id);
+            r = hal_pin_new_real(hm2->llio->comp_id, HAL_IN, &(hm2->rcpwmgen.instance[i].hal.pin.scale),
+                                 1.0, "%s.rcpwmgen.%02d.scale", hm2->llio->name, i);
             if (r < 0) {
-                HM2_ERR("error adding pin '%s', aborting\n", name);
+                HM2_ERR("error %d adding pin '%s.rcpwmgen.%02d.scale', aborting\n", r, hm2->llio->name, i);
                 r = -ENOMEM;
                 goto fail1;
             }
-            rtapi_snprintf(name, sizeof(name), "%s.rcpwmgen.%02d.offset", hm2->llio->name, i);
-            r = hal_pin_float_new(name, HAL_IN, &(hm2->rcpwmgen.instance[i].hal.pin.offset), hm2->llio->comp_id);
+            r = hal_pin_new_real(hm2->llio->comp_id, HAL_IN, &(hm2->rcpwmgen.instance[i].hal.pin.offset),
+                                 0.0, "%s.rcpwmgen.%02d.offset", hm2->llio->name, i);
             if (r < 0) {
-                HM2_ERR("error adding pin '%s', aborting\n", name);
+                HM2_ERR("error %d adding pin '%s.rcpwmgen.%02d.offset', aborting\n", r, hm2->llio->name, i);
                 r = -ENOMEM;
                 goto fail1;
             }
         }
 
-        rtapi_snprintf(name, sizeof(name), "%s.rcpwmgen.rate", hm2->llio->name);
-        r = hal_pin_float_new(name, HAL_IN, &(hm2->rcpwmgen.hal->pin.rate), hm2->llio->comp_id);
+        r = hal_pin_new_real(hm2->llio->comp_id, HAL_IN, &(hm2->rcpwmgen.hal->pin.rate),
+                             50.0, "%s.rcpwmgen.rate", hm2->llio->name);
         if (r < 0) {
-            HM2_ERR("error adding pin '%s', aborting\n", name);
+            HM2_ERR("error %d adding pin '%s.rcpwmgen.rate', aborting\n", r, hm2->llio->name);
             goto fail1;
         }
     }
 
-    // initialize width to 0, scale to 1, offset 0 and rate to 50 Hz
-    *hm2->rcpwmgen.hal->pin.rate = 50;
-    int i;
-    for (i = 0; i < hm2->rcpwmgen.num_instances; i ++) {
-       *hm2->rcpwmgen.instance[i].hal.pin.width = 0;
-       *hm2->rcpwmgen.instance[i].hal.pin.scale = 1.0;
-       *hm2->rcpwmgen.instance[i].hal.pin.offset = 0;
-    }
     hm2->rcpwmgen.error_throttle = 0;
 
     return hm2->rcpwmgen.num_instances;
@@ -191,9 +180,9 @@ void hm2_rcpwmgen_update_regs(hostmot2_t *hm2) {
     rtapi_u32 reg;
 
     // Set rate
-    double rate = *hm2->rcpwmgen.hal->pin.rate;
+    double rate = hal_get_real(hm2->rcpwmgen.hal->pin.rate);
     if  (rate < 0.01) {
-        *hm2->rcpwmgen.hal->pin.rate = 0.01;
+        hal_set_real(hm2->rcpwmgen.hal->pin.rate, 0.01);
         rate = 0.01;
         if (hm2->rcpwmgen.error_throttle == 0) {
             HM2_ERR("rcpwmgen frequency must be >= .01, resetting to %.3lf \n",0.01);
@@ -202,7 +191,7 @@ void hm2_rcpwmgen_update_regs(hostmot2_t *hm2) {
     } 
 
     if (rate > 1000) {
-        *hm2->rcpwmgen.hal->pin.rate = 1000;
+        hal_set_real(hm2->rcpwmgen.hal->pin.rate, 1000);
         rate = 1000;
          if (hm2->rcpwmgen.error_throttle == 0) {
              HM2_ERR("rcpwmgen frequency must be <= 1000, resetting to %.3lf \n",1000.0);
@@ -219,19 +208,19 @@ void hm2_rcpwmgen_update_regs(hostmot2_t *hm2) {
     int i;   
     // Set width.
     for (i = 0; i < hm2->rcpwmgen.num_instances; i ++) {
-	if (*hm2->rcpwmgen.instance[i].hal.pin.scale == 0) {
+	if (hal_get_real(hm2->rcpwmgen.instance[i].hal.pin.scale) == 0) {
             if (hm2->rcpwmgen.error_throttle == 0) {
                 HM2_ERR("rcpwmgen %d zero scale is illegal, resetting to %.3lf \n", i,1.0);
                 hm2->rcpwmgen.error_throttle = 100;
             }
-	    *hm2->rcpwmgen.instance[i].hal.pin.scale = 1.0;
+	    hal_set_real(hm2->rcpwmgen.instance[i].hal.pin.scale, 1.0);
         }
-        double width = (*hm2->rcpwmgen.instance[i].hal.pin.width)/(*hm2->rcpwmgen.instance[i].hal.pin.scale)+(*hm2->rcpwmgen.instance[i].hal.pin.offset);
+        double width = hal_get_real(hm2->rcpwmgen.instance[i].hal.pin.width) / hal_get_real(hm2->rcpwmgen.instance[i].hal.pin.scale) + hal_get_real(hm2->rcpwmgen.instance[i].hal.pin.offset);
         // The `width` variable has the desired pulse width in milliseconds.
         // The width register sets the width to reg*(CLockLow/16+1)
 
         if (width < 0) {
-            *hm2->rcpwmgen.instance[i].hal.pin.width = 0.0;
+            hal_set_real(hm2->rcpwmgen.instance[i].hal.pin.width, 0.0);
             width = 0.0;
             if (hm2->rcpwmgen.error_throttle == 0) {
                 HM2_ERR("rcpwmgen %d width must be >= 0, resetting to %.3lf \n", i,0.0);
@@ -240,10 +229,10 @@ void hm2_rcpwmgen_update_regs(hostmot2_t *hm2) {
 	 }
          reg = ((hm2->rcpwmgen.clock_frequency/(16.0*1000.0)))*width -1; 
          if ((reg +1) > 65535 ) {
-            *hm2->rcpwmgen.instance[i].hal.pin.width = 65535/(hm2->rcpwmgen.clock_frequency/(16.0*1000.0));
+            hal_set_real(hm2->rcpwmgen.instance[i].hal.pin.width, 65535/(hm2->rcpwmgen.clock_frequency/(16.0*1000.0)));
             reg = 65535;
             if (hm2->rcpwmgen.error_throttle == 0) {
-                HM2_ERR("rcpwmgen %d width too large,resetting to %.3lf \n", i,*hm2->rcpwmgen.instance[i].hal.pin.width);  
+                HM2_ERR("rcpwmgen %d width too large,resetting to %.3lf \n", i, hal_get_real(hm2->rcpwmgen.instance[i].hal.pin.width));  
                 hm2->rcpwmgen.error_throttle = 100;
             }
         }
@@ -261,8 +250,8 @@ void hm2_rcpwmgen_write(hostmot2_t *hm2) {
 
     // check rate 
  
-    if ( *hm2->rcpwmgen.hal->pin.rate != hm2->rcpwmgen.written_rate) {
-            hm2->rcpwmgen.written_rate = *hm2->rcpwmgen.hal->pin.rate;
+    if ( hal_get_real(hm2->rcpwmgen.hal->pin.rate) != hm2->rcpwmgen.written_rate) {
+            hm2->rcpwmgen.written_rate = hal_get_real(hm2->rcpwmgen.hal->pin.rate);
             goto force_write;
        }
 	

--- a/src/hal/drivers/mesa-hostmot2/resolver.c
+++ b/src/hal/drivers/mesa-hostmot2/resolver.c
@@ -94,15 +94,13 @@ int hm2_resolver_parse_md(hostmot2_t *hm2, int md_index) {
         hm2->resolver.num_instances = md->instances;
     }
     
-    hm2->resolver.hal = (hm2_resolver_global_t *)hal_malloc(
-                                                sizeof(hm2_resolver_global_t));
+    hm2->resolver.hal = hal_malloc(sizeof(*hm2->resolver.hal));
     if (hm2->resolver.hal == NULL) {
         HM2_ERR("out of memory!\n");
         r = -ENOMEM;
         goto fail0;
     }
-    hm2->resolver.instance = (hm2_resolver_instance_t *)hal_malloc(
-                hm2->resolver.num_resolvers * sizeof(hm2_resolver_instance_t));
+    hm2->resolver.instance = hal_malloc(hm2->resolver.num_resolvers * sizeof(*hm2->resolver.instance));
     if (hm2->resolver.instance == NULL) {
         HM2_ERR("out of memory!\n");
         r = -ENOMEM;
@@ -142,161 +140,112 @@ int hm2_resolver_parse_md(hostmot2_t *hm2, int md_index) {
     // export the resolvers to HAL
     
     {
-        int i;
-        int ret;
-        char name[HAL_NAME_LEN + 1];
-        
-        rtapi_snprintf(name, sizeof(name), "%s.resolver.excitation-khz", 
-                       hm2->llio->name);
-        ret= hal_param_float_new(name, HAL_RW, 
-                                 &(hm2->resolver.hal->param.excitation_khz), 
-                                 hm2->llio->comp_id);
-        if (ret < 0) {
-            HM2_ERR("error adding param '%s', aborting\n", name);
+        r = hal_param_new_real(hm2->llio->comp_id, HAL_RW, &(hm2->resolver.hal->param.excitation_khz),
+                                -1.0, "%s.resolver.excitation-khz", hm2->llio->name);
+        if (r < 0) {
+            HM2_ERR("error %d adding param '%s.resolver.excitation-khz', aborting\n", r, hm2->llio->name);
             goto fail1;
         }
         
-        for (i = 0; i < hm2->resolver.num_resolvers; i ++) {
+        for (int i = 0; i < hm2->resolver.num_resolvers; i ++) {
             // pins
             
-            rtapi_snprintf(name, sizeof(name), "%s.resolver.%02d.position", 
-                           hm2->llio->name, i);
-            ret= hal_pin_float_new(name, HAL_OUT, 
-                                   &(hm2->resolver.instance[i].hal.pin.position),
-                                   hm2->llio->comp_id);
-            if (ret < 0) {
-                HM2_ERR("error adding pin '%s', aborting\n", name);
+            r = hal_pin_new_real(hm2->llio->comp_id, HAL_OUT, &(hm2->resolver.instance[i].hal.pin.position),
+                                  0.0, "%s.resolver.%02d.position", hm2->llio->name, i);
+            if (r < 0) {
+                HM2_ERR("error %d adding pin '%s.resolver.%02d.position', aborting\n", r, hm2->llio->name, i);
                 goto fail1;
             }
             
-            rtapi_snprintf(name, sizeof(name), "%s.resolver.%02d.angle", 
-                           hm2->llio->name, i);
-            ret= hal_pin_float_new(name, HAL_OUT, 
-                                   &(hm2->resolver.instance[i].hal.pin.angle), 
-                                   hm2->llio->comp_id);
-            if (ret < 0) {
-                HM2_ERR("error adding pin '%s', aborting\n", name);
+            r = hal_pin_new_real(hm2->llio->comp_id, HAL_OUT, &(hm2->resolver.instance[i].hal.pin.angle),
+                                  0.0, "%s.resolver.%02d.angle", hm2->llio->name, i);
+            if (r < 0) {
+                HM2_ERR("error %d adding pin '%s.resolver.%02d.angle', aborting\n", r, hm2->llio->name, i);
                 goto fail1;
             }
             
-            rtapi_snprintf(name, sizeof(name), "%s.resolver.%02d.velocity", 
-                           hm2->llio->name, i);
-            ret= hal_pin_float_new(name, HAL_OUT, 
-                                   &(hm2->resolver.instance[i].hal.pin.velocity), 
-                                   hm2->llio->comp_id);
-            if (ret < 0) {
-                HM2_ERR("error adding pin '%s', aborting\n", name);
+            r = hal_pin_new_real(hm2->llio->comp_id, HAL_OUT, &(hm2->resolver.instance[i].hal.pin.velocity),
+                                  0.0, "%s.resolver.%02d.velocity", hm2->llio->name, i);
+            if (r < 0) {
+                HM2_ERR("error %d adding pin '%s.resolver.%02d.velocity', aborting\n", r, hm2->llio->name, i);
                 goto fail1;
             }
 
-                        rtapi_snprintf(name, sizeof(name), "%s.resolver.%02d.velocity-rpm",
-                           hm2->llio->name, i);
-            ret= hal_pin_float_new(name, HAL_OUT,
-                                   &(hm2->resolver.instance[i].hal.pin.velocity_rpm),
-                                   hm2->llio->comp_id);
-            if (ret < 0) {
-                HM2_ERR("error adding pin '%s', aborting\n", name);
+            r = hal_pin_new_real(hm2->llio->comp_id, HAL_OUT, &(hm2->resolver.instance[i].hal.pin.velocity_rpm),
+                                  0.0, "%s.resolver.%02d.velocity-rpm", hm2->llio->name, i);
+            if (r < 0) {
+                HM2_ERR("error %d adding pin '%s.resolver.%02d.velocity-rpm', aborting\n", r, hm2->llio->name, i);
                 goto fail1;
             }
 
-            rtapi_snprintf(name, sizeof(name), "%s.resolver.%02d.count", 
-                           hm2->llio->name, i);
-            ret= hal_pin_s32_new(name, HAL_OUT, 
-                                 &(hm2->resolver.instance[i].hal.pin.count), 
-                                 hm2->llio->comp_id);
-            if (ret < 0) {
-                HM2_ERR("error adding pin '%s', aborting\n", name);
+            r = hal_pin_new_si32(hm2->llio->comp_id, HAL_OUT, &(hm2->resolver.instance[i].hal.pin.count),
+                                  0, "%s.resolver.%02d.count", hm2->llio->name, i);
+            if (r < 0) {
+                HM2_ERR("error %d adding pin '%s.resolver.%02d.count', aborting\n", r, hm2->llio->name, i);
                 goto fail1;
             }
             
-            rtapi_snprintf(name, sizeof(name), "%s.resolver.%02d.rawcounts",
-                           hm2->llio->name, i);
-            ret= hal_pin_s32_new(name, HAL_OUT, 
-                                 &(hm2->resolver.instance[i].hal.pin.rawcounts), 
-                                 hm2->llio->comp_id);
-            if (ret < 0) {
-                HM2_ERR("error adding pin '%s', aborting\n", name);
+            r = hal_pin_new_si32(hm2->llio->comp_id, HAL_OUT, &(hm2->resolver.instance[i].hal.pin.rawcounts),
+                                  0, "%s.resolver.%02d.rawcounts", hm2->llio->name, i);
+            if (r < 0) {
+                HM2_ERR("error %d adding pin '%s.resolver.%02d.rawcounts', aborting\n", r, hm2->llio->name, i);
                 goto fail1;
             }
             
-            rtapi_snprintf(name, sizeof(name), "%s.resolver.%02d.reset", 
-                           hm2->llio->name, i);
-            ret= hal_pin_bit_new(name, HAL_IN, 
-                                 &(hm2->resolver.instance[i].hal.pin.reset), 
-                                 hm2->llio->comp_id);
-            if (ret < 0) {
-                HM2_ERR("error adding pin '%s', aborting\n", name);
+            r = hal_pin_new_bool(hm2->llio->comp_id, HAL_IN, &(hm2->resolver.instance[i].hal.pin.reset),
+                                  0, "%s.resolver.%02d.reset", hm2->llio->name, i);
+            if (r < 0) {
+                HM2_ERR("error %d adding pin '%s.resolver.%02d.reset', aborting\n", r, hm2->llio->name, i);
                 goto fail1;
             }
             
-            rtapi_snprintf(name, sizeof(name), "%s.resolver.%02d.index-enable", 
-                           hm2->llio->name, i);
-            ret= hal_pin_bit_new(name, HAL_IO,
-                                 &(hm2->resolver.instance[i].hal.pin.index_enable), 
-                                 hm2->llio->comp_id);
-            if (ret < 0) {
-                HM2_ERR("error adding pin '%s', aborting\n", name);
+            r = hal_pin_new_bool(hm2->llio->comp_id, HAL_IO, &(hm2->resolver.instance[i].hal.pin.index_enable),
+                                  0, "%s.resolver.%02d.index-enable", hm2->llio->name, i);
+            if (r < 0) {
+                HM2_ERR("error %d adding pin '%s.resolver.%02d.index-enable', aborting\n", r, hm2->llio->name, i);
                 goto fail1;
             }
             
-            rtapi_snprintf(name, sizeof(name), "%s.resolver.%02d.error", 
-                           hm2->llio->name, i);
-            ret= hal_pin_bit_new(name, HAL_OUT, 
-                                 &(hm2->resolver.instance[i].hal.pin.error), 
-                                 hm2->llio->comp_id);
-            if (ret < 0) {
-                HM2_ERR("error adding pin '%s', aborting\n", name);
+            r = hal_pin_new_bool(hm2->llio->comp_id, HAL_OUT, &(hm2->resolver.instance[i].hal.pin.error),
+                                  0, "%s.resolver.%02d.error", hm2->llio->name, i);
+            if (r < 0) {
+                HM2_ERR("error %d adding pin '%s.resolver.%02d.error', aborting\n", r, hm2->llio->name, i);
                 goto fail1;
             }
             
-            rtapi_snprintf(name, sizeof(name), "%s.resolver.%02d.joint-pos-fb",
-                           hm2->llio->name, i);
-            ret= hal_pin_float_new(name, HAL_IN,
-                                 &(hm2->resolver.instance[i].hal.pin.joint_pos_fb),
-                                 hm2->llio->comp_id);
-            if (ret < 0) {
-                HM2_ERR("error adding pin '%s', aborting\n", name);
+            r = hal_pin_new_real(hm2->llio->comp_id, HAL_IN, &(hm2->resolver.instance[i].hal.pin.joint_pos_fb),
+                                  0.0, "%s.resolver.%02d.joint-pos-fb", hm2->llio->name, i);
+            if (r < 0) {
+                HM2_ERR("error %d adding pin '%s.resolver.%02d.joint-pos-fb', aborting\n", r, hm2->llio->name, i);
                 goto fail1;
             }
 
             // parameters
-            rtapi_snprintf(name, sizeof(name), "%s.resolver.%02d.scale", 
-                           hm2->llio->name, i);
-            ret= hal_param_float_new(name, HAL_RW, 
-                                     &(hm2->resolver.instance[i].hal.param.scale), 
-                                     hm2->llio->comp_id);
-            if (ret < 0) {
-                HM2_ERR("error adding param '%s', aborting\n", name);
+            r = hal_param_new_real(hm2->llio->comp_id, HAL_RW, &(hm2->resolver.instance[i].hal.param.scale), 
+                                    1.0, "%s.resolver.%02d.scale", hm2->llio->name, i);
+            if (r < 0) {
+                HM2_ERR("error %d adding param '%s.resolver.%02d.scale', aborting\n", r, hm2->llio->name, i);
                 goto fail1;
             }
             
-            rtapi_snprintf(name, sizeof(name), "%s.resolver.%02d.velocity-scale", 
-                           hm2->llio->name, i);
-            ret= hal_param_float_new(name, HAL_RW, 
-                                     &(hm2->resolver.instance[i].hal.param.vel_scale), 
-                                     hm2->llio->comp_id);
-            if (ret < 0) {
-                HM2_ERR("error adding param '%s', aborting\n", name);
+            r = hal_param_new_real(hm2->llio->comp_id, HAL_RW, &(hm2->resolver.instance[i].hal.param.vel_scale),
+                                    1.0, "%s.resolver.%02d.velocity-scale", hm2->llio->name, i);
+            if (r < 0) {
+                HM2_ERR("error %d adding param '%s.resolver.%02d.velocity-scale', aborting\n", r, hm2->llio->name, i);
                 goto fail1;
             }
 
-            rtapi_snprintf(name, sizeof(name), "%s.resolver.%02d.index-divisor",
-                           hm2->llio->name, i);
-            ret= hal_param_u32_new(name, HAL_RW,
-                                     &(hm2->resolver.instance[i].hal.param.index_div),
-                                     hm2->llio->comp_id);
-            if (ret < 0) {
-                HM2_ERR("error adding param '%s', aborting\n", name);
+            r = hal_param_new_ui32(hm2->llio->comp_id, HAL_RW, &(hm2->resolver.instance[i].hal.param.index_div),
+                                    1, "%s.resolver.%02d.index-divisor", hm2->llio->name, i);
+            if (r < 0) {
+                HM2_ERR("error %d adding param '%s.resolver.%02d.index-divisor', aborting\n", r, hm2->llio->name, i);
                 goto fail1;
             }
 
-            rtapi_snprintf(name, sizeof(name), "%s.resolver.%02d.use-position-file",
-                           hm2->llio->name, i);
-            ret= hal_param_bit_new(name, HAL_RW,
-                                     &(hm2->resolver.instance[i].hal.param.use_abs),
-                                     hm2->llio->comp_id);
-            if (ret < 0) {
-                HM2_ERR("error adding param '%s', aborting\n", name);
+            r = hal_param_new_bool(hm2->llio->comp_id, HAL_RW, &(hm2->resolver.instance[i].hal.param.use_abs),
+                                    0, "%s.resolver.%02d.use-position-file", hm2->llio->name, i);
+            if (r < 0) {
+                HM2_ERR("error %d adding param '%s.resolver.%02d.use-position-file', aborting\n", r, hm2->llio->name, i);
                 goto fail1;
             }
 
@@ -304,12 +253,6 @@ int hm2_resolver_parse_md(hostmot2_t *hm2, int md_index) {
             // init the hal objects that need it
             // the things not initialized here will be set by hm2_resolver_tram_init()
             //
-            
-            *hm2->resolver.instance[i].hal.pin.reset = 0;
-            hm2->resolver.instance[i].hal.param.scale = 1.0;
-            hm2->resolver.instance[i].hal.param.vel_scale = 1.0;
-            hm2->resolver.instance[i].hal.param.index_div = 1;
-            hm2->resolver.hal->param.excitation_khz = -1; // don't-write
             hm2->resolver.kHz = (hm2->resolver.clock_frequency / 5000);
         }
     }
@@ -341,23 +284,23 @@ void hm2_resolver_process_tram_read(hostmot2_t *hm2, long period) {
         
         res = &hm2->resolver.instance[i];
         
+        scale = hal_get_real(res->hal.param.scale);
+        
         // sanity check
-        if (res->hal.param.scale == 0.0) {
+        if (scale == 0.0) {
             HM2_ERR("resolver.%02d.scale == 0.0, bogus, setting to 1.0\n", i);
-            res->hal.param.scale = 1.0;
+            scale = hal_set_real(res->hal.param.scale, 1.0);
         }
-        if (res->hal.param.vel_scale == 0.0) {
+        if (hal_get_real(res->hal.param.vel_scale) == 0.0) {
             HM2_ERR("resolver.%02d.velocity-scale == 0.0, bogus, setting to 1.0\n", i);
-            res->hal.param.vel_scale = 1.0;
+            hal_set_real(res->hal.param.vel_scale, 1.0);
         }
 
-        scale = res->hal.param.scale;
-        
-        if (res->hal.param.use_abs){ // pseudo-absolute behaviour enabled but not initialised
+        if (hal_get_bool(res->hal.param.use_abs)){ // pseudo-absolute behaviour enabled but not initialised
             double new_pos;
             int turns;
 
-            old_pos = *res->hal.pin.joint_pos_fb;
+            old_pos = hal_get_real(res->hal.pin.joint_pos_fb);
             if (old_pos == 0 && cycle_count++ < 5000 ) { // position.txt not updated yet. Or (small probability) position.txt = 0
                 continue; // stop and process next resolver
             }
@@ -373,7 +316,7 @@ void hm2_resolver_process_tram_read(hostmot2_t *hm2, long period) {
             res->offset = -((turns * scale) - old_pos) * (0x1p32 / scale);
             res->old_reg = hm2->resolver.position_reg[i]; // prevent wrap detection at init.
             res->accum = hm2->resolver.position_reg[i];   //necessary to allow rawcounts to still work for commutation
-            res->hal.param.use_abs = 0;                   // tag as initialised
+            hal_set_bool(res->hal.param.use_abs, 0);      // tag as initialised
         }
 
         // PROCESS THE REGISTERS, SET THE PINS
@@ -382,38 +325,39 @@ void hm2_resolver_process_tram_read(hostmot2_t *hm2, long period) {
         
         if ((res->old_reg > hm2->resolver.position_reg[i]) && (res->old_reg - hm2->resolver.position_reg[i] > 0x80000000)){
             res->index_cnts++;
-            if (*res->hal.pin.index_enable){
-                int r = (res->index_cnts % res->hal.param.index_div);
-                if ((res->hal.param.index_div  > 1 && r == 1) 
-                 || (res->hal.param.index_div == 1 && r == 0)){
+            if (hal_get_bool(res->hal.pin.index_enable)){
+                rtapi_u32 index_div = hal_get_ui32(res->hal.param.index_div);
+                int r = (res->index_cnts % index_div);
+                if ((index_div  > 1 && r == 1) 
+                 || (index_div == 1 && r == 0)){
                     res->offset = (res->accum - hm2->resolver.position_reg[i]);
-                    *res->hal.pin.index_enable = 0;
+                    hal_set_bool(res->hal.pin.index_enable, 0);
                 }
             }
         }
         else if ((res->old_reg < hm2->resolver.position_reg[i]) && (hm2->resolver.position_reg[i] - res->old_reg > 0x80000000)){
             res->index_cnts--;
-            if (*res->hal.pin.index_enable && (res->index_cnts % res->hal.param.index_div == 0)){
+            if (hal_get_bool(res->hal.pin.index_enable) && (res->index_cnts % hal_get_ui32(res->hal.param.index_div) == 0)){
                 res->offset = (res->accum - hm2->resolver.position_reg[i] + 0x100000000LL);
-                *res->hal.pin.index_enable = 0;
+                hal_set_bool(res->hal.pin.index_enable, 0);
             }
         }
         
-        if (*res->hal.pin.reset){
+        if (hal_get_bool(res->hal.pin.reset)){
             res->offset = res->accum;
         }
 
         res->old_reg = hm2->resolver.position_reg[i];
         
-        *res->hal.pin.angle = hm2->resolver.position_reg[i] / 0x1P32;
-        *res->hal.pin.rawcounts = (res->accum >> 8);
-        *res->hal.pin.count = (res->accum - res->offset) >> 8;
-        *res->hal.pin.position = (res->accum - res->offset) / 0x1P32
-                                 * res->hal.param.scale;
-        *res->hal.pin.velocity = ((hm2->resolver.velocity_reg[i] / 0x1P32)
-                                  * hm2->resolver.kHz * res->hal.param.vel_scale);
-        *res->hal.pin.velocity_rpm = *res->hal.pin.velocity * 60.0;
-        *res->hal.pin.error = *hm2->resolver.status_reg & (1 << i);
+        hal_set_real(res->hal.pin.angle, hm2->resolver.position_reg[i] / 0x1P32);
+        hal_set_si32(res->hal.pin.rawcounts, (res->accum >> 8));
+        hal_set_si32(res->hal.pin.count, (res->accum - res->offset) >> 8);
+        hal_set_real(res->hal.pin.position, (res->accum - res->offset) / 0x1P32
+                                 * hal_get_real(res->hal.param.scale));
+        hal_set_real(res->hal.pin.velocity, ((hm2->resolver.velocity_reg[i] / 0x1P32)
+                                  * hm2->resolver.kHz * hal_get_real(res->hal.param.vel_scale)));
+        hal_set_real(res->hal.pin.velocity_rpm, hal_get_real(res->hal.pin.velocity) * 60.0);
+        hal_set_bool(res->hal.pin.error, *hm2->resolver.status_reg & (1 << i));
     }
 }
 
@@ -424,27 +368,29 @@ void hm2_resolver_write(hostmot2_t *hm2, long period){
     static rtapi_u32 cmd_val, data_val;
     static rtapi_u32 timer;
     rtapi_u32 buff;
+    rtapi_real exc;
     
     if (hm2->resolver.num_instances <= 0) return;
     
     switch (state){
         case 0: // Idle/waiting
-            if (hm2->resolver.hal->param.excitation_khz < 0){
+            exc = hal_get_real(hm2->resolver.hal->param.excitation_khz);
+            if (exc < 0){
                 return;
             }
-            if (hm2->resolver.hal->param.excitation_khz != hm2->resolver.written_khz){
-                if (hm2->resolver.hal->param.excitation_khz > 8){
-                    hm2->resolver.hal->param.excitation_khz = 10;
+            if (exc != hm2->resolver.written_khz){
+                if (exc > 8){
+                    hal_set_real(hm2->resolver.hal->param.excitation_khz, 10);
                     hm2->resolver.written_khz = 10;
                     hm2->resolver.kHz = (hm2->resolver.clock_frequency / 5000);
                     cmd_val = 0x803;
-                } else if (hm2->resolver.hal->param.excitation_khz > 4){
-                    hm2->resolver.hal->param.excitation_khz = 5;
+                } else if (exc > 4){
+                    hal_set_real(hm2->resolver.hal->param.excitation_khz, 5);
                     hm2->resolver.written_khz = 5;
                     hm2->resolver.kHz = (hm2->resolver.clock_frequency / 10000);
                     cmd_val = 0x802;
                 }else{
-                    hm2->resolver.hal->param.excitation_khz = 2.5;
+                    hal_set_real(hm2->resolver.hal->param.excitation_khz, 2.5);
                     hm2->resolver.written_khz = 2.5;
                     hm2->resolver.kHz= (hm2->resolver.clock_frequency / 20000);
                     cmd_val = 0x801;

--- a/src/hal/drivers/mesa-hostmot2/sserial.c
+++ b/src/hal/drivers/mesa-hostmot2/sserial.c
@@ -66,7 +66,7 @@ int hm2_sserial_wait(hostmot2_t *hm2, hm2_sserial_instance_t *inst, long period)
     // real-time wait function (relies on process data)
     *inst->command_reg_write = 0x80000000; // mask pointless writes
     inst->timer -= period;
-    *inst->debug = inst->timer;
+    hal_set_si32(inst->debug, inst->timer);
     if (*inst->command_reg_read != 0) {
         if (inst->timer > 0) {
             return 1;
@@ -359,30 +359,30 @@ int hm2_sserial_get_param_value(hostmot2_t *hm2,
             r = hm2_sserial_get_bytes(hm2, chan, (void*)&(p->u32_written),
                                       g->ParmAddr, g->DataLength/8);
             if (r < 0) {HM2_ERR("SSerial Parameter read error\n") ; return -EINVAL;}
-            if (set_hal) p->u32_param = p->u32_written;
-            HM2_DBG("LBP_UNSIGNED %i %i \n", p->u32_param, p->u32_written);
-            if ((strcmp(g->NameString, "swrevision") == 0) && (p->u32_param < 14)) {
+            if (set_hal) hal_set_ui32(p->param.u, p->u32_written);
+            HM2_DBG("LBP_UNSIGNED %i %i \n", hal_get_ui32(p->param.u), p->u32_written);
+            if ((strcmp(g->NameString, "swrevision") == 0) && (hal_get_ui32(p->param.u) < 14)) {
                 HM2_ERR("Warning: sserial remote device %s channel %d has old firmware that should be updated\n", chan->raw_name, chan->index);
             }
             break;
         case LBP_SIGNED:
             r = hm2_sserial_get_bytes(hm2, chan, (void*)&(p->s32_written),
                                       g->ParmAddr, g->DataLength/8);
-            if (set_hal) p->s32_param = p->s32_written;
-            HM2_DBG("LBP_SIGNED %i %i \n", p->s32_param, p->s32_written);
+            if (set_hal) hal_set_si32(p->param.s, p->s32_written);
+            HM2_DBG("LBP_SIGNED %i %i \n", hal_get_si32(p->param.s), p->s32_written);
             break;
         case LBP_NONVOL_UNSIGNED:
             r = hm2_sserial_read_nvram_word(hm2, chan, (void*)&(p->u32_written),
                                                 g->ParmAddr,
                                                 g->DataLength/8);
-            if (set_hal) p->u32_param = p->u32_written;
-            HM2_DBG("LBP_NONVOL_UNSIGNED %i %i \n", p->u32_param, p->u32_written);
+            if (set_hal) hal_set_ui32(p->param.u, p->u32_written);
+            HM2_DBG("LBP_NONVOL_UNSIGNED %i %i \n", hal_get_ui32(p->param.u), p->u32_written);
             break;
         case LBP_NONVOL_SIGNED:
             r = hm2_sserial_read_nvram_word(hm2, chan, (void*)&(p->s32_written),
                                                 g->ParmAddr,
                                                 g->DataLength/8);
-            if (set_hal) p->s32_param = p->s32_written;
+            if (set_hal) hal_set_si32(p->param.s, p->s32_written);
         case LBP_STREAM:
             break; // Have not seen a stream type yet
         case LBP_BOOLEAN:
@@ -405,8 +405,8 @@ int hm2_sserial_get_param_value(hostmot2_t *hm2,
                     HM2_ERR("sserial get param value: LBP_FLOAT of bit-length %i not handled\n", g->DataLength);
                 }
             }
-            if (set_hal) p->float_param = p->float_written;
-            HM2_DBG("LBP_FLOAT %f %f \n", p->float_param, p->float_written);
+            if (set_hal) hal_set_real(p->param.r, p->float_written);
+            HM2_DBG("LBP_FLOAT %f %f \n", hal_get_real(p->param.r), p->float_written);
             break;
         case LBP_ENCODER_H:
         case LBP_ENCODER_L:
@@ -423,7 +423,7 @@ int hm2_sserial_create_params(hostmot2_t *hm2, hm2_sserial_remote_t *chan){
     hm2_sserial_data_t global;
     int hal_dir;
 
-    chan->params = hal_malloc(chan->num_globals * sizeof(hm2_sserial_params_t));
+    chan->params = hal_malloc(chan->num_globals * sizeof(*chan->params));
     for (i = 0 ; i < chan->num_globals ; i++){
         global = chan->globals[i];
 
@@ -433,13 +433,11 @@ int hm2_sserial_create_params(hostmot2_t *hm2, hm2_sserial_remote_t *chan){
 
         chan->params[i].type = global.DataType;
         switch (chan->params[i].type) {
-            case LBP_BITS:
-                break;
             case LBP_UNSIGNED:
             case LBP_NONVOL_UNSIGNED:
-                r = hal_param_u32_newf(hal_dir,
-                                       &(chan->params[i].u32_param),
-                                       hm2->llio->comp_id,
+                r = hal_param_new_ui32(hm2->llio->comp_id, hal_dir,
+                                       &(chan->params[i].param.u),
+                                       0,
                                        "%s.%s",
                                        chan->name,
                                        global.NameString);
@@ -447,9 +445,9 @@ int hm2_sserial_create_params(hostmot2_t *hm2, hm2_sserial_remote_t *chan){
                 break;
             case LBP_SIGNED:
             case LBP_NONVOL_SIGNED:
-                r = hal_param_s32_newf(hal_dir,
-                                       &(chan->params[i].s32_param),
-                                       hm2->llio->comp_id,
+                r = hal_param_new_si32(hm2->llio->comp_id, hal_dir,
+                                       &(chan->params[i].param.s),
+                                       0,
                                        "%s.%s",
                                        chan->name,
                                        global.NameString);
@@ -457,18 +455,24 @@ int hm2_sserial_create_params(hostmot2_t *hm2, hm2_sserial_remote_t *chan){
                 break;
             case LBP_FLOAT:
             case LBP_NONVOL_FLOAT:
-                r = hal_param_float_newf(hal_dir,
-                                       &(chan->params[i].float_param),
-                                       hm2->llio->comp_id,
+                r = hal_param_new_real(hm2->llio->comp_id, hal_dir,
+                                       &(chan->params[i].param.r),
+                                       0.0,
                                        "%s.%s",
                                        chan->name,
                                        global.NameString);
                 if (r < 0) {HM2_ERR("Out of memory\n") ; return -ENOMEM;}
+                break;
+            case LBP_BITS:
             case LBP_STREAM: // Don't anticipate seeing these as params
             case LBP_BOOLEAN:
             case LBP_ENCODER:
             case LBP_ENCODER_H:
             case LBP_ENCODER_L:
+            default:
+                // Still make sure we have memory allocated for a fake parameter
+                r = hal_param_new_fake(hm2->llio->comp_id, (hal_refs_u *)&(chan->params[i].param.r));
+                if (r < 0) {HM2_ERR("Out of memory\n") ; return -ENOMEM;}
                 break;
         }
 
@@ -628,8 +632,7 @@ int hm2_sserial_parse_md(hostmot2_t *hm2, int md_index){
     HM2_DBG("sserial_num_instances = %i\n", hm2->sserial.num_instances);
 
     // allocate the per-instance HAL shared memory
-    hm2->sserial.instance = (hm2_sserial_instance_t *)
-    hal_malloc(hm2->sserial.num_instances * sizeof(hm2_sserial_instance_t));
+    hm2->sserial.instance = hal_malloc(hm2->sserial.num_instances * sizeof(*hm2->sserial.instance));
     if (hm2->sserial.instance == NULL) {
         HM2_ERR("hm2_sserial_parse_md: hm2_sserial_instance: out of memory!\n");
         r = -ENOMEM;
@@ -849,97 +852,74 @@ fail0:
 int hm2_sserial_setup_channel(hostmot2_t *hm2, hm2_sserial_instance_t *inst, int index){
     int r;
 
-    r = hal_pin_s32_newf(HAL_OUT, &(inst->debug),
-                         hm2->llio->comp_id,
-                         "%s.%i.debug",
-                         hm2->llio->name, index);
+    r = hal_pin_new_si32(hm2->llio->comp_id, HAL_OUT, &(inst->debug),
+                         0, "%s.%i.debug", hm2->llio->name, index);
     if (r < 0) {
-        HM2_ERR("error adding pin %s.sserial.%1d.run. aborting\n",
-                hm2->llio->name, index);
+        HM2_ERR("error %d adding pin %s.sserial.%1d.run. aborting\n",
+                r, hm2->llio->name, index);
         return -EINVAL;
     }
 
-    r = hal_pin_bit_newf(HAL_IN, &(inst->run),
-                         hm2->llio->comp_id,
-                         "%s.sserial.port-%1d.run",
-                         hm2->llio->name, index);
+    r = hal_pin_new_bool(hm2->llio->comp_id, HAL_IN, &(inst->run),
+                         true, "%s.sserial.port-%1d.run", hm2->llio->name, index);
     if (r < 0) {
-        HM2_ERR("error adding pin %s.sserial.%1d.run. aborting\n",
-                hm2->llio->name, index);
-        return -EINVAL;
-    }
-    *inst->run = true;
-
-    r = hal_pin_u32_newf(HAL_OUT, &(inst->state),
-                         hm2->llio->comp_id,
-                         "%s.sserial.port-%1d.port_state",
-                         hm2->llio->name, index);
-    if (r < 0) {
-        HM2_ERR("error adding pin %s.sserial.%1d.port_state. aborting\n",
-                hm2->llio->name, index);
-        return -EINVAL;
-    }
-    r = hal_pin_u32_newf(HAL_OUT, &(inst->state2),
-                         hm2->llio->comp_id,
-                         "%s.sserial.port-%1d.port_state2",
-                         hm2->llio->name, index);
-    if (r < 0) {
-        HM2_ERR("error adding pin %s.sserial.%1d.port_state. aborting\n",
-                hm2->llio->name, index);
-        return -EINVAL;
-    }
-     r = hal_pin_u32_newf(HAL_OUT, &(inst->state3),
-                         hm2->llio->comp_id,
-                         "%s.sserial.port-%1d.port_state3",
-                         hm2->llio->name, index);
-    if (r < 0) {
-        HM2_ERR("error adding pin %s.sserial.%1d.port_state. aborting\n",
-                hm2->llio->name, index);
+        HM2_ERR("error %d adding pin %s.sserial.%1d.run. aborting\n",
+                r, hm2->llio->name, index);
         return -EINVAL;
     }
 
-    r = hal_pin_u32_newf(HAL_OUT, &(inst->fault_count),
-                         hm2->llio->comp_id,
-                         "%s.sserial.port-%1d.fault-count",
-                         hm2->llio->name, index);
+    r = hal_pin_new_ui32(hm2->llio->comp_id, HAL_OUT, &(inst->state),
+                         0, "%s.sserial.port-%1d.port_state", hm2->llio->name, index);
     if (r < 0) {
-        HM2_ERR("error adding pin %s.sserial.%1d.fault-count. aborting\n",
-                hm2->llio->name, index);
+        HM2_ERR("error %d adding pin %s.sserial.%1d.port_state. aborting\n",
+                r, hm2->llio->name, index);
         return -EINVAL;
     }
-    r = hal_param_u32_newf(HAL_RW, &(inst->fault_inc),
-                           hm2->llio->comp_id,
-                           "%s.sserial.port-%1d.fault-inc",
-                           hm2->llio->name, index);
+    r = hal_pin_new_ui32(hm2->llio->comp_id, HAL_OUT, &(inst->state2),
+                         0, "%s.sserial.port-%1d.port_state2", hm2->llio->name, index);
     if (r < 0) {
-        HM2_ERR("error adding parameter %s.sserial.port-%1d.fault-inc"
-                " aborting\n",hm2->llio->name, index);
+        HM2_ERR("error %d adding pin %s.sserial.%1d.port_state. aborting\n",
+                r, hm2->llio->name, index);
         return -EINVAL;
     }
-
-    r = hal_param_u32_newf(HAL_RW, &(inst->fault_dec),
-                           hm2->llio->comp_id,
-                           "%s.sserial.port-%1d.fault-dec",
-                           hm2->llio->name, index);
+     r = hal_pin_new_ui32(hm2->llio->comp_id, HAL_OUT, &(inst->state3),
+                         0, "%s.sserial.port-%1d.port_state3", hm2->llio->name, index);
     if (r < 0) {
-        HM2_ERR("error adding parameter %s.sserial.port-%1d.fault-dec"
-                " aborting\n",hm2->llio->name, index);
+        HM2_ERR("error %d adding pin %s.sserial.%1d.port_state. aborting\n",
+                r, hm2->llio->name, index);
         return -EINVAL;
     }
 
-    r = hal_param_u32_newf(HAL_RW, &(inst->fault_lim),
-                           hm2->llio->comp_id,
-                           "%s.sserial.port-%1d.fault-lim",
-                           hm2->llio->name, index);
+    r = hal_pin_new_ui32(hm2->llio->comp_id, HAL_OUT, &(inst->fault_count),
+                         0, "%s.sserial.port-%1d.fault-count", hm2->llio->name, index);
     if (r < 0) {
-        HM2_ERR("error adding parameter %s.sserial.port-%1d.fault-lim"
-                " aborting\n",hm2->llio->name, index);
+        HM2_ERR("error %d adding pin %s.sserial.%1d.fault-count. aborting\n",
+                r, hm2->llio->name, index);
         return -EINVAL;
     }
-    //parameter defaults;
-    inst->fault_dec = 1;
-    inst->fault_inc = 10;
-    inst->fault_lim = 200;
+    r = hal_param_new_ui32(hm2->llio->comp_id, HAL_RW, &(inst->fault_inc),
+                           10, "%s.sserial.port-%1d.fault-inc", hm2->llio->name, index);
+    if (r < 0) {
+        HM2_ERR("error %d adding parameter %s.sserial.port-%1d.fault-inc"
+                " aborting\n", r, hm2->llio->name, index);
+        return -EINVAL;
+    }
+
+    r = hal_param_new_ui32(hm2->llio->comp_id, HAL_RW, &(inst->fault_dec),
+                           1, "%s.sserial.port-%1d.fault-dec", hm2->llio->name, index);
+    if (r < 0) {
+        HM2_ERR("error %d adding parameter %s.sserial.port-%1d.fault-dec"
+                " aborting\n", r, hm2->llio->name, index);
+        return -EINVAL;
+    }
+
+    r = hal_param_new_ui32(hm2->llio->comp_id, HAL_RW, &(inst->fault_lim),
+                           200, "%s.sserial.port-%1d.fault-lim", hm2->llio->name, index);
+    if (r < 0) {
+        HM2_ERR("error %d adding parameter %s.sserial.port-%1d.fault-lim"
+                " aborting\n", r, hm2->llio->name, index);
+        return -EINVAL;
+    }
 
     // setup read-back in all modes
 
@@ -1118,10 +1098,8 @@ int hm2_sserial_read_configs(hostmot2_t *hm2,  hm2_sserial_remote_t *chan){
 int hm2_sserial_create_pins(hostmot2_t *hm2, hm2_sserial_remote_t *chan){
     int i, j;
     int r = 0;
-    char name[HAL_NAME_LEN + 1];
     int data_dir;
-    chan->pins = (hm2_sserial_pins_t*)hal_malloc(chan->num_confs
-                                                 * sizeof(hm2_sserial_pins_t));
+    chan->pins = hal_malloc(chan->num_confs * sizeof(*chan->pins));
 
     chan->num_read_bits = 0 ; chan->num_write_bits = 0;
 
@@ -1173,51 +1151,31 @@ int hm2_sserial_create_pins(hostmot2_t *hm2, hm2_sserial_remote_t *chan){
             case LBP_PAD:
                 break;
             case LBP_BITS:
-                chan->pins[i].bit_pins = (hal_bit_t**)
-                hal_malloc(chan->confs[i].DataLength * sizeof(hal_bit_t*));
-                chan->pins[i].bit_pins_not = (hal_bit_t**)
-                hal_malloc(chan->confs[i].DataLength * sizeof(hal_bit_t*));
-                chan->pins[i].invert = (hal_bit_t*)
-                hal_malloc(chan->confs[i].DataLength * sizeof(hal_bit_t));
+                chan->pins[i].bit_pins = hal_malloc(chan->confs[i].DataLength * sizeof(*chan->pins[i].bit_pins));
+                chan->pins[i].bit_pins_not = hal_malloc(chan->confs[i].DataLength * sizeof(*chan->pins[i].bit_pins_not));
+                chan->pins[i].invert = hal_malloc(chan->confs[i].DataLength * sizeof(*chan->pins[i].invert));
                 for (j = 0; j < chan->confs[i].DataLength ; j++){
 
-                    rtapi_snprintf(name, sizeof(name), "%s.%s-%02d",
-                                   chan->name,
-                                   chan->confs[i].NameString,
-                                   j);
-                    r = hal_pin_bit_new(name,
-                                        data_dir,
-                                        &(chan->pins[i].bit_pins[j]),
-                                        hm2->llio->comp_id);
+                    r = hal_pin_new_bool(hm2->llio->comp_id, data_dir, &(chan->pins[i].bit_pins[j]),
+                                        0, "%s.%s-%02d", chan->name, chan->confs[i].NameString, j);
                     if (r < 0) {
-                        HM2_ERR("error adding pin '%s', aborting\n", name);
+                        HM2_ERR("error %d adding pin '%s.%s-%02d', aborting\n", r, chan->name, chan->confs[i].NameString, j);
                         return r;
                     }
                     if (data_dir == HAL_OUT) {
-                        rtapi_snprintf(name, sizeof(name), "%s.%s-%02d-not",
-                                       chan->name,
-                                       chan->confs[i].NameString,
-                                       j);
-                        r = hal_pin_bit_new(name,
-                                            data_dir,
-                                            &(chan->pins[i].bit_pins_not[j]),
-                                            hm2->llio->comp_id);
+                        r = hal_pin_new_bool(hm2->llio->comp_id, data_dir, &(chan->pins[i].bit_pins_not[j]),
+                                            0, "%s.%s-%02d-not", chan->name, chan->confs[i].NameString, j);
                         if (r < 0) {
-                            HM2_ERR("error adding pin '%s', aborting\n", name);
+                            HM2_ERR("error %d adding pin '%s.%s-%02d-not', aborting\n", r, chan->name, chan->confs[i].NameString, j);
                             return r;
                         }
                     }
                     if (data_dir == HAL_IN){
-                        rtapi_snprintf(name, sizeof(name), "%s.%s-%02d-invert",
-                                       chan->name,
-                                       chan->confs[i].NameString,
-                                       j);
-                        r = hal_param_bit_new(name,
-                                              HAL_RW,
-                                              &(chan->pins[i].invert[j]),
-                                              hm2->llio->comp_id);
+                        r = hal_param_new_bool(hm2->llio->comp_id, HAL_RW, &(chan->pins[i].invert[j]),
+                                              0, "%s.%s-%02d-invert", chan->name, chan->confs[i].NameString, j);
                         if (r < 0) {
-                            HM2_ERR("error adding pin '%s', aborting\n", name);
+                            HM2_ERR("error %d adding pin '%s.%s-%02d-invert', aborting\n",
+                                    r, chan->name, chan->confs[i].NameString, j);
                             return r;
                         }
                     }
@@ -1225,54 +1183,31 @@ int hm2_sserial_create_pins(hostmot2_t *hm2, hm2_sserial_remote_t *chan){
                 break;
             case LBP_UNSIGNED:
             case LBP_SIGNED:
-                rtapi_snprintf(name, sizeof(name), "%s.%s",
-                               chan->name,
-                               chan->confs[i].NameString);
-                r = hal_pin_float_new(name,
-                                      data_dir,
-                                      &(chan->pins[i].float_pin),
-                                      hm2->llio->comp_id);
+                r = hal_pin_new_real(hm2->llio->comp_id, data_dir, &(chan->pins[i].float_pin),
+                                      0.0, "%s.%s", chan->name, chan->confs[i].NameString);
                 if (r < 0) {
-                    HM2_ERR("error adding pin '%s', aborting\n", name);
+                    HM2_ERR("error %d adding pin '%s.%s', aborting\n", r, chan->name, chan->confs[i].NameString);
                     return r;
                 }
-                rtapi_snprintf(name, sizeof(name), "%s.%s-scalemax",
-                               chan->name,
-                               chan->confs[i].NameString);
-                r = hal_param_float_new(name,
-                                        HAL_RW,
-                                        &(chan->pins[i].fullscale),
-                                        hm2->llio->comp_id);
+                r = hal_param_new_real(hm2->llio->comp_id, HAL_RW, &(chan->pins[i].fullscale),
+                                        chan->confs[i].ParmMax, "%s.%s-scalemax", chan->name, chan->confs[i].NameString);
                 if (r < 0) {
-                    HM2_ERR("error adding pin '%s', aborting\n", name);
+                    HM2_ERR("error %d adding pin '%s.%s-scalemax', aborting\n", r, chan->name, chan->confs[i].NameString);
                     return r;
                 }
-                chan->pins[i].fullscale = chan->confs[i].ParmMax;
                 if (data_dir == HAL_OUT) {break;}
-                rtapi_snprintf(name, sizeof(name), "%s.%s-maxlim",
-                               chan->name,
-                               chan->confs[i].NameString);
-                r = hal_param_float_new(name,
-                                        HAL_RW,
-                                        &(chan->pins[i].maxlim),
-                                        hm2->llio->comp_id);
+                r = hal_param_new_real(hm2->llio->comp_id, HAL_RW, &(chan->pins[i].maxlim),
+                                        chan->confs[i].ParmMax, "%s.%s-maxlim", chan->name, chan->confs[i].NameString);
                 if (r < 0) {
-                    HM2_ERR("error adding pin '%s', aborting\n", name);
+                    HM2_ERR("error %d adding pin '%s.%s-maxlim', aborting\n", r, chan->name, chan->confs[i].NameString);
                     return r;
                 }
-                chan->pins[i].maxlim = chan->confs[i].ParmMax;
-                rtapi_snprintf(name, sizeof(name), "%s.%s-minlim",
-                               chan->name,
-                               chan->confs[i].NameString);
-                r = hal_param_float_new(name,
-                                        HAL_RW,
-                                        &(chan->pins[i].minlim),
-                                        hm2->llio->comp_id);
+                r = hal_param_new_real(hm2->llio->comp_id, HAL_RW, &(chan->pins[i].minlim),
+                                        chan->confs[i].ParmMin, "%s.%s-minlim", chan->name, chan->confs[i].NameString);
                 if (r < 0) {
-                    HM2_ERR("error adding pin '%s', aborting\n", name);
+                    HM2_ERR("error %d adding pin '%s.%s-minlim', aborting\n", r, chan->name, chan->confs[i].NameString);
                     return r;
                 }
-                chan->pins[i].minlim = chan->confs[i].ParmMin;
                 break;
             case LBP_NONVOL_UNSIGNED:
             case LBP_NONVOL_SIGNED:
@@ -1280,156 +1215,95 @@ int hm2_sserial_create_pins(hostmot2_t *hm2, hm2_sserial_remote_t *chan){
                         "never happen. Aborting");
                 return r;
             case LBP_STREAM:
-                rtapi_snprintf(name, sizeof(name), "%s.%s",
-                               chan->name,
-                               chan->confs[i].NameString);
-                r = hal_pin_u32_new(name,
-                                    data_dir,
-                                    &(chan->pins[i].u32_pin),
-                                    hm2->llio->comp_id);
+                r = hal_pin_new_ui32(hm2->llio->comp_id, data_dir, &(chan->pins[i].u32_pin),
+                                    0, "%s.%s", chan->name, chan->confs[i].NameString);
                 if (r < 0) {
-                    HM2_ERR("error adding pin '%s', aborting\n", name);
+                    HM2_ERR("error %d adding pin '%s.%s', aborting\n", r, chan->name, chan->confs[i].NameString);
                     return r;
                 }
                 break;
             case LBP_BOOLEAN:
-                rtapi_snprintf(name, sizeof(name), "%s.%s",
-                               chan->name,
-                               chan->confs[i].NameString);
-                r = hal_pin_bit_new(name,
-                                    data_dir,
-                                    &(chan->pins[i].boolean),
-                                    hm2->llio->comp_id);
+                r = hal_pin_new_bool(hm2->llio->comp_id, data_dir, &(chan->pins[i].boolean),
+                                    0, "%s.%s", chan->name, chan->confs[i].NameString);
                 if (r < 0) {
-                    HM2_ERR("error adding pin '%s', aborting\n", name);
+                    HM2_ERR("error %d adding pin '%s.%s', aborting\n", r, chan->name, chan->confs[i].NameString);
                     return r;
                 }
                 if (data_dir == HAL_OUT) {
-                    rtapi_snprintf(name, sizeof(name), "%s.%s-not",
-                                   chan->name,
-                                   chan->confs[i].NameString);
-                    r = hal_pin_bit_new(name,
-                                        data_dir,
-                                        &(chan->pins[i].boolean2),
-                                        hm2->llio->comp_id);
+                    r = hal_pin_new_bool(hm2->llio->comp_id, data_dir, &(chan->pins[i].boolean2),
+                                        0, "%s.%s-not", chan->name, chan->confs[i].NameString);
                     if (r < 0) {
-                        HM2_ERR("error adding pin '%s', aborting\n", name);
+                        HM2_ERR("error %d adding pin '%s.%s-not', aborting\n", r, chan->name, chan->confs[i].NameString);
                         return r;
                     }
                 }
                 if (data_dir == HAL_IN) {
-                    chan->pins[i].invert = hal_malloc(sizeof(hal_bit_t));
-                    rtapi_snprintf(name, sizeof(name), "%s.%s-invert",
-                                   chan->name,
-                                   chan->confs[i].NameString);
-                    r = hal_param_bit_new(name,
-                                          HAL_RW,
-                                          chan->pins[i].invert,
-                                          hm2->llio->comp_id);
+                    chan->pins[i].invert = hal_malloc(sizeof(*chan->pins[i].invert));
+                    r = hal_param_new_bool(hm2->llio->comp_id, HAL_RW, chan->pins[i].invert,
+                                           0, "%s.%s-invert", chan->name, chan->confs[i].NameString);
                     if (r < 0) {
-                        HM2_ERR("error adding pin '%s', aborting\n", name);
+                        HM2_ERR("error %d adding pin '%s.%s-invert', aborting\n", r, chan->name, chan->confs[i].NameString);
                         return r;
                     }
                 }
                 break;
             case LBP_ENCODER:
             case LBP_ENCODER_H:
-
-                rtapi_snprintf(name, sizeof(name), "%s.%s.count",
-                               chan->name,
-                               chan->confs[i].NameString);
-                r = hal_pin_s32_new(name,
-                                    HAL_OUT,
-                                    &(chan->pins[i].s32_pin),
-                                    hm2->llio->comp_id);
+                r = hal_pin_new_si32(hm2->llio->comp_id, HAL_OUT, &(chan->pins[i].s32_pin),
+                                    0, "%s.%s.count", chan->name, chan->confs[i].NameString);
                 if (r < 0) {
-                    HM2_ERR("error adding pin '%s', aborting\n", name);
+                    HM2_ERR("error %d adding pin '%s.%s.count', aborting\n", r, chan->name, chan->confs[i].NameString);
                     return -EINVAL;
                 }
-                rtapi_snprintf(name, sizeof(name), "%s.%s.rawcounts",
-                               chan->name,
-                               chan->confs[i].NameString);
-                r = hal_pin_s32_new(name,
-                                    HAL_OUT,
-                                    &(chan->pins[i].s32_pin2),
-                                    hm2->llio->comp_id);
+                r = hal_pin_new_si32(hm2->llio->comp_id, HAL_OUT, &(chan->pins[i].s32_pin2),
+                                    0, "%s.%s.rawcounts", chan->name, chan->confs[i].NameString);
                 if (r < 0) {
-                    HM2_ERR("error adding pin '%s', aborting\n", name);
+                    HM2_ERR("error %d adding pin '%s.%s.rawcounts', aborting\n", r, chan->name, chan->confs[i].NameString);
                     return -EINVAL;
                 }
-                rtapi_snprintf(name, sizeof(name), "%s.%s.position",
-                               chan->name,
-                               chan->confs[i].NameString);
-                r = hal_pin_float_new(name,
-                                    HAL_OUT,
-                                    &(chan->pins[i].float_pin),
-                                    hm2->llio->comp_id);
+                r = hal_pin_new_real(hm2->llio->comp_id, HAL_OUT, &(chan->pins[i].float_pin),
+                                    0.0, "%s.%s.position", chan->name, chan->confs[i].NameString);
                 if (r < 0) {
-                    HM2_ERR("error adding pin '%s', aborting\n", name);
+                    HM2_ERR("error %d adding pin '%s.%s.position', aborting\n", r, chan->name, chan->confs[i].NameString);
                     return -EINVAL;
                 }
-                rtapi_snprintf(name, sizeof(name), "%s.%s.index-enable",
-                               chan->name,
-                               chan->confs[i].NameString);
-                r = hal_pin_bit_new(name,
-                                    HAL_IO,
-                                    &(chan->pins[i].boolean),
-                                    hm2->llio->comp_id);
+                r = hal_pin_new_bool(hm2->llio->comp_id, HAL_IO, &(chan->pins[i].boolean),
+                                    0, "%s.%s.index-enable", chan->name, chan->confs[i].NameString);
                 if (r < 0) {
-                    HM2_ERR("error adding pin '%s', aborting\n", name);
+                    HM2_ERR("error %d adding pin '%s.%s.index-enable', aborting\n", r, chan->name, chan->confs[i].NameString);
                     return -EINVAL;
                 }
 
-                rtapi_snprintf(name, sizeof(name), "%s.%s.reset",
-                               chan->name,
-                               chan->confs[i].NameString);
-                r = hal_pin_bit_new(name,
-                                    HAL_IO,
-                                    &(chan->pins[i].boolean2),
-                                    hm2->llio->comp_id);
+                r = hal_pin_new_bool(hm2->llio->comp_id, HAL_IO, &(chan->pins[i].boolean2),
+                                    0, "%s.%s.reset", chan->name, chan->confs[i].NameString);
                 if (r < 0) {
-                    HM2_ERR("error adding pin '%s', aborting\n", name);
+                    HM2_ERR("error %d adding pin '%s.%s.reset', aborting\n", r, chan->name, chan->confs[i].NameString);
                     return -EINVAL;
                 }
-                rtapi_snprintf(name, sizeof(name), "%s.%s.scale",
-                               chan->name,
-                               chan->confs[i].NameString);
-                r = hal_param_float_new(name,
-                                    HAL_RW,
-                                    &(chan->pins[i].fullscale),
-                                    hm2->llio->comp_id);
+                r = hal_param_new_real(hm2->llio->comp_id, HAL_RW, &(chan->pins[i].fullscale),
+                                    chan->confs[i].ParmMax, "%s.%s.scale", chan->name, chan->confs[i].NameString);
                 if (r < 0) {
-                    HM2_ERR("error adding pin '%s', aborting\n", name);
+                    HM2_ERR("error %d adding pin '%s.%s.scale', aborting\n",
+                            r, chan->name, chan->confs[i].NameString);
                     return -EINVAL;
                 }
 
-                rtapi_snprintf(name, sizeof(name), "%s.%s.counts-per-rev",
-                               chan->name,
-                               chan->confs[i].NameString);
-                r = hal_param_u32_new(name,
-                                    HAL_RW,
-                                    &(chan->pins[i].u32_param),
-                                    hm2->llio->comp_id);
+                r = hal_param_new_ui32(hm2->llio->comp_id, HAL_RW, &(chan->pins[i].u32_param),
+                                    256, "%s.%s.counts-per-rev", chan->name, chan->confs[i].NameString);
                 if (r < 0) {
-                    HM2_ERR("error adding pin '%s', aborting\n", name);
+                    HM2_ERR("error %d adding pin '%s.%s.counts-per-rev', aborting\n",
+                            r, chan->name, chan->confs[i].NameString);
                     return -EINVAL;
                 }
-                chan->pins[i].fullscale = chan->confs[i].ParmMax;
-                chan->pins[i].u32_param = 256;
                 break;
             case LBP_ENCODER_L:
                 //No pins for encoder L
                 break;
             case LBP_FLOAT:
-                rtapi_snprintf(name, sizeof(name), "%s.%s",
-                               chan->name,
-                               chan->confs[i].NameString);
-                r = hal_pin_float_new(name,
-                                      data_dir,
-                                      &(chan->pins[i].float_pin),
-                                      hm2->llio->comp_id);
+                r = hal_pin_new_real(hm2->llio->comp_id, data_dir, &(chan->pins[i].float_pin),
+                                      0.0, "%s.%s", chan->name, chan->confs[i].NameString);
                 if (r < 0) {
-                    HM2_ERR("error adding pin '%s', aborting\n", name);
+                    HM2_ERR("error %d adding pin '%s.%s', aborting\n", r, chan->name, chan->confs[i].NameString);
                     return r;
                 }
                 break;
@@ -1499,11 +1373,11 @@ fail1:
     hm2_sserial_data_t   *g;
     int shift; // used for floating point comparisons
 
-    switch (*inst->state2){
+    switch (hal_get_ui32(inst->state2)){
         case 0: // init loop counters
             inst->r_index = 0;
             inst->g_index = 0;
-            *inst->state2 = 1;
+            hal_set_ui32(inst->state2, 1);
             /* Fallthrough */
         case 1:
             if (inst->num_remotes == 0) return 0;
@@ -1512,29 +1386,27 @@ fail1:
                 p = &(r->params[inst->g_index]);
                 g = &(r->globals[inst->g_index]);
             } else {
-                *inst->state2 = 2;
+                hal_set_ui32(inst->state2, 2);
                 break;
             }
-            switch (*inst->state3){
+            switch (hal_get_ui32(inst->state3)){
                 //Commands are queued for TRAM write, so every change in
                 //command needs a break to poll the thread
                 int ret;
                 default:
-                    HM2_ERR("Unhandled state %i", *inst->state3);
+                    HM2_ERR("Unhandled state %i", hal_get_ui32(inst->state3));
                     return 1;
                 case 0:
                     HM2_DBG("Checking Param %s datatype %02X\n", g->NameString, p->type);
                     switch (p->type){
                         case LBP_SIGNED:
                         case LBP_NONVOL_SIGNED:
-                            if (p->s32_param != p->s32_written) break;
-                            *inst->state2 = 2; // increment indices
-                            return *inst->state2;
+                            if (hal_get_si32(p->param.s) != p->s32_written) break;
+                            return hal_set_ui32(inst->state2, 2); // increment indices
                         case LBP_UNSIGNED:
                         case LBP_NONVOL_UNSIGNED:
-                            if (p->u32_param != p->u32_written) break;
-                            *inst->state2 = 2; // increment indices
-                            return *inst->state2;
+                            if (hal_get_ui32(p->param.u) != p->u32_written) break;
+                            return hal_set_ui32(inst->state2, 2); // increment indices
                         case LBP_FLOAT:
                         case LBP_NONVOL_FLOAT:
                             // comparing floats that might have different sizes is not trivial
@@ -1554,30 +1426,31 @@ fail1:
                                 case 64:
                                     shift = 0;
                                 }
-                            if (xlabs((p->s64_param - p->s64_written) >> shift) > 2) break;
-                            *inst->state2 = 2; // increment indices
-                            return *inst->state2;
+                            // FIXME: This overlayed s64 read is very wrong!
+                            if (xlabs((hal_get_sint(p->param.s) - p->s64_written) >> shift) > 2) break;
+                            return hal_set_ui32(inst->state2, 2); // increment indices
                         default:
-                            *inst->state2 = 2; // increment indices
-                            return *inst->state2;
+                            return hal_set_ui32(inst->state2, 2); // increment indices
                         }
                     HM2_WARN("Writing value of %s datatype %02X\n", g->NameString, p->type);
-                    *inst->state3 = 1;
+                    hal_set_ui32(inst->state3, 1);
                     inst->timer = 20000000;
                     *inst->command_reg_write = 0x800; // stop all
                     break;
                  case 1:
                     ret = hm2_sserial_wait(hm2, inst, period);
                     if (ret > 0) break;
-                    if (ret < 0) *inst->state3 = 100; // quit and tidy up
-                    *inst->state3 = 2;
+                    // FIXME: Assigns 100 to state3 and then unconditionally assigns 2
+                    if (ret < 0) hal_set_ui32(inst->state3, 100); // quit and tidy up
+                    hal_set_ui32(inst->state3, 2);
                     inst->timer = 20000000;
                     *inst->command_reg_write = 0xF00 | (1 << r->index); // channel in setup mode
                     break;
                 case 2: // Unlock Nonvol access
                     ret = hm2_sserial_wait(hm2, inst, period);
                     if (ret > 0) break;
-                    if (ret < 0) *inst->state3 = 100; // quit and tidy up
+                    // FIXME: Assigns 100 to state3 and then 3 or 4 inside the if/else.
+                    if (ret < 0) hal_set_ui32(inst->state3, 100); // quit and tidy up
                     if (   p->type == LBP_NONVOL_FLOAT
                         || p->type == LBP_NONVOL_UNSIGNED
                         || p->type == LBP_NONVOL_SIGNED){
@@ -1585,38 +1458,39 @@ fail1:
                         *r->write[0] = LBPNONVOLEEPROM;
                         *inst->command_reg_write = 0x1000 | (1 << r->index); // doit command
                         inst->timer = 20000000;
-                        *inst->state3 = 3;
+                        hal_set_ui32(inst->state3, 3);
                         HM2_PRINT("A non-volatile smart-serial parameter has been changed\n"
                                         "A full power-cycle will be needed before the effect is seen\n");
                     } else {
-                        *inst->state3 = 4;
+                        hal_set_ui32(inst->state3, 4);
                     }
                     break;
                 case 3: // wait for doit clear
                     ret = hm2_sserial_wait(hm2, inst, period);
                     if (ret > 0) break;
-                    if (ret < 0) *inst->state3 = 100; // quit and tidy up
+                    // FIXME: Assigns 100 to state3 and then unconditionally assigns 4
+                    if (ret < 0) hal_set_ui32(inst->state3, 100); // quit and tidy up
                     // NV access now enabled.
                     HM2_DBG("NV Access unlocked: param %s\n", g->NameString);
-                    *inst->state3 = 4;
+                    hal_set_ui32(inst->state3, 4);
                     break;
                 case 4: // Now send the data
                     switch (p->type){
                         case LBP_SIGNED:
                         case LBP_NONVOL_SIGNED:
-                            *r->write[0] = (rtapi_u32) p->s32_param;
+                            *r->write[0] = (rtapi_u32)hal_get_si32(p->param.s);
                             break;
                         case LBP_UNSIGNED:
                         case LBP_NONVOL_UNSIGNED:
-                            *r->write[0] = p->u32_param;
+                            *r->write[0] = hal_get_ui32(p->param.u);
                             break;
                         case LBP_FLOAT:
                         case LBP_NONVOL_FLOAT:
                             if (g->DataLength == sizeof(float) * 8 ){
-                                float temp = p->float_param;
+                                float temp = hal_get_real(p->param.r);
                                 memcpy(r->write[0], &temp, sizeof(float));    // Data Value
                             } else if (g->DataLength == sizeof(double) * 8){
-                                double temp = p->float_param;
+                                double temp = hal_get_real(p->param.r);
                                 memcpy(r->write[0], &temp, sizeof(double));
                             } else {
                                 HM2_ERR("sserial write: LBP_FLOAT of bit-length %i not handled\n", g->DataLength);
@@ -1642,26 +1516,27 @@ fail1:
                         }
                     *inst->command_reg_write = 0x1000 | (1 << r->index); // doit command
                     inst->timer = 200000000;
-                    *inst->state3 = 5;
+                    hal_set_ui32(inst->state3, 5);
                     break;
                 case 5: // wait for doit clear
                     ret = hm2_sserial_wait(hm2, inst, period);
                     if (ret > 0) break;
-                    if (ret < 0) *inst->state3 = 100; // quit and tidy up
+                    // FIXME: Assigns 100 to state3 and then 7 or 8 inside the if/else.
+                    if (ret < 0) hal_set_ui32(inst->state3, 100); // quit and tidy up
 
                     // success? Set the written = param
                     switch (p->type){
                         case LBP_SIGNED:
                         case LBP_NONVOL_SIGNED:
-                            p->s32_written = p->s32_param;
+                            p->s32_written = hal_get_si32(p->param.s);
                             break;
                         case LBP_UNSIGNED:
                         case LBP_NONVOL_UNSIGNED:
-                            p->u32_written = p->u32_param;
+                            p->u32_written = hal_get_ui32(p->param.u);
                             break;
                         case LBP_FLOAT:
                         case LBP_NONVOL_FLOAT:
-                            p->float_written = p->float_param;
+                            p->float_written = hal_get_real(p->param.r);
                             break;
                         default:
                             break;
@@ -1676,52 +1551,54 @@ fail1:
                         *r->write[0] = LBPNONVOLCLEAR;
                         *inst->command_reg_write = 0x1000 | (1 << r->index); // doit command
                         inst->timer = 0x2000000;
-                        *inst->state3 = 7;
+                        hal_set_ui32(inst->state3, 7);
                     } else {
-                        *inst->state3 = 8;
+                        hal_set_ui32(inst->state3, 8);
                     }
                     break;
                 case 7: // wait for doit clear
                     ret = hm2_sserial_wait(hm2, inst, period);
                     if (ret > 0) break;
-                    if (ret < 0) *inst->state3 = 100; // quit and tidy up
+                    // FIXME: Assigns 100 to state3 and then unconditionally assigns 8
+                    if (ret < 0) hal_set_ui32(inst->state3, 100); // quit and tidy up
                     // NV access now cleared
                     HM2_DBG("NV Access Cleared: param %s\n", g->NameString);
-                    * inst->state3 = 8;
+                    hal_set_ui32(inst->state3, 8);
                     break;
                 case 8: // stop-all
                     inst->timer = 0x2000000;
                     *inst->command_reg_write = 0x800; //stop
-                    *inst->state3 = 9;
+                    hal_set_ui32(inst->state3, 9);
                     break;
                 case 9: //wait for final stop-all
                     ret = hm2_sserial_wait(hm2, inst, period);
                     if (ret > 0) break;
-                    if (ret < 0) *inst->state3 = 100; // quit and tidy up
+                    // FIXME: Assigns 100 to state3 and then unconditionally assigns 0
+                    if (ret < 0) hal_set_ui32(inst->state3, 100); // quit and tidy up
                     // NV access now cleared
                     HM2_DBG("Board out of setup mode: param %s\n", g->NameString);
-                    *inst->state3 = 0;
-                    *inst->state2 = 2; // increment indices
+                    hal_set_ui32(inst->state3, 0);
+                    hal_set_ui32(inst->state2, 2); // increment indices
                     break;
                 case 100: // error recovery
                     HM2_ERR("Problem found writing sserial parameter %s\n", g->NameString);
                     *inst->command_reg_write = 0x800; //stop all command
-                    *inst->state3 = 0;
-                    *inst->state2 = 2; // increment indices
+                    hal_set_ui32(inst->state3, 0);
+                    hal_set_ui32(inst->state2, 2); // increment indices
                     break;
             } // End of switch(inst->state3)
         break;
     case 2:
-        *inst->state2 = 1;
+        hal_set_ui32(inst->state2, 1);
         if ((int)++inst->g_index >= inst->remotes[inst->r_index].num_globals){
             inst->g_index = 0;
             if ((int)++inst->r_index >= inst->num_remotes){//checked them all
-                *inst->state2 = 0;
+                hal_set_ui32(inst->state2, 0);
             }
         }
         break;
     } // end of switch(inst->state2)
-    return *inst->state2;
+    return hal_get_ui32(inst->state2);
 }
 
 void hm2_sserial_write_pins(hostmot2_t *hm2, hm2_sserial_instance_t *inst){
@@ -1733,7 +1610,8 @@ void hm2_sserial_write_pins(hostmot2_t *hm2, hm2_sserial_instance_t *inst){
     // the side effect of reporting this error will suffice
     (void)hm2_sserial_check_remote_errors(hm2, inst);
 
-    if (*inst->fault_count > inst->fault_lim) {
+    rtapi_u32 fault_count = hal_get_ui32(inst->fault_count);
+    if (fault_count > hal_get_ui32(inst->fault_lim)) {
         // If there have been a large percentage of misses, for quite
         // a long time, it's time to take it seriously.
         hm2_sserial_check_local_errors(hm2, inst);
@@ -1741,9 +1619,9 @@ void hm2_sserial_write_pins(hostmot2_t *hm2, hm2_sserial_instance_t *inst){
                 "There have been more than %i errors in %i "
                 "thread executions at least %i times. "
                 "See other error messages for details.\n",
-                inst->fault_dec,
-                inst->fault_inc,
-                inst->fault_lim);
+                hal_get_ui32(inst->fault_dec),
+                hal_get_ui32(inst->fault_inc),
+                hal_get_ui32(inst->fault_lim));
         HM2_ERR("***Smart Serial Port %i will be stopped***\n",inst->index);
         static bool printed;
         if(!inst->ever_read && !printed) {
@@ -1753,7 +1631,7 @@ void hm2_sserial_write_pins(hostmot2_t *hm2, hm2_sserial_instance_t *inst){
                 "This error message will not repeat.\n");
             printed = true;
         }
-        *inst->state = 10;
+        hal_set_ui32(inst->state, 10);
         *inst->command_reg_write = 0x800; // stop command
         return;
     }
@@ -1767,20 +1645,20 @@ void hm2_sserial_write_pins(hostmot2_t *hm2, hm2_sserial_instance_t *inst){
                     "if this is happening frequently.\n",
                     inst->index, hm2->llio->name, inst->index);
         }
-        *inst->fault_count += inst->fault_inc;
+        fault_count = hal_set_ui32(inst->fault_count, fault_count + hal_get_ui32(inst->fault_inc));
         *inst->command_reg_write = 0x80000000; // set bit31 for ignored cmd
         return; // give the register chance to clear
     }
     if (*inst->data_reg_read & 0xff) { // indicates a failed transfer
-        *inst->fault_count += inst->fault_inc;
+        fault_count = hal_set_ui32(inst->fault_count, fault_count + hal_get_ui32(inst->fault_inc));
     }
 
-    if (*inst->fault_count > inst->fault_dec) {
-        *inst->fault_count -= inst->fault_dec;
+    if (fault_count > hal_get_ui32(inst->fault_dec)) {
+        fault_count = hal_set_ui32(inst->fault_count, fault_count - hal_get_ui32(inst->fault_dec));
     }
     else
     {
-        *inst->fault_count = 0;
+        fault_count = hal_set_ui32(inst->fault_count, 0);
     }
 
     // All seems well, handle the pins.
@@ -1805,32 +1683,32 @@ void hm2_sserial_write_pins(hostmot2_t *hm2, hm2_sserial_instance_t *inst){
                     case LBP_BITS:
                         buff = 0;
                         for (b = 0 ; b < conf->DataLength ; b++){
-                            buff |= ((rtapi_u64)(*pin->bit_pins[b] != 0) << b)
-                            ^ ((rtapi_u64)(pin->invert[b] != 0) << b);
+                            buff |= ((rtapi_u64)(hal_get_bool(pin->bit_pins[b])) << b)
+                            ^ ((rtapi_u64)hal_get_bool(pin->invert[b]) << b);
                         }
                         break;
                     case LBP_UNSIGNED:
-                        val = *pin->float_pin;
-                        if (val > pin->maxlim) val = pin->maxlim;
-                        if (val < pin->minlim) val = pin->minlim;
-                        buff = (rtapi_u64)((val / pin->fullscale)
+                        val = hal_get_real(pin->float_pin);
+                        if (val > hal_get_real(pin->maxlim)) val = hal_get_real(pin->maxlim);
+                        if (val < hal_get_real(pin->minlim)) val = hal_get_real(pin->minlim);
+                        buff = (rtapi_u64)((val / hal_get_real(pin->fullscale))
                                      * (~0ull >> (64 - conf->DataLength)));
                         break;
                     case LBP_SIGNED:
                         //this only works if DataLength <= 32
-                        val = *pin->float_pin;
-                        if (val > pin->maxlim) val = pin->maxlim;
-                        if (val < pin->minlim) val = pin->minlim;
-                        buff = (((rtapi_s32)(val / pin->fullscale * 2147483647))
+                        val = hal_get_real(pin->float_pin);
+                        if (val > hal_get_real(pin->maxlim)) val = hal_get_real(pin->maxlim);
+                        if (val < hal_get_real(pin->minlim)) val = hal_get_real(pin->minlim);
+                        buff = (((rtapi_s32)(val / hal_get_real(pin->fullscale) * 2147483647))
                                 >> (32 - conf->DataLength))
                         & (~0ull >> (64 - conf->DataLength));
                         break;
                     case LBP_STREAM:
-                        buff = *pin->u32_pin & (~0ull >> (64 - conf->DataLength));
+                        buff = hal_get_ui32(pin->u32_pin) & (~0ull >> (64 - conf->DataLength));
                         break;
                     case LBP_BOOLEAN:
                         buff = 0;
-                        if (*pin->boolean ^ ((conf->DataDir == LBP_OUT)?(*pin->invert):0)){
+                        if (hal_get_bool(pin->boolean) ^ ((conf->DataDir == LBP_OUT)?(hal_get_bool(*pin->invert)):0)){
                             buff = (~0ull >> (64 - conf->DataLength));
                         }
                         break;
@@ -1840,10 +1718,10 @@ void hm2_sserial_write_pins(hostmot2_t *hm2, hm2_sserial_instance_t *inst){
                         break;
                     case LBP_FLOAT:
                         if (conf->DataLength == sizeof(float) * 8 ){
-                            float temp = *pin->float_pin;
+                            float temp = hal_get_real(pin->float_pin);
                             memcpy(&buff, &temp, sizeof(float));
                         } else if (conf->DataLength == sizeof(double) * 8){
-                            double temp = *pin->float_pin;
+                            double temp = hal_get_real(pin->float_pin);
                             memcpy(&buff, &temp, sizeof(double));
                         } else {
                             HM2_ERR_NO_LL("sserial write: LBP_FLOAT of bit-length %i not handled\n", conf->DataLength);
@@ -1877,28 +1755,28 @@ void hm2_sserial_prepare_tram_write(hostmot2_t *hm2, long period){
 
         hm2_sserial_instance_t *inst = &(hm2->sserial.instance[i]);
 
-        switch ((*inst->state) & 0xFF){
+        switch (hal_get_ui32(inst->state) & 0xFF){
 
             case 0: // Idle
-                if (! *inst->run){ break; }
+                if (! hal_get_bool(inst->run)){ break; }
                 // Check for any changed parameters
                 if (hm2_sserial_update_params(hm2, inst, period) > 0) break;
                 //set the modes for the cards
                 hm2_sserial_setmode(hm2, inst);
                 *inst->command_reg_write = 0x900 | inst->tag;
                 HM2_DBG("Enabled Remotes tag = = %x\n", inst->tag);
-                *inst->fault_count = 0;
+                hal_set_ui32(inst->fault_count, 0);
                 inst->doit_err_count = 0;
                 inst->timer = 2100000000;
-                 *inst->state = 2;
+                hal_set_ui32(inst->state, 2);
                 break;
             case 2: // just transitioning to running
                 if (hm2_sserial_wait(hm2, inst, period) > 0) break;
-                *inst->state = 3;
+                hal_set_ui32(inst->state, 3);
                 break;
             case 3: // normal running
-                if (!*inst->run){
-                     *inst->state = 4;
+                if (!hal_get_bool(inst->run)){
+                    hal_set_ui32(inst->state, 4);
                     break;
                 }
                 hm2_sserial_write_pins(hm2, inst);
@@ -1906,21 +1784,21 @@ void hm2_sserial_prepare_tram_write(hostmot2_t *hm2, long period){
             case 4: // run to stop transition
                 *inst->command_reg_write = 0x800;
                 inst->timer = 2100000000;
-                *inst->state = 5;
+                hal_set_ui32(inst->state, 5);
                 break;
             case 5:
                 if (hm2_sserial_wait(hm2, inst, period) > 0) break;
-                *inst->state = 0;
+                hal_set_ui32(inst->state, 0);
                 break;
             case 10:// Do-nothing state for serious errors. require run pin to cycle
                 *inst->command_reg_write = 0x80000000; // set bit31 for ignored cmd
-                if ( ! *inst->run){*inst->state = 0;}
+                if ( !hal_get_bool(inst->run)){hal_set_ui32(inst->state, 0);}
                 break;
             default: // Should never happen
                 HM2_ERR("Unhandled run/stop configuration in \n"
                         "hm2_sserial_write (%x)\n",
-                        *inst->state);
-                *inst->state = 0;
+                        hal_get_ui32(inst->state));
+                hal_set_ui32(inst->state, 0);
         }
     }
 }
@@ -1948,8 +1826,8 @@ int hm2_sserial_read_pins(hm2_sserial_remote_t *chan){
                 break;
             case LBP_BITS:
                 for (b = 0 ; b < conf->DataLength ; b++){
-                    *pin->bit_pins[b] = ((buff & (1LL << b)) != 0);
-                    *pin->bit_pins_not[b] = ! *pin->bit_pins[b];
+                    rtapi_bool _v = hal_set_bool(pin->bit_pins[b], (buff & (1LL << b)) != 0);
+                    hal_set_bool(pin->bit_pins_not[b], !_v);
                 }
                 break;
             case LBP_UNSIGNED:
@@ -1961,21 +1839,19 @@ int hm2_sserial_read_pins(hm2_sserial_remote_t *chan){
                     }
                 }
 
-                *pin->float_pin = (buff * pin->fullscale)
-                / ((1 << conf->DataLength) - 1);
+                hal_set_real(pin->float_pin, (buff * hal_get_real(pin->fullscale)) / ((1 << conf->DataLength) - 1));
                 break;
             case LBP_SIGNED:
                 buff32 = (buff & 0xFFFFFFFFL) << (32 - conf->DataLength);
-                *pin->float_pin = (buff32 / 2147483647.0 )
-                                    * pin->fullscale;
+                hal_set_real(pin->float_pin, (buff32 / 2147483647.0 ) * hal_get_real(pin->fullscale));
                 break;
             case LBP_STREAM:
-                *pin->u32_pin = buff & (~0ull >> (64 - conf->DataLength));
+                hal_set_ui32(pin->u32_pin, buff & (~0ull >> (64 - conf->DataLength)));
                 break;
             case LBP_BOOLEAN:
-                *pin->boolean = (buff != 0);
+                hal_set_bool(pin->boolean, buff != 0);
                 if(conf->DataDir == LBP_IN){
-                    *pin->boolean2 = (buff == 0);
+                    hal_set_bool(pin->boolean2, buff == 0);
                 }
                 break;
             case LBP_ENCODER_H:
@@ -1998,7 +1874,7 @@ int hm2_sserial_read_pins(hm2_sserial_remote_t *chan){
                 int bitlength;
                 rtapi_s32 rem1, rem2;
                 rtapi_s64 previous;
-                rtapi_u32 ppr = pin->u32_param;
+                rtapi_u32 ppr = hal_get_ui32(pin->u32_param);
 
                 if (conf->DataType == LBP_ENCODER){
                     bitlength = conf->DataLength;
@@ -2031,10 +1907,10 @@ int hm2_sserial_read_pins(hm2_sserial_remote_t *chan){
                 pin->accum += (buff64 - pin->oldval);
 
                 //reset
-                if (*pin->boolean2){pin->offset = pin->accum;}
+                if (hal_get_bool(pin->boolean2)){pin->offset = pin->accum;}
 
                 //index-enable
-                if (*pin->boolean && ppr > 0){ // index-enable set
+                if (hal_get_bool(pin->boolean) && ppr > 0){ // index-enable set
                     rtapi_div_s64_rem(previous, ppr, &rem1);
                     rtapi_div_s64_rem(pin->accum, ppr, &rem2);
                     if ((unsigned)abs(rem1 - rem2) > ppr / 2
@@ -2057,23 +1933,23 @@ int hm2_sserial_read_pins(hm2_sserial_remote_t *chan){
                                 pin->offset = 0;
                             }
                         }
-                        *pin->boolean = 0;
+                        hal_set_bool(pin->boolean, 0);
                     }
                 }
                 pin->oldval = buff64;
-                *pin->s32_pin = pin->accum - pin->offset;
-                *pin->s32_pin2 = pin->accum;
-                *pin->float_pin = (double)(pin->accum - pin->offset) / pin->fullscale ;
+                hal_set_si32(pin->s32_pin, pin->accum - pin->offset);
+                hal_set_si32(pin->s32_pin2, pin->accum);
+                hal_set_real(pin->float_pin, (double)(pin->accum - pin->offset) / hal_get_real(pin->fullscale));
                 break;
             case LBP_FLOAT:
                 if (conf->DataLength == sizeof(float) * 8){
                     float temp;
                     memcpy(&temp, &buff, sizeof(float));
-                    *pin->float_pin = temp;
+                    hal_set_real(pin->float_pin, temp);
                 } else if (conf->DataLength == sizeof(double) * 8){
                     double temp;
                     memcpy(&temp, &buff, sizeof(double));
-                    *pin->float_pin = temp;
+                    hal_set_real(pin->float_pin, temp);
                 } else {
                     HM2_ERR_NO_LL("sserial read: LBP_FLOAT of bit-length %i not handled\n", conf->DataLength);
                     conf->DataType = 0; // Only warn once, then ignore
@@ -2099,7 +1975,7 @@ void hm2_sserial_process_tram_read(hostmot2_t *hm2, long period){
     for (i = 0 ; i < hm2->sserial.num_instances ; i++){
         hm2_sserial_instance_t *inst = &hm2->sserial.instance[i];
         inst->ever_read = true;
-        if (*inst->state != 3) continue ; // Only work on running instances
+        if (hal_get_ui32(inst->state) != 3) continue ; // Only work on running instances
         for (c = 0 ; c < inst->num_remotes ; c++ ) {
             hm2_sserial_remote_t *chan = &inst->remotes[c];
             hm2_sserial_read_pins(chan);

--- a/src/hal/drivers/mesa-hostmot2/sserial.h
+++ b/src/hal/drivers/mesa-hostmot2/sserial.h
@@ -110,21 +110,21 @@ typedef struct {
 }hm2_sserial_mode_t;
 
 typedef struct {
-    hal_u32_t *u32_pin;
-    hal_s32_t *s32_pin;
-    hal_s32_t *s32_pin2;
-    hal_float_t *float_pin;
-    hal_bit_t **bit_pins;
-    hal_bit_t **bit_pins_not;
-    hal_bit_t *invert;
-    hal_bit_t *boolean;
-    hal_bit_t *boolean2;
-    hal_float_t maxlim;
-    hal_float_t minlim;
-    hal_float_t fullscale;
-    hal_u32_t u32_param;
-    hal_bit_t graycode;
-    hal_bit_t nowrap;
+    hal_uint_t u32_pin;
+    hal_sint_t s32_pin;
+    hal_sint_t s32_pin2;
+    hal_real_t float_pin;
+    hal_bool_t *bit_pins;
+    hal_bool_t *bit_pins_not;
+    hal_bool_t *invert;
+    hal_bool_t boolean;
+    hal_bool_t boolean2;
+    hal_real_t maxlim;
+    hal_real_t minlim;
+    hal_real_t fullscale;
+    hal_uint_t u32_param;
+    rtapi_bool graycode;
+    rtapi_bool nowrap;
     rtapi_s64 oldval; // not pins, but this way every pin can have one
     rtapi_s64 accum; // these two are only currently used by encoders
     rtapi_s64 offset;
@@ -132,22 +132,17 @@ typedef struct {
 
 typedef struct {
     int type;
+    hal_refs_u param;
     union {
-        long long s64_param;
-        hal_u32_t u32_param;
-        hal_s32_t s32_param;
-        hal_float_t float_param;
-        hal_bit_t bit_param;
+        rtapi_u64  u64_written;
+        rtapi_s64  s64_written;
+        rtapi_u32  u32_written;
+        rtapi_s32  s32_written;
+        rtapi_real float_written;
     };
-    union {
-        long long s64_written;
-        hal_u32_t u32_written;
-        hal_s32_t s32_written;
-        hal_float_t float_written;
-        hal_bit_t bit_written;
-    };
-    hal_u32_t timer_num;
-    hal_bit_t *error;
+    hal_real_t fanucf; // HM2_GTAG_FABS frequency because 'param' above is used as filter
+    hal_uint_t timer_num;
+    hal_bool_t error;
 }hm2_sserial_params_t;
 
 typedef struct {
@@ -164,8 +159,9 @@ typedef struct {
     hm2_sserial_data_t *globals;
     hm2_sserial_pins_t *pins;
     hm2_sserial_params_t *params;
-    hal_u32_t serialnumber;
-    hal_u32_t status, seen_remote_errors;
+    rtapi_u32 serialnumber;
+    rtapi_u32 status;
+    rtapi_u32 seen_remote_errors;
 
     rtapi_u32 *reg_cs_read;
     rtapi_u32 *reg_cs_write;
@@ -196,18 +192,18 @@ typedef struct {
     rtapi_u32 data_reg_addr;
     rtapi_u32 *data_reg_read;
     rtapi_u32 *data_reg_write;
-    hal_u32_t *fault_count;
-    hal_u32_t fault_inc;
-    hal_u32_t fault_dec;
-    hal_u32_t fault_lim;
+    hal_uint_t fault_count;
+    hal_uint_t fault_inc;
+    hal_uint_t fault_dec;
+    hal_uint_t fault_lim;
     
-    hal_bit_t *run;
-    hal_u32_t *state;
-    hal_u32_t *state2;
-    hal_u32_t *state3;
-    hal_s32_t *debug;
-    hal_u32_t r_index;
-    hal_u32_t g_index;
+    hal_bool_t run;
+    hal_uint_t state;
+    hal_uint_t state2;
+    hal_uint_t state3;
+    hal_sint_t debug;
+    rtapi_u32 r_index;
+    rtapi_u32 g_index;
     int doit_err_count;
     rtapi_s32 timer;
     bool ever_read;

--- a/src/hal/drivers/mesa-hostmot2/ssr.c
+++ b/src/hal/drivers/mesa-hostmot2/ssr.c
@@ -82,7 +82,7 @@ int hm2_ssr_parse_md(hostmot2_t *hm2, int md_index) {
     hm2->ssr.clock_freq = md->clock_freq;
     hm2->ssr.version = md->version;
 
-    hm2->ssr.instance = (hm2_ssr_instance_t *)hal_malloc(hm2->ssr.num_instances * sizeof(hm2_ssr_instance_t));
+    hm2->ssr.instance = hal_malloc(hm2->ssr.num_instances * sizeof(*hm2->ssr.instance));
     if (hm2->ssr.instance == NULL) {
         HM2_ERR("out of memory!\n");
         r = -ENOMEM;
@@ -126,22 +126,18 @@ int hm2_ssr_parse_md(hostmot2_t *hm2, int md_index) {
     //
 
     {
-        int i;
-        char name[HAL_NAME_LEN + 1];
-
-        for (i = 0; i < hm2->ssr.num_instances; i ++) {
-            rtapi_snprintf(name, sizeof(name), "%s.ssr.%02d.rate", hm2->llio->name, i);
-            r = hal_pin_u32_new(name, HAL_IN, &(hm2->ssr.instance[i].hal.pin.rate), hm2->llio->comp_id);
+        for (int i = 0; i < hm2->ssr.num_instances; i ++) {
+            r = hal_pin_new_ui32(hm2->llio->comp_id, HAL_IN, &(hm2->ssr.instance[i].hal.pin.rate),
+                                 1000*1000, "%s.ssr.%02d.rate", hm2->llio->name, i);
             if (r < 0) {
-                HM2_ERR("error adding pin '%s', aborting\n", name);
+                HM2_ERR("error %d adding pin '%s.ssr.%02d.rate', aborting\n", r, hm2->llio->name, i);
                 r = -ENOMEM;
                 goto fail1;
             }
 
             {
-                int j = 0;
                 int ssr_number;
-                for (j = 0; j < hm2->num_pins; j++){
+                for (int j = 0; j < hm2->num_pins; j++){
                     if (hm2->pin[j].sec_tag == HM2_GTAG_SSR && hm2->pin[j].sec_unit == i) {
                         if ((hm2->pin[j].sec_pin & 0x80) != 0x80) {
                             HM2_ERR("Pin Descriptor %d has an SSR pin that's not an output!\n", j);
@@ -160,17 +156,17 @@ int hm2_ssr_parse_md(hostmot2_t *hm2, int md_index) {
                             goto fail1;
                         }
 
-                        rtapi_snprintf(name, sizeof(name), "%s.ssr.%02d.out-%02d", hm2->llio->name, i, ssr_number);
-                        r = hal_pin_bit_new(name, HAL_IN, &(hm2->ssr.instance[i].hal.pin.out[ssr_number]), hm2->llio->comp_id);
+                        r = hal_pin_new_bool(hm2->llio->comp_id, HAL_IN, &(hm2->ssr.instance[i].hal.pin.out[ssr_number]),
+                                             0, "%s.ssr.%02d.out-%02d", hm2->llio->name, i, ssr_number);
                         if (r < 0) {
-                            HM2_ERR("error adding pin '%s', aborting\n", name);
+                            HM2_ERR("error %d adding pin '%s.ssr.%02d.out-%02d', aborting\n", r, hm2->llio->name, i, ssr_number);
                             r = -ENOMEM;
                             goto fail1;
                         }
-                        rtapi_snprintf(name, sizeof(name), "%s.ssr.%02d.invert-%02d", hm2->llio->name, i, ssr_number);
-                        r = hal_pin_bit_new(name, HAL_IN, &(hm2->ssr.instance[i].hal.pin.invert[ssr_number]), hm2->llio->comp_id);
+                        r = hal_pin_new_bool(hm2->llio->comp_id, HAL_IN, &(hm2->ssr.instance[i].hal.pin.invert[ssr_number]),
+                                             0, "%s.ssr.%02d.invert-%02d", hm2->llio->name, i, ssr_number);
                         if (r < 0) {
-                            HM2_ERR("error adding pin '%s', aborting\n", name);
+                            HM2_ERR("error %d adding pin '%s.ssr.%02d.invert-%02d', aborting\n", r, hm2->llio->name, i, ssr_number);
                             r = -ENOMEM;
                             goto fail1;
                         }
@@ -192,17 +188,7 @@ int hm2_ssr_parse_md(hostmot2_t *hm2, int md_index) {
     {
         int i;
         for (i = 0; i < hm2->ssr.num_instances; i ++) {
-            int pin;
             rtapi_u32 zero = 0;
-
-            *hm2->ssr.instance[i].hal.pin.rate = 1000*1000;
-
-            for (pin = 0; pin < 32; pin ++) {
-                if (hm2->ssr.instance[i].hal.pin.out[pin] != NULL) {
-                    *hm2->ssr.instance[i].hal.pin.out[pin] = 0;
-                    *hm2->ssr.instance[i].hal.pin.invert[pin] = 0;
-                }
-            }		 
             hm2->llio->write(hm2->llio, hm2->ssr.rate_addr + (i * md->instance_stride), &zero, sizeof(zero));
             hm2->llio->write(hm2->llio, hm2->ssr.data_addr + (i * md->instance_stride), &zero, sizeof(zero));
         }
@@ -232,16 +218,17 @@ static void hm2_ssr_compute_rate_regs(hostmot2_t *hm2) {
     for (i = 0; i < hm2->ssr.num_instances; i ++) {
         rtapi_u32 reg;
 
-        if (*hm2->ssr.instance[i].hal.pin.rate <= 0) {
+        rtapi_u32 urate = hal_get_ui32(hm2->ssr.instance[i].hal.pin.rate);
+        if (urate <= 0) {
             // Writing all bits zero to the Rate register clears bit 12,
             // the enable bit.
             reg = 0;
         } else {
-            double rate = *hm2->ssr.instance[i].hal.pin.rate;
+            double rate = urate;
 
-            if (*hm2->ssr.instance[i].hal.pin.rate < 25000) {
+            if (urate < 25000) {
                 rate = 25000;
-            } else if (*hm2->ssr.instance[i].hal.pin.rate > (25*1000*1000)) {
+            } else if (urate > (25*1000*1000)) {
                 rate = 25*1000*1000;
             }
 
@@ -286,8 +273,8 @@ void hm2_ssr_force_write(hostmot2_t *hm2) {
         hm2->ssr.data_reg[i] = 0;
         for (pin = 0; pin < 32; pin ++) {
             if (hm2->ssr.instance[i].hal.pin.out[pin] != NULL) {
-                hm2->ssr.data_reg[i] |= *hm2->ssr.instance[i].hal.pin.out[pin] << pin;
-                hm2->ssr.data_reg[i] ^= *hm2->ssr.instance[i].hal.pin.invert[pin] << pin;
+                hm2->ssr.data_reg[i] |= hal_get_bool(hm2->ssr.instance[i].hal.pin.out[pin]) << pin;
+                hm2->ssr.data_reg[i] ^= hal_get_bool(hm2->ssr.instance[i].hal.pin.invert[pin]) << pin;
             }
         }
     }
@@ -330,8 +317,8 @@ void hm2_ssr_prepare_tram_write(hostmot2_t *hm2) {
         hm2->ssr.data_reg[i] = 0;
         for (pin = 0; pin < 32; pin ++) {
             if (hm2->ssr.instance[i].hal.pin.out[pin] != NULL) {
-                hm2->ssr.data_reg[i] |= *hm2->ssr.instance[i].hal.pin.out[pin] << pin;
-                hm2->ssr.data_reg[i] ^= *hm2->ssr.instance[i].hal.pin.invert[pin] << pin;
+                hm2->ssr.data_reg[i] |= hal_get_bool(hm2->ssr.instance[i].hal.pin.out[pin]) << pin;
+                hm2->ssr.data_reg[i] ^= hal_get_bool(hm2->ssr.instance[i].hal.pin.invert[pin]) << pin;
             }
         }
         if (hm2->ssr.data_reg[i] != hm2->ssr.instance[i].written_data) {

--- a/src/hal/drivers/mesa-hostmot2/stepgen.c
+++ b/src/hal/drivers/mesa-hostmot2/stepgen.c
@@ -43,6 +43,7 @@ void hm2_stepgen_process_tram_read(hostmot2_t *hm2, long l_period_ns) {
     rtapi_u32 mode = 0;
     rtapi_u32 latch = 0;
     for (i = 0; i < hm2->stepgen.num_instances; i ++) {
+        hm2_stepgen_instance_t *inst = &hm2->stepgen.instance[i];
         rtapi_u32 acc = hm2->stepgen.accumulator_reg[i];
         if (hm2->stepgen.firmware_supports_index) {
             mode = hm2->stepgen.mode_reg[i] & HM2_STEPGEN_MODE_MASK ;
@@ -52,12 +53,13 @@ void hm2_stepgen_process_tram_read(hostmot2_t *hm2, long l_period_ns) {
         rtapi_s64 latch_delta;
 
         // those tricky users are always trying to get us to divide by zero
-        if (fabs(hm2->stepgen.instance[i].hal.param.position_scale) < 1e-6) {
-            if (hm2->stepgen.instance[i].hal.param.position_scale >= 0.0) {
-                hm2->stepgen.instance[i].hal.param.position_scale = 1.0;
+        rtapi_real position_scale = hal_get_real(inst->hal.param.position_scale);
+        if (fabs(position_scale) < 1e-6) {
+            if (position_scale >= 0.0) {
+                position_scale = hal_set_real(inst->hal.param.position_scale, 1.0);
                 HM2_ERR("stepgen %d position_scale is too close to 0, resetting to 1.0\n", i);
             } else {
-                hm2->stepgen.instance[i].hal.param.position_scale = -1.0;
+                position_scale = hal_set_real(inst->hal.param.position_scale, -1.0);
                 HM2_ERR("stepgen %d position_scale is too close to 0, resetting to -1.0\n", i);
             }
         }
@@ -66,7 +68,7 @@ void hm2_stepgen_process_tram_read(hostmot2_t *hm2, long l_period_ns) {
         // representation of the current stepper position.
         // The fractional part gives accurate velocity at low speeds, and
         // sub-step position feedback (like sw stepgen).
-        acc_delta = (rtapi_s64)acc - (rtapi_s64)hm2->stepgen.instance[i].prev_accumulator;
+        acc_delta = (rtapi_s64)acc - (rtapi_s64)inst->prev_accumulator;
         if (acc_delta > RTAPI_INT32_MAX) {
             acc_delta -= RTAPI_UINT32_MAX;
         } else if (acc_delta < RTAPI_INT32_MIN) {
@@ -76,49 +78,49 @@ void hm2_stepgen_process_tram_read(hostmot2_t *hm2, long l_period_ns) {
 
 
         if (hm2->stepgen.firmware_supports_index) {
-            if (hm2->stepgen.instance[i].written_index_enable)  {     // searching for index
+            if (inst->written_index_enable)  {     // searching for index
                 if ((mode & HM2_STEPGEN_LATCH_ON_INDEX) == 0) {   // hardware index detected and position at index latched
-                    latch_delta = (rtapi_s64)latch - (rtapi_s64)hm2->stepgen.instance[i].prev_accumulator;
+                    latch_delta = (rtapi_s64)latch - (rtapi_s64)inst->prev_accumulator;
                     if (latch_delta > RTAPI_INT32_MAX) {
                         latch_delta -= RTAPI_UINT32_MAX;
                     } else if (latch_delta < RTAPI_INT32_MIN) {
                         latch_delta += RTAPI_UINT32_MAX;
                     }
-                    *hm2->stepgen.instance[i].hal.pin.position_latch = ((double)(hm2->stepgen.instance[i].subcounts+latch_delta) / 65536.0) / hm2->stepgen.instance[i].hal.param.position_scale;
+                    hal_set_real(inst->hal.pin.position_latch, ((double)(inst->subcounts+latch_delta) / 65536.0) / position_scale);
                     acc_delta -= latch_delta;		
-                    hm2->stepgen.instance[i].subcounts = 0;
-                    *hm2->stepgen.instance[i].hal.pin.index_enable = 0;
-                    hm2->stepgen.instance[i].written_index_enable  = 0;
+                    inst->subcounts = 0;
+                    hal_set_bool(inst->hal.pin.index_enable, 0);
+                    inst->written_index_enable  = 0;
                 }
             }
-            else if (hm2->stepgen.instance[i].written_probe_enable) {
+            else if (inst->written_probe_enable) {
                 if ((mode & HM2_STEPGEN_LATCH_ON_PROBE) == 0) {
-                    latch_delta = (rtapi_s64)latch - (rtapi_s64)hm2->stepgen.instance[i].prev_accumulator;
+                    latch_delta = (rtapi_s64)latch - (rtapi_s64)inst->prev_accumulator;
                     if (latch_delta > RTAPI_INT32_MAX) {
                         latch_delta -= RTAPI_UINT32_MAX;
                     } else if (latch_delta < RTAPI_INT32_MIN) {
                         latch_delta += RTAPI_UINT32_MAX;
                     }
-                    *hm2->stepgen.instance[i].hal.pin.position_latch = ((double)(hm2->stepgen.instance[i].subcounts+latch_delta) / 65536.0) / hm2->stepgen.instance[i].hal.param.position_scale;
-                    *hm2->stepgen.instance[i].hal.pin.latch_enable = 0;
-                     hm2->stepgen.instance[i].written_probe_enable  = 0;
+                    hal_set_real(inst->hal.pin.position_latch, ((double)(inst->subcounts+latch_delta) / 65536.0) / position_scale);
+                    hal_set_bool(inst->hal.pin.latch_enable, 0);
+                    inst->written_probe_enable = 0;
                 } 
             }
         }
 
-        hm2->stepgen.instance[i].subcounts += acc_delta;
+        inst->subcounts += acc_delta;
 
-        if ((*hm2->stepgen.instance[i].hal.pin.position_reset) != 0) {
-            hm2->stepgen.instance[i].subcounts = 0;
+        if (hal_get_bool(inst->hal.pin.position_reset)) {
+            inst->subcounts = 0;
         }
 
-        *(hm2->stepgen.instance[i].hal.pin.counts) = hm2->stepgen.instance[i].subcounts >> 16;
+        hal_set_si32(inst->hal.pin.counts, inst->subcounts >> 16);
 
         // note that it's important to use "subcounts/65536.0" instead of just
         // "counts" when computing position_fb, because position_fb needs sub-count
         // precision
-        *(hm2->stepgen.instance[i].hal.pin.position_fb) = ((double)hm2->stepgen.instance[i].subcounts / 65536.0) / hm2->stepgen.instance[i].hal.param.position_scale;
-        hm2->stepgen.instance[i].prev_accumulator = acc;
+        hal_set_real(inst->hal.pin.position_fb, ((double)inst->subcounts / 65536.0) / position_scale);
+        inst->prev_accumulator = acc;
     }    
 }
 
@@ -144,16 +146,18 @@ static void hm2_stepgen_instance_position_control(hostmot2_t *hm2, long l_period
     hm2_stepgen_instance_t *s = &hm2->stepgen.instance[i];
 
 
-    (*s->hal.pin.dbg_pos_minus_prev_cmd) = (*s->hal.pin.position_fb) - s->old_position_cmd;
+    hal_set_real(s->hal.pin.dbg_pos_minus_prev_cmd, hal_get_real(s->hal.pin.position_fb) - s->old_position_cmd);
 
     // calculate feed-forward velocity in machine units per second
-    ff_vel = ((*s->hal.pin.position_cmd) - s->old_position_cmd) / f_period_s;
-    (*s->hal.pin.dbg_ff_vel) = ff_vel;
+    rtapi_real position_cmd = hal_get_real(s->hal.pin.position_cmd);
+    ff_vel = (position_cmd - s->old_position_cmd) / f_period_s;
+    hal_set_real(s->hal.pin.dbg_ff_vel, ff_vel);
 
-    s->old_position_cmd = (*s->hal.pin.position_cmd);
+    s->old_position_cmd = position_cmd;
 
-    velocity_error = (*s->hal.pin.velocity_fb) - ff_vel;
-    (*s->hal.pin.dbg_vel_error) = velocity_error;
+    rtapi_real velocity_fb = hal_get_real(s->hal.pin.velocity_fb);
+    velocity_error = velocity_fb - ff_vel;
+    hal_set_real(s->hal.pin.dbg_vel_error, velocity_error);
 
     // Do we need to change speed to match the speed of position-cmd?
     // If maxaccel is 0, there's no accel limit: fix this velocity error
@@ -162,16 +166,18 @@ static void hm2_stepgen_instance_position_control(hostmot2_t *hm2, long l_period
     // If maxaccel is not zero, the user has specified a maxaccel and we
     // adhere to that.
     if (velocity_error > 0.0) {
-        if (s->hal.param.maxaccel == 0) {
+        rtapi_real maxaccel = hal_get_real(s->hal.param.maxaccel);
+        if (maxaccel == 0) {
             match_accel = -velocity_error / f_period_s;
         } else {
-            match_accel = -s->hal.param.maxaccel;
+            match_accel = -maxaccel;
         }
     } else if (velocity_error < 0.0) {
-        if (s->hal.param.maxaccel == 0) {
+        rtapi_real maxaccel = hal_get_real(s->hal.param.maxaccel);
+        if (maxaccel == 0) {
             match_accel = velocity_error / f_period_s;
         } else {
-            match_accel = s->hal.param.maxaccel;
+            match_accel = maxaccel;
         }
     } else {
         match_accel = 0;
@@ -183,21 +189,21 @@ static void hm2_stepgen_instance_position_control(hostmot2_t *hm2, long l_period
     } else {
         seconds_to_vel_match = -velocity_error / match_accel;
     }
-    *s->hal.pin.dbg_s_to_match = seconds_to_vel_match;
+    hal_set_real(s->hal.pin.dbg_s_to_match, seconds_to_vel_match);
 
     // compute expected position at the time of velocity match
     // Note: this is "feedback position at the beginning of the servo period after we attain velocity match"
     {
         double avg_v;
-        avg_v = (ff_vel + *s->hal.pin.velocity_fb) * 0.5;
-        position_at_match = *s->hal.pin.position_fb + (avg_v * (seconds_to_vel_match + f_period_s));
+        avg_v = (ff_vel + velocity_fb) * 0.5;
+        position_at_match = hal_get_real(s->hal.pin.position_fb) + (avg_v * (seconds_to_vel_match + f_period_s));
     }
 
     // Note: this assumes that position-cmd keeps the current velocity
-    position_cmd_at_match = *s->hal.pin.position_cmd + (ff_vel * seconds_to_vel_match);
+    position_cmd_at_match = position_cmd + (ff_vel * seconds_to_vel_match);
     error_at_match = position_at_match - position_cmd_at_match;
 
-    *s->hal.pin.dbg_err_at_match = error_at_match;
+    hal_set_real(s->hal.pin.dbg_err_at_match, error_at_match);
 
     if (seconds_to_vel_match < f_period_s) {
         // we can match velocity in one period
@@ -205,11 +211,12 @@ static void hm2_stepgen_instance_position_control(hostmot2_t *hm2, long l_period
         velocity_cmd = ff_vel - (0.5 * error_at_match / f_period_s);
 
         // apply accel limits?
-        if (s->hal.param.maxaccel > 0) {
-            if (velocity_cmd > (*s->hal.pin.velocity_fb + (s->hal.param.maxaccel * f_period_s))) {
-                velocity_cmd = *s->hal.pin.velocity_fb + (s->hal.param.maxaccel * f_period_s);
-            } else if (velocity_cmd < (*s->hal.pin.velocity_fb - (s->hal.param.maxaccel * f_period_s))) {
-                velocity_cmd = *s->hal.pin.velocity_fb - (s->hal.param.maxaccel * f_period_s);
+        rtapi_real maxaccel = hal_get_real(s->hal.param.maxaccel);
+        if (maxaccel > 0) {
+            if (velocity_cmd > (velocity_fb + (maxaccel * f_period_s))) {
+                velocity_cmd = velocity_fb + (maxaccel * f_period_s);
+            } else if (velocity_cmd < (velocity_fb - (maxaccel * f_period_s))) {
+                velocity_cmd = velocity_fb - (maxaccel * f_period_s);
             }
         }
 
@@ -230,7 +237,7 @@ static void hm2_stepgen_instance_position_control(hostmot2_t *hm2, long l_period
         }
 
         /* and do it */
-        velocity_cmd = *s->hal.pin.velocity_fb + (match_accel * f_period_s);
+        velocity_cmd = velocity_fb + (match_accel * f_period_s);
     }
 
     *new_vel = velocity_cmd;
@@ -263,47 +270,50 @@ static void hm2_stepgen_instance_prepare_tram_write(hostmot2_t *hm2, long l_peri
 
     // maxvel must be >= 0.0, and may not be faster than 1 step per (steplen+stepspace) seconds
     {
-        double min_ns_per_step = s->hal.param.steplen + s->hal.param.stepspace;
+        double min_ns_per_step = hal_get_ui32(s->hal.param.steplen) + hal_get_ui32(s->hal.param.stepspace);
         double max_steps_per_s = 1.0e9 / min_ns_per_step;
 
-        physical_maxvel = max_steps_per_s / fabs(s->hal.param.position_scale);
+        physical_maxvel = max_steps_per_s / fabs(hal_get_real(s->hal.param.position_scale));
         physical_maxvel = force_precision(physical_maxvel);
 
-        if (s->hal.param.maxvel < 0.0) {
+        rtapi_real pmaxvel = hal_get_real(s->hal.param.maxvel);
+        if (pmaxvel < 0.0) {
             HM2_ERR("stepgen.%02d.maxvel < 0, setting to its absolute value\n", i);
-            s->hal.param.maxvel = fabs(s->hal.param.maxvel);
+            pmaxvel = hal_set_real(s->hal.param.maxvel, fabs(pmaxvel));
         }
 
-        if (s->hal.param.maxvel > physical_maxvel) {
+        if (pmaxvel > physical_maxvel) {
             HM2_ERR("stepgen.%02d.maxvel is too big for current step timings & position-scale, clipping to max possible\n", i);
-            s->hal.param.maxvel = physical_maxvel;
+            pmaxvel= hal_set_real(s->hal.param.maxvel, physical_maxvel);
         }
 
-        if (s->hal.param.maxvel == 0.0) {
+        if (pmaxvel == 0.0) {
             maxvel = physical_maxvel;
         } else {
-            maxvel = s->hal.param.maxvel;
+            maxvel = pmaxvel;
         }
     }
 
     // maxaccel may not be negative
-    if (s->hal.param.maxaccel < 0.0) {
+    rtapi_real maxaccel = hal_get_real(s->hal.param.maxaccel);
+    if (maxaccel < 0.0) {
         HM2_ERR("stepgen.%02d.maxaccel < 0, setting to its absolute value\n", i);
-        s->hal.param.maxaccel = fabs(s->hal.param.maxaccel);
+        maxaccel = hal_set_real(s->hal.param.maxaccel, fabs(maxaccel));
     }
 
 
     // select the new velocity we want
-    if (*s->hal.pin.control_type == 0) {
+    if (!hal_get_bool(s->hal.pin.control_type)) {
         hm2_stepgen_instance_position_control(hm2, l_period_ns, i, &new_vel);
     } else {
         // velocity-mode control is easy
-        new_vel = *s->hal.pin.velocity_cmd;
-        if (s->hal.param.maxaccel > 0.0) {
-            if (((new_vel - *s->hal.pin.velocity_fb) / f_period_s) > s->hal.param.maxaccel) {
-                new_vel = (*s->hal.pin.velocity_fb) + (s->hal.param.maxaccel * f_period_s);
-            } else if (((new_vel - *s->hal.pin.velocity_fb) / f_period_s) < -s->hal.param.maxaccel) {
-                new_vel = (*s->hal.pin.velocity_fb) - (s->hal.param.maxaccel * f_period_s);
+        new_vel = hal_get_real(s->hal.pin.velocity_cmd);
+        rtapi_real velocity_fb = hal_get_real(s->hal.pin.velocity_fb);
+        if (maxaccel > 0.0) {
+            if (((new_vel - velocity_fb) / f_period_s) > maxaccel) {
+                new_vel = velocity_fb + (maxaccel * f_period_s);
+            } else if (((new_vel - velocity_fb) / f_period_s) < -maxaccel) {
+                new_vel = velocity_fb - (maxaccel * f_period_s);
             }
         }
     }
@@ -316,26 +326,26 @@ static void hm2_stepgen_instance_prepare_tram_write(hostmot2_t *hm2, long l_peri
     }
 
 
-    *s->hal.pin.velocity_fb = (hal_float_t)new_vel;
+    hal_set_real(s->hal.pin.velocity_fb, (rtapi_real)new_vel);
 
-    steps_per_sec_cmd = new_vel * s->hal.param.position_scale;
+    steps_per_sec_cmd = new_vel * hal_get_real(s->hal.param.position_scale);
     // the double cast here is intentional.  (uint32_t)(-1.0) is undefined in
     // C (and in practice it gives the undesired value 0 on arm systems), but
     // (uint32_t)(int32-t)(-1.0) is defined and gives the desired value on all
     // systems.
     hm2->stepgen.step_rate_reg[i] = (uint32_t)(int32_t)(steps_per_sec_cmd * (4294967296.0 / (double)hm2->stepgen.clock_frequency));
 
-    *s->hal.pin.dbg_step_rate = hm2->stepgen.step_rate_reg[i];
+    hal_set_si32(s->hal.pin.dbg_step_rate, hm2->stepgen.step_rate_reg[i]);
 }
 
 
 void hm2_stepgen_prepare_tram_write(hostmot2_t *hm2, long l_period_ns) {
     int i;
     for (i = 0; i < hm2->stepgen.num_instances; i ++) {
-        if (*(hm2->stepgen.instance[i].hal.pin.enable) == 0) {
+        if (!hal_get_bool(hm2->stepgen.instance[i].hal.pin.enable)) {
             hm2->stepgen.step_rate_reg[i] = 0;
-            hm2->stepgen.instance[i].old_position_cmd = *(hm2->stepgen.instance[i].hal.pin.position_cmd);
-            *(hm2->stepgen.instance[i].hal.pin.velocity_fb) = 0;
+            hm2->stepgen.instance[i].old_position_cmd = hal_get_real(hm2->stepgen.instance[i].hal.pin.position_cmd);
+            hal_set_real(hm2->stepgen.instance[i].hal.pin.velocity_fb, 0);
         } else {
             hm2_stepgen_instance_prepare_tram_write(hm2, l_period_ns, i);
         }
@@ -346,46 +356,50 @@ void hm2_stepgen_prepare_tram_write(hostmot2_t *hm2, long l_period_ns) {
 
 
 static void hm2_stepgen_update_dir_setup_time(hostmot2_t *hm2, int i) {
-    hm2->stepgen.dir_setup_time_reg[i] = (double)hm2->stepgen.instance[i].hal.param.dirsetup * ((double)hm2->stepgen.clock_frequency / (double)1e9);
+    rtapi_u32 dirsetup = hal_get_ui32(hm2->stepgen.instance[i].hal.param.dirsetup);
+    hm2->stepgen.dir_setup_time_reg[i] = (double)dirsetup * ((double)hm2->stepgen.clock_frequency / (double)1e9);
     if (hm2->stepgen.dir_setup_time_reg[i] > 0x3FFF) {
         HM2_ERR("stepgen %d has invalid dirsetup, resetting to max\n", i);
         hm2->stepgen.dir_setup_time_reg[i] = 0x3FFF;
-        hm2->stepgen.instance[i].hal.param.dirsetup = (double)hm2->stepgen.dir_setup_time_reg[i] * ((double)1e9 / (double)hm2->stepgen.clock_frequency);
+        dirsetup = hal_set_ui32(hm2->stepgen.instance[i].hal.param.dirsetup, (double)hm2->stepgen.dir_setup_time_reg[i] * ((double)1e9 / (double)hm2->stepgen.clock_frequency));
     }
-    hm2->stepgen.instance[i].written_dirsetup = hm2->stepgen.instance[i].hal.param.dirsetup;
+    hm2->stepgen.instance[i].written_dirsetup = dirsetup;
 }
 
 
 static void hm2_stepgen_update_dir_hold_time(hostmot2_t *hm2, int i) {
-    hm2->stepgen.dir_hold_time_reg[i] = (double)hm2->stepgen.instance[i].hal.param.dirhold * ((double)hm2->stepgen.clock_frequency / (double)1e9);
+    rtapi_u32 dirhold = hal_get_ui32(hm2->stepgen.instance[i].hal.param.dirhold);
+    hm2->stepgen.dir_hold_time_reg[i] = (double)dirhold * ((double)hm2->stepgen.clock_frequency / (double)1e9);
     if (hm2->stepgen.dir_hold_time_reg[i] > 0x3FFF) {
         HM2_ERR("stepgen %d has invalid dirhold, resetting to max\n", i);
         hm2->stepgen.dir_hold_time_reg[i] = 0x3FFF;
-        hm2->stepgen.instance[i].hal.param.dirhold = (double)hm2->stepgen.dir_hold_time_reg[i] * ((double)1e9 / (double)hm2->stepgen.clock_frequency);
+        dirhold = hal_set_ui32(hm2->stepgen.instance[i].hal.param.dirhold, (double)hm2->stepgen.dir_hold_time_reg[i] * ((double)1e9 / (double)hm2->stepgen.clock_frequency));
     }
-    hm2->stepgen.instance[i].written_dirhold = hm2->stepgen.instance[i].hal.param.dirhold;
+    hm2->stepgen.instance[i].written_dirhold = dirhold;
 }
 
 
 static void hm2_stepgen_update_pulse_idle_width(hostmot2_t *hm2, int i) {
-    hm2->stepgen.pulse_idle_width_reg[i] = (double)hm2->stepgen.instance[i].hal.param.stepspace * ((double)hm2->stepgen.clock_frequency / (double)1e9);
+    rtapi_u32 stepspace = hal_get_ui32(hm2->stepgen.instance[i].hal.param.stepspace);
+    hm2->stepgen.pulse_idle_width_reg[i] = (double)stepspace * ((double)hm2->stepgen.clock_frequency / (double)1e9);
     if (hm2->stepgen.pulse_idle_width_reg[i] > 0x3FFF) {
         HM2_ERR("stepgen %d has invalid stepspace, resetting to max\n", i);
         hm2->stepgen.pulse_idle_width_reg[i] = 0x3FFF;
-        hm2->stepgen.instance[i].hal.param.stepspace = (double)hm2->stepgen.pulse_idle_width_reg[i] * ((double)1e9 / (double)hm2->stepgen.clock_frequency);
+        stepspace = hal_set_ui32(hm2->stepgen.instance[i].hal.param.stepspace, (double)hm2->stepgen.pulse_idle_width_reg[i] * ((double)1e9 / (double)hm2->stepgen.clock_frequency));
     }
-    hm2->stepgen.instance[i].written_stepspace = hm2->stepgen.instance[i].hal.param.stepspace;
+    hm2->stepgen.instance[i].written_stepspace = stepspace;
 }
 
 
 static void hm2_stepgen_update_pulse_width(hostmot2_t *hm2, int i) {
-    hm2->stepgen.pulse_width_reg[i] = (double)hm2->stepgen.instance[i].hal.param.steplen * ((double)hm2->stepgen.clock_frequency / (double)1e9);
+    rtapi_u32 steplen = hal_get_ui32(hm2->stepgen.instance[i].hal.param.steplen);
+    hm2->stepgen.pulse_width_reg[i] = (double)steplen * ((double)hm2->stepgen.clock_frequency / (double)1e9);
     if (hm2->stepgen.pulse_width_reg[i] > 0x3FFF) {
         HM2_ERR("stepgen %d has invalid steplen, resetting to max\n", i);
         hm2->stepgen.pulse_width_reg[i] = 0x3FFF;
-        hm2->stepgen.instance[i].hal.param.steplen = (double)hm2->stepgen.pulse_width_reg[i] * ((double)1e9 / (double)hm2->stepgen.clock_frequency);
+        steplen = hal_set_ui32(hm2->stepgen.instance[i].hal.param.steplen, (double)hm2->stepgen.pulse_width_reg[i] * ((double)1e9 / (double)hm2->stepgen.clock_frequency));
     }
-    hm2->stepgen.instance[i].written_steplen = hm2->stepgen.instance[i].hal.param.steplen;
+    hm2->stepgen.instance[i].written_steplen = steplen;
 }
 
 
@@ -396,40 +410,41 @@ static void hm2_stepgen_update_mode(hostmot2_t *hm2, int i) {
     hm2_stepgen_instance_t *inst =  &hm2->stepgen.instance[i];
     
     // No point coming back unless something changes
-    inst->written_step_type  = inst->hal.param.step_type;
+    rtapi_u32 step_type = hal_get_ui32(inst->hal.param.step_type);
+    inst->written_step_type = step_type;
     if (hm2->stepgen.firmware_supports_swap) {
-        inst->written_swap_step_dir  = inst->hal.param.swap_step_dir;
+        inst->written_swap_step_dir  = hal_get_bool(inst->hal.param.swap_step_dir);
     }
     if (hm2->stepgen.firmware_supports_index) {
-        inst->written_index_polarity  = *inst->hal.pin.index_polarity;
-        inst->written_probe_polarity  = *inst->hal.pin.latch_polarity;
+        inst->written_index_polarity  = hal_get_bool(inst->hal.pin.index_polarity);
+        inst->written_probe_polarity  = hal_get_bool(inst->hal.pin.latch_polarity);
     } 
-    inst->hal.param.table[4] = (((inst->hal.param.table[0] ^ inst->hal.param.table[1]) 
-                            ^ inst->hal.param.table[2]) ^ inst->hal.param.table[3]);
+    inst->tablehash = (((hal_get_ui32(inst->hal.param.table[0])  ^ hal_get_ui32(inst->hal.param.table[1]))
+                       ^ hal_get_ui32(inst->hal.param.table[2])) ^ hal_get_ui32(inst->hal.param.table[3]));
 
-    modebuff = inst->hal.param.step_type;  // start with the step mode
+    modebuff = step_type;  // start with the step mode
 
 
     if (hm2->stepgen.firmware_supports_index) {  // or in the index/probe control bits if needed
-       if (*inst->hal.pin.index_enable) {
+       if (hal_get_bool(inst->hal.pin.index_enable)) {
 	    modebuff |= HM2_STEPGEN_LATCH_ON_INDEX;
         }
-        if (*inst->hal.pin.index_polarity) {
+        if (hal_get_bool(inst->hal.pin.index_polarity)) {
 	    modebuff |= HM2_STEPGEN_INDEX_POLARITY;
         }
-        if (*inst->hal.pin.latch_enable) {
+        if (hal_get_bool(inst->hal.pin.latch_enable)) {
 	    modebuff |= HM2_STEPGEN_LATCH_ON_PROBE;
         }
-        if (*inst->hal.pin.latch_polarity) {
+        if (hal_get_bool(inst->hal.pin.latch_polarity)) {
 	    modebuff |= HM2_STEPGEN_PROBE_POLARITY;
         }
     }
 
                                                                              
-    if (inst->hal.param.step_type <= 2) {
+    if (step_type <= 2) {
         
         if (hm2->stepgen.firmware_supports_swap) {
-            if  (inst->hal.param.swap_step_dir) {
+            if  (hal_get_bool(inst->hal.param.swap_step_dir)) {
                 modebuff |= HM2_STEPGEN_SWAP_STEP_DIR;
             }
 	}
@@ -437,32 +452,36 @@ static void hm2_stepgen_update_mode(hostmot2_t *hm2, int i) {
         return;
     } 
 
-    if (inst->table_width <  inst->hal.param.step_type){
+    if (inst->table_width < step_type){
         HM2_ERR("the firmware only supports %i pins in the step pattern for "
                 "stepgen instance %i, you asked for %i. Reverting to step type 0\n",
                 inst->table_width, 
                 i,
-                inst->hal.param.step_type);
+                step_type);
         hm2->stepgen.mode_reg[i] = 0;
     }
-    if (inst->hal.param.step_type > 16){
-        HM2_ERR("the firmware only supports tables up to a depth of 16, you"
+    if (step_type > 16){
+        HM2_ERR("the firmware only supports tables up to a depth of 16, you "
                 "requested %i. Reverting to step type 0\n",
-                inst->hal.param.step_type);
+                step_type);
         hm2->stepgen.mode_reg[i] = 0;
+        // Assure that we do not index outside the param.table[] array in the
+        // loop below. But the code may be off anyway and the result is
+        // anybody's guess.
+        step_type = 16;
     }
     // In that case, we can assume that we have been fed a step table and the
     // step_type is actually the table length. 
 
-    for (j = inst->hal.param.step_type - 1; j >= 0 ; j--){
-        buff = ((inst->hal.param.table[j / 4] >> ((j % 4) * 8)) & 0xFF);
+    for (j = step_type - 1; j >= 0 ; j--){
+        buff = ((hal_get_ui32(inst->hal.param.table[j / 4]) >> ((j % 4) * 8)) & 0xFF);
         hm2->llio->write(hm2->llio, hm2->stepgen.table_sequence_data_setup_addr 
                 + (i * sizeof(rtapi_u32)), &buff, sizeof(rtapi_u32));
     }
     
     hm2->stepgen.mode_reg[i] = 3 | modebuff; // force 2 LSbs to 1,1 to select table mode in stepgen hardware
 
-    buff = inst->hal.param.step_type -1;	    
+    buff = step_type -1;
     
     hm2->llio->write(hm2->llio, hm2->stepgen.table_sequence_length_addr
             + (i * sizeof(rtapi_u32)), &buff, sizeof(rtapi_u32));
@@ -471,15 +490,15 @@ static void hm2_stepgen_update_mode(hostmot2_t *hm2, int i) {
 
 static void hm2_stepgen_set_dpll_timer(hostmot2_t *hm2) {
     rtapi_u32 data = 0;
-
-    if ((*hm2->stepgen.hal->pin.dpll_timer_num < -1) || (*hm2->stepgen.hal->pin.dpll_timer_num > 4)) {
-        *hm2->stepgen.hal->pin.dpll_timer_num = 0;
+    rtapi_s32 dpll_timer_num = hal_get_si32(hm2->stepgen.hal->pin.dpll_timer_num);
+    if ((dpll_timer_num < -1) || (dpll_timer_num > 4)) {
+        dpll_timer_num = hal_set_si32(hm2->stepgen.hal->pin.dpll_timer_num, 0);
     }
-    if (*hm2->stepgen.hal->pin.dpll_timer_num > -1) {
-        data = (*hm2->stepgen.hal->pin.dpll_timer_num << 12) | (1 << 15);
+    if (dpll_timer_num > -1) {
+        data = (dpll_timer_num << 12) | (1 << 15);
     }
     hm2->llio->write(hm2->llio, hm2->stepgen.dpll_timer_num_addr, &data, sizeof(rtapi_u32));
-    hm2->stepgen.written_dpll_timer_num = *hm2->stepgen.hal->pin.dpll_timer_num;
+    hm2->stepgen.written_dpll_timer_num = dpll_timer_num;
 }
 
 
@@ -490,46 +509,46 @@ void hm2_stepgen_write(hostmot2_t *hm2) {
     // FIXME
     for (i = 0; i < hm2->stepgen.num_instances; i ++) {
         hm2_stepgen_instance_t *inst = &hm2->stepgen.instance[i];
-        if (inst->hal.param.dirsetup != inst->written_dirsetup) {
+        if (hal_get_ui32(inst->hal.param.dirsetup) != inst->written_dirsetup) {
             hm2_stepgen_update_dir_setup_time(hm2, i);
             hm2->llio->write(hm2->llio, hm2->stepgen.dir_setup_time_addr + (i * sizeof(rtapi_u32)), &hm2->stepgen.dir_setup_time_reg[i], sizeof(rtapi_u32));
         }
 
-        if (inst->hal.param.dirhold != inst->written_dirhold) {
+        if (hal_get_ui32(inst->hal.param.dirhold) != inst->written_dirhold) {
             hm2_stepgen_update_dir_hold_time(hm2, i);
             hm2->llio->write(hm2->llio, hm2->stepgen.dir_hold_time_addr + (i * sizeof(rtapi_u32)), &hm2->stepgen.dir_hold_time_reg[i], sizeof(rtapi_u32));
         }
 
-        if (inst->hal.param.steplen != inst->written_steplen) {
+        if (hal_get_ui32(inst->hal.param.steplen) != inst->written_steplen) {
             hm2_stepgen_update_pulse_width(hm2, i);
             hm2->llio->write(hm2->llio, hm2->stepgen.pulse_width_addr + (i * sizeof(rtapi_u32)), &hm2->stepgen.pulse_width_reg[i], sizeof(rtapi_u32));
         }
 
-        if (inst->hal.param.stepspace != inst->written_stepspace) {
+        if (hal_get_ui32(inst->hal.param.stepspace) != inst->written_stepspace) {
             hm2_stepgen_update_pulse_idle_width(hm2, i);
             hm2->llio->write(hm2->llio, hm2->stepgen.pulse_idle_width_addr + (i * sizeof(rtapi_u32)), &hm2->stepgen.pulse_idle_width_reg[i], sizeof(rtapi_u32));
         }
 
         need_mode_update=0;
 
-	if ((inst->hal.param.step_type != inst->written_step_type) 
-           || (((inst->hal.param.table[0] ^ inst->hal.param.table[1]) 
-           ^ inst->hal.param.table[2]) ^ inst->hal.param.table[3])
-           != inst->hal.param.table[4]) {   
+	if ((hal_get_ui32(inst->hal.param.step_type) != inst->written_step_type)
+           || (((hal_get_ui32(inst->hal.param.table[0]) ^ hal_get_ui32(inst->hal.param.table[1]))
+               ^ hal_get_ui32(inst->hal.param.table[2])) ^ hal_get_ui32(inst->hal.param.table[3]))
+           != inst->tablehash) {
             need_mode_update = 1;
         }
 
         if (hm2->stepgen.firmware_supports_swap) {
-            if (inst->hal.param.swap_step_dir != inst->written_swap_step_dir) {
+            if (hal_get_bool(inst->hal.param.swap_step_dir) != inst->written_swap_step_dir) {
                 need_mode_update |= 1;
             }
         }
 
         if (hm2->stepgen.firmware_supports_index) {
-            if ((*inst->hal.pin.index_enable != inst->written_index_enable)
-               || (*inst->hal.pin.latch_enable != inst->written_probe_enable)
-               || (*inst->hal.pin.index_polarity != inst->written_index_polarity)
-               || (*inst->hal.pin.latch_polarity != inst->written_probe_polarity)) {
+            if ((hal_get_bool(inst->hal.pin.index_enable) != inst->written_index_enable)
+               || (hal_get_bool(inst->hal.pin.latch_enable) != inst->written_probe_enable)
+               || (hal_get_bool(inst->hal.pin.index_polarity) != inst->written_index_polarity)
+               || (hal_get_bool(inst->hal.pin.latch_polarity) != inst->written_probe_polarity)) {
                 need_mode_update |= 1;
             }
         }
@@ -537,14 +556,14 @@ void hm2_stepgen_write(hostmot2_t *hm2) {
             hm2_stepgen_update_mode(hm2, i);
             hm2->llio->write(hm2->llio, hm2->stepgen.mode_addr + (i * sizeof(rtapi_u32)), &hm2->stepgen.mode_reg[i], sizeof(rtapi_u32));
             if (hm2->stepgen.firmware_supports_index) {
-                inst->written_index_enable  = *inst->hal.pin.index_enable; // we need to update these only after the write has occurred
-                inst->written_probe_enable  = *inst->hal.pin.latch_enable; // to avoid a race condition (index detected before index enable has been set)
+                inst->written_index_enable  = hal_get_bool(inst->hal.pin.index_enable); // we need to update these only after the write has occurred
+                inst->written_probe_enable  = hal_get_bool(inst->hal.pin.latch_enable); // to avoid a race condition (index detected before index enable has been set)
             }
         }
     }
 
     if (hm2->stepgen.num_instances > 0 && hm2->dpll_module_present) {
-        if (*hm2->stepgen.hal->pin.dpll_timer_num != (int)hm2->stepgen.written_dpll_timer_num) {
+        if (hal_get_si32(hm2->stepgen.hal->pin.dpll_timer_num) != (int)hm2->stepgen.written_dpll_timer_num) {
             hm2_stepgen_set_dpll_timer(hm2);
         }
     }
@@ -658,7 +677,7 @@ void hm2_stepgen_tram_init(hostmot2_t *hm2) {
 
     for (i = 0; i < hm2->stepgen.num_instances; i ++) {
         hm2->stepgen.instance[i].prev_accumulator = hm2->stepgen.accumulator_reg[i];
-        hm2->stepgen.instance[i].old_position_cmd = *hm2->stepgen.instance[i].hal.pin.position_cmd;
+        hm2->stepgen.instance[i].old_position_cmd = hal_get_real(hm2->stepgen.instance[i].hal.pin.position_cmd);
     }
 }
 
@@ -757,14 +776,14 @@ int hm2_stepgen_parse_md(hostmot2_t *hm2, int md_index) {
 
 
     // allocate the module-global HAL shared memory
-    hm2->stepgen.hal = (hm2_stepgen_module_global_t *)hal_malloc(sizeof(hm2_stepgen_module_global_t));
+    hm2->stepgen.hal = hal_malloc(sizeof(*hm2->stepgen.hal));
     if (hm2->stepgen.hal == NULL) {
         HM2_ERR("out of memory!\n");
         r = -ENOMEM;
         goto fail0;
     }
 
-    hm2->stepgen.instance = (hm2_stepgen_instance_t *)hal_malloc(hm2->stepgen.num_instances * sizeof(hm2_stepgen_instance_t));
+    hm2->stepgen.instance = hal_malloc(hm2->stepgen.num_instances * sizeof(*hm2->stepgen.instance));
     if (hm2->stepgen.instance == NULL) {
         HM2_ERR("out of memory!\n");
         r = -ENOMEM;
@@ -853,26 +872,21 @@ int hm2_stepgen_parse_md(hostmot2_t *hm2, int md_index) {
     // export to HAL
 
     {
-        int i;
-        char name[HAL_NAME_LEN + 1];
-
         if (hm2->dpll_module_present) {
-            rtapi_snprintf(name, sizeof(name), "%s.stepgen.timer-number", hm2->llio->name);
-            r = hal_pin_s32_new(name, HAL_IN, &(hm2->stepgen.hal->pin.dpll_timer_num), hm2->llio->comp_id);
+            r = hal_pin_new_si32(hm2->llio->comp_id, HAL_IN, &(hm2->stepgen.hal->pin.dpll_timer_num),
+                                 -1, "%s.stepgen.timer-number", hm2->llio->name);
             if (r < 0) {
-                HM2_ERR("error adding timer number param, aborting\n");
+                HM2_ERR("error %d adding pin '%s.stepgen.timer-number', aborting\n", r, hm2->llio->name);
                 return -EINVAL;
             }
-            *(hm2->stepgen.hal->pin.dpll_timer_num) = -1;
         }
 
-        for (i = 0; i < hm2->stepgen.num_instances; i ++) {
+        for (int i = 0; i < hm2->stepgen.num_instances; i ++) {
             
             // Work out if table setup registers are needed. 
             {
-                int j = 0;
                 hm2->stepgen.instance[i].table_width = 0;
-                for (j = 0; j < hm2->num_pins; j++){
+                for (int j = 0; j < hm2->num_pins; j++){
                     if (hm2->pin[j].sec_tag == HM2_GTAG_STEPGEN && hm2->pin[j].sec_unit == i){
                         if (hm2->pin[j].sec_pin > hm2->stepgen.instance[i].table_width){
                             hm2->stepgen.instance[i].table_width =  hm2->pin[j].sec_pin;
@@ -881,108 +895,108 @@ int hm2_stepgen_parse_md(hostmot2_t *hm2, int md_index) {
                 }
             }
             // pins
-            rtapi_snprintf(name, sizeof(name), "%s.stepgen.%02d.position-cmd", hm2->llio->name, i);
-            r = hal_pin_float_new(name, HAL_IN, &(hm2->stepgen.instance[i].hal.pin.position_cmd), hm2->llio->comp_id);
+            r = hal_pin_new_real(hm2->llio->comp_id, HAL_IN, &(hm2->stepgen.instance[i].hal.pin.position_cmd),
+                                 0.0, "%s.stepgen.%02d.position-cmd", hm2->llio->name, i);
             if (r < 0) {
-                HM2_ERR("error adding pin '%s', aborting\n", name);
+                HM2_ERR("error %d adding pin '%s.stepgen.%02d.position-cmd', aborting\n", r, hm2->llio->name, i);
                 r = -ENOMEM;
                 goto fail5;
             }
 
-            rtapi_snprintf(name, sizeof(name), "%s.stepgen.%02d.velocity-cmd", hm2->llio->name, i);
-            r = hal_pin_float_new(name, HAL_IN, &(hm2->stepgen.instance[i].hal.pin.velocity_cmd), hm2->llio->comp_id);
+            r = hal_pin_new_real(hm2->llio->comp_id, HAL_IN, &(hm2->stepgen.instance[i].hal.pin.velocity_cmd),
+                                 0.0, "%s.stepgen.%02d.velocity-cmd", hm2->llio->name, i);
             if (r < 0) {
-                HM2_ERR("error adding pin '%s', aborting\n", name);
+                HM2_ERR("error %d adding pin '%s.stepgen.%02d.velocity-cmd', aborting\n", r, hm2->llio->name, i);
                 r = -ENOMEM;
                 goto fail5;
             }
 
-            rtapi_snprintf(name, sizeof(name), "%s.stepgen.%02d.velocity-fb", hm2->llio->name, i);
-            r = hal_pin_float_new(name, HAL_OUT, &(hm2->stepgen.instance[i].hal.pin.velocity_fb), hm2->llio->comp_id);
+            r = hal_pin_new_real(hm2->llio->comp_id, HAL_OUT, &(hm2->stepgen.instance[i].hal.pin.velocity_fb),
+                                 0.0, "%s.stepgen.%02d.velocity-fb", hm2->llio->name, i);
             if (r < 0) {
-                HM2_ERR("error adding pin '%s', aborting\n", name);
+                HM2_ERR("error %d adding pin '%s.stepgen.%02d.velocity-fb', aborting\n", r, hm2->llio->name, i);
                 r = -ENOMEM;
                 goto fail5;
             }
 
-            rtapi_snprintf(name, sizeof(name), "%s.stepgen.%02d.position-fb", hm2->llio->name, i);
-            r = hal_pin_float_new(name, HAL_OUT, &(hm2->stepgen.instance[i].hal.pin.position_fb), hm2->llio->comp_id);
+            r = hal_pin_new_real(hm2->llio->comp_id, HAL_OUT, &(hm2->stepgen.instance[i].hal.pin.position_fb),
+                                 0.0, "%s.stepgen.%02d.position-fb", hm2->llio->name, i);
             if (r < 0) {
-                HM2_ERR("error adding pin '%s', aborting\n", name);
+                HM2_ERR("error %d adding pin '%s.stepgen.%02d.position-fb', aborting\n", r, hm2->llio->name, i);
                 r = -ENOMEM;
                 goto fail5;
             }
 
-            rtapi_snprintf(name, sizeof(name), "%s.stepgen.%02d.counts", hm2->llio->name, i);
-            r = hal_pin_s32_new(name, HAL_OUT, &(hm2->stepgen.instance[i].hal.pin.counts), hm2->llio->comp_id);
+            r = hal_pin_new_si32(hm2->llio->comp_id, HAL_OUT, &(hm2->stepgen.instance[i].hal.pin.counts),
+                                 0, "%s.stepgen.%02d.counts", hm2->llio->name, i);
             if (r < 0) {
-                HM2_ERR("error adding pin '%s', aborting\n", name);
+                HM2_ERR("error %d adding pin '%s.stepgen.%02d.counts', aborting\n", r, hm2->llio->name, i);
                 r = -ENOMEM;
                 goto fail5;
             }
 
-            rtapi_snprintf(name, sizeof(name), "%s.stepgen.%02d.enable", hm2->llio->name, i);
-            r = hal_pin_bit_new(name, HAL_IN, &(hm2->stepgen.instance[i].hal.pin.enable), hm2->llio->comp_id);
+            r = hal_pin_new_bool(hm2->llio->comp_id, HAL_IN, &(hm2->stepgen.instance[i].hal.pin.enable),
+                                 0, "%s.stepgen.%02d.enable", hm2->llio->name, i);
             if (r < 0) {
-                HM2_ERR("error adding pin '%s', aborting\n", name);
+                HM2_ERR("error %d adding pin '%s.stepgen.%02d.enable', aborting\n", r, hm2->llio->name, i);
                 r = -ENOMEM;
                 goto fail5;
             }
 
-            rtapi_snprintf(name, sizeof(name), "%s.stepgen.%02d.control-type", hm2->llio->name, i);
-            r = hal_pin_bit_new(name, HAL_IN, &(hm2->stepgen.instance[i].hal.pin.control_type), hm2->llio->comp_id);
+            r = hal_pin_new_bool(hm2->llio->comp_id, HAL_IN, &(hm2->stepgen.instance[i].hal.pin.control_type),
+                                 0, "%s.stepgen.%02d.control-type", hm2->llio->name, i);
             if (r < 0) {
-                HM2_ERR("error adding pin '%s', aborting\n", name);
+                HM2_ERR("error %d adding pin '%s.stepgen.%02d.control-type', aborting\n", r, hm2->llio->name, i);
                 r = -ENOMEM;
                 goto fail5;
             }
 
-            rtapi_snprintf(name, sizeof(name), "%s.stepgen.%02d.position-reset", hm2->llio->name, i);
-            r = hal_pin_bit_new(name, HAL_IN, &(hm2->stepgen.instance[i].hal.pin.position_reset), hm2->llio->comp_id);
+            r = hal_pin_new_bool(hm2->llio->comp_id, HAL_IN, &(hm2->stepgen.instance[i].hal.pin.position_reset),
+                                 0, "%s.stepgen.%02d.position-reset", hm2->llio->name, i);
             if (r < 0) {
-                HM2_ERR("error adding pin '%s', aborting\n", name);
+                HM2_ERR("error %d adding pin '%s.stepgen.%02d.position-reset', aborting\n", r, hm2->llio->name, i);
                 r = -ENOMEM;
                 goto fail5;
             }
 
             if (hm2->stepgen.firmware_supports_index) {
 
-                rtapi_snprintf(name, sizeof(name), "%s.stepgen.%02d.position-latch", hm2->llio->name, i);
-                r = hal_pin_float_new(name, HAL_OUT, &(hm2->stepgen.instance[i].hal.pin.position_latch), hm2->llio->comp_id);
+                r = hal_pin_new_real(hm2->llio->comp_id, HAL_OUT, &(hm2->stepgen.instance[i].hal.pin.position_latch),
+                                     0.0, "%s.stepgen.%02d.position-latch", hm2->llio->name, i);
                 if (r < 0) {
-                    HM2_ERR("error adding pin '%s', aborting\n", name);
+                    HM2_ERR("error %d adding pin '%s.stepgen.%02d.position-latch', aborting\n", r, hm2->llio->name, i);
                     r = -ENOMEM;
                     goto fail5;
                 }
 
-                rtapi_snprintf(name, sizeof(name), "%s.stepgen.%02d.index-enable", hm2->llio->name, i);
-                r = hal_pin_bit_new(name, HAL_IO, &(hm2->stepgen.instance[i].hal.pin.index_enable), hm2->llio->comp_id);
+                r = hal_pin_new_bool(hm2->llio->comp_id, HAL_IO, &(hm2->stepgen.instance[i].hal.pin.index_enable),
+                                     0, "%s.stepgen.%02d.index-enable", hm2->llio->name, i);
                 if (r < 0) {
-                    HM2_ERR("error adding pin '%s', aborting\n", name);
+                    HM2_ERR("error %d adding pin '%s.stepgen.%02d.index-enable', aborting\n", r, hm2->llio->name, i);
                     r = -ENOMEM;
                     goto fail5;
                 }
      
-               rtapi_snprintf(name, sizeof(name), "%s.stepgen.%02d.probe-enable", hm2->llio->name, i);
-                r = hal_pin_bit_new(name, HAL_IO, &(hm2->stepgen.instance[i].hal.pin.latch_enable), hm2->llio->comp_id);
+                r = hal_pin_new_bool(hm2->llio->comp_id, HAL_IO, &(hm2->stepgen.instance[i].hal.pin.latch_enable),
+                                     0, "%s.stepgen.%02d.probe-enable", hm2->llio->name, i);
                 if (r < 0) {
-                    HM2_ERR("error adding pin '%s', aborting\n", name);
+                    HM2_ERR("error %d adding pin '%s.stepgen.%02d.probe-enable', aborting\n", r, hm2->llio->name, i);
                     r = -ENOMEM;
                     goto fail5;
                 }
 
-                rtapi_snprintf(name, sizeof(name), "%s.stepgen.%02d.index-invert", hm2->llio->name, i);
-                r = hal_pin_bit_new(name, HAL_IN, &(hm2->stepgen.instance[i].hal.pin.index_polarity), hm2->llio->comp_id);
+                r = hal_pin_new_bool(hm2->llio->comp_id, HAL_IN, &(hm2->stepgen.instance[i].hal.pin.index_polarity),
+                                     0, "%s.stepgen.%02d.index-invert", hm2->llio->name, i);
                 if (r < 0) {
-                    HM2_ERR("error adding pin '%s', aborting\n", name);
+                    HM2_ERR("error %d adding pin '%s.stepgen.%02d.index-invert', aborting\n", r, hm2->llio->name, i);
                     r = -ENOMEM;
                     goto fail5;
                 }
  
-               rtapi_snprintf(name, sizeof(name), "%s.stepgen.%02d.probe-invert", hm2->llio->name, i);
-                r = hal_pin_bit_new(name, HAL_IN, &(hm2->stepgen.instance[i].hal.pin.latch_polarity), hm2->llio->comp_id);
+                r = hal_pin_new_bool(hm2->llio->comp_id, HAL_IN, &(hm2->stepgen.instance[i].hal.pin.latch_polarity),
+                                     0, "%s.stepgen.%02d.probe-invert", hm2->llio->name, i);
                 if (r < 0) {
-                    HM2_ERR("error adding pin '%s', aborting\n", name);
+                    HM2_ERR("error %d adding pin '%s.stepgen.%02d.probe-invert', aborting\n", r, hm2->llio->name, i);
                     r = -ENOMEM;
                     goto fail5;
                 }
@@ -990,206 +1004,192 @@ int hm2_stepgen_parse_md(hostmot2_t *hm2, int md_index) {
 
             // debug pins
 
-            rtapi_snprintf(name, sizeof(name), "%s.stepgen.%02d.dbg_pos_minus_prev_cmd", hm2->llio->name, i);
-            r = hal_pin_float_new(name, HAL_OUT, &(hm2->stepgen.instance[i].hal.pin.dbg_pos_minus_prev_cmd), hm2->llio->comp_id);
+            r = hal_pin_new_real(hm2->llio->comp_id, HAL_OUT, &(hm2->stepgen.instance[i].hal.pin.dbg_pos_minus_prev_cmd),
+                                 0.0, "%s.stepgen.%02d.dbg_pos_minus_prev_cmd", hm2->llio->name, i);
             if (r < 0) {
-                HM2_ERR("error adding pin '%s', aborting\n", name);
+                HM2_ERR("error %d adding pin '%s.stepgen.%02d.dbg_pos_minus_prev_cmd', aborting\n", r, hm2->llio->name, i);
                 r = -ENOMEM;
                 goto fail5;
             }
 
-            rtapi_snprintf(name, sizeof(name), "%s.stepgen.%02d.dbg_ff_vel", hm2->llio->name, i);
-            r = hal_pin_float_new(name, HAL_OUT, &(hm2->stepgen.instance[i].hal.pin.dbg_ff_vel), hm2->llio->comp_id);
+            r = hal_pin_new_real(hm2->llio->comp_id, HAL_OUT, &(hm2->stepgen.instance[i].hal.pin.dbg_ff_vel),
+                                 0.0, "%s.stepgen.%02d.dbg_ff_vel", hm2->llio->name, i);
             if (r < 0) {
-                HM2_ERR("error adding pin '%s', aborting\n", name);
+                HM2_ERR("error %d adding pin '%s.stepgen.%02d.dbg_ff_vel', aborting\n", r, hm2->llio->name, i);
                 r = -ENOMEM;
                 goto fail5;
             }
 
-            rtapi_snprintf(name, sizeof(name), "%s.stepgen.%02d.dbg_s_to_match", hm2->llio->name, i);
-            r = hal_pin_float_new(name, HAL_OUT, &(hm2->stepgen.instance[i].hal.pin.dbg_s_to_match), hm2->llio->comp_id);
+            r = hal_pin_new_real(hm2->llio->comp_id, HAL_OUT, &(hm2->stepgen.instance[i].hal.pin.dbg_s_to_match),
+                                 0.0, "%s.stepgen.%02d.dbg_s_to_match", hm2->llio->name, i);
             if (r < 0) {
-                HM2_ERR("error adding pin '%s', aborting\n", name);
+                HM2_ERR("error %d adding pin '%s.stepgen.%02d.dbg_s_to_match', aborting\n", r, hm2->llio->name, i);
                 r = -ENOMEM;
                 goto fail5;
             }
 
-            rtapi_snprintf(name, sizeof(name), "%s.stepgen.%02d.dbg_vel_error", hm2->llio->name, i);
-            r = hal_pin_float_new(name, HAL_OUT, &(hm2->stepgen.instance[i].hal.pin.dbg_vel_error), hm2->llio->comp_id);
+            r = hal_pin_new_real(hm2->llio->comp_id, HAL_OUT, &(hm2->stepgen.instance[i].hal.pin.dbg_vel_error),
+                                 0.0, "%s.stepgen.%02d.dbg_vel_error", hm2->llio->name, i);
             if (r < 0) {
-                HM2_ERR("error adding pin '%s', aborting\n", name);
+                HM2_ERR("error %d adding pin '%s.stepgen.%02d.dbg_vel_error', aborting\n", r, hm2->llio->name, i);
                 r = -ENOMEM;
                 goto fail5;
             }
 
-            rtapi_snprintf(name, sizeof(name), "%s.stepgen.%02d.dbg_err_at_match", hm2->llio->name, i);
-            r = hal_pin_float_new(name, HAL_OUT, &(hm2->stepgen.instance[i].hal.pin.dbg_err_at_match), hm2->llio->comp_id);
+            r = hal_pin_new_real(hm2->llio->comp_id, HAL_OUT, &(hm2->stepgen.instance[i].hal.pin.dbg_err_at_match),
+                                 0.0, "%s.stepgen.%02d.dbg_err_at_match", hm2->llio->name, i);
             if (r < 0) {
-                HM2_ERR("error adding pin '%s', aborting\n", name);
+                HM2_ERR("error %d adding pin '%s.stepgen.%02d.dbg_err_at_match', aborting\n", r, hm2->llio->name, i);
                 r = -ENOMEM;
                 goto fail5;
             }
 
-            rtapi_snprintf(name, sizeof(name), "%s.stepgen.%02d.dbg_step_rate", hm2->llio->name, i);
-            r = hal_pin_s32_new(name, HAL_OUT, &(hm2->stepgen.instance[i].hal.pin.dbg_step_rate), hm2->llio->comp_id);
+            r = hal_pin_new_si32(hm2->llio->comp_id, HAL_OUT, &(hm2->stepgen.instance[i].hal.pin.dbg_step_rate),
+                                 0, "%s.stepgen.%02d.dbg_step_rate", hm2->llio->name, i);
             if (r < 0) {
-                HM2_ERR("error adding pin '%s', aborting\n", name);
+                HM2_ERR("error %d adding pin '%s.stepgen.%02d.dbg_step_rate', aborting\n", r, hm2->llio->name, i);
                 r = -ENOMEM;
                 goto fail5;
             }
 
 
             // parameters
-            rtapi_snprintf(name, sizeof(name), "%s.stepgen.%02d.position-scale", hm2->llio->name, i);
-            r = hal_param_float_new(name, HAL_RW, &(hm2->stepgen.instance[i].hal.param.position_scale), hm2->llio->comp_id);
+            r = hal_param_new_real(hm2->llio->comp_id, HAL_RW, &(hm2->stepgen.instance[i].hal.param.position_scale),
+                                   1.0, "%s.stepgen.%02d.position-scale", hm2->llio->name, i);
             if (r < 0) {
-                HM2_ERR("error adding param '%s', aborting\n", name);
+                HM2_ERR("error %d adding param '%s.stepgen.%02d.position-scale', aborting\n", r, hm2->llio->name, i);
                 r = -ENOMEM;
                 goto fail5;
             }
 
-            rtapi_snprintf(name, sizeof(name), "%s.stepgen.%02d.maxvel", hm2->llio->name, i);
-            r = hal_param_float_new(name, HAL_RW, &(hm2->stepgen.instance[i].hal.param.maxvel), hm2->llio->comp_id);
+            r = hal_param_new_real(hm2->llio->comp_id, HAL_RW, &(hm2->stepgen.instance[i].hal.param.maxvel),
+                                   0.0, "%s.stepgen.%02d.maxvel", hm2->llio->name, i);
             if (r < 0) {
-                HM2_ERR("error adding param '%s', aborting\n", name);
+                HM2_ERR("error %d adding param '%s.stepgen.%02d.maxvel', aborting\n", r, hm2->llio->name, i);
                 r = -ENOMEM;
                 goto fail5;
             }
 
-            rtapi_snprintf(name, sizeof(name), "%s.stepgen.%02d.maxaccel", hm2->llio->name, i);
-            r = hal_param_float_new(name, HAL_RW, &(hm2->stepgen.instance[i].hal.param.maxaccel), hm2->llio->comp_id);
+            r = hal_param_new_real(hm2->llio->comp_id, HAL_RW, &(hm2->stepgen.instance[i].hal.param.maxaccel),
+                                   1.0, "%s.stepgen.%02d.maxaccel", hm2->llio->name, i);
             if (r < 0) {
-                HM2_ERR("error adding param '%s', aborting\n", name);
+                HM2_ERR("error %d adding param '%s.stepgen.%02d.maxaccel', aborting\n", r, hm2->llio->name, i);
                 r = -ENOMEM;
                 goto fail5;
             }
 
-            rtapi_snprintf(name, sizeof(name), "%s.stepgen.%02d.steplen", hm2->llio->name, i);
-            r = hal_param_u32_new(name, HAL_RW, &(hm2->stepgen.instance[i].hal.param.steplen), hm2->llio->comp_id);
+            // start out the slowest possible, let the user speed up if they want
+            rtapi_u32 v = (double)0x3FFF * ((double)1e9 / (double)hm2->stepgen.clock_frequency);
+            r = hal_param_new_ui32(hm2->llio->comp_id, HAL_RW, &(hm2->stepgen.instance[i].hal.param.steplen),
+                                   v, "%s.stepgen.%02d.steplen", hm2->llio->name, i);
             if (r < 0) {
-                HM2_ERR("error adding param '%s', aborting\n", name);
+                HM2_ERR("error %d adding param '%s.stepgen.%02d.steplen', aborting\n", r, hm2->llio->name, i);
                 r = -ENOMEM;
                 goto fail5;
             }
 
-            rtapi_snprintf(name, sizeof(name), "%s.stepgen.%02d.stepspace", hm2->llio->name, i);
-            r = hal_param_u32_new(name, HAL_RW, &(hm2->stepgen.instance[i].hal.param.stepspace), hm2->llio->comp_id);
+            r = hal_param_new_ui32(hm2->llio->comp_id, HAL_RW, &(hm2->stepgen.instance[i].hal.param.stepspace),
+                                   v, "%s.stepgen.%02d.stepspace", hm2->llio->name, i);
             if (r < 0) {
-                HM2_ERR("error adding param '%s', aborting\n", name);
+                HM2_ERR("error %d adding param '%s.stepgen.%02d.stepspace', aborting\n", r, hm2->llio->name, i);
                 r = -ENOMEM;
                 goto fail5;
             }
 
-            rtapi_snprintf(name, sizeof(name), "%s.stepgen.%02d.dirsetup", hm2->llio->name, i);
-            r = hal_param_u32_new(name, HAL_RW, &(hm2->stepgen.instance[i].hal.param.dirsetup), hm2->llio->comp_id);
+            r = hal_param_new_ui32(hm2->llio->comp_id, HAL_RW, &(hm2->stepgen.instance[i].hal.param.dirsetup),
+                                   v, "%s.stepgen.%02d.dirsetup", hm2->llio->name, i);
             if (r < 0) {
-                HM2_ERR("error adding param '%s', aborting\n", name);
+                HM2_ERR("error %d adding param '%s.stepgen.%02d.dirsetup', aborting\n", r, hm2->llio->name, i);
                 r = -ENOMEM;
                 goto fail5;
             }
 
-            rtapi_snprintf(name, sizeof(name), "%s.stepgen.%02d.dirhold", hm2->llio->name, i);
-            r = hal_param_u32_new(name, HAL_RW, &(hm2->stepgen.instance[i].hal.param.dirhold), hm2->llio->comp_id);
+            r = hal_param_new_ui32(hm2->llio->comp_id, HAL_RW, &(hm2->stepgen.instance[i].hal.param.dirhold),
+                                   v, "%s.stepgen.%02d.dirhold", hm2->llio->name, i);
             if (r < 0) {
-                HM2_ERR("error adding param '%s', aborting\n", name);
+                HM2_ERR("error %d adding param '%s.stepgen.%02d.dirhold', aborting\n", r, hm2->llio->name, i);
                 r = -ENOMEM;
                 goto fail5;
             }
 
-            rtapi_snprintf(name, sizeof(name), "%s.stepgen.%02d.step_type", hm2->llio->name, i);
-            r = hal_param_u32_new(name, HAL_RW, &(hm2->stepgen.instance[i].hal.param.step_type), hm2->llio->comp_id);
+            r = hal_param_new_ui32(hm2->llio->comp_id, HAL_RW, &(hm2->stepgen.instance[i].hal.param.step_type),
+                                   0, "%s.stepgen.%02d.step_type", hm2->llio->name, i);
             if (r < 0) {
-                HM2_ERR("error adding param '%s', aborting\n", name);
+                HM2_ERR("error %d adding param '%s.stepgen.%02d.step_type', aborting\n", r, hm2->llio->name, i);
                 r = -ENOMEM;
                 goto fail5;
             }
 
             if (hm2->stepgen.firmware_supports_swap) {
-                rtapi_snprintf(name, sizeof(name), "%s.stepgen.%02d.swap_step_dir", hm2->llio->name, i);
-                r = hal_param_bit_new(name, HAL_RW, &(hm2->stepgen.instance[i].hal.param.swap_step_dir), hm2->llio->comp_id);
+                r = hal_param_new_bool(hm2->llio->comp_id, HAL_RW, &(hm2->stepgen.instance[i].hal.param.swap_step_dir),
+                                       0, "%s.stepgen.%02d.swap_step_dir", hm2->llio->name, i);
                 if (r < 0) {
-                    HM2_ERR("error adding param '%s', aborting\n", name);
+                    HM2_ERR("error %d adding param '%s.stepgen.%02d.swap_step_dir', aborting\n", r, hm2->llio->name, i);
+                    r = -ENOMEM;
+                    goto fail5;
+                }
+            } else {
+                r = hal_param_new_fake(hm2->llio->comp_id, (hal_refs_u *)&(hm2->stepgen.instance[i].hal.param.swap_step_dir));
+                if (r < 0) {
+                    HM2_ERR("error %d allocating fake param '%s.stepgen.%02d.swap_step_dir', aborting\n", r, hm2->llio->name, i);
                     r = -ENOMEM;
                     goto fail5;
                 }
             }       
 
             if (hm2->stepgen.instance[i].table_width > 2){
-                rtapi_snprintf(name, sizeof(name), "%s.stepgen.%02d.table-data-0", hm2->llio->name, i);
-                r = hal_param_u32_new(name, HAL_RW, &(hm2->stepgen.instance[i].hal.param.table[0]), hm2->llio->comp_id);
+                r = hal_param_new_ui32(hm2->llio->comp_id, HAL_RW, &(hm2->stepgen.instance[i].hal.param.table[0]),
+                                       0, "%s.stepgen.%02d.table-data-0", hm2->llio->name, i);
                 if (r < 0) {
-                    HM2_ERR("error adding param '%s', aborting\n", name);
+                    HM2_ERR("error %d adding param '%s.stepgen.%02d.table-data-0', aborting\n", r, hm2->llio->name, i);
                     r = -ENOMEM;
                     goto fail5;
                 }
-                rtapi_snprintf(name, sizeof(name), "%s.stepgen.%02d.table-data-1", hm2->llio->name, i);
-                r = hal_param_u32_new(name, HAL_RW, &(hm2->stepgen.instance[i].hal.param.table[1]), hm2->llio->comp_id);
+                r = hal_param_new_ui32(hm2->llio->comp_id, HAL_RW, &(hm2->stepgen.instance[i].hal.param.table[1]),
+                                       0, "%s.stepgen.%02d.table-data-1", hm2->llio->name, i);
                 if (r < 0) {
-                    HM2_ERR("error adding param '%s', aborting\n", name);
+                    HM2_ERR("error %d adding param '%s.stepgen.%02d.table-data-1', aborting\n", r, hm2->llio->name, i);
                     r = -ENOMEM;
                     goto fail5;
                 }
-                rtapi_snprintf(name, sizeof(name), "%s.stepgen.%02d.table-data-2", hm2->llio->name, i);
-                r = hal_param_u32_new(name, HAL_RW, &(hm2->stepgen.instance[i].hal.param.table[2]), hm2->llio->comp_id);
+                r = hal_param_new_ui32(hm2->llio->comp_id, HAL_RW, &(hm2->stepgen.instance[i].hal.param.table[2]),
+                                       0, "%s.stepgen.%02d.table-data-2", hm2->llio->name, i);
                 if (r < 0) {
-                    HM2_ERR("error adding param '%s', aborting\n", name);
+                    HM2_ERR("error %d adding param '%s.stepgen.%02d.table-data-2', aborting\n", r, hm2->llio->name, i);
                     r = -ENOMEM;
                     goto fail5;
                 }
-                rtapi_snprintf(name, sizeof(name), "%s.stepgen.%02d.table-data-3", hm2->llio->name, i);
-                r = hal_param_u32_new(name, HAL_RW, &(hm2->stepgen.instance[i].hal.param.table[3]), hm2->llio->comp_id);
+                r = hal_param_new_ui32(hm2->llio->comp_id, HAL_RW, &(hm2->stepgen.instance[i].hal.param.table[3]),
+                                       0, "%s.stepgen.%02d.table-data-3", hm2->llio->name, i);
                 if (r < 0) {
-                    HM2_ERR("error adding param '%s', aborting\n", name);
+                    HM2_ERR("error %d adding param '%s.stepgen.%02d.table-data-3', aborting\n", r, hm2->llio->name, i);
                     r = -ENOMEM;
                     goto fail5;
                 }
- 
+            } else {
+                // Still allocate storage to prevent crashing when dereferencing the table
+                r  = hal_param_new_fake(hm2->llio->comp_id, (hal_refs_u *)&(hm2->stepgen.instance[i].hal.param.table[0]));
+                r += hal_param_new_fake(hm2->llio->comp_id, (hal_refs_u *)&(hm2->stepgen.instance[i].hal.param.table[1]));
+                r += hal_param_new_fake(hm2->llio->comp_id, (hal_refs_u *)&(hm2->stepgen.instance[i].hal.param.table[2]));
+                r += hal_param_new_fake(hm2->llio->comp_id, (hal_refs_u *)&(hm2->stepgen.instance[i].hal.param.table[3]));
+                if (r < 0) {
+                    HM2_ERR("error allocating fake param '%s.stepgen.%02d.table-data-N', aborting\n", hm2->llio->name, i);
+                    r = -ENOMEM;
+                    goto fail5;
+                }
             }
 
             // init
-            *(hm2->stepgen.instance[i].hal.pin.position_cmd) = 0.0;
-            *(hm2->stepgen.instance[i].hal.pin.counts) = 0;
-            *(hm2->stepgen.instance[i].hal.pin.position_fb) = 0.0;
-            *(hm2->stepgen.instance[i].hal.pin.velocity_fb) = 0.0;
-            *(hm2->stepgen.instance[i].hal.pin.enable) = 0;
-            *(hm2->stepgen.instance[i].hal.pin.control_type) = 0;
-            *(hm2->stepgen.instance[i].hal.pin.position_reset) = 0;
-            if (hm2->stepgen.firmware_supports_index) {
-                *(hm2->stepgen.instance[i].hal.pin.index_enable) = 0;
-                *(hm2->stepgen.instance[i].hal.pin.latch_enable) = 0;
-                *(hm2->stepgen.instance[i].hal.pin.index_polarity) = 0;
-                *(hm2->stepgen.instance[i].hal.pin.latch_polarity) = 0;
-            }
-            hm2->stepgen.instance[i].hal.param.position_scale = 1.0;
-            hm2->stepgen.instance[i].hal.param.maxvel = 0.0;
-            hm2->stepgen.instance[i].hal.param.maxaccel = 1.0;
-
             hm2->stepgen.instance[i].subcounts = 0;
 
-            // start out the slowest possible, let the user speed up if they want
-            hm2->stepgen.instance[i].hal.param.steplen   = (double)0x3FFF * ((double)1e9 / (double)hm2->stepgen.clock_frequency);
-            hm2->stepgen.instance[i].hal.param.stepspace = (double)0x3FFF * ((double)1e9 / (double)hm2->stepgen.clock_frequency);
-            hm2->stepgen.instance[i].hal.param.dirsetup  = (double)0x3FFF * ((double)1e9 / (double)hm2->stepgen.clock_frequency);
-            hm2->stepgen.instance[i].hal.param.dirhold   = (double)0x3FFF * ((double)1e9 / (double)hm2->stepgen.clock_frequency);
-
-            hm2->stepgen.instance[i].hal.param.step_type = 0;      // step & dir
-
-            if (hm2->stepgen.firmware_supports_swap) {
-                hm2->stepgen.instance[i].hal.param.swap_step_dir = 0;  // no swap
-            }
             hm2->stepgen.instance[i].written_steplen = 0;
             hm2->stepgen.instance[i].written_stepspace = 0;
             hm2->stepgen.instance[i].written_dirsetup = 0;
             hm2->stepgen.instance[i].written_dirhold = 0;
 
             hm2->stepgen.instance[i].written_step_type = 0xffffffff;
-            hm2->stepgen.instance[i].hal.param.table[0] = 0;
-            hm2->stepgen.instance[i].hal.param.table[1] = 0;
-            hm2->stepgen.instance[i].hal.param.table[2] = 0;
-            hm2->stepgen.instance[i].hal.param.table[3] = 0;
 
             hm2->stepgen.instance[i].prev_accumulator = 0;
-
         }
     }
 
@@ -1237,15 +1237,15 @@ void hm2_stepgen_print_module(hostmot2_t *hm2) {
     HM2_PRINT("    master_dds_addr: 0x%04X\n", hm2->stepgen.master_dds_addr);
     for (i = 0; i < hm2->stepgen.num_instances; i ++) {
         HM2_PRINT("    instance %d:\n", i);
-        HM2_PRINT("        enable = %d\n", *hm2->stepgen.instance[i].hal.pin.enable);
+        HM2_PRINT("        enable = %d\n", (int)hal_get_bool(hm2->stepgen.instance[i].hal.pin.enable));
         HM2_PRINT("        hw:\n");
         HM2_PRINT("            step_rate = 0x%08X\n", hm2->stepgen.step_rate_reg[i]);
         HM2_PRINT("            accumulator = 0x%08X\n", hm2->stepgen.accumulator_reg[i]);
         HM2_PRINT("            mode = 0x%08X\n", hm2->stepgen.mode_reg[i]);
-        HM2_PRINT("            dir_setup_time = 0x%08X (%u ns)\n", hm2->stepgen.dir_setup_time_reg[i], hm2->stepgen.instance[i].hal.param.dirsetup);
-        HM2_PRINT("            dir_hold_time = 0x%08X (%u ns)\n", hm2->stepgen.dir_hold_time_reg[i], hm2->stepgen.instance[i].hal.param.dirhold);
-        HM2_PRINT("            pulse_width = 0x%08X (%u ns)\n", hm2->stepgen.pulse_width_reg[i], hm2->stepgen.instance[i].hal.param.steplen);
-        HM2_PRINT("            pulse_idle_width = 0x%08X (%u ns)\n", hm2->stepgen.pulse_idle_width_reg[i], hm2->stepgen.instance[i].hal.param.stepspace);
+        HM2_PRINT("            dir_setup_time = 0x%08X (%u ns)\n", hm2->stepgen.dir_setup_time_reg[i], hal_get_ui32(hm2->stepgen.instance[i].hal.param.dirsetup));
+        HM2_PRINT("            dir_hold_time = 0x%08X (%u ns)\n", hm2->stepgen.dir_hold_time_reg[i], hal_get_ui32(hm2->stepgen.instance[i].hal.param.dirhold));
+        HM2_PRINT("            pulse_width = 0x%08X (%u ns)\n", hm2->stepgen.pulse_width_reg[i], hal_get_ui32(hm2->stepgen.instance[i].hal.param.steplen));
+        HM2_PRINT("            pulse_idle_width = 0x%08X (%u ns)\n", hm2->stepgen.pulse_idle_width_reg[i], hal_get_ui32(hm2->stepgen.instance[i].hal.param.stepspace));
     }
 }
 

--- a/src/hal/drivers/mesa-hostmot2/tp_pwmgen.c
+++ b/src/hal/drivers/mesa-hostmot2/tp_pwmgen.c
@@ -33,10 +33,10 @@ void hm2_tp_pwmgen_handle_pwm_frequency(hostmot2_t *hm2) {
 	int deadtime;
 	int i;
 
-    if (hm2->tp_pwmgen.hal->param.pwm_frequency < 1) {
-        HM2_ERR("3pwmgen.pwm_frequency %d is too low, setting to 1\n",
-            hm2->tp_pwmgen.hal->param.pwm_frequency);
-        hm2->tp_pwmgen.hal->param.pwm_frequency = 1;
+    rtapi_u32 pwm_frequency = hal_get_ui32(hm2->tp_pwmgen.hal->param.pwm_frequency);
+    if (pwm_frequency < 1) {
+        HM2_ERR("3pwmgen.pwm_frequency %d is too low, setting to 1\n", pwm_frequency);
+        pwm_frequency = hal_set_ui32(hm2->tp_pwmgen.hal->param.pwm_frequency, 1);
     }
 
 
@@ -57,7 +57,7 @@ void hm2_tp_pwmgen_handle_pwm_frequency(hostmot2_t *hm2) {
     //
 
     // check that the frequency is achievable
-    dds = ((double)hm2->tp_pwmgen.hal->param.pwm_frequency * 65536.0 * 2048.0)
+    dds = ((double)pwm_frequency * 65536.0 * 2048.0)
             / (double)hm2->tp_pwmgen.clock_frequency;
     if (dds < 65536) {
         hm2->tp_pwmgen.pwmgen_master_rate_dds_reg = dds;
@@ -65,11 +65,10 @@ void hm2_tp_pwmgen_handle_pwm_frequency(hostmot2_t *hm2) {
 	// not possible so try the fastest we can
         //     PWMFreq = (ClockHigh * DDS) / (65536 * 2048)
 	dds = 65535;
-	hm2->tp_pwmgen.hal->param.pwm_frequency =
+	pwm_frequency = hal_set_ui32(hm2->tp_pwmgen.hal->param.pwm_frequency,
             ((double)hm2->tp_pwmgen.clock_frequency * 65535.0)
-            / (65536.0 * 2048.0);
-	HM2_ERR("max PWM frequency is %d Hz\n",
-            hm2->tp_pwmgen.hal->param.pwm_frequency);
+            / (65536.0 * 2048.0));
+	HM2_ERR("max PWM frequency is %d Hz\n", pwm_frequency);
 	hm2->tp_pwmgen.pwmgen_master_rate_dds_reg = dds;
     }
 
@@ -78,37 +77,38 @@ void hm2_tp_pwmgen_handle_pwm_frequency(hostmot2_t *hm2) {
     // = (2*65536*1e9 / ClockHigh*dds)nS
 
     for (i=0; i < hm2->tp_pwmgen.num_instances; i++) {
-        if (hm2->tp_pwmgen.instance[i].hal.param.sampletime > 1){
+        rtapi_real sampletime = hal_get_real(hm2->tp_pwmgen.instance[i].hal.param.sampletime);
+        if (sampletime > 1){
                 HM2_ERR("Max sampletime is 1 (end of PWM cycle");
-                hm2->tp_pwmgen.instance[i].hal.param.sampletime = 1;
+                sampletime = hal_set_real(hm2->tp_pwmgen.instance[i].hal.param.sampletime, 1);
         }
-        else if (hm2->tp_pwmgen.instance[i].hal.param.sampletime < 0){
+        else if (sampletime < 0){
                 HM2_ERR("Min sampletime is 0 (beginning of PWM cycle");
-                hm2->tp_pwmgen.instance[i].hal.param.sampletime = 0;
+                sampletime = hal_set_real(hm2->tp_pwmgen.instance[i].hal.param.sampletime, 0);
         }
 
-        deadtime = (hm2->tp_pwmgen.instance[i].hal.param.deadzone
+        deadtime = (hal_get_real(hm2->tp_pwmgen.instance[i].hal.param.deadzone)
             * hm2->tp_pwmgen.clock_frequency * dds) / (2 * 65536 * 1e9);
 
         if (deadtime > 511){
                 deadtime = 511;
-                hm2->tp_pwmgen.instance[i].hal.param.deadzone =
+                hal_set_real(hm2->tp_pwmgen.instance[i].hal.param.deadzone,
                     ((double)deadtime * 2.0 * 65536.0 * 1.0e9)
-                    /((double)hm2->tp_pwmgen.clock_frequency * dds);
+                    /((double)hm2->tp_pwmgen.clock_frequency * dds));
                 HM2_ERR("At this PWM frequency the maximum deadtime is %dnS\n",
-                    (int)hm2->tp_pwmgen.instance[i].hal.param.deadzone);
+                    (int)hal_get_real(hm2->tp_pwmgen.instance[i].hal.param.deadzone));
         }
         else if (deadtime < 0) {
                 HM2_ERR("Deadtime must be positive");
                 deadtime = 0;
-                hm2->tp_pwmgen.instance[i].hal.param.deadzone = 0;
+                hal_set_real(hm2->tp_pwmgen.instance[i].hal.param.deadzone, 0);
         }
 
         // Now setup the control register
 
         hm2->tp_pwmgen.setup_reg[i] = (
-             ((int)(hm2->tp_pwmgen.instance[i].hal.param.sampletime*1023) << 16)
-             +((hm2->tp_pwmgen.instance[i].hal.param.faultpolarity != 0) << 15)
+             ((int)(sampletime*1023) << 16)
+             +(hal_get_bool(hm2->tp_pwmgen.instance[i].hal.param.faultpolarity) << 15)
              +(deadtime));
 	}
 }
@@ -125,7 +125,7 @@ void hm2_tp_pwmgen_force_write(hostmot2_t *hm2) {
 
     // update enable and setup registers
     for (i = 0; i < hm2->tp_pwmgen.num_instances; i ++) {
-        if (*hm2->tp_pwmgen.instance[i].hal.pin.enable)
+        if (hal_get_bool(hm2->tp_pwmgen.instance[i].hal.pin.enable))
                 hm2->tp_pwmgen.enable_reg[i] = 1;
         else
             hm2->tp_pwmgen.enable_reg[i] = 0;
@@ -136,15 +136,15 @@ void hm2_tp_pwmgen_force_write(hostmot2_t *hm2) {
     hm2->llio->write(hm2->llio, hm2->tp_pwmgen.enable_addr, hm2->tp_pwmgen.enable_reg, (hm2->tp_pwmgen.num_instances * sizeof(rtapi_u32)));
     hm2->llio->write(hm2->llio, hm2->tp_pwmgen.pwmgen_master_rate_dds_addr, &hm2->tp_pwmgen.pwmgen_master_rate_dds_reg, sizeof(rtapi_u32));
 
-    if ((*hm2->llio->io_error) != 0) return;
+    if (hal_get_bool(*hm2->llio->io_error)) return;
 
     for (i = 0; i < hm2->tp_pwmgen.num_instances; i ++) {
-        hm2->tp_pwmgen.instance[i].written_faultpolarity = hm2->tp_pwmgen.instance[i].hal.param.faultpolarity;
-        hm2->tp_pwmgen.instance[i].written_deadzone = hm2->tp_pwmgen.instance[i].hal.param.deadzone;
-        hm2->tp_pwmgen.instance[i].written_sampletime = hm2->tp_pwmgen.instance[i].hal.param.sampletime;
+        hm2->tp_pwmgen.instance[i].written_faultpolarity = hal_get_bool(hm2->tp_pwmgen.instance[i].hal.param.faultpolarity);
+        hm2->tp_pwmgen.instance[i].written_deadzone = hal_get_real(hm2->tp_pwmgen.instance[i].hal.param.deadzone);
+        hm2->tp_pwmgen.instance[i].written_sampletime = hal_get_real(hm2->tp_pwmgen.instance[i].hal.param.sampletime);
     }
 
-    hm2->tp_pwmgen.written_pwm_frequency = hm2->tp_pwmgen.hal->param.pwm_frequency;
+    hm2->tp_pwmgen.written_pwm_frequency = hal_get_ui32(hm2->tp_pwmgen.hal->param.pwm_frequency);
 }
 
 
@@ -158,13 +158,14 @@ void hm2_tp_pwmgen_write(hostmot2_t *hm2) {
     if (hm2->tp_pwmgen.num_instances == 0) return;
 
     // check pwm frequency
-    if (hm2->tp_pwmgen.hal->param.pwm_frequency != hm2->tp_pwmgen.written_pwm_frequency) goto force_write;
+    if (hal_get_ui32(hm2->tp_pwmgen.hal->param.pwm_frequency) != hm2->tp_pwmgen.written_pwm_frequency) goto force_write;
 
     // update enable register?
     for (i = 0; i < hm2->tp_pwmgen.num_instances; i ++) {
-        if ((hm2->tp_pwmgen.instance[i].hal.param.deadzone != hm2->tp_pwmgen.instance[i].written_deadzone)
-		 || (hm2->tp_pwmgen.instance[i].hal.param.sampletime != hm2->tp_pwmgen.instance[i].written_sampletime)
-		 || (hm2->tp_pwmgen.instance[i].hal.param.faultpolarity != hm2->tp_pwmgen.instance[i].written_faultpolarity))
+        hm2_tp_pwmgen_instance_t *inst = &hm2->tp_pwmgen.instance[i];
+        if ((hal_get_real(inst->hal.param.deadzone) != inst->written_deadzone)
+         || (hal_get_real(inst->hal.param.sampletime) != inst->written_sampletime)
+         || (hal_get_bool(inst->hal.param.faultpolarity) != inst->written_faultpolarity))
             goto force_write;
 
     // The enable register is a little odd. Writing a 1 to bit0 of the
@@ -174,7 +175,7 @@ void hm2_tp_pwmgen_write(hostmot2_t *hm2) {
     // enable if there is a mismatch between the hal-pin and the enable
     // bit.
 
-        if ((*hm2->tp_pwmgen.instance[i].hal.pin.enable != (hm2->tp_pwmgen.enable_reg[i] & 1)))
+        if ((hal_get_bool(inst->hal.pin.enable) != (hm2->tp_pwmgen.enable_reg[i] & 1)))
             goto force_write;
     }
 
@@ -194,8 +195,7 @@ void hm2_tp_pwmgen_queue_read(hostmot2_t *hm2) {
 void hm2_tp_pwmgen_process_read(hostmot2_t *hm2) {
     int i;
     for (i = 0 ; i < hm2->tp_pwmgen.num_instances ; i++) {
-        *hm2->tp_pwmgen.instance[i].hal.pin.fault
-            = (hm2->tp_pwmgen.enable_reg[i] & 2);
+        hal_set_bool(hm2->tp_pwmgen.instance[i].hal.pin.fault, (hm2->tp_pwmgen.enable_reg[i] & 2));
     }
 }
 
@@ -249,14 +249,14 @@ int hm2_tp_pwmgen_parse_md(hostmot2_t *hm2, int md_index) {
 
     // allocate the module-global HAL shared memory
 
-    hm2->tp_pwmgen.instance = (hm2_tp_pwmgen_instance_t *)hal_malloc(hm2->tp_pwmgen.num_instances * sizeof(hm2_tp_pwmgen_instance_t));
+    hm2->tp_pwmgen.instance = hal_malloc(hm2->tp_pwmgen.num_instances * sizeof(*hm2->tp_pwmgen.instance));
     if (hm2->tp_pwmgen.instance == NULL) {
         HM2_ERR("out of memory!\n");
         r = -ENOMEM;
         goto fail0;
     }
 
-    hm2->tp_pwmgen.hal = (hm2_tp_pwmgen_global_hal_t *)hal_malloc(sizeof(hm2_tp_pwmgen_global_hal_t));
+    hm2->tp_pwmgen.hal = hal_malloc(sizeof(*hm2->tp_pwmgen.hal));
     if (hm2->tp_pwmgen.instance == NULL) {
         HM2_ERR("out of memory!\n");
         r = -ENOMEM;
@@ -294,17 +294,13 @@ int hm2_tp_pwmgen_parse_md(hostmot2_t *hm2, int md_index) {
     }
 
     // export to HAL
-    // FIXME: r hides the r in enclosing function, and it returns the wrong thing
     {
-        int i;
-        int r;
-        char name[HAL_NAME_LEN + 1];
-
         // this hal parameter affects all the 3-Phase pwmgen instances
-        r = hal_param_u32_newf(
+        r = hal_param_new_ui32(
+	    hm2->llio->comp_id,
 	    HAL_RW,
 	    &(hm2->tp_pwmgen.hal->param.pwm_frequency),
-	    hm2->llio->comp_id,
+	    20000,
 	    "%s.3pwmgen.frequency",
 	    hm2->llio->name
         );
@@ -313,88 +309,75 @@ int hm2_tp_pwmgen_parse_md(hostmot2_t *hm2, int md_index) {
             goto fail2;
         }
 
-        hm2->tp_pwmgen.hal->param.pwm_frequency = 20000;
         hm2->tp_pwmgen.written_pwm_frequency = 0; // force a write
 
 
-        for (i = 0; i < hm2->tp_pwmgen.num_instances; i ++) {
+        for (int i = 0; i < hm2->tp_pwmgen.num_instances; i ++) {
             // pins
-            rtapi_snprintf(name, sizeof(name), "%s.3pwmgen.%02d.A-value", hm2->llio->name, i);
-            r = hal_pin_float_new(name, HAL_IN, &(hm2->tp_pwmgen.instance[i].hal.pin.Avalue), hm2->llio->comp_id);
+            r = hal_pin_new_real(hm2->llio->comp_id, HAL_IN, &(hm2->tp_pwmgen.instance[i].hal.pin.Avalue),
+                                 0.0, "%s.3pwmgen.%02d.A-value", hm2->llio->name, i);
             if (r < 0) {
-                HM2_ERR("error adding pin '%s', aborting\n", name);
+                HM2_ERR("error %d adding pin '%s.3pwmgen.%02d.A-value', aborting\n", r, hm2->llio->name, i);
                 goto fail2;
             }
 
-	    rtapi_snprintf(name, sizeof(name), "%s.3pwmgen.%02d.B-value", hm2->llio->name, i);
-            r = hal_pin_float_new(name, HAL_IN, &(hm2->tp_pwmgen.instance[i].hal.pin.Bvalue), hm2->llio->comp_id);
+            r = hal_pin_new_real(hm2->llio->comp_id, HAL_IN, &(hm2->tp_pwmgen.instance[i].hal.pin.Bvalue),
+                                 0.0, "%s.3pwmgen.%02d.B-value", hm2->llio->name, i);
             if (r < 0) {
-                HM2_ERR("error adding pin '%s', aborting\n", name);
+                HM2_ERR("error %d adding pin '%s.3pwmgen.%02d.B-value', aborting\n", r, hm2->llio->name, i);
                 goto fail2;
             }
 
-	    rtapi_snprintf(name, sizeof(name), "%s.3pwmgen.%02d.C-value", hm2->llio->name, i);
-            r = hal_pin_float_new(name, HAL_IN, &(hm2->tp_pwmgen.instance[i].hal.pin.Cvalue), hm2->llio->comp_id);
+            r = hal_pin_new_real(hm2->llio->comp_id, HAL_IN, &(hm2->tp_pwmgen.instance[i].hal.pin.Cvalue),
+                                 0.0, "%s.3pwmgen.%02d.C-value", hm2->llio->name, i);
             if (r < 0) {
-                HM2_ERR("error adding pin '%s', aborting\n", name);
+                HM2_ERR("error %d adding pin '%s.3pwmgen.%02d.C-value', aborting\n", r, hm2->llio->name, i);
                 goto fail2;
             }
 
-            rtapi_snprintf(name, sizeof(name), "%s.3pwmgen.%02d.enable", hm2->llio->name, i);
-            r = hal_pin_bit_new(name, HAL_IN, &(hm2->tp_pwmgen.instance[i].hal.pin.enable), hm2->llio->comp_id);
+            r = hal_pin_new_bool(hm2->llio->comp_id, HAL_IN, &(hm2->tp_pwmgen.instance[i].hal.pin.enable),
+                                 0, "%s.3pwmgen.%02d.enable", hm2->llio->name, i);
             if (r < 0) {
-                HM2_ERR("error adding pin '%s', aborting\n", name);
+                HM2_ERR("error %d adding pin '%s.3pwmgen.%02d.enable', aborting\n", r, hm2->llio->name, i);
                 goto fail2;
             }
 
-	    rtapi_snprintf(name, sizeof(name), "%s.3pwmgen.%02d.fault", hm2->llio->name, i);
-            r = hal_pin_bit_new(name, HAL_OUT, &(hm2->tp_pwmgen.instance[i].hal.pin.fault), hm2->llio->comp_id);
+            r = hal_pin_new_bool(hm2->llio->comp_id, HAL_OUT, &(hm2->tp_pwmgen.instance[i].hal.pin.fault),
+                                 0, "%s.3pwmgen.%02d.fault", hm2->llio->name, i);
             if (r < 0) {
-                HM2_ERR("error adding pin '%s', aborting\n", name);
+                HM2_ERR("error %d adding pin '%s.3pwmgen.%02d.fault', aborting\n", r, hm2->llio->name, i);
                 goto fail2;
             }
 
             // parameters
 
-            rtapi_snprintf(name, sizeof(name), "%s.3pwmgen.%02d.scale", hm2->llio->name, i);
-            r = hal_param_float_new(name, HAL_RW, &(hm2->tp_pwmgen.instance[i].hal.param.scale), hm2->llio->comp_id);
+            r = hal_param_new_real(hm2->llio->comp_id, HAL_RW, &(hm2->tp_pwmgen.instance[i].hal.param.scale),
+                                   1.0, "%s.3pwmgen.%02d.scale", hm2->llio->name, i);
             if (r < 0) {
-                HM2_ERR("error adding param '%s', aborting\n", name);
+                HM2_ERR("error %d adding param '%s.3pwmgen.%02d.scale', aborting\n", r, hm2->llio->name, i);
                 goto fail2;
             }
 
-	    rtapi_snprintf(name, sizeof(name), "%s.3pwmgen.%02d.deadtime", hm2->llio->name, i);
-            r = hal_param_float_new(name, HAL_RW, &(hm2->tp_pwmgen.instance[i].hal.param.deadzone), hm2->llio->comp_id);
+            r = hal_param_new_real(hm2->llio->comp_id, HAL_RW, &(hm2->tp_pwmgen.instance[i].hal.param.deadzone),
+                                   5000.0, "%s.3pwmgen.%02d.deadtime", hm2->llio->name, i);
             if (r < 0) {
-                HM2_ERR("error adding param '%s', aborting\n", name);
+                HM2_ERR("error %d adding param '%s.3pwmgen.%02d.deadtime', aborting\n", r, hm2->llio->name, i);
                 goto fail2;
             }
 
-	    rtapi_snprintf(name, sizeof(name), "%s.3pwmgen.%02d.fault-invert", hm2->llio->name, i);
-            r = hal_param_bit_new(name, HAL_RW, &(hm2->tp_pwmgen.instance[i].hal.param.faultpolarity), hm2->llio->comp_id);
+            r = hal_param_new_bool(hm2->llio->comp_id, HAL_RW, &(hm2->tp_pwmgen.instance[i].hal.param.faultpolarity),
+                                   0, "%s.3pwmgen.%02d.fault-invert", hm2->llio->name, i);
             if (r < 0) {
-                HM2_ERR("error adding param '%s', aborting\n", name);
+                HM2_ERR("error %d adding param '%s.3pwmgen.%02d.fault-invert', aborting\n", r, hm2->llio->name, i);
                 goto fail2;
             }
 
-	    rtapi_snprintf(name, sizeof(name), "%s.3pwmgen.%02d.sample-time", hm2->llio->name, i);
-            r = hal_param_float_new(name, HAL_RW, &(hm2->tp_pwmgen.instance[i].hal.param.sampletime), hm2->llio->comp_id);
+            r = hal_param_new_real(hm2->llio->comp_id, HAL_RW, &(hm2->tp_pwmgen.instance[i].hal.param.sampletime),
+                                   0.5, "%s.3pwmgen.%02d.sample-time", hm2->llio->name, i);
             if (r < 0) {
-                HM2_ERR("error adding param '%s', aborting\n", name);
+                HM2_ERR("error %d adding param '%s.3pwmgen.%02d.sample-time', aborting\n", r, hm2->llio->name, i);
                 goto fail2;
             }
-
-
-            // init hal objects
-            *(hm2->tp_pwmgen.instance[i].hal.pin.enable) = 0;
-            *(hm2->tp_pwmgen.instance[i].hal.pin.Avalue) = 0.0;
-	    *(hm2->tp_pwmgen.instance[i].hal.pin.Bvalue) = 0.0;
-	    *(hm2->tp_pwmgen.instance[i].hal.pin.Cvalue) = 0.0;
-
-            hm2->tp_pwmgen.instance[i].hal.param.scale = 1.0;
-            hm2->tp_pwmgen.instance[i].hal.param.sampletime = 0.5;
-	    hm2->tp_pwmgen.instance[i].hal.param.faultpolarity = 0.0; //active low
-	    hm2->tp_pwmgen.instance[i].hal.param.deadzone = 5000; // 5000nS conservative deadzone for safety
 
             hm2->tp_pwmgen.instance[i].written_sampletime = -666;       // force an update at the start
         }
@@ -448,14 +431,15 @@ void hm2_tp_pwmgen_prepare_tram_write(hostmot2_t *hm2) {
         // pwmgen)
 
         // Check for /0 problems
-        if (hm2->tp_pwmgen.instance[i].hal.param.scale ==0) {
-            hm2->tp_pwmgen.instance[i].hal.param.scale = 1;
-            HM2_ERR("3pwmgen scale must be greater than zero. Scale set to %i", (int)hm2->tp_pwmgen.instance[i].hal.param.scale);
+        rtapi_real scale = hal_get_real(hm2->tp_pwmgen.instance[i].hal.param.scale);
+        if (scale ==0) {
+            scale = hal_set_real(hm2->tp_pwmgen.instance[i].hal.param.scale, 1);
+            HM2_ERR("3pwmgen scale must be greater than zero. Scale set to %i", (int)scale);
         }
 
-        scaled_Avalue = (*hm2->tp_pwmgen.instance[i].hal.pin.Avalue / hm2->tp_pwmgen.instance[i].hal.param.scale);
-        scaled_Bvalue = (*hm2->tp_pwmgen.instance[i].hal.pin.Bvalue / hm2->tp_pwmgen.instance[i].hal.param.scale);
-        scaled_Cvalue = (*hm2->tp_pwmgen.instance[i].hal.pin.Cvalue / hm2->tp_pwmgen.instance[i].hal.param.scale);
+        scaled_Avalue = hal_get_real(hm2->tp_pwmgen.instance[i].hal.pin.Avalue) / scale;
+        scaled_Bvalue = hal_get_real(hm2->tp_pwmgen.instance[i].hal.pin.Bvalue) / scale;
+        scaled_Cvalue = hal_get_real(hm2->tp_pwmgen.instance[i].hal.pin.Cvalue) / scale;
 
         if (scaled_Avalue > 1.0) scaled_Avalue = 1.0;
         else if (scaled_Avalue < -1.0) scaled_Avalue = -1.0;

--- a/src/hal/drivers/mesa-hostmot2/uart.c
+++ b/src/hal/drivers/mesa-hostmot2/uart.c
@@ -79,8 +79,7 @@ int hm2_uart_parse_md(hostmot2_t *hm2, int md_index)
             hm2->uart.num_instances = hm2->config.num_uarts;
         }
         
-        hm2->uart.instance = (hm2_uart_instance_t *)hal_malloc(hm2->uart.num_instances 
-                                                               * sizeof(hm2_uart_instance_t));
+        hm2->uart.instance = hal_malloc(hm2->uart.num_instances * sizeof(*hm2->uart.instance));
         if (hm2->uart.instance == NULL) {
             HM2_ERR("out of memory!\n");
             r = -ENOMEM;
@@ -141,7 +140,7 @@ EXPORT_SYMBOL_GPL(hm2_uart_setup);
 // use -1 for tx_mode and rx_mode to leave the mode unchanged
 int hm2_uart_setup(char *name, int bitrate, rtapi_s32 tx_mode, rtapi_s32 rx_mode){
     hostmot2_t *hm2;
-    hm2_uart_instance_t *inst = 0;
+    hm2_uart_instance_t *inst = NULL;
     rtapi_u32 buff;
     int i,r;
     

--- a/src/hal/drivers/mesa-hostmot2/watchdog.c
+++ b/src/hal/drivers/mesa-hostmot2/watchdog.c
@@ -35,7 +35,7 @@ void hm2_watchdog_process_tram_read(hostmot2_t *hm2) {
     if (hm2->watchdog.num_instances == 0) return;
 
     // if there are comm problems, wait for the user to fix it
-    if ((*hm2->llio->io_error) != 0) return;
+    if (hal_get_bool(*hm2->llio->io_error)) return;
 
     // if we've already noticed the board needs to be reset, don't re-read
     // the watchdog has-bit bit
@@ -48,7 +48,7 @@ void hm2_watchdog_process_tram_read(hostmot2_t *hm2) {
     // see if the watchdog has bit since then
     if (hm2->watchdog.status_reg[0] & 0x1) {
         HM2_ERR("Watchdog has bit! (set the .has-bit pin to False to resume)\n");
-        *hm2->watchdog.instance[0].hal.pin.has_bit = 1;
+        hal_set_bool(hm2->watchdog.instance[0].hal.pin.has_bit, 1);
         hm2->llio->needs_reset = 1;
     }
 }
@@ -93,7 +93,7 @@ int hm2_watchdog_parse_md(hostmot2_t *hm2, int md_index) {
 
     hm2->watchdog.num_instances = 1;
 
-    hm2->watchdog.instance = (hm2_watchdog_instance_t *)hal_malloc(hm2->watchdog.num_instances * sizeof(hm2_watchdog_instance_t));
+    hm2->watchdog.instance = hal_malloc(hm2->watchdog.num_instances * sizeof(*hm2->watchdog.instance));
     if (hm2->watchdog.instance == NULL) {
         HM2_ERR("out of memory!\n");
         r = -ENOMEM;
@@ -137,10 +137,11 @@ int hm2_watchdog_parse_md(hostmot2_t *hm2, int md_index) {
     //
 
     // pins
-    r = hal_pin_bit_newf(
+    r = hal_pin_new_bool(
+        hm2->llio->comp_id,
         HAL_IO,
         &(hm2->watchdog.instance[0].hal.pin.has_bit),
-        hm2->llio->comp_id,
+        0,
         "%s.watchdog.has_bit",
         hm2->llio->name
     );
@@ -151,10 +152,12 @@ int hm2_watchdog_parse_md(hostmot2_t *hm2, int md_index) {
     }
 
     // params
-    r = hal_param_u32_newf(
+    // default timeout is 5 milliseconds (5*1000*1000 nanoseconds)
+    r = hal_param_new_ui32(
+        hm2->llio->comp_id,
         HAL_RW,
         &(hm2->watchdog.instance[0].hal.param.timeout_ns),
-        hm2->llio->comp_id,
+        5 * 1000 * 1000,
         "%s.watchdog.timeout_ns",
         hm2->llio->name
     );
@@ -168,8 +171,6 @@ int hm2_watchdog_parse_md(hostmot2_t *hm2, int md_index) {
     // initialize the watchdog
     //
 
-    *hm2->watchdog.instance[0].hal.pin.has_bit = 0;
-    hm2->watchdog.instance[0].hal.param.timeout_ns = 5 * 1000 * 1000;  // default timeout is 5 milliseconds
     hm2->watchdog.instance[0].enable = 0;  // the first pet_watchdog will turn it on
 
     return hm2->watchdog.num_instances;
@@ -195,8 +196,8 @@ void hm2_watchdog_print_module(hostmot2_t *hm2) {
     HM2_PRINT("    reset_addr: 0x%04X\n", hm2->watchdog.reset_addr);
     for (i = 0; i < hm2->watchdog.num_instances; i ++) {
         HM2_PRINT("    instance %d:\n", i);
-        HM2_PRINT("        param timeout_ns = %u\n", hm2->watchdog.instance[i].hal.param.timeout_ns);
-        HM2_PRINT("        pin has_bit = %d\n", (*hm2->watchdog.instance[i].hal.pin.has_bit));
+        HM2_PRINT("        param timeout_ns = %u\n", hal_get_ui32(hm2->watchdog.instance[i].hal.param.timeout_ns));
+        HM2_PRINT("        pin has_bit = %d\n", (int)hal_get_bool(hm2->watchdog.instance[i].hal.pin.has_bit));
         HM2_PRINT("        reg timer = 0x%08X\n", hm2->watchdog.timer_reg[i]);
     }
 }
@@ -222,25 +223,27 @@ void hm2_watchdog_force_write(hostmot2_t *hm2) {
 
     if (hm2->watchdog.num_instances != 1) return;
 
+    rtapi_u32 timeout_ns = hal_get_ui32(hm2->watchdog.instance[0].hal.param.timeout_ns);
     if (hm2->watchdog.instance[0].enable == 0) {
         // watchdog is disabled, MSb=1 is secret handshake with FPGA
         hm2->watchdog.timer_reg[0] = 0x80000000;
     } else {
-        tmp = (hm2->watchdog.instance[0].hal.param.timeout_ns * ((double)hm2->watchdog.clock_frequency / (double)(1000 * 1000 * 1000))) - 1;
+        tmp = (timeout_ns * ((double)hm2->watchdog.clock_frequency / (double)(1000 * 1000 * 1000))) - 1;
         if (tmp < 0x80000000) {
             hm2->watchdog.timer_reg[0] = tmp;
         } else {
             // truncate watchdog timeout
             tmp = 0x7FFFFFFF;
             hm2->watchdog.timer_reg[0] = tmp;
-            hm2->watchdog.instance[0].hal.param.timeout_ns = (tmp + 1) / ((double)hm2->watchdog.clock_frequency / (double)(1000 * 1000 * 1000));
-            HM2_ERR("requested watchdog timeout is out of range, setting it to max: %u ns\n", hm2->watchdog.instance[0].hal.param.timeout_ns);
+            timeout_ns = hal_set_ui32(hm2->watchdog.instance[0].hal.param.timeout_ns,
+                             (tmp + 1) / ((double)hm2->watchdog.clock_frequency / (double)(1000 * 1000 * 1000)));
+            HM2_ERR("requested watchdog timeout is out of range, setting it to max: %u ns\n", timeout_ns);
         }
     }
 
     // set the watchdog timeout (we'll check for i/o errors later)
     hm2->llio->write(hm2->llio, hm2->watchdog.timer_addr, hm2->watchdog.timer_reg, (hm2->watchdog.num_instances * sizeof(rtapi_u32)));
-    hm2->watchdog.instance[0].written_timeout_ns = hm2->watchdog.instance[0].hal.param.timeout_ns;
+    hm2->watchdog.instance[0].written_timeout_ns = timeout_ns;
     hm2->watchdog.instance[0].written_enable = hm2->watchdog.instance[0].enable;
 
     // clear the has-bit bit
@@ -253,10 +256,10 @@ void hm2_watchdog_write(hostmot2_t *hm2, long period_ns) {
     if (hm2->watchdog.num_instances != 1) return;
 
     // if there are comm problems, wait for the user to fix it
-    if ((*hm2->llio->io_error) != 0) return;
+    if (hal_get_bool(*hm2->llio->io_error)) return;
 
     // if the watchdog has bit, wait for the user to reset it
-    if (*hm2->watchdog.instance[0].hal.pin.has_bit) return;
+    if (hal_get_bool(hm2->watchdog.instance[0].hal.pin.has_bit)) return;
 
     // writing to the watchdog wakes it up, and now we can't stop or it will bite!
     hm2->watchdog.instance[0].enable = 1;
@@ -271,7 +274,7 @@ void hm2_watchdog_write(hostmot2_t *hm2, long period_ns) {
 
         // write all settings out to the FPGA
         hm2_force_write(hm2);
-        if ((*hm2->llio->io_error) != 0) {
+        if (hal_get_bool(*hm2->llio->io_error)) {
             HM2_PRINT("error recovery failed\n");
             return;
         }
@@ -281,8 +284,9 @@ void hm2_watchdog_write(hostmot2_t *hm2, long period_ns) {
         hm2->llio->needs_reset = hm2->llio->needs_soft_reset = 0;
     }
 
+    rtapi_u32 timeout_ns = hal_get_ui32(hm2->watchdog.instance[0].hal.param.timeout_ns);
     if (
-        (hm2->watchdog.instance[0].hal.param.timeout_ns == hm2->watchdog.instance[0].written_timeout_ns)
+        (timeout_ns == hm2->watchdog.instance[0].written_timeout_ns)
         &&
         (hm2->watchdog.instance[0].enable == hm2->watchdog.instance[0].written_enable)
     ) {
@@ -290,10 +294,10 @@ void hm2_watchdog_write(hostmot2_t *hm2, long period_ns) {
     }
 
     // if the requested timeout is dangerously short compared to the petting-period, warn the user once
-    if (hm2->watchdog.instance[0].hal.param.timeout_ns < (1.5 * period_ns)) {
+    if (timeout_ns < (1.5 * period_ns)) {
         HM2_PRINT(
             "Watchdog timeout (%u ns) is dangerously short compared to hm2_write() period (%ld ns)\n",
-            hm2->watchdog.instance[0].hal.param.timeout_ns,
+            timeout_ns,
             period_ns
         );
     }

--- a/src/hal/drivers/mesa-hostmot2/xy2mod.c
+++ b/src/hal/drivers/mesa-hostmot2/xy2mod.c
@@ -38,58 +38,58 @@
 void hm2_xy2mod_process_tram_read(hostmot2_t *hm2) {
     int i;
     for (i = 0; i < hm2->xy2mod.num_instances; i ++) {
-    	hm2_xy2mod_instance_t *s = &hm2->xy2mod.instance[i];
+        hm2_xy2mod_instance_t *s = &hm2->xy2mod.instance[i];
         rtapi_u32 posx = hm2->xy2mod.posx_reg[i];
         rtapi_u32 posy = hm2->xy2mod.posy_reg[i];
         rtapi_u32 velx = hm2->xy2mod.velx_reg[i];
         rtapi_u32 vely = hm2->xy2mod.vely_reg[i];
-	rtapi_u32 mode = hm2->xy2mod.mode_reg[i];
-	rtapi_u32 status = hm2->xy2mod.status_reg[i];
+        rtapi_u32 mode = hm2->xy2mod.mode_reg[i];
+        rtapi_u32 status = hm2->xy2mod.status_reg[i];
 
         // those tricky users are always trying to get us to divide by zero
-        if (fabs(*s->hal.pin.posx_scale) < 1e-6) {
-            if (*s->hal.pin.posx_scale >= 0.0) {
-                *s->hal.pin.posx_scale = 1.0;
+        rtapi_real posx_scale = hal_get_real(s->hal.pin.posx_scale);
+        if (fabs(posx_scale) < 1e-6) {
+            if (posx_scale >= 0.0) {
+                posx_scale = hal_set_real(s->hal.pin.posx_scale, 1.0);
                 HM2_ERR("xy2mod %d position_scalex is too close to 0, resetting to 1.0\n", i);
             } else {
-                *s->hal.pin.posx_scale = -1.0;
+                posx_scale = hal_set_real(s->hal.pin.posx_scale, -1.0);
                 HM2_ERR("xy2mod %d position_scalxe is too close to 0, resetting to -1.0\n", i);
             }
         }
 
-        if (fabs(*s->hal.pin.posy_scale) < 1e-6) {
-            if (*s->hal.pin.posy_scale >= 0.0) {
-                *s->hal.pin.posy_scale = 1.0;
+        rtapi_real posy_scale = hal_get_real(s->hal.pin.posy_scale);
+        if (fabs(posy_scale) < 1e-6) {
+            if (posy_scale >= 0.0) {
+                posy_scale = hal_set_real(s->hal.pin.posy_scale, 1.0);
                 HM2_ERR("xy2mod %d position_scaley is too close to 0, resetting to 1.0\n", i);
             } else {
-                *s->hal.pin.posy_scale = -1.0;
+                posy_scale = hal_set_real(s->hal.pin.posy_scale, -1.0);
                 HM2_ERR("xy2mod %d position_scaley is too close to 0, resetting to -1.0\n", i);
             }
         }
-	
+
 
         // The xy2mod position Registers are a 16.16 bit fixed-point
         // representation of the current galvanometer position.
         // The fractional part gives accurate velocity at low speeds, and
         // sub bit position feedback
 
-	// need to "unscale" the position registers to return to machine units 
+        // need to "unscale" the position registers to return to machine units
 
-        *(s->hal.pin.posx_fb) = ((double)(int32_t)(posx) / 2147483647.0) / *s->hal.pin.posx_scale;
-        *(s->hal.pin.posy_fb) = ((double)(int32_t)(posy) / 2147483647.0) / *s->hal.pin.posy_scale;
+        hal_set_real(s->hal.pin.posx_fb, ((double)(int32_t)(posx) / 2147483647.0) / posx_scale);
+        hal_set_real(s->hal.pin.posy_fb, ((double)(int32_t)(posy) / 2147483647.0) / posy_scale);
 
-	// need to "unscale" the velocity registers to return to machine units 
+        // need to "unscale" the velocity registers to return to machine units
 
-	*(s->hal.pin.velx_fb) = ((double)(int32_t)velx) / (*s->hal.pin.posx_scale * (256*2147483647.0/(double)hm2->xy2mod.clock_frequency));
- 	*(s->hal.pin.vely_fb) = ((double)(int32_t)vely) / (*s->hal.pin.posy_scale * (256*2147483647.0/(double)hm2->xy2mod.clock_frequency));
+        hal_set_real(s->hal.pin.velx_fb, ((double)(int32_t)velx) / (posx_scale * (256*2147483647.0/(double)hm2->xy2mod.clock_frequency)));
+        hal_set_real(s->hal.pin.vely_fb, ((double)(int32_t)vely) / (posy_scale * (256*2147483647.0/(double)hm2->xy2mod.clock_frequency)));
 
-	*(s->hal.pin.posx_overflow) = (mode & (1 << 6));
-	*(s->hal.pin.posy_overflow) = (mode & (1 << 7));
-	*(s->hal.pin.velx_overflow) = (mode & (1 << 8));
-	*(s->hal.pin.vely_overflow) = (mode & (1 << 9));
-	*(s->hal.pin.status) = (status & 0x000FFFFF);
-
-
+        hal_set_bool(s->hal.pin.posx_overflow, mode & (1 << 6));
+        hal_set_bool(s->hal.pin.posy_overflow, mode & (1 << 7));
+        hal_set_bool(s->hal.pin.velx_overflow, mode & (1 << 8));
+        hal_set_bool(s->hal.pin.vely_overflow, mode & (1 << 9));
+        hal_set_ui32(s->hal.pin.status, status & 0x000FFFFF);
     }
 }
 
@@ -112,99 +112,107 @@ static void hm2_xy2mod_instance_write(hostmot2_t *hm2, int i) {
 
     hm2_xy2mod_instance_t *s = &hm2->xy2mod.instance[i];
     istride = i * sizeof(rtapi_u32);
-    	
-    if (*s->hal.pin.enable != 0) { 
+
+    if (hal_get_bool(s->hal.pin.enable)) {
         // position setting
-        stepsx_cmd =( *s->hal.pin.posx_cmd * 2147483647.0) / *s->hal.pin.posx_scale;
-        stepsy_cmd =( *s->hal.pin.posy_cmd * 2147483647.0) / *s->hal.pin.posy_scale;
+        rtapi_real posx_scale = hal_get_real(s->hal.pin.posx_scale);
+        rtapi_real posy_scale = hal_get_real(s->hal.pin.posy_scale);
+        rtapi_real posx_cmd = hal_get_real(s->hal.pin.posx_cmd);
+        rtapi_real posy_cmd = hal_get_real(s->hal.pin.posy_cmd);
+        stepsx_cmd = (posx_cmd * 2147483647.0) / posx_scale;
+        stepsy_cmd = (posy_cmd * 2147483647.0) / posy_scale;
         // the double cast here is intentional.  (uint32_t)(-1.0) is undefined in
         // C (and in practice it gives the undesired value 0 on arm systems), but
         // (uint32_t)(int32-t)(-1.0) is defined and gives the desired value on all
         // systems.
-        if (*s->hal.pin.posx_cmd != s->prev_posx_cmd) {
-	    lposx_reg = (int32_t)(stepsx_cmd);
+        if (posx_cmd != s->prev_posx_cmd) {
+            lposx_reg = (int32_t)(stepsx_cmd);
             hm2->xy2mod.posx_reg[i] = lposx_reg;
         //  HM2_PRINT("StepsX register set to: %f\n",stepsx_cmd);
         //  HM2_PRINT("POSX register set to:0x%08X\n",lposx_reg);
             hm2->llio->write(hm2->llio, hm2->xy2mod.posx_addr + istride, &hm2->xy2mod.posx_reg[i], sizeof(rtapi_u32));
-   	    s->prev_posx_cmd = *s->hal.pin.posx_cmd;
+            s->prev_posx_cmd = posx_cmd;
         }
 
-        if (*s->hal.pin.posy_cmd != s->prev_posy_cmd) {
+        if (posy_cmd != s->prev_posy_cmd) {
             lposy_reg = (int32_t)(stepsy_cmd);
             hm2->xy2mod.posy_reg[i] = lposy_reg;
         //  HM2_PRINT("Stepsy register set to: %fhalcmd\n",stepsy_cmd);
         //  HM2_PRINT("POSY register set to:0x%08X\n",lposy_reg);
             hm2->llio->write(hm2->llio, hm2->xy2mod.posy_addr + istride, &hm2->xy2mod.posy_reg[i], sizeof(rtapi_u32));
-            s->prev_posy_cmd = *s->hal.pin.posy_cmd;
+            s->prev_posy_cmd = posy_cmd;
         }
 
         // velocity setting
-        steps_per_secx_cmd = *s->hal.pin.velx_cmd * *s->hal.pin.posx_scale;
-        steps_per_secy_cmd = *s->hal.pin.vely_cmd * *s->hal.pin.posy_scale;
+        rtapi_real velx_cmd = hal_get_real(s->hal.pin.velx_cmd);
+        rtapi_real vely_cmd = hal_get_real(s->hal.pin.vely_cmd);
+        steps_per_secx_cmd = velx_cmd * posx_scale;
+        steps_per_secy_cmd = vely_cmd * posy_scale;
         // the double cast here is intentional.  (uint32_t)(-1.0) is undefined in
         // C (and in practice it gives the undesired value 0 on arm systems), but
         // (uint32_t)(int32-t)(-1.0) is defined and gives the desired value on all
         // systems.
-	// Note 256 factor is from velocity scaling in xy2mod hardware (velocity added only every 256 clocks)
-        if (*s->hal.pin.velx_cmd != s->prev_velx_cmd) {
+        // Note 256 factor is from velocity scaling in xy2mod hardware (velocity added only every 256 clocks)
+        if (velx_cmd != s->prev_velx_cmd) {
             lvelx_reg = (uint32_t)(int32_t)(steps_per_secx_cmd * (256*2147483648.0 / (double)hm2->xy2mod.clock_frequency));
             hm2->xy2mod.velx_reg[i] = lvelx_reg;
     //      HM2_PRINT("VELX register set to:0x%08X\n",lvelx_reg);
             hm2->llio->write(hm2->llio, hm2->xy2mod.velx_addr + istride, &hm2->xy2mod.velx_reg[i], sizeof(rtapi_u32));
-            s->prev_velx_cmd = *s->hal.pin.velx_cmd;
+            s->prev_velx_cmd = velx_cmd;
         }
 
-        if (*s->hal.pin.vely_cmd != s->prev_vely_cmd) {
+        if (vely_cmd != s->prev_vely_cmd) {
             lvely_reg = (uint32_t)(int32_t)(steps_per_secy_cmd * (256*2147483648.0 / (double)hm2->xy2mod.clock_frequency));
             hm2->xy2mod.vely_reg[i] = lvely_reg;
     //      HM2_PRINT("VELY register set to:0x%08X\n",lvely_reg);
             hm2->llio->write(hm2->llio, hm2->xy2mod.vely_addr + istride, &hm2->xy2mod.vely_reg[i], sizeof(rtapi_u32));
-            s->prev_vely_cmd = *s->hal.pin.vely_cmd;
+            s->prev_vely_cmd = vely_cmd;
         }
 
 
         // acceleration setting no idea if anywhere near reality
-        steps_per_sec2x_cmd = *s->hal.pin.accx_cmd * *s->hal.pin.posx_scale;
-        steps_per_sec2y_cmd = *s->hal.pin.accy_cmd * *s->hal.pin.posy_scale;
+        rtapi_real accx_cmd = hal_get_real(s->hal.pin.accx_cmd);
+        rtapi_real accy_cmd = hal_get_real(s->hal.pin.accy_cmd);
+        steps_per_sec2x_cmd = accx_cmd * posx_scale;
+        steps_per_sec2y_cmd = accy_cmd * posy_scale;
         // the double cast here is intentional.  (uint32_t)(-1.0) is undefined in
         // C (and in practice it gives the undesired value 0 on arm systems), but
         // (uint32_t)(int32-t)(-1.0) is defined and gives the desired value on all
         // systems.
-        if (*s->hal.pin.accx_cmd != s->prev_accx_cmd) {
+        if (accx_cmd != s->prev_accx_cmd) {
         laccx_reg = (uint32_t)(int32_t)(steps_per_sec2x_cmd * (double)(4096.0*4294967296.0*32768.0) / ((double)(hm2->xy2mod.clock_frequency*(double)hm2->xy2mod.clock_frequency*256)));
         hm2->xy2mod.accx_reg[i] = laccx_reg;
         //    HM2_PRINT("ACCX register set to:0x%08X\n",laccx_reg);
         hm2->llio->write(hm2->llio, hm2->xy2mod.accx_addr + istride, &hm2->xy2mod.accx_reg[i], sizeof(rtapi_u32));
-        s->prev_accx_cmd = *s->hal.pin.accx_cmd;
+        s->prev_accx_cmd = accx_cmd;
         }
 
-        if (*s->hal.pin.accy_cmd != s->prev_accy_cmd) {
-        laccy_reg = (uint32_t)(int32_t)(steps_per_sec2y_cmd * (double)(4096.0*4294967296.0*32768.0) / ((double)(hm2->xy2mod.clock_frequency*(double)hm2->xy2mod.clock_frequency*256)));
-        hm2->xy2mod.accy_reg[i] = laccy_reg;
+        if (accy_cmd != s->prev_accy_cmd) {
+            laccy_reg = (uint32_t)(int32_t)(steps_per_sec2y_cmd * (double)(4096.0*4294967296.0*32768.0) / ((double)(hm2->xy2mod.clock_frequency*(double)hm2->xy2mod.clock_frequency*256)));
+            hm2->xy2mod.accy_reg[i] = laccy_reg;
         //    HM2_PRINT("ACCY register set to:0x%08X\n",laccy_reg);
-        hm2->llio->write(hm2->llio, hm2->xy2mod.accy_addr + istride, &hm2->xy2mod.accy_reg[i], sizeof(rtapi_u32));
-        s->prev_accy_cmd = *s->hal.pin.accy_cmd;
+            hm2->llio->write(hm2->llio, hm2->xy2mod.accy_addr + istride, &hm2->xy2mod.accy_reg[i], sizeof(rtapi_u32));
+            s->prev_accy_cmd = accy_cmd;
         }
-	*s->hal.pin.controlx = (*s->hal.pin.controlx & 7);
-	*s->hal.pin.controly = (*s->hal.pin.controly & 7);
+        hal_set_ui32(s->hal.pin.controlx, hal_get_ui32(s->hal.pin.controlx) & 7);
+        hal_set_ui32(s->hal.pin.controly, hal_get_ui32(s->hal.pin.controly) & 7);
         
-	hm2->xy2mod.mode_reg[i] = 
-        *s->hal.pin.controlx << 0  |
-        *s->hal.pin.controly << 3  |
-        *s->hal.pin.mode18bitx<< 10 |
-        *s->hal.pin.mode18bity<< 11 |
-        *s->hal.pin.commandmodex<< 12 |
-        *s->hal.pin.commandmodey<< 13;
+        hm2->xy2mod.mode_reg[i] =
+            (hal_get_ui32(s->hal.pin.controlx) << 0)  |
+            (hal_get_ui32(s->hal.pin.controly) << 3)  |
+            (hal_get_bool(s->hal.pin.mode18bitx)<< 10) |
+            (hal_get_bool(s->hal.pin.mode18bity)<< 11) |
+            (hal_get_bool(s->hal.pin.commandmodex)<< 12) |
+            (hal_get_bool(s->hal.pin.commandmodey)<< 13);
 
         hm2->llio->write(hm2->llio,hm2->xy2mod.mode_addr + istride, &hm2->xy2mod.mode_reg[i], sizeof(rtapi_u32));
 
-	*s->hal.pin.commandx = (*s->hal.pin.commandx & 0xFFFF);
-	*s->hal.pin.commandy = (*s->hal.pin.commandy & 0xFFFF);
+        hal_set_ui32(s->hal.pin.commandx, hal_get_ui32(s->hal.pin.commandx) & 0xFFFF);
+        hal_set_ui32(s->hal.pin.commandy, hal_get_ui32(s->hal.pin.commandy) & 0xFFFF);
 
-	hm2->xy2mod.command_reg[i] = 
-        *s->hal.pin.commandx << 0  |
-        *s->hal.pin.commandy << 16;
+        hm2->xy2mod.command_reg[i] =
+            (hal_get_ui32(s->hal.pin.commandx) << 0)  |
+            (hal_get_ui32(s->hal.pin.commandy) << 16);
 
         hm2->llio->write(hm2->llio,hm2->xy2mod.command_addr + istride, &hm2->xy2mod.command_reg[i], sizeof(rtapi_u32));
 
@@ -213,43 +221,43 @@ static void hm2_xy2mod_instance_write(hostmot2_t *hm2, int i) {
 // may eventually want to spilt out resetting the overflow flags
 
 // reset position registers
-        *s->hal.pin.posx_cmd = 0;
-   	s->prev_posx_cmd = 0;
+        hal_set_real(s->hal.pin.posx_cmd, 0);
+        s->prev_posx_cmd = 0;
         hm2->xy2mod.posx_reg[i] =0;
         hm2->llio->write(hm2->llio, hm2->xy2mod.posx_addr + istride, &hm2->xy2mod.posx_reg[i], sizeof(rtapi_u32));
 
-        *s->hal.pin.posy_cmd = 0;
-   	s->prev_posy_cmd = 0;
+        hal_set_real(s->hal.pin.posy_cmd, 0);
+        s->prev_posy_cmd = 0;
         hm2->xy2mod.posy_reg[i] =0;
         hm2->llio->write(hm2->llio, hm2->xy2mod.posy_addr + istride, &hm2->xy2mod.posy_reg[i], sizeof(rtapi_u32));
  
 
 // reset velocity registers
-        *s->hal.pin.velx_cmd = 0;
+        hal_set_real(s->hal.pin.velx_cmd, 0);
         s->prev_velx_cmd = 0;
         hm2->xy2mod.velx_reg[i] = 0;
         hm2->llio->write(hm2->llio, hm2->xy2mod.velx_addr + istride, &hm2->xy2mod.velx_reg[i], sizeof(rtapi_u32));
 
-        *s->hal.pin.vely_cmd = 0;
+        hal_set_real(s->hal.pin.vely_cmd, 0);
         s->prev_vely_cmd = 0;
         hm2->xy2mod.vely_reg[i] = 0;
         hm2->llio->write(hm2->llio, hm2->xy2mod.vely_addr + istride, &hm2->xy2mod.vely_reg[i], sizeof(rtapi_u32));
 
 // reset acceleration registers
-        *s->hal.pin.accx_cmd = 0;
+        hal_set_real(s->hal.pin.accx_cmd, 0);
         s->prev_accx_cmd = 0;
         hm2->xy2mod.accx_reg[i] = 0;
         hm2->llio->write(hm2->llio, hm2->xy2mod.accx_addr + istride, &hm2->xy2mod.accx_reg[i], sizeof(rtapi_u32));
 
-        *s->hal.pin.accy_cmd = 0;
+        hal_set_real(s->hal.pin.accy_cmd, 0);
         s->prev_accy_cmd = 0;
         hm2->xy2mod.accy_reg[i] = 0;
         hm2->llio->write(hm2->llio, hm2->xy2mod.accy_addr + istride, &hm2->xy2mod.accy_reg[i], sizeof(rtapi_u32));
 
 //reset control bits and overflow flags
 
-        *s->hal.pin.controlx = 1;  // default to 16 bit mode	
-        *s->hal.pin.controly = 1;
+        hal_set_ui32(s->hal.pin.controlx, 1);  // default to 16 bit mode
+        hal_set_ui32(s->hal.pin.controly, 1);
         hm2->xy2mod.mode_reg[i] = 0x000003C9; // reset X and Y overflow bits when disabled
         hm2->llio->write(hm2->llio, hm2->xy2mod.mode_addr + istride, &hm2->xy2mod.mode_reg[i], sizeof(rtapi_u32));
     }   
@@ -258,28 +266,30 @@ static void hm2_xy2mod_instance_write(hostmot2_t *hm2, int i) {
 
 static void hm2_xy2mod_set_dpll_rtimer(hostmot2_t *hm2) {
     rtapi_u32 data = 0;
+    rtapi_s32 dpll_rtimer_num = hal_get_si32(hm2->xy2mod.hal->pin.dpll_rtimer_num);
 
-    if ((*hm2->xy2mod.hal->pin.dpll_rtimer_num < -1) || (*hm2->xy2mod.hal->pin.dpll_rtimer_num > 4)) {
-        *hm2->xy2mod.hal->pin.dpll_rtimer_num = 0;
+    if ((dpll_rtimer_num < -1) || (dpll_rtimer_num > 4)) {
+        dpll_rtimer_num = hal_set_si32(hm2->xy2mod.hal->pin.dpll_rtimer_num, 0);
     }
-    if (*hm2->xy2mod.hal->pin.dpll_rtimer_num > -1) {
-        data = (*hm2->xy2mod.hal->pin.dpll_rtimer_num << 12) | (1 << 15);
+    if (dpll_rtimer_num > -1) {
+        data = (dpll_rtimer_num << 12) | (1 << 15);
     }
     hm2->llio->write(hm2->llio, hm2->xy2mod.dpll_rtimer_num_addr, &data, sizeof(rtapi_u32));
-    hm2->xy2mod.written_dpll_rtimer_num = *hm2->xy2mod.hal->pin.dpll_rtimer_num;
+    hm2->xy2mod.written_dpll_rtimer_num = dpll_rtimer_num;
 }
 
 static void hm2_xy2mod_set_dpll_wtimer(hostmot2_t *hm2) {
     rtapi_u32 data = 0;
+    rtapi_s32 dpll_wtimer_num = hal_get_si32(hm2->xy2mod.hal->pin.dpll_wtimer_num);
 
-    if ((*hm2->xy2mod.hal->pin.dpll_wtimer_num < -1) || (*hm2->xy2mod.hal->pin.dpll_wtimer_num > 4)) {
-        *hm2->xy2mod.hal->pin.dpll_wtimer_num = 0;
+    if ((dpll_wtimer_num < -1) || (dpll_wtimer_num > 4)) {
+        dpll_wtimer_num = hal_set_si32(hm2->xy2mod.hal->pin.dpll_wtimer_num, 0);
     }
-    if (*hm2->xy2mod.hal->pin.dpll_wtimer_num > -1) {
-        data = (*hm2->xy2mod.hal->pin.dpll_wtimer_num << 12) | (1 << 15);
+    if (dpll_wtimer_num > -1) {
+        data = (dpll_wtimer_num << 12) | (1 << 15);
     }
     hm2->llio->write(hm2->llio, hm2->xy2mod.dpll_wtimer_num_addr, &data, sizeof(rtapi_u32));
-    hm2->xy2mod.written_dpll_wtimer_num = *hm2->xy2mod.hal->pin.dpll_wtimer_num;
+    hm2->xy2mod.written_dpll_wtimer_num = dpll_wtimer_num;
 }
 
 
@@ -289,10 +299,10 @@ void hm2_xy2mod_write(hostmot2_t *hm2) {
          hm2_xy2mod_instance_write(hm2, i);
     }
     if (hm2->xy2mod.num_instances > 0 && hm2->dpll_module_present) {
-        if (*hm2->xy2mod.hal->pin.dpll_rtimer_num != (int)hm2->xy2mod.written_dpll_rtimer_num) {
+        if (hal_get_si32(hm2->xy2mod.hal->pin.dpll_rtimer_num) != hm2->xy2mod.written_dpll_rtimer_num) {
             hm2_xy2mod_set_dpll_rtimer(hm2);
         }
-        if (*hm2->xy2mod.hal->pin.dpll_wtimer_num != (int)hm2->xy2mod.written_dpll_wtimer_num) {
+        if (hal_get_si32(hm2->xy2mod.hal->pin.dpll_wtimer_num) != hm2->xy2mod.written_dpll_wtimer_num) {
             hm2_xy2mod_set_dpll_wtimer(hm2);
         }
     }
@@ -322,16 +332,13 @@ void hm2_xy2mod_force_write(hostmot2_t *hm2) {
 
 
 void hm2_xy2mod_tram_init(hostmot2_t *hm2) {
-    int i;
-
-    for (i = 0; i < hm2->xy2mod.num_instances; i ++) {
-
-    *hm2->xy2mod.instance[i].hal.pin.posx_cmd = 0;
-    *hm2->xy2mod.instance[i].hal.pin.posy_cmd = 0;
-    *hm2->xy2mod.instance[i].hal.pin.velx_cmd = 0;
-    *hm2->xy2mod.instance[i].hal.pin.vely_cmd = 0;
-    *hm2->xy2mod.instance[i].hal.pin.accx_cmd = 0;
-    *hm2->xy2mod.instance[i].hal.pin.accy_cmd = 0;
+    for (int i = 0; i < hm2->xy2mod.num_instances; i ++) {
+        hal_set_real(hm2->xy2mod.instance[i].hal.pin.posx_cmd, 0);
+        hal_set_real(hm2->xy2mod.instance[i].hal.pin.posy_cmd, 0);
+        hal_set_real(hm2->xy2mod.instance[i].hal.pin.velx_cmd, 0);
+        hal_set_real(hm2->xy2mod.instance[i].hal.pin.vely_cmd, 0);
+        hal_set_real(hm2->xy2mod.instance[i].hal.pin.accx_cmd, 0);
+        hal_set_real(hm2->xy2mod.instance[i].hal.pin.accy_cmd, 0);
     }
 }
 
@@ -417,14 +424,14 @@ int hm2_xy2mod_parse_md(hostmot2_t *hm2, int md_index) {
 
 
     // allocate the module-global HAL shared memory
-    hm2->xy2mod.hal = (hm2_xy2mod_module_global_t *)hal_malloc(sizeof(hm2_xy2mod_module_global_t));
+    hm2->xy2mod.hal = hal_malloc(sizeof(*hm2->xy2mod.hal));
     if (hm2->xy2mod.hal == NULL) {
         HM2_ERR("out of memory!\n");
         r = -ENOMEM;
         goto fail0;
     }
 
-    hm2->xy2mod.instance = (hm2_xy2mod_instance_t *)hal_malloc(hm2->xy2mod.num_instances * sizeof(hm2_xy2mod_instance_t));
+    hm2->xy2mod.instance = hal_malloc(hm2->xy2mod.num_instances * sizeof(*hm2->xy2mod.instance));
     if (hm2->xy2mod.instance == NULL) {
         HM2_ERR("out of memory!\n");
         r = -ENOMEM;
@@ -513,268 +520,208 @@ int hm2_xy2mod_parse_md(hostmot2_t *hm2, int md_index) {
     // export to HAL
 
     {
-        int i;
-        char name[HAL_NAME_LEN + 1];
-
         if (hm2->dpll_module_present) {
-            rtapi_snprintf(name, sizeof(name), "%s.xy2mod.read-timer-number", hm2->llio->name);
-            r = hal_pin_s32_new(name, HAL_IN, &(hm2->xy2mod.hal->pin.dpll_rtimer_num), hm2->llio->comp_id);
+            r = hal_pin_new_si32(hm2->llio->comp_id, HAL_IN, &(hm2->xy2mod.hal->pin.dpll_rtimer_num),
+                                 -1, "%s.xy2mod.read-timer-number", hm2->llio->name);
             if (r < 0) {
-                HM2_ERR("error adding read timer number param, aborting\n");
+                HM2_ERR("error %d adding pin '%s.xy2mod.read-timer-number', aborting\n", r, hm2->llio->name);
                 return -EINVAL;
             }
-            *(hm2->xy2mod.hal->pin.dpll_rtimer_num) = -1;
-        }
 
-        if (hm2->dpll_module_present) {
-            rtapi_snprintf(name, sizeof(name), "%s.xy2mod.write-timer-number", hm2->llio->name);
-            r = hal_pin_s32_new(name, HAL_IN, &(hm2->xy2mod.hal->pin.dpll_wtimer_num), hm2->llio->comp_id);
+            r = hal_pin_new_si32(hm2->llio->comp_id, HAL_IN, &(hm2->xy2mod.hal->pin.dpll_wtimer_num),
+                                 -1, "%s.xy2mod.write-timer-number", hm2->llio->name);
             if (r < 0) {
-                HM2_ERR("error adding write timer number param, aborting\n");
+                HM2_ERR("error %d adding pin '%s.xy2mod.write-timer-number', aborting\n", r, hm2->llio->name);
                 return -EINVAL;
             }
-            *(hm2->xy2mod.hal->pin.dpll_wtimer_num) = -1;
         }
 
-        for (i = 0; i < hm2->xy2mod.num_instances; i ++) {
-            
+        for (int i = 0; i < hm2->xy2mod.num_instances; i ++) {
             // pins
-            rtapi_snprintf(name, sizeof(name), "%s.xy2mod.%02d.posx-cmd", hm2->llio->name, i);
-            r = hal_pin_float_new(name, HAL_IN, &(hm2->xy2mod.instance[i].hal.pin.posx_cmd), hm2->llio->comp_id);
+            r = hal_pin_new_real(hm2->llio->comp_id, HAL_IN, &(hm2->xy2mod.instance[i].hal.pin.posx_cmd),
+                                 0.0, "%s.xy2mod.%02d.posx-cmd", hm2->llio->name, i);
             if (r < 0) {
-                HM2_ERR("error adding pin '%s', aborting\n", name);
-                r = -ENOMEM;
+                HM2_ERR("error %d adding pin '%s.xy2mod.%02d.posx-cmd', aborting\n", r, hm2->llio->name, i);
                 goto fail0;
             }
 
-            rtapi_snprintf(name, sizeof(name), "%s.xy2mod.%02d.posy-cmd", hm2->llio->name, i);
-            r = hal_pin_float_new(name, HAL_IN, &(hm2->xy2mod.instance[i].hal.pin.posy_cmd), hm2->llio->comp_id);
+            r = hal_pin_new_real(hm2->llio->comp_id, HAL_IN, &(hm2->xy2mod.instance[i].hal.pin.posy_cmd),
+                                 0.0, "%s.xy2mod.%02d.posy-cmd", hm2->llio->name, i);
             if (r < 0) {
-                HM2_ERR("error adding pin '%s', aborting\n", name);
-                r = -ENOMEM;
+                HM2_ERR("error %d adding pin '%s.xy2mod.%02d.posy-cmd', aborting\n", r, hm2->llio->name, i);
                 goto fail0;
             }
 
-            rtapi_snprintf(name, sizeof(name), "%s.xy2mod.%02d.velx-cmd", hm2->llio->name, i);
-            r = hal_pin_float_new(name, HAL_IN, &(hm2->xy2mod.instance[i].hal.pin.velx_cmd), hm2->llio->comp_id);
+            r = hal_pin_new_real(hm2->llio->comp_id, HAL_IN, &(hm2->xy2mod.instance[i].hal.pin.velx_cmd),
+                                 0.0, "%s.xy2mod.%02d.velx-cmd", hm2->llio->name, i);
             if (r < 0) {
-                HM2_ERR("error adding pin '%s', aborting\n", name);
-                r = -ENOMEM;
+                HM2_ERR("error %d adding pin '%s.xy2mod.%02d.velx-cmd', aborting\n", r, hm2->llio->name, i);
                 goto fail0;
             }
 
-            rtapi_snprintf(name, sizeof(name), "%s.xy2mod.%02d.vely-cmd", hm2->llio->name, i);
-            r = hal_pin_float_new(name, HAL_IN, &(hm2->xy2mod.instance[i].hal.pin.vely_cmd), hm2->llio->comp_id);
+            r = hal_pin_new_real(hm2->llio->comp_id, HAL_IN, &(hm2->xy2mod.instance[i].hal.pin.vely_cmd),
+                                 0.0, "%s.xy2mod.%02d.vely-cmd", hm2->llio->name, i);
             if (r < 0) {
-                HM2_ERR("error adding pin '%s', aborting\n", name);
-                r = -ENOMEM;
+                HM2_ERR("error %d adding pin '%s.xy2mod.%02d.vely-cmd', aborting\n", r, hm2->llio->name, i);
                 goto fail0;
             }
 
-            rtapi_snprintf(name, sizeof(name), "%s.xy2mod.%02d.accx-cmd", hm2->llio->name, i);
-            r = hal_pin_float_new(name, HAL_IN, &(hm2->xy2mod.instance[i].hal.pin.accx_cmd), hm2->llio->comp_id);
+            r = hal_pin_new_real(hm2->llio->comp_id, HAL_IN, &(hm2->xy2mod.instance[i].hal.pin.accx_cmd),
+                                 0.0, "%s.xy2mod.%02d.accx-cmd", hm2->llio->name, i);
             if (r < 0) {
-                HM2_ERR("error adding pin '%s', aborting\n", name);
-                r = -ENOMEM;
+                HM2_ERR("error %d adding pin '%s.xy2mod.%02d.accx-cmd', aborting\n", r, hm2->llio->name, i);
                 goto fail0;
             }
 
-            rtapi_snprintf(name, sizeof(name), "%s.xy2mod.%02d.accy-cmd", hm2->llio->name, i);
-            r = hal_pin_float_new(name, HAL_IN, &(hm2->xy2mod.instance[i].hal.pin.accy_cmd), hm2->llio->comp_id);
+            r = hal_pin_new_real(hm2->llio->comp_id, HAL_IN, &(hm2->xy2mod.instance[i].hal.pin.accy_cmd),
+                                 0.0, "%s.xy2mod.%02d.accy-cmd", hm2->llio->name, i);
             if (r < 0) {
-                HM2_ERR("error adding pin '%s', aborting\n", name);
-                r = -ENOMEM;
+                HM2_ERR("error %d adding pin '%s.xy2mod.%02d.accy-cmd', aborting\n", r, hm2->llio->name, i);
                 goto fail0;
             }
 
-            rtapi_snprintf(name, sizeof(name), "%s.xy2mod.%02d.velx-fb", hm2->llio->name, i);
-            r = hal_pin_float_new(name, HAL_OUT, &(hm2->xy2mod.instance[i].hal.pin.velx_fb), hm2->llio->comp_id);
+            r = hal_pin_new_real(hm2->llio->comp_id, HAL_OUT, &(hm2->xy2mod.instance[i].hal.pin.velx_fb),
+                                 0.0, "%s.xy2mod.%02d.velx-fb", hm2->llio->name, i);
             if (r < 0) {
-                HM2_ERR("error adding pin '%s', aborting\n", name);
-                r = -ENOMEM;
+                HM2_ERR("error %d adding pin '%s.xy2mod.%02d.velx-fb', aborting\n", r, hm2->llio->name, i);
                 goto fail0;
             }
 
-            rtapi_snprintf(name, sizeof(name), "%s.xy2mod.%02d.vely-fb", hm2->llio->name, i);
-            r = hal_pin_float_new(name, HAL_OUT, &(hm2->xy2mod.instance[i].hal.pin.vely_fb), hm2->llio->comp_id);
+            r = hal_pin_new_real(hm2->llio->comp_id, HAL_OUT, &(hm2->xy2mod.instance[i].hal.pin.vely_fb),
+                                 0.0, "%s.xy2mod.%02d.vely-fb", hm2->llio->name, i);
             if (r < 0) {
-                HM2_ERR("error adding pin '%s', aborting\n", name);
-                r = -ENOMEM;
+                HM2_ERR("error %d adding pin '%s.xy2mod.%02d.vely-fb', aborting\n", r, hm2->llio->name, i);
                 goto fail0;
             }
 
-            rtapi_snprintf(name, sizeof(name), "%s.xy2mod.%02d.posx-fb", hm2->llio->name, i);
-            r = hal_pin_float_new(name, HAL_OUT, &(hm2->xy2mod.instance[i].hal.pin.posx_fb), hm2->llio->comp_id);
+            r = hal_pin_new_real(hm2->llio->comp_id, HAL_OUT, &(hm2->xy2mod.instance[i].hal.pin.posx_fb),
+                                 0.0, "%s.xy2mod.%02d.posx-fb", hm2->llio->name, i);
             if (r < 0) {
-                HM2_ERR("error adding pin '%s', aborting\n", name);
-                r = -ENOMEM;
+                HM2_ERR("error %d adding pin '%s.xy2mod.%02d.posx-fb', aborting\n", r, hm2->llio->name, i);
                 goto fail0;
             }
 
-            rtapi_snprintf(name, sizeof(name), "%s.xy2mod.%02d.posy-fb", hm2->llio->name, i);
-            r = hal_pin_float_new(name, HAL_OUT, &(hm2->xy2mod.instance[i].hal.pin.posy_fb), hm2->llio->comp_id);
+            r = hal_pin_new_real(hm2->llio->comp_id, HAL_OUT, &(hm2->xy2mod.instance[i].hal.pin.posy_fb),
+                                 0.0, "%s.xy2mod.%02d.posy-fb", hm2->llio->name, i);
             if (r < 0) {
-                HM2_ERR("error adding pin '%s', aborting\n", name);
-                r = -ENOMEM;
+                HM2_ERR("error %d adding pin '%s.xy2mod.%02d.posy-fb', aborting\n", r, hm2->llio->name, i);
                 goto fail0;
             }
  
-            rtapi_snprintf(name, sizeof(name), "%s.xy2mod.%02d.posx-scale", hm2->llio->name, i);
-            r = hal_pin_float_new(name, HAL_IN, &(hm2->xy2mod.instance[i].hal.pin.posx_scale), hm2->llio->comp_id);
+            r = hal_pin_new_real(hm2->llio->comp_id, HAL_IN, &(hm2->xy2mod.instance[i].hal.pin.posx_scale),
+                                 1.0, "%s.xy2mod.%02d.posx-scale", hm2->llio->name, i);
             if (r < 0) {
-                HM2_ERR("error adding pin '%s', aborting\n", name);
-                r = -ENOMEM;
+                HM2_ERR("error %d adding pin '%s.xy2mod.%02d.posx-scale', aborting\n", r, hm2->llio->name, i);
                 goto fail0;
             }
 
-            rtapi_snprintf(name, sizeof(name), "%s.xy2mod.%02d.posy-scale", hm2->llio->name, i);
-            r = hal_pin_float_new(name, HAL_IN, &(hm2->xy2mod.instance[i].hal.pin.posy_scale), hm2->llio->comp_id);
+            r = hal_pin_new_real(hm2->llio->comp_id, HAL_IN, &(hm2->xy2mod.instance[i].hal.pin.posy_scale),
+                                 1.0, "%s.xy2mod.%02d.posy-scale", hm2->llio->name, i);
             if (r < 0) {
-                HM2_ERR("error adding pin '%s', aborting\n", name);
-                r = -ENOMEM;
+                HM2_ERR("error %d adding pin '%s.xy2mod.%02d.posy-scale', aborting\n", r, hm2->llio->name, i);
                 goto fail0;
             }
 
-            rtapi_snprintf(name, sizeof(name), "%s.xy2mod.%02d.enable", hm2->llio->name, i);
-            r = hal_pin_bit_new(name, HAL_IN, &(hm2->xy2mod.instance[i].hal.pin.enable), hm2->llio->comp_id);
+            r = hal_pin_new_bool(hm2->llio->comp_id, HAL_IN, &(hm2->xy2mod.instance[i].hal.pin.enable),
+                                 0, "%s.xy2mod.%02d.enable", hm2->llio->name, i);
             if (r < 0) {
-                HM2_ERR("error adding pin '%s', aborting\n", name);
-                r = -ENOMEM;
+                HM2_ERR("error %d adding pin '%s.xy2mod.%02d.enable', aborting\n", r, hm2->llio->name, i);
                 goto fail0;
             }
  
-           rtapi_snprintf(name, sizeof(name), "%s.xy2mod.%02d.controlx", hm2->llio->name, i);
-            r = hal_pin_u32_new(name, HAL_IN, &(hm2->xy2mod.instance[i].hal.pin.controlx), hm2->llio->comp_id);
+            r = hal_pin_new_ui32(hm2->llio->comp_id, HAL_IN, &(hm2->xy2mod.instance[i].hal.pin.controlx),
+                                 1, "%s.xy2mod.%02d.controlx", hm2->llio->name, i);
             if (r < 0) {
-                HM2_ERR("error adding pin '%s', aborting\n", name);
-                r = -ENOMEM;
+                HM2_ERR("error %d adding pin '%s.xy2mod.%02d.controlx', aborting\n", r, hm2->llio->name, i);
                 goto fail0;
             }
 
  
-           rtapi_snprintf(name, sizeof(name), "%s.xy2mod.%02d.controly", hm2->llio->name, i);
-            r = hal_pin_u32_new(name, HAL_IN, &(hm2->xy2mod.instance[i].hal.pin.controly), hm2->llio->comp_id);
+            r = hal_pin_new_ui32(hm2->llio->comp_id, HAL_IN, &(hm2->xy2mod.instance[i].hal.pin.controly),
+                                 1, "%s.xy2mod.%02d.controly", hm2->llio->name, i);
             if (r < 0) {
-                HM2_ERR("error adding pin '%s', aborting\n", name);
-                r = -ENOMEM;
+                HM2_ERR("error %d adding pin '%s.xy2mod.%02d.controly', aborting\n", r, hm2->llio->name, i);
                 goto fail0;
             }
 
-           rtapi_snprintf(name, sizeof(name), "%s.xy2mod.%02d.commandx", hm2->llio->name, i);
-            r = hal_pin_u32_new(name, HAL_IN, &(hm2->xy2mod.instance[i].hal.pin.commandx), hm2->llio->comp_id);
+            r = hal_pin_new_ui32(hm2->llio->comp_id, HAL_IN, &(hm2->xy2mod.instance[i].hal.pin.commandx),
+                                 0, "%s.xy2mod.%02d.commandx", hm2->llio->name, i);
             if (r < 0) {
-                HM2_ERR("error adding pin '%s', aborting\n", name);
-                r = -ENOMEM;
+                HM2_ERR("error %d adding pin '%s.xy2mod.%02d.commandx', aborting\n", r, hm2->llio->name, i);
                 goto fail0;
             }
 
  
-           rtapi_snprintf(name, sizeof(name), "%s.xy2mod.%02d.commandy", hm2->llio->name, i);
-            r = hal_pin_u32_new(name, HAL_IN, &(hm2->xy2mod.instance[i].hal.pin.commandy), hm2->llio->comp_id);
+            r = hal_pin_new_ui32(hm2->llio->comp_id, HAL_IN, &(hm2->xy2mod.instance[i].hal.pin.commandy),
+                                 0, "%s.xy2mod.%02d.commandy", hm2->llio->name, i);
             if (r < 0) {
-                HM2_ERR("error adding pin '%s', aborting\n", name);
-                r = -ENOMEM;
+                HM2_ERR("error %d adding pin '%s.xy2mod.%02d.commandy', aborting\n", r, hm2->llio->name, i);
                 goto fail0;
             }
 
 
-           rtapi_snprintf(name, sizeof(name), "%s.xy2mod.%02d.18bitmodex", hm2->llio->name, i);
-            r = hal_pin_bit_new(name, HAL_IN, &(hm2->xy2mod.instance[i].hal.pin.mode18bitx), hm2->llio->comp_id);
+            r = hal_pin_new_bool(hm2->llio->comp_id, HAL_IN, &(hm2->xy2mod.instance[i].hal.pin.mode18bitx),
+                                 0, "%s.xy2mod.%02d.18bitmodex", hm2->llio->name, i);
             if (r < 0) {
-                HM2_ERR("error adding pin '%s', aborting\n", name);
-                r = -ENOMEM;
+                HM2_ERR("error %d adding pin '%s.xy2mod.%02d.18bitmodex', aborting\n", r, hm2->llio->name, i);
                 goto fail0;
             }
 
-           rtapi_snprintf(name, sizeof(name), "%s.xy2mod.%02d.18bitmodey", hm2->llio->name, i);
-            r = hal_pin_bit_new(name, HAL_IN, &(hm2->xy2mod.instance[i].hal.pin.mode18bity), hm2->llio->comp_id);
+            r = hal_pin_new_bool(hm2->llio->comp_id, HAL_IN, &(hm2->xy2mod.instance[i].hal.pin.mode18bity),
+                                 0, "%s.xy2mod.%02d.18bitmodey", hm2->llio->name, i);
             if (r < 0) {
-                HM2_ERR("error adding pin '%s', aborting\n", name);
-                r = -ENOMEM;
+                HM2_ERR("error %d adding pin '%s.xy2mod.%02d.18bitmodey', aborting\n", r, hm2->llio->name, i);
                 goto fail0;
             }
 
-           rtapi_snprintf(name, sizeof(name), "%s.xy2mod.%02d.commandmodex", hm2->llio->name, i);
-            r = hal_pin_bit_new(name, HAL_IN, &(hm2->xy2mod.instance[i].hal.pin.commandmodex), hm2->llio->comp_id);
+            r = hal_pin_new_bool(hm2->llio->comp_id, HAL_IN, &(hm2->xy2mod.instance[i].hal.pin.commandmodex),
+                                 0, "%s.xy2mod.%02d.commandmodex", hm2->llio->name, i);
             if (r < 0) {
-                HM2_ERR("error adding pin '%s', aborting\n", name);
-                r = -ENOMEM;
+                HM2_ERR("error %d adding pin '%s.xy2mod.%02d.commandmodex', aborting\n", r, hm2->llio->name, i);
                 goto fail0;
             }
 
-           rtapi_snprintf(name, sizeof(name), "%s.xy2mod.%02d.commandmodey", hm2->llio->name, i);
-            r = hal_pin_bit_new(name, HAL_IN, &(hm2->xy2mod.instance[i].hal.pin.commandmodey), hm2->llio->comp_id);
+            r = hal_pin_new_bool(hm2->llio->comp_id, HAL_IN, &(hm2->xy2mod.instance[i].hal.pin.commandmodey),
+                                 0, "%s.xy2mod.%02d.commandmodey", hm2->llio->name, i);
             if (r < 0) {
-                HM2_ERR("error adding pin '%s', aborting\n", name);
-                r = -ENOMEM;
+                HM2_ERR("error %d adding pin '%s.xy2mod.%02d.commandmodey', aborting\n", r, hm2->llio->name, i);
                 goto fail0;
             }
 
-           rtapi_snprintf(name, sizeof(name), "%s.xy2mod.%02d.posx-overflow", hm2->llio->name, i);
-            r = hal_pin_bit_new(name, HAL_OUT, &(hm2->xy2mod.instance[i].hal.pin.posx_overflow), hm2->llio->comp_id);
+            r = hal_pin_new_bool(hm2->llio->comp_id, HAL_OUT, &(hm2->xy2mod.instance[i].hal.pin.posx_overflow),
+                                 0, "%s.xy2mod.%02d.posx-overflow", hm2->llio->name, i);
             if (r < 0) {
-                HM2_ERR("error adding pin '%s', aborting\n", name);
-                r = -ENOMEM;
+                HM2_ERR("error %d adding pin '%s.xy2mod.%02d.posx-overflow', aborting\n", r, hm2->llio->name, i);
                 goto fail0;
             }
 
-           rtapi_snprintf(name, sizeof(name), "%s.xy2mod.%02d.posy-overflow", hm2->llio->name, i);
-            r = hal_pin_bit_new(name, HAL_OUT, &(hm2->xy2mod.instance[i].hal.pin.posy_overflow), hm2->llio->comp_id);
+            r = hal_pin_new_bool(hm2->llio->comp_id, HAL_OUT, &(hm2->xy2mod.instance[i].hal.pin.posy_overflow),
+                                 0, "%s.xy2mod.%02d.posy-overflow", hm2->llio->name, i);
             if (r < 0) {
-                HM2_ERR("error adding pin '%s', aborting\n", name);
-                r = -ENOMEM;
+                HM2_ERR("error %d adding pin '%s.xy2mod.%02d.posy-overflow', aborting\n", r, hm2->llio->name, i);
                 goto fail0;
             }
 
-           rtapi_snprintf(name, sizeof(name), "%s.xy2mod.%02d.velx-overflow", hm2->llio->name, i);
-            r = hal_pin_bit_new(name, HAL_OUT, &(hm2->xy2mod.instance[i].hal.pin.velx_overflow), hm2->llio->comp_id);
+            r = hal_pin_new_bool(hm2->llio->comp_id, HAL_OUT, &(hm2->xy2mod.instance[i].hal.pin.velx_overflow),
+                                 0, "%s.xy2mod.%02d.velx-overflow", hm2->llio->name, i);
             if (r < 0) {
-                HM2_ERR("error adding pin '%s', aborting\n", name);
-                r = -ENOMEM;
+                HM2_ERR("error %d adding pin '%s.xy2mod.%02d.velx-overflow', aborting\n", r, hm2->llio->name, i);
                 goto fail0;
             }
 
-           rtapi_snprintf(name, sizeof(name), "%s.xy2mod.%02d.vely-overflow", hm2->llio->name, i);
-            r = hal_pin_bit_new(name, HAL_OUT, &(hm2->xy2mod.instance[i].hal.pin.vely_overflow), hm2->llio->comp_id);
+            r = hal_pin_new_bool(hm2->llio->comp_id, HAL_OUT, &(hm2->xy2mod.instance[i].hal.pin.vely_overflow),
+                                 0, "%s.xy2mod.%02d.vely-overflow", hm2->llio->name, i);
             if (r < 0) {
-                HM2_ERR("error adding pin '%s', aborting\n", name);
-                r = -ENOMEM;
+                HM2_ERR("error %d adding pin '%s.xy2mod.%02d.vely-overflow', aborting\n", r, hm2->llio->name, i);
                 goto fail0;
             }
  
-           rtapi_snprintf(name, sizeof(name), "%s.xy2mod.%02d.status", hm2->llio->name, i);
-            r = hal_pin_u32_new(name, HAL_OUT, &(hm2->xy2mod.instance[i].hal.pin.status), hm2->llio->comp_id);
+            r = hal_pin_new_ui32(hm2->llio->comp_id, HAL_OUT, &(hm2->xy2mod.instance[i].hal.pin.status),
+                                 0, "%s.xy2mod.%02d.status", hm2->llio->name, i);
             if (r < 0) {
-                HM2_ERR("error adding pin '%s', aborting\n", name);
-                r = -ENOMEM;
+                HM2_ERR("error %d adding pin '%s.xy2mod.%02d.status', aborting\n", r, hm2->llio->name, i);
                 goto fail0;
             }
- 
-
-            // init
-            *(hm2->xy2mod.instance[i].hal.pin.posx_cmd) = 0.0;
-            *(hm2->xy2mod.instance[i].hal.pin.posy_cmd) = 0.0;
-            *(hm2->xy2mod.instance[i].hal.pin.velx_cmd) = 0.0;
-            *(hm2->xy2mod.instance[i].hal.pin.vely_cmd) = 0.0;
-            *(hm2->xy2mod.instance[i].hal.pin.accx_cmd) = 0.0;
-            *(hm2->xy2mod.instance[i].hal.pin.accy_cmd) = 0.0;
-            *(hm2->xy2mod.instance[i].hal.pin.posx_fb) = 0.0;
-            *(hm2->xy2mod.instance[i].hal.pin.posy_fb) = 0.0;
-            *(hm2->xy2mod.instance[i].hal.pin.velx_fb) = 0.0;
-            *(hm2->xy2mod.instance[i].hal.pin.vely_fb) = 0.0;
-            *(hm2->xy2mod.instance[i].hal.pin.posx_scale) = 1.0;
-            *(hm2->xy2mod.instance[i].hal.pin.posy_scale) = 1.0;
-            *(hm2->xy2mod.instance[i].hal.pin.enable) = 0;
-            *(hm2->xy2mod.instance[i].hal.pin.controlx) = 1;
-            *(hm2->xy2mod.instance[i].hal.pin.controly) = 1;
-            *(hm2->xy2mod.instance[i].hal.pin.commandx) = 0;
-            *(hm2->xy2mod.instance[i].hal.pin.commandy) = 0;
-            *(hm2->xy2mod.instance[i].hal.pin.mode18bitx) = 0;
-            *(hm2->xy2mod.instance[i].hal.pin.mode18bity) = 0;
-            *(hm2->xy2mod.instance[i].hal.pin.commandmodex) = 0;
-            *(hm2->xy2mod.instance[i].hal.pin.commandmodey) = 0;
-
-
         }
     }
 
@@ -810,7 +757,7 @@ void hm2_xy2mod_print_module(hostmot2_t *hm2) {
     HM2_PRINT("    status_addr: 0x%04X\n", hm2->xy2mod.status_addr);
     for (i = 0; i < hm2->xy2mod.num_instances; i ++) {
         HM2_PRINT("    instance %d:\n", i);
-        HM2_PRINT("        enable = %d\n", *hm2->xy2mod.instance[i].hal.pin.enable);
+        HM2_PRINT("        enable = %d\n", hal_get_bool(hm2->xy2mod.instance[i].hal.pin.enable));
         HM2_PRINT("        hw:\n");
         HM2_PRINT("            accx = 0x%08X\n", hm2->xy2mod.accx_reg[i]);
         HM2_PRINT("            accy = 0x%08X\n", hm2->xy2mod.accy_reg[i]);


### PR DESCRIPTION
This is the last in the series to update the code base to the HAL getter/setter infrastructure.

The hostmot2 drivers are a very large interconnected set of drivers in several layers that are, unfortunately, difficult to migrate step by step. This PR needs to be reviewed and tested on real hardware before it can be merged.

All changes have been tested on a RPi5 with an 7i96s board+modbus. It is therefore known that at least the basic outline of the driver is functional and behaves as it has done before.

The main issue in porting the hostmot2 drivers (and also others) has been the (ab)use of parameters. Other drivers had similar problems, but they could be handled one-by-one. Parameters are now similar to pins, which means all use of parameters (as expensive local variables) had to be detected and adapted.

An important test is with attached smart serial board(s). The sserial driver is known to have some quirks and has code that needed special attention while porting. Note that the sserial/abs_encoder part has been internally changed slightly. The Fanuc style absolute encoder had an overlapping value, which now has been untangled. It should not change behaviour or appearance for the user, but it is nice if it can be tested, just like the other absolute encoders.

It is also necessary to test this with a variety of boards, both networked and local PCI bus boards (and others). Also, the more configurations that can be tested, the better we can guarantee that no hidden defects are present.

@pcw-mesa you probably have most hardware, somewhere. Have a go, please, with different setups if possible.
@rene-dev you have tested earlier with a smart serial board, please try again.

Anybody else, please test and report.

Edit to add:
* The step_type parameter in `...stepgen.NN.step_type` is now capped at 16 to prevent read/write to unknown memory. There may be more failure modes when you set step_type to larger than 16, but that has not been considered.
* A bug in pwmgen that failed to consider all run-time config changes has been fixed (closing '}' misplaced). This should not alter operation or function.
* This does not fix #4144 and its behaviour is not changed to prevent mixing old and new failure modes.
* This PR does fix #4130 because the getter/setter update needed to untangle the access. The overlapped data access while also exporting that data as parameter does no longer function because parameters work similar as pins now.
* A bug in pwmgen when the firmware has no pwmgens was exposed with HAL's internal changes to add more checks. This has also been fixed. (see: https://github.com/LinuxCNC/linuxcnc/pull/4369#issuecomment-5236357655 below)