### PR TITLE
switchkins: allow more than three kinematics types

### DIFF
--- a/docs/src/motion/switchkins.adoc
+++ b/docs/src/motion/switchkins.adoc
@@ -420,4 +420,55 @@ kinstypes must not create the same pin twice.  When all setup
 routines finish, rtapi_app_main() issues hal_ready() for the
 component to complete creation of the module.
 
+=== Outline
+
+The two routes in one switchkinsSetup(), with the kinematics itself
+left out.  Types 0 to 2 are filled in through the pointer arguments as
+they always were, and a fourth is registered:
+
+[source,c]
+----
+int switchkinsSetup(kparms* kp,
+                    KS* kset0, KS* kset1, KS* kset2,
+                    KF* kfwd0, KF* kfwd1, KF* kfwd2,
+                    KI* kinv0, KI* kinv1, KI* kinv2
+                   )
+{
+    kp->kinsname             = "mykins"; // must agree with the filename
+    kp->halprefix            = "mykins"; // hal pin names
+    kp->required_coordinates = "xyzab";
+    kp->max_joints           = strlen(kp->required_coordinates);
+    // remaining kparms fields
+
+    *kset0 = identityKinematicsSetup;    // kinstype 0 is the startup default
+    *kfwd0 = identityKinematicsForward;
+    *kinv0 = identityKinematicsInverse;
+
+    *kset1 = myKinematicsSetup;
+    *kfwd1 = myKinematicsForward;
+    *kinv1 = myKinematicsInverse;
+
+    *kset2 = userkKinematicsSetup;
+    *kfwd2 = userkKinematicsForward;
+    *kinv2 = userkKinematicsInverse;
+
+    // any further kinstype comes from switchkinsRegister(), and the
+    // numbering carries on from the three above with no gaps
+    if (switchkinsRegister(3, myOtherKinematicsSetup,
+                              myOtherKinematicsForward,
+                              myOtherKinematicsInverse)) { return -1; }
+
+    return 0;
+} // switchkinsSetup()
+----
+
+A module wanting fewer than three kinstypes leaves the unused pointer
+arguments alone and starts registering at the first free number.
+
+For the surrounding shape, the in-tree switchkinsSetup() routines are
+in src/emc/kinematics: 5axiskins.c, xyzac-trt-kins.c, genserkins.c,
+scarakins.c and the others listed at the top of this document.  None of
+them registers a fourth kinstype yet, so the call above has no in-tree
+example to copy.
+
 // vim: set syntax=asciidoc:

--- a/docs/src/motion/switchkins.adoc
+++ b/docs/src/motion/switchkins.adoc
@@ -128,6 +128,9 @@ program behavior in accordance with the active kinematics type.
 . *kinstype.is-1*           Output (bit)
 . *kinstype.is-2*           Output (bit)
 
+A module providing more than three kinematics types has one
+'kinstype.is-N' pin per type.
+
 == Usage
 
 === HAL Connections
@@ -388,13 +391,29 @@ routines and the functions for forward an inverse calculation for
 each kinstype (0,1,2) and sets a number of configuration
 settings.
 
+A module needing more than three kinstypes calls
+switchkinsRegister() from within switchkinsSetup() for each
+additional one:
+
+----
+int switchkinsRegister(int ktype, KS kset, KF kfwd, KI kinv);
+----
+
+'ktype' runs from 3 to SWITCHKINS_MAX_TYPES-1 (defined in
+switchkins.h) and every kinstype below the highest one registered
+must be provided.  Each additional kinstype gets its own
+'kinstype.is-N' pin, so 'kinstype.is-0', 'kinstype.is-1' and
+'kinstype.is-2' keep the names they always had.
+
 After calling switchkinsSetup(), rtapi_app_main() checks the
 supplied parameters, creates a HAL component, and then invokes
-the setup routine identified for each kinstype (0,1,2).
+the setup routine identified for each kinstype.
 
-Each kinstype (0,1,2) setup routine can (optionally) create HAL
-pins and set them to default values.  When all setup routines
-finish, rtapi_app_main() issues hal_ready() for the component
-to complete creation of the module.
+Each kinstype setup routine can (optionally) create HAL
+pins and set them to default values.  A setup routine is called
+once per kinstype it is registered for, so a routine used for two
+kinstypes must not create the same pin twice.  When all setup
+routines finish, rtapi_app_main() issues hal_ready() for the
+component to complete creation of the module.
 
 // vim: set syntax=asciidoc:

--- a/docs/src/motion/switchkins.adoc
+++ b/docs/src/motion/switchkins.adoc
@@ -391,19 +391,23 @@ routines and the functions for forward an inverse calculation for
 each kinstype (0,1,2) and sets a number of configuration
 settings.
 
-A module needing more than three kinstypes calls
-switchkinsRegister() from within switchkinsSetup() for each
-additional one:
+A module can provide further kinstypes by calling
+switchkinsRegister() from within switchkinsSetup(), once per
+kinstype:
 
 ----
 int switchkinsRegister(int ktype, KS kset, KF kfwd, KI kinv);
 ----
 
-'ktype' runs from 3 to SWITCHKINS_MAX_TYPES-1 (defined in
-switchkins.h) and every kinstype below the highest one registered
-must be provided.  Each additional kinstype gets its own
-'kinstype.is-N' pin, so 'kinstype.is-0', 'kinstype.is-1' and
-'kinstype.is-2' keep the names they always had.
+'ktype' runs from 0 to SWITCHKINS_MAX_TYPES-1 (defined in
+switchkins.h).  A kinstype has to come from one route or the
+other, so registering one that switchkinsSetup() has already
+filled in is an error, and so is leaving a gap below the highest
+kinstype provided.  Either mistake fails the module load and says
+which kinstype is at fault.
+
+Each kinstype gets its own 'kinstype.is-N' pin, so a module
+providing the usual three keeps the pin names it always had.
 
 After calling switchkinsSetup(), rtapi_app_main() checks the
 supplied parameters, creates a HAL component, and then invokes

--- a/src/emc/kinematics/switchkins.c
+++ b/src/emc/kinematics/switchkins.c
@@ -38,19 +38,17 @@
 // kinematic functions (default=0 for err detection):
 static kparms kp; // kinematics parms (common all types)
 
-static KF kfwd0 = NULL; // 0==switchkins_type kinematics forward
-static KF kfwd1 = NULL; // 1
-static KF kfwd2 = NULL; // 2
+// indexed by switchkins_type (NULL==not provided, for err detection):
+static KS ksetups[SWITCHKINS_MAX_TYPES] = {NULL};
+static KF kfwds[SWITCHKINS_MAX_TYPES]   = {NULL};
+static KI kinvs[SWITCHKINS_MAX_TYPES]   = {NULL};
 
-static KI kinv0 = NULL; // 0==switchkins_type kinematics inverse
-static KI kinv1 = NULL; // 1
-static KI kinv2 = NULL; // 2
+// types provided: 3 from switchkinsSetup(), more from switchkinsRegister()
+static int kins_count = 3;
 
 static int switchkins_type;
 static struct swdata {
-    hal_bool_t kinstype_is_0;
-    hal_bool_t kinstype_is_1;
-    hal_bool_t kinstype_is_2;
+    hal_bool_t kinstype_is[SWITCHKINS_MAX_TYPES];
 
     hal_real_t gui_x;
     hal_real_t gui_y;
@@ -104,15 +102,16 @@ static int gui_forward_kins(const double *joints)
     int res;
     KINEMATICS_FORWARD_FLAGS  fflags = 0;
     KINEMATICS_INVERSE_FLAGS  iflags;
-    switch (kp.gui_kinstype) {
-        case 0: res = kfwd0(joints, &lastpose[0], &fflags, &iflags);break;
-        case 1: res = kfwd1(joints, &lastpose[1], &fflags, &iflags);break;
-        case 2: res = kfwd2(joints, &lastpose[2], &fflags, &iflags);break;
-       default: rtapi_print_msg(RTAPI_MSG_ERR,
-                  "gui_forward_kins BAD gui_kinstype <%d>\n",
-                  kp.gui_kinstype);
-                  return -1;
-     }
+    if (   kp.gui_kinstype < 0
+        || kp.gui_kinstype >= kins_count
+        || !kfwds[kp.gui_kinstype]) {
+        rtapi_print_msg(RTAPI_MSG_ERR,
+                        "gui_forward_kins BAD gui_kinstype <%d>\n",
+                        kp.gui_kinstype);
+        return -1;
+    }
+    res = kfwds[kp.gui_kinstype](joints, &lastpose[kp.gui_kinstype],
+                                 &fflags, &iflags);
     hal_set_real(swdata->gui_x, lastpose[kp.gui_kinstype].tran.x);
     hal_set_real(swdata->gui_y, lastpose[kp.gui_kinstype].tran.y);
     hal_set_real(swdata->gui_z, lastpose[kp.gui_kinstype].tran.z);
@@ -130,7 +129,7 @@ int kinematicsSwitch(int new_switchkins_type)
     int k;
 
     // reject first, so a bad request leaves the running kinematics alone
-    if (new_switchkins_type < 0 || new_switchkins_type >= SWITCHKINS_MAX_TYPES) {
+    if (new_switchkins_type < 0 || new_switchkins_type >= kins_count) {
         rtapi_print_msg(RTAPI_MSG_ERR,
                         "kinematicsSwitch:BAD VALUE <%d>\n",
                         new_switchkins_type);
@@ -140,26 +139,13 @@ int kinematicsSwitch(int new_switchkins_type)
     for (k=0; k< SWITCHKINS_MAX_TYPES; k++) { use_lastpose[k] = 0;}
 
     switchkins_type = new_switchkins_type;
-    switch (switchkins_type) {
-        case 0: rtapi_print_msg(RTAPI_MSG_INFO,
-                "kinematicsSwitch:TYPE0\n");
-                hal_set_bool(swdata->kinstype_is_0, 1);
-                hal_set_bool(swdata->kinstype_is_1, 0);
-                hal_set_bool(swdata->kinstype_is_2, 0);
-                break;
-        case 1: rtapi_print_msg(RTAPI_MSG_INFO,
-                "kinematicsSwitch:TYPE1\n");
-                hal_set_bool(swdata->kinstype_is_0, 0);
-                hal_set_bool(swdata->kinstype_is_1, 1);
-                hal_set_bool(swdata->kinstype_is_2, 0);
-                break;
-        case 2: rtapi_print_msg(RTAPI_MSG_INFO,
-                "kinematicsSwitch:TYPE2\n");
-                hal_set_bool(swdata->kinstype_is_0, 0);
-                hal_set_bool(swdata->kinstype_is_1, 0);
-                hal_set_bool(swdata->kinstype_is_2, 1);
-                break;
+
+    rtapi_print_msg(RTAPI_MSG_INFO,
+                    "kinematicsSwitch:TYPE%d\n", switchkins_type);
+    for (k=0; k < kins_count; k++) {
+        hal_set_bool(swdata->kinstype_is[k], k == switchkins_type);
     }
+
     if (fwd_iterates[switchkins_type]) {
         use_lastpose[switchkins_type] = 1; // restarting a kins types
     }
@@ -179,15 +165,15 @@ int kinematicsForward(const double *joint,
         use_lastpose[switchkins_type] = 0;
     }
 
-    switch (switchkins_type) {
-       case 0: r = kfwd0(joint, pos, fflags, iflags); break;
-       case 1: r = kfwd1(joint, pos, fflags, iflags); break;
-       case 2: r = kfwd2(joint, pos, fflags, iflags); break;
-      default: rtapi_print_msg(RTAPI_MSG_ERR,
-                    "switchkins: Forward BAD switchkins_type </%d>\n",
-                    switchkins_type);
-               return -1;
+    if (   switchkins_type < 0
+        || switchkins_type >= kins_count
+        || !kfwds[switchkins_type]) {
+        rtapi_print_msg(RTAPI_MSG_ERR,
+                        "switchkins: Forward BAD switchkins_type </%d>\n",
+                        switchkins_type);
+        return -1;
     }
+    r = kfwds[switchkins_type](joint, pos, fflags, iflags);
     if (fwd_iterates[switchkins_type]) {save_lastpose(switchkins_type,pos);}
     if (r) return r;
 
@@ -213,15 +199,15 @@ int kinematicsInverse(const EmcPose * pos,
 {
     int r;
 
-    switch (switchkins_type) {
-       case 0: r = kinv0(pos, joint, iflags, fflags); break;
-       case 1: r = kinv1(pos, joint, iflags, fflags); break;
-       case 2: r = kinv2(pos, joint, iflags, fflags); break;
-       default: rtapi_print_msg(RTAPI_MSG_ERR,
-                     "switchkins: Inverse BAD switchkins_type </%d>\n",
-                     switchkins_type);
-               return -1;
+    if (   switchkins_type < 0
+        || switchkins_type >= kins_count
+        || !kinvs[switchkins_type]) {
+        rtapi_print_msg(RTAPI_MSG_ERR,
+                        "switchkins: Inverse BAD switchkins_type </%d>\n",
+                        switchkins_type);
+        return -1;
     }
+    r = kinvs[switchkins_type](pos, joint, iflags, fflags);
     return r;
 } // kinematicsInverse()
 
@@ -229,6 +215,22 @@ KINEMATICS_TYPE kinematicsType()
 {
     return KINEMATICS_BOTH;
 }
+
+int switchkinsRegister(int ktype, KS kset, KF kfwd, KI kinv)
+{
+    if (ktype < 3 || ktype >= SWITCHKINS_MAX_TYPES) {
+        rtapi_print_msg(RTAPI_MSG_ERR,
+                        "switchkinsRegister: BAD switchkins_type <%d>"
+                        " (must be 3..%d)\n",
+                        ktype, SWITCHKINS_MAX_TYPES - 1);
+        return -1;
+    }
+    ksetups[ktype] = kset;
+    kfwds[ktype]   = kfwd;
+    kinvs[ktype]   = kinv;
+    if (ktype >= kins_count) { kins_count = ktype + 1; }
+    return 0;
+} // switchkinsRegister()
 
 //*********************************************************************
 static char *coordinates;
@@ -241,6 +243,7 @@ EXPORT_SYMBOL(kinematicsSwitch);
 EXPORT_SYMBOL(kinematicsType);
 EXPORT_SYMBOL(kinematicsForward);
 EXPORT_SYMBOL(kinematicsInverse);
+EXPORT_SYMBOL(switchkinsRegister);
 MODULE_LICENSE("GPL");
 
 static int    comp_id;
@@ -261,14 +264,11 @@ int rtapi_app_main(void)
 
     kp.sparm = sparm; // module parm passed to kins
 
-    KS ksetup0 = NULL;
-    KS ksetup1 = NULL;
-    KS ksetup2 = NULL;
-
+    // may call switchkinsRegister() for types above 2
     res = switchkinsSetup(&kp,
-                          &ksetup0, &ksetup1, &ksetup2,
-                          &kfwd0,   &kfwd1,   &kfwd2,
-                          &kinv0,   &kinv1,   &kinv2);
+                          &ksetups[0], &ksetups[1], &ksetups[2],
+                          &kfwds[0],   &kfwds[1],   &kfwds[2],
+                          &kinvs[0],   &kinvs[1],   &kinvs[2]);
     if (res) {emsg="switchkinsSetp FAIL"; goto error;}
 
     for (i=0; i < SWITCHKINS_MAX_TYPES; i++) {
@@ -288,18 +288,14 @@ int rtapi_app_main(void)
     if (kp.max_joints <= 0 || kp.max_joints > EMCMOT_MAX_JOINTS) {
         emsg = "bogus max_joints"; goto error;
     }
-    if (kp.gui_kinstype >= SWITCHKINS_MAX_TYPES) {
+    if (kp.gui_kinstype >= kins_count) {
         emsg = "bogus gui_kinstype"; goto error;
     }
 
-    if (!ksetup0 || !ksetup1 || !ksetup2) {
-        emsg = "Missing setup function"; goto error;
-    }
-    if (!kfwd0 || !kfwd1 || !kfwd2) {
-        emsg = "Missing fwd functionn"; goto error;
-    }
-    if (!kinv0 || !kinv1 || !kinv2) {
-        emsg =  "Missing inv function"; goto error;
+    for (i=0; i < kins_count; i++) {
+        if (!ksetups[i]) { emsg = "Missing setup function"; goto error; }
+        if (!kfwds[i])   { emsg = "Missing fwd function";   goto error; }
+        if (!kinvs[i])   { emsg = "Missing inv function";   goto error; }
     }
 
     comp_id = hal_init(kp.kinsname);
@@ -308,9 +304,10 @@ int rtapi_app_main(void)
     swdata = hal_malloc(sizeof(struct swdata));
     if (!swdata) goto error;
 
-    res += hal_pin_new_bool(comp_id, HAL_OUT, &(swdata->kinstype_is_0), 0, "kinstype.is-0");
-    res += hal_pin_new_bool(comp_id, HAL_OUT, &(swdata->kinstype_is_1), 0, "kinstype.is-1");
-    res += hal_pin_new_bool(comp_id, HAL_OUT, &(swdata->kinstype_is_2), 0, "kinstype.is-2");
+    for (i=0; i < kins_count; i++) {
+        res += hal_pin_new_bool(comp_id, HAL_OUT, &(swdata->kinstype_is[i]),
+                                0, "kinstype.is-%d", i);
+    }
 
     if (kp.gui_kinstype >=0) {
         res += hal_pin_new_real(comp_id, HAL_IN, &swdata->gui_x, 0.0, "skgui.x");
@@ -327,9 +324,9 @@ int rtapi_app_main(void)
 
     if (!coordinates) {coordinates = kp.required_coordinates;}
 
-    ksetup0(comp_id,coordinates,&kp);
-    ksetup1(comp_id,coordinates,&kp);
-    ksetup2(comp_id,coordinates,&kp);
+    for (i=0; i < kins_count; i++) {
+        ksetups[i](comp_id,coordinates,&kp);
+    }
 
     hal_ready(comp_id);
     return 0;

--- a/src/emc/kinematics/switchkins.c
+++ b/src/emc/kinematics/switchkins.c
@@ -43,8 +43,9 @@ static KS ksetups[SWITCHKINS_MAX_TYPES] = {NULL};
 static KF kfwds[SWITCHKINS_MAX_TYPES]   = {NULL};
 static KI kinvs[SWITCHKINS_MAX_TYPES]   = {NULL};
 
-// types provided: 3 from switchkinsSetup(), more from switchkinsRegister()
-static int kins_count = 3;
+// types provided, counted in rtapi_app_main() once they are all in
+static int kins_count;
+static int register_error;
 
 static int switchkins_type;
 static struct swdata {
@@ -218,17 +219,24 @@ KINEMATICS_TYPE kinematicsType()
 
 int switchkinsRegister(int ktype, KS kset, KF kfwd, KI kinv)
 {
-    if (ktype < 3 || ktype >= SWITCHKINS_MAX_TYPES) {
+    if (ktype < 0 || ktype >= SWITCHKINS_MAX_TYPES) {
         rtapi_print_msg(RTAPI_MSG_ERR,
                         "switchkinsRegister: BAD switchkins_type <%d>"
-                        " (must be 3..%d)\n",
+                        " (must be 0..%d)\n",
                         ktype, SWITCHKINS_MAX_TYPES - 1);
+        register_error = 1;
+        return -1;
+    }
+    if (ksetups[ktype] || kfwds[ktype] || kinvs[ktype]) {
+        rtapi_print_msg(RTAPI_MSG_ERR,
+                        "switchkinsRegister: switchkins-type %d"
+                        " already provided\n", ktype);
+        register_error = 1;
         return -1;
     }
     ksetups[ktype] = kset;
     kfwds[ktype]   = kfwd;
     kinvs[ktype]   = kinv;
-    if (ktype >= kins_count) { kins_count = ktype + 1; }
     return 0;
 } // switchkinsRegister()
 
@@ -264,12 +272,19 @@ int rtapi_app_main(void)
 
     kp.sparm = sparm; // module parm passed to kins
 
-    // may call switchkinsRegister() for types above 2
+    // may also call switchkinsRegister()
     res = switchkinsSetup(&kp,
                           &ksetups[0], &ksetups[1], &ksetups[2],
                           &kfwds[0],   &kfwds[1],   &kfwds[2],
                           &kinvs[0],   &kinvs[1],   &kinvs[2]);
     if (res) {emsg="switchkinsSetp FAIL"; goto error;}
+    if (register_error) {emsg="switchkinsRegister FAIL"; goto error;}
+
+    // the highest type provided by either route sets the count
+    for (i=0; i < SWITCHKINS_MAX_TYPES; i++) {
+        if (ksetups[i] || kfwds[i] || kinvs[i]) { kins_count = i + 1; }
+    }
+    if (!kins_count) { emsg = "no switchkins-types provided"; goto error; }
 
     for (i=0; i < SWITCHKINS_MAX_TYPES; i++) {
        if (kp.fwd_iterates_mask & (1<<i)) {
@@ -292,10 +307,16 @@ int rtapi_app_main(void)
         emsg = "bogus gui_kinstype"; goto error;
     }
 
+    // a type left out below the highest one provided is a gap, not a count
     for (i=0; i < kins_count; i++) {
-        if (!ksetups[i]) { emsg = "Missing setup function"; goto error; }
-        if (!kfwds[i])   { emsg = "Missing fwd function";   goto error; }
-        if (!kinvs[i])   { emsg = "Missing inv function";   goto error; }
+        if (ksetups[i] && kfwds[i] && kinvs[i]) { continue; }
+        rtapi_print_msg(RTAPI_MSG_ERR,
+                        "switchkins: switchkins-type %d incomplete:%s%s%s\n",
+                        i,
+                        ksetups[i] ? "" : " no setup",
+                        kfwds[i]   ? "" : " no forward",
+                        kinvs[i]   ? "" : " no inverse");
+        emsg = "incomplete switchkins-type"; goto error;
     }
 
     comp_id = hal_init(kp.kinsname);

--- a/src/emc/kinematics/switchkins.c
+++ b/src/emc/kinematics/switchkins.c
@@ -128,6 +128,15 @@ int kinematicsSwitchable() {return 1;}
 int kinematicsSwitch(int new_switchkins_type)
 {
     int k;
+
+    // reject first, so a bad request leaves the running kinematics alone
+    if (new_switchkins_type < 0 || new_switchkins_type >= SWITCHKINS_MAX_TYPES) {
+        rtapi_print_msg(RTAPI_MSG_ERR,
+                        "kinematicsSwitch:BAD VALUE <%d>\n",
+                        new_switchkins_type);
+        return -1; // FAIL
+    }
+
     for (k=0; k< SWITCHKINS_MAX_TYPES; k++) { use_lastpose[k] = 0;}
 
     switchkins_type = new_switchkins_type;
@@ -150,13 +159,6 @@ int kinematicsSwitch(int new_switchkins_type)
                 hal_set_bool(swdata->kinstype_is_1, 0);
                 hal_set_bool(swdata->kinstype_is_2, 1);
                 break;
-       default: rtapi_print_msg(RTAPI_MSG_ERR,
-                "kinematicsSwitch:BAD VALUE <%d>\n",
-                switchkins_type);
-                hal_set_bool(swdata->kinstype_is_1, 0);
-                hal_set_bool(swdata->kinstype_is_0, 0);
-                hal_set_bool(swdata->kinstype_is_2, 0);
-                return -1; // FAIL
     }
     if (fwd_iterates[switchkins_type]) {
         use_lastpose[switchkins_type] = 1; // restarting a kins types

--- a/src/emc/kinematics/switchkins.h
+++ b/src/emc/kinematics/switchkins.h
@@ -6,8 +6,8 @@
 
 #include <kinematics.h>
 
-//hardcoded number of switchkins types (KS,KF,KI):
-#define SWITCHKINS_MAX_TYPES 3
+//max number of switchkins types (KS,KF,KI) a module may provide:
+#define SWITCHKINS_MAX_TYPES 9
 
 // KinematicsFORWARD functions
 typedef int (*KF)(const double *joint,
@@ -28,9 +28,13 @@ typedef int (*KS)(const int   comp_id,     // halpins
                  );
 
 //*********************************************************************
+// supplied by the using module, provides types 0,1,2
 extern int switchkinsSetup(kparms* ksetup_parms,
                            KS* kset0, KS* kset1, KS* kset2,
                            KF* kfwd0, KF* kfwd1, KF* kfwd2,
                            KI* kinv0, KI* kinv1, KI* kinv2
                           );
+
+// called from switchkinsSetup() for each type above 2
+extern int switchkinsRegister(int ktype, KS kset, KF kfwd, KI kinv);
 #endif // }

--- a/src/emc/kinematics/switchkins.h
+++ b/src/emc/kinematics/switchkins.h
@@ -35,6 +35,6 @@ extern int switchkinsSetup(kparms* ksetup_parms,
                            KI* kinv0, KI* kinv1, KI* kinv2
                           );
 
-// called from switchkinsSetup() for each type above 2
+// called from switchkinsSetup(), once per type it does not provide itself
 extern int switchkinsRegister(int ktype, KS kset, KF kfwd, KI kinv);
 #endif // }


### PR DESCRIPTION
`switchkins.c` dispatched on `switchkins_type` with a three way switch statement and created a fixed set of `kinstype.is-0/1/2` pins, so a kinematics module could never offer more than three kinematics. This changes the dispatch to arrays indexed by type, and adds a way for a module to provide more.

Nothing changes for any existing module or configuration.

## What a module sees

`switchkinsSetup()` keeps its exact prototype and still provides types 0, 1 and 2. None of the eight in-tree kinematics modules is touched, and out of tree modules keep compiling unchanged.

A module that wants more calls the new export from inside its own `switchkinsSetup()`, once per additional type:

```c
int switchkinsRegister(int ktype, KS kset, KF kfwd, KI kinv);
```

`ktype` runs from 3 to `SWITCHKINS_MAX_TYPES - 1`, and every type below the highest one registered has to be provided. `SWITCHKINS_MAX_TYPES` goes from 3 to 9. It is now only a ceiling on the array sizes rather than the number of types in use, so a module still provides exactly three unless it registers more, and the extra headroom costs a few unused array entries.

## HAL pins

The `kinstype.is-N` pins are created in a loop, one per provided type. For a module providing three types that produces `kinstype.is-0`, `kinstype.is-1` and `kinstype.is-2`, the same names as before, so nothing that nets those pins breaks. A module providing five gets `kinstype.is-0` through `kinstype.is-4`.

A setup routine now runs once per type it is registered for, so a routine used for two types must not create the same pin twice. Noted in the docs.

## The first commit is a separate bug fix

`kinematicsSwitch()` stored the requested type in `switchkins_type` and only then ran the switch statement that validates it. The switch returned -1 and motion raised its error flag, but `switchkins_type` kept the bad value, so the module was left pointing at a kinematics that does not exist. Every `kinematicsForward()` and `kinematicsInverse()` call after that failed as well, printing

```
switchkins: Forward BAD switchkins_type </7>
```

once per servo cycle for as long as the machine stayed up. On the scara sim, `M68 E3 Q7` reproduces it on master.

The fix validates the request first and returns without touching `switchkins_type`, which leaves the running kinematics in place. It stands on its own and does not depend on the rest, which is why it is a separate commit.

## Testing

All eight switchable modules (`scarakins`, `genhexkins`, `genserkins`, `pumakins`, `three21kins`, `5axiskins`, `xyzac-trt-kins`, `xyzbc-trt-kins`) load under `halrun` and create exactly the same three pins, with the same names, as they do on master.

On `configs/sim/axis/vismach/scara/scara.ini`:

- `M68 E3 Q1` selects kinematics 1, `M68 E3 Q0` selects 0.
- `M68 E3 Q7` is refused, kinematics 1 keeps running, and there is no per cycle log spam.

With `scarakins` temporarily registering two extra types (a local test edit, not part of this PR), the same config gives `kinstype.is-0` through `kinstype.is-4` and switches to type 4 and back.

## Why

I have a machine that needs more than three kinematics for the same config. There is no in-tree module that needs a fourth type today, so the second commit is enabling work rather than something with a visible user in this repository. I would rather add the capability in a shape you are happy with than carry a fork of `switchkins.c`.

I looked at doing this with a second array based `switchkinsSetup()` prototype selected by `#if`, but that duplicates every dispatch site and every module's setup function for something that is decided at compile time anyway. A registration call seemed like much less to maintain.
