### PR TITLE
Multiaxis kinematics and limits

### DIFF
--- a/docs/src/hal/components.adoc
+++ b/docs/src/hal/components.adoc
@@ -338,6 +338,7 @@ Limit its slew rate to less than maxv per second. Limit its second derivative to
 | link:../man/man9/rosekins.9.html[rosekins] |Kinematics for a rose engine ||
 | link:../man/man9/rotatekins.9.html[rotatekins] |The X and Y axes are rotated 45 degrees compared to the joints 0 and 1. ||
 | link:../man/man9/scarakins.9.html[scarakins] |Kinematics for SCARA-type robots. ||
+| link:../man/man9/switchkinscomp.9.html[switchkinscomp] |Switchable kinematics module template ||
 | link:../man/man9/kins.9.html[three21kins] |Analytical kinematics solver for 6-DOF arm + wrist robots. ||
 | link:../man/man9/tripodkins.9.html[tripodkins] |The joints represent the distance of the controlled point from three predefined locations (the motors), giving three degrees of freedom in position (XYZ). ||
 | link:../man/man9/userkins.9.html[userkins] |Template for user-built kinematics ||

--- a/docs/src/motion/switchkins.adoc
+++ b/docs/src/motion/switchkins.adoc
@@ -44,6 +44,10 @@ The following kinematics modules support switchable kinematics:
 . *three21kins*     (type0:three21kins    type1:identity)
 . *scarakins*      (type0:scarakins      type1:identity)
 . *5axiskins*      (type0:5axiskins      type1:identity) (bridgemill)
+. *millturn*       (type0:identity       type1:turn)
+. *xyzab_tdr_kins* (type0:identity       type1:tcp)
+. *xyzacb_trsrn*   (type0:identity       type1:tcp        type2:tool)
+. *xyzbca_trsrn*   (type0:identity       type1:tcp        type2:tool)
 
 The xyz[ab]c-trt-kins modules by default use type0==xyz[ab]c-trt-kins
 for backwards compatibility.  The provided sim configs alter the
@@ -333,6 +337,10 @@ configs/sim/axis/vismach/ .
 . puma/puma560.ini (genserkins)
 . puma/puma.ini (pumakins)
 . hexapod-sim/hexapod.ini (genhexkins)
+. millturn/millturn.ini (millturn)
+. 5axis/table-dual-rotary/xyzab-tdr.ini (xyzab_tdr_kins)
+. 5axis/table-rotary_spindle-rotary-nutating/xyzacb-trsrn_twp/xyzacb-trsrn.ini (xyzacb_trsrn)
+. 5axis/table-rotary_spindle-rotary-nutating/xyzbca-trsrn_twp/xyzbca-trsrn.ini (xyzbca_trsrn)
 
 == User kinematics provisions
 
@@ -380,19 +388,14 @@ protocols.
 == Code Notes
 
 Kinematic modules providing switchkins functionality are linked to
-the switchkins.o object (switchkins.c) that provides the module
-'main' program (rtapi_app_main()) and related functions.  This
-'main' program reads (optional) module command-line parameters
-(coordinates, sparm) and passes them to the module-provided
-function switchkinsSetup().
+the switchkins.o object (switchkins.c).  It provides
+kinematicsForward(), kinematicsInverse(), kinematicsSwitch() and
+the rest of the kinematics interface, dispatching each call to the
+kinstype currently selected, and it creates the HAL pins common to
+all switchkins modules.  It does not provide the module 'main'
+program, so a module can get that from wherever suits it.
 
-The switchkinsSetup() function identifies kinstype-specific setup
-routines and the functions for forward an inverse calculation for
-each kinstype (0,1,2) and sets a number of configuration
-settings.
-
-A module can provide further kinstypes by calling
-switchkinsRegister() from within switchkinsSetup(), once per
+A kinstype is supplied by calling switchkinsRegister(), once per
 kinstype:
 
 ----
@@ -400,24 +403,59 @@ int switchkinsRegister(int ktype, KS kset, KF kfwd, KI kinv);
 ----
 
 'ktype' runs from 0 to SWITCHKINS_MAX_TYPES-1 (defined in
-switchkins.h).  A kinstype has to come from one route or the
-other, so registering one that switchkinsSetup() has already
-filled in is an error, and so is leaving a gap below the highest
-kinstype provided.  Either mistake fails the module load and says
-which kinstype is at fault.
+switchkins.h).  Registering a kinstype twice is an error, and so is
+leaving a gap below the highest kinstype provided.  Either mistake
+fails the module load and says which kinstype is at fault.
 
 Each kinstype gets its own 'kinstype.is-N' pin, so a module
 providing the usual three keeps the pin names it always had.
 
-After calling switchkinsSetup(), rtapi_app_main() checks the
-supplied parameters, creates a HAL component, and then invokes
-the setup routine identified for each kinstype.
+When every kinstype is registered, the module calls:
+
+----
+int switchkinsInit(const int comp_id, kparms* kp, const char* coordinates);
+----
+
+which checks the supplied parameters, creates the HAL pins, selects
+kinstype 0, and then invokes the setup routine registered for each
+kinstype.  The caller owns the HAL component: it does hal_init()
+before switchkinsInit() and hal_ready() after it.
 
 Each kinstype setup routine can (optionally) create HAL
 pins and set them to default values.  A setup routine is called
 once per kinstype it is registered for, so a routine used for two
-kinstypes must not create the same pin twice.  When all setup
-routines finish, rtapi_app_main() issues hal_ready() for the
-component to complete creation of the module.
+kinstypes must not create the same pin twice.
+
+=== Module main program
+
+A module written as a plain C file links switchkins_main.o
+(switchkins_main.c) for its rtapi_app_main().  That 'main' program
+reads the (optional) module command-line parameters (coordinates,
+sparm) and passes them to the module-provided function
+switchkinsSetup():
+
+----
+int switchkinsSetup(kparms* kp,
+                    KS* kset0, KS* kset1, KS* kset2,
+                    KF* kfwd0, KF* kfwd1, KF* kfwd2,
+                    KI* kinv0, KI* kinv1, KI* kinv2);
+----
+
+which identifies the setup, forward and inverse routines for
+kinstypes 0,1,2 and sets a number of configuration settings.  Those
+three are registered for the module, so it can supply further
+kinstypes by calling switchkinsRegister() itself, and registering
+one that switchkinsSetup() has already filled in is the same error
+as any other duplicate.
+
+A module written as a halcompile component gets rtapi_app_main()
+from halcompile instead.  It registers its kinstypes and calls
+switchkinsInit() from its EXTRA_SETUP() routine, which halcompile
+runs after hal_init() and before hal_ready().  The component names
+the objects it needs in hal/components/Submakefile:
+
+----
+millturn-extra-objs := emc/kinematics/switchkins.o emc/kinematics/kins_util.o
+----
 
 // vim: set syntax=asciidoc:

--- a/docs/src/motion/switchkins.adoc
+++ b/docs/src/motion/switchkins.adoc
@@ -344,6 +344,12 @@ configs/sim/axis/vismach/ .
 
 == User kinematics provisions
 
+There are two ways to supply custom kinematics.  Adding a kinstype to
+a module that is already in the tree is the smaller job; building a
+module of your own gives you every kinstype it provides.
+
+=== Adding a kinstype to an in-tree module
+
 Custom kinematics can be coded and tested on Run-In-Place ('RIP')
 builds.  A template file src/emc/kinematics/userkfuncs.c is provided
 in the distribution.  This file can be copied/renamed to a user
@@ -360,6 +366,47 @@ Preempt-rt make example:
 ----
 $ userkfuncs=/home/myname/kins/mykins.c make && sudo make setuid
 ----
+
+=== Building a switchkins module of your own
+
+A complete kinematics module can be built out-of-tree with halcompile
+using the same switchkins implementation the in-tree modules use, so
+it gets the kinematics switching, the 'kinstype.is-N' pins, the
+'coordinates=' identity mapping and the G-code and HAL controls
+without reimplementing any of them.
+
+The template is src/hal/components/switchkinscomp.comp.  Copy and
+rename it (both the file and the component name), point its TOPDIR
+at a LinuxCNC source tree, and replace the example kinstype with the
+real kinematics:
+
+[source,c]
+----
+#define TOPDIR /home/myname/linuxcnc-dev
+// ...
+#include USE_TOPDIR(src/emc/kinematics/switchkins.c)
+#include USE_TOPDIR(src/emc/kinematics/kins_util.c)
+----
+
+The module registers each of its kinstypes and calls switchkinsInit()
+from EXTRA_SETUP(), which halcompile runs after hal_init() and before
+hal_ready().  See <<sec:switchkins-code-notes,Code Notes>> for both
+calls.
+
+----
+$ halcompile --install user_switchkins.comp
+----
+
+[source,ini]
+----
+[KINS]
+KINEMATICS = user_switchkins
+JOINTS = 3
+----
+
+[NOTE]
+The switchkins sources are compiled into the module, so it is built
+against one source tree and has to be rebuilt when that tree changes.
 
 == Warnings
 
@@ -385,6 +432,7 @@ The management of coordinate offsets, tool compensation, and
 INI file limits may require complicated and non-standard operating
 protocols.
 
+[[sec:switchkins-code-notes]]
 == Code Notes
 
 Kinematic modules providing switchkins functionality are linked to

--- a/docs/src/motion/switchkins.adoc
+++ b/docs/src/motion/switchkins.adoc
@@ -128,6 +128,9 @@ program behavior in accordance with the active kinematics type.
 . *kinstype.is-1*           Output (bit)
 . *kinstype.is-2*           Output (bit)
 
+A module providing more than three kinematics types has one
+'kinstype.is-N' pin per type.
+
 == Usage
 
 === HAL Connections
@@ -388,13 +391,29 @@ routines and the functions for forward an inverse calculation for
 each kinstype (0,1,2) and sets a number of configuration
 settings.
 
+A module needing more than three kinstypes calls
+switchkinsRegister() from within switchkinsSetup() for each
+additional one:
+
+----
+int switchkinsRegister(int ktype, KS kset, KF kfwd, KI kinv);
+----
+
+'ktype' runs from 3 to SWITCHKINS_MAX_TYPES-1 (defined in
+switchkins.h) and every kinstype below the highest one registered
+must be provided.  Each additional kinstype gets its own
+'kinstype.is-N' pin, so 'kinstype.is-0', 'kinstype.is-1' and
+'kinstype.is-2' keep the names they always had.
+
 After calling switchkinsSetup(), rtapi_app_main() checks the
 supplied parameters, creates a HAL component, and then invokes
-the setup routine identified for each kinstype (0,1,2).
+the setup routine identified for each kinstype.
 
-Each kinstype (0,1,2) setup routine can (optionally) create HAL
-pins and set them to default values.  When all setup routines
-finish, rtapi_app_main() issues hal_ready() for the component
-to complete creation of the module.
+Each kinstype setup routine can (optionally) create HAL
+pins and set them to default values.  A setup routine is called
+once per kinstype it is registered for, so a routine used for two
+kinstypes must not create the same pin twice.  When all setup
+routines finish, rtapi_app_main() issues hal_ready() for the
+component to complete creation of the module.
 
 // vim: set syntax=asciidoc:

--- a/docs/src/motion/switchkins.adoc
+++ b/docs/src/motion/switchkins.adoc
@@ -391,19 +391,23 @@ routines and the functions for forward an inverse calculation for
 each kinstype (0,1,2) and sets a number of configuration
 settings.
 
-A module needing more than three kinstypes calls
-switchkinsRegister() from within switchkinsSetup() for each
-additional one:
+A module can provide further kinstypes by calling
+switchkinsRegister() from within switchkinsSetup(), once per
+kinstype:
 
 ----
 int switchkinsRegister(int ktype, KS kset, KF kfwd, KI kinv);
 ----
 
-'ktype' runs from 3 to SWITCHKINS_MAX_TYPES-1 (defined in
-switchkins.h) and every kinstype below the highest one registered
-must be provided.  Each additional kinstype gets its own
-'kinstype.is-N' pin, so 'kinstype.is-0', 'kinstype.is-1' and
-'kinstype.is-2' keep the names they always had.
+'ktype' runs from 0 to SWITCHKINS_MAX_TYPES-1 (defined in
+switchkins.h).  A kinstype has to come from one route or the
+other, so registering one that switchkinsSetup() has already
+filled in is an error, and so is leaving a gap below the highest
+kinstype provided.  Either mistake fails the module load and says
+which kinstype is at fault.
+
+Each kinstype gets its own 'kinstype.is-N' pin, so a module
+providing the usual three keeps the pin names it always had.
 
 After calling switchkinsSetup(), rtapi_app_main() checks the
 supplied parameters, creates a HAL component, and then invokes

--- a/src/Makefile
+++ b/src/Makefile
@@ -397,6 +397,7 @@ SRCHEADERS := \
     hal/drivers/mesa-hostmot2/hostmot2-serial.h \
     emc/linuxcnc.h \
     emc/kinematics/kinematics.h \
+    emc/kinematics/switchkins.h \
     emc/motion/emcmotcfg.h \
     emc/ini/inifile.hh \
     emc/ini/inifile.h \

--- a/src/Makefile
+++ b/src/Makefile
@@ -1159,6 +1159,7 @@ genhexkins-objs += libnml/posemath/_posemath.o
 genhexkins-objs += libnml/posemath/sincos.o $(MATHSTUB)
 genhexkins-objs += emc/kinematics/kins_util.o
 genhexkins-objs += emc/kinematics/switchkins.o
+genhexkins-objs += emc/kinematics/switchkins_main.o
 genhexkins-objs += $(USERKFUNCS)
 
 obj-m += genserkins.o
@@ -1168,6 +1169,7 @@ genserkins-objs += libnml/posemath/gomath.o
 genserkins-objs += libnml/posemath/sincos.o $(MATHSTUB)
 genserkins-objs += emc/kinematics/kins_util.o
 genserkins-objs += emc/kinematics/switchkins.o
+genserkins-objs += emc/kinematics/switchkins_main.o
 genserkins-objs += $(USERKFUNCS)
 
 obj-m += xyzac-trt-kins.o
@@ -1175,6 +1177,7 @@ xyzac-trt-kins-objs := emc/kinematics/xyzac-trt-kins.o
 xyzac-trt-kins-objs += emc/kinematics/trtfuncs.o
 xyzac-trt-kins-objs += emc/kinematics/kins_util.o
 xyzac-trt-kins-objs += emc/kinematics/switchkins.o
+xyzac-trt-kins-objs += emc/kinematics/switchkins_main.o
 xyzac-trt-kins-objs += $(USERKFUNCS)
 
 obj-m += xyzbc-trt-kins.o
@@ -1182,6 +1185,7 @@ xyzbc-trt-kins-objs := emc/kinematics/xyzbc-trt-kins.o
 xyzbc-trt-kins-objs += emc/kinematics/trtfuncs.o
 xyzbc-trt-kins-objs += emc/kinematics/kins_util.o
 xyzbc-trt-kins-objs += emc/kinematics/switchkins.o
+xyzbc-trt-kins-objs += emc/kinematics/switchkins_main.o
 xyzbc-trt-kins-objs += $(USERKFUNCS)
 
 obj-m += scarakins.o
@@ -1190,6 +1194,7 @@ scarakins-objs += libnml/posemath/_posemath.o
 scarakins-objs += libnml/posemath/sincos.o $(MATHSTUB)
 scarakins-objs += emc/kinematics/kins_util.o
 scarakins-objs += emc/kinematics/switchkins.o
+scarakins-objs += emc/kinematics/switchkins_main.o
 scarakins-objs += $(USERKFUNCS)
 
 obj-m += pumakins.o
@@ -1198,6 +1203,7 @@ pumakins-objs += libnml/posemath/_posemath.o
 pumakins-objs += libnml/posemath/sincos.o $(MATHSTUB)
 pumakins-objs += emc/kinematics/kins_util.o
 pumakins-objs += emc/kinematics/switchkins.o
+pumakins-objs += emc/kinematics/switchkins_main.o
 pumakins-objs += $(USERKFUNCS)
 
 obj-m += three21kins.o
@@ -1206,6 +1212,7 @@ three21kins-objs += libnml/posemath/_posemath.o
 three21kins-objs += libnml/posemath/sincos.o $(MATHSTUB)
 three21kins-objs += emc/kinematics/kins_util.o
 three21kins-objs += emc/kinematics/switchkins.o
+three21kins-objs += emc/kinematics/switchkins_main.o
 three21kins-objs += $(USERKFUNCS)
 
 obj-m += 5axiskins.o
@@ -1214,6 +1221,7 @@ obj-m += 5axiskins.o
 5axiskins-objs += libnml/posemath/sincos.o $(MATHSTUB)
 5axiskins-objs += emc/kinematics/kins_util.o
 5axiskins-objs += emc/kinematics/switchkins.o
+5axiskins-objs += emc/kinematics/switchkins_main.o
 5axiskins-objs += $(USERKFUNCS)
 #----------------------------------------------------------------
 

--- a/src/emc/kinematics/Submakefile
+++ b/src/emc/kinematics/Submakefile
@@ -35,7 +35,8 @@ $(RDELTAMODULE): $(call TOOBJS, $(RDELTAMODULESRCS))
 PYTARGETS += $(RDELTAMODULE)
 
 EMCKINEMATICSINCS = \
-	./emc/kinematics/kinematics.h
+	./emc/kinematics/kinematics.h \
+	./emc/kinematics/switchkins.h
 
 $(patsubst ./emc/kinematics/%,../include/%,$(EMCKINEMATICSINCS)): ../include/%.h: ./emc/kinematics/%.h
 	cp $^ $@

--- a/src/emc/kinematics/switchkins.c
+++ b/src/emc/kinematics/switchkins.c
@@ -38,19 +38,17 @@
 // kinematic functions (default=0 for err detection):
 static kparms kp; // kinematics parms (common all types)
 
-static KF kfwd0 = NULL; // 0==switchkins_type kinematics forward
-static KF kfwd1 = NULL; // 1
-static KF kfwd2 = NULL; // 2
+// indexed by switchkins_type (NULL==not provided, for err detection):
+static KS ksetups[SWITCHKINS_MAX_TYPES] = {NULL};
+static KF kfwds[SWITCHKINS_MAX_TYPES]   = {NULL};
+static KI kinvs[SWITCHKINS_MAX_TYPES]   = {NULL};
 
-static KI kinv0 = NULL; // 0==switchkins_type kinematics inverse
-static KI kinv1 = NULL; // 1
-static KI kinv2 = NULL; // 2
+// types provided: 3 from switchkinsSetup(), more from switchkinsRegister()
+static int kins_count = 3;
 
 static int switchkins_type;
 static struct swdata {
-    hal_bool_t kinstype_is_0;
-    hal_bool_t kinstype_is_1;
-    hal_bool_t kinstype_is_2;
+    hal_bool_t kinstype_is[SWITCHKINS_MAX_TYPES];
 
     hal_real_t gui_x;
     hal_real_t gui_y;
@@ -104,15 +102,16 @@ static int gui_forward_kins(const double *joints)
     int res;
     KINEMATICS_FORWARD_FLAGS  fflags = 0;
     KINEMATICS_INVERSE_FLAGS  iflags;
-    switch (kp.gui_kinstype) {
-        case 0: res = kfwd0(joints, &lastpose[0], &fflags, &iflags);break;
-        case 1: res = kfwd1(joints, &lastpose[1], &fflags, &iflags);break;
-        case 2: res = kfwd2(joints, &lastpose[2], &fflags, &iflags);break;
-       default: rtapi_print_msg(RTAPI_MSG_ERR,
-                  "gui_forward_kins BAD gui_kinstype <%d>\n",
-                  kp.gui_kinstype);
-                  return -1;
-     }
+    if (   kp.gui_kinstype < 0
+        || kp.gui_kinstype >= kins_count
+        || !kfwds[kp.gui_kinstype]) {
+        rtapi_print_msg(RTAPI_MSG_ERR,
+                        "gui_forward_kins BAD gui_kinstype <%d>\n",
+                        kp.gui_kinstype);
+        return -1;
+    }
+    res = kfwds[kp.gui_kinstype](joints, &lastpose[kp.gui_kinstype],
+                                 &fflags, &iflags);
     hal_set_real(swdata->gui_x, lastpose[kp.gui_kinstype].tran.x);
     hal_set_real(swdata->gui_y, lastpose[kp.gui_kinstype].tran.y);
     hal_set_real(swdata->gui_z, lastpose[kp.gui_kinstype].tran.z);
@@ -130,7 +129,7 @@ int kinematicsSwitch(int new_switchkins_type)
     int k;
 
     // reject first, so a bad request leaves the running kinematics alone
-    if (new_switchkins_type < 0 || new_switchkins_type >= SWITCHKINS_MAX_TYPES) {
+    if (new_switchkins_type < 0 || new_switchkins_type >= kins_count) {
         rtapi_print_msg(RTAPI_MSG_ERR,
                         "kinematicsSwitch:BAD VALUE <%d>\n",
                         new_switchkins_type);
@@ -140,26 +139,13 @@ int kinematicsSwitch(int new_switchkins_type)
     for (k=0; k< SWITCHKINS_MAX_TYPES; k++) { use_lastpose[k] = 0;}
 
     switchkins_type = new_switchkins_type;
-    switch (switchkins_type) {
-        case 0: rtapi_print_msg(RTAPI_MSG_INFO,
-                "kinematicsSwitch:TYPE0\n");
-                hal_set_bool(swdata->kinstype_is_0, 1);
-                hal_set_bool(swdata->kinstype_is_1, 0);
-                hal_set_bool(swdata->kinstype_is_2, 0);
-                break;
-        case 1: rtapi_print_msg(RTAPI_MSG_INFO,
-                "kinematicsSwitch:TYPE1\n");
-                hal_set_bool(swdata->kinstype_is_0, 0);
-                hal_set_bool(swdata->kinstype_is_1, 1);
-                hal_set_bool(swdata->kinstype_is_2, 0);
-                break;
-        case 2: rtapi_print_msg(RTAPI_MSG_INFO,
-                "kinematicsSwitch:TYPE2\n");
-                hal_set_bool(swdata->kinstype_is_0, 0);
-                hal_set_bool(swdata->kinstype_is_1, 0);
-                hal_set_bool(swdata->kinstype_is_2, 1);
-                break;
+
+    rtapi_print_msg(RTAPI_MSG_INFO,
+                    "kinematicsSwitch:TYPE%d\n", switchkins_type);
+    for (k=0; k < kins_count; k++) {
+        hal_set_bool(swdata->kinstype_is[k], k == switchkins_type);
     }
+
     if (fwd_iterates[switchkins_type]) {
         use_lastpose[switchkins_type] = 1; // restarting a kins types
     }
@@ -179,15 +165,15 @@ int kinematicsForward(const double *joint,
         use_lastpose[switchkins_type] = 0;
     }
 
-    switch (switchkins_type) {
-       case 0: r = kfwd0(joint, pos, fflags, iflags); break;
-       case 1: r = kfwd1(joint, pos, fflags, iflags); break;
-       case 2: r = kfwd2(joint, pos, fflags, iflags); break;
-      default: rtapi_print_msg(RTAPI_MSG_ERR,
-                    "switchkins: Forward BAD switchkins_type </%d>\n",
-                    switchkins_type);
-               return -1;
+    if (   switchkins_type < 0
+        || switchkins_type >= kins_count
+        || !kfwds[switchkins_type]) {
+        rtapi_print_msg(RTAPI_MSG_ERR,
+                        "switchkins: Forward BAD switchkins_type </%d>\n",
+                        switchkins_type);
+        return -1;
     }
+    r = kfwds[switchkins_type](joint, pos, fflags, iflags);
     if (fwd_iterates[switchkins_type]) {save_lastpose(switchkins_type,pos);}
     if (r) return r;
 
@@ -213,15 +199,15 @@ int kinematicsInverse(const EmcPose * pos,
 {
     int r;
 
-    switch (switchkins_type) {
-       case 0: r = kinv0(pos, joint, iflags, fflags); break;
-       case 1: r = kinv1(pos, joint, iflags, fflags); break;
-       case 2: r = kinv2(pos, joint, iflags, fflags); break;
-       default: rtapi_print_msg(RTAPI_MSG_ERR,
-                     "switchkins: Inverse BAD switchkins_type </%d>\n",
-                     switchkins_type);
-               return -1;
+    if (   switchkins_type < 0
+        || switchkins_type >= kins_count
+        || !kinvs[switchkins_type]) {
+        rtapi_print_msg(RTAPI_MSG_ERR,
+                        "switchkins: Inverse BAD switchkins_type </%d>\n",
+                        switchkins_type);
+        return -1;
     }
+    r = kinvs[switchkins_type](pos, joint, iflags, fflags);
     return r;
 } // kinematicsInverse()
 
@@ -229,6 +215,22 @@ KINEMATICS_TYPE kinematicsType()
 {
     return KINEMATICS_BOTH;
 }
+
+int switchkinsRegister(int ktype, KS kset, KF kfwd, KI kinv)
+{
+    if (ktype < 3 || ktype >= SWITCHKINS_MAX_TYPES) {
+        rtapi_print_msg(RTAPI_MSG_ERR,
+                        "switchkinsRegister: BAD switchkins_type <%d>"
+                        " (must be 3..%d)\n",
+                        ktype, SWITCHKINS_MAX_TYPES - 1);
+        return -1;
+    }
+    ksetups[ktype] = kset;
+    kfwds[ktype]   = kfwd;
+    kinvs[ktype]   = kinv;
+    if (ktype >= kins_count) { kins_count = ktype + 1; }
+    return 0;
+} // switchkinsRegister()
 
 //*********************************************************************
 static char *coordinates;
@@ -241,6 +243,7 @@ EXPORT_SYMBOL(kinematicsSwitch);
 EXPORT_SYMBOL(kinematicsType);
 EXPORT_SYMBOL(kinematicsForward);
 EXPORT_SYMBOL(kinematicsInverse);
+EXPORT_SYMBOL(switchkinsRegister);
 MODULE_LICENSE("GPL");
 
 static int    comp_id;
@@ -261,14 +264,11 @@ int rtapi_app_main(void)
 
     kp.sparm = sparm; // module parm passed to kins
 
-    KS ksetup0 = NULL;
-    KS ksetup1 = NULL;
-    KS ksetup2 = NULL;
-
+    // may call switchkinsRegister() for types above 2
     res = switchkinsSetup(&kp,
-                          &ksetup0, &ksetup1, &ksetup2,
-                          &kfwd0,   &kfwd1,   &kfwd2,
-                          &kinv0,   &kinv1,   &kinv2);
+                          &ksetups[0], &ksetups[1], &ksetups[2],
+                          &kfwds[0],   &kfwds[1],   &kfwds[2],
+                          &kinvs[0],   &kinvs[1],   &kinvs[2]);
     if (res) {emsg="switchkinsSetp FAIL"; goto error;}
 
     for (i=0; i < SWITCHKINS_MAX_TYPES; i++) {
@@ -288,18 +288,14 @@ int rtapi_app_main(void)
     if (kp.max_joints <= 0 || kp.max_joints > EMCMOT_MAX_JOINTS) {
         emsg = "bogus max_joints"; goto error;
     }
-    if (kp.gui_kinstype >= SWITCHKINS_MAX_TYPES) {
+    if (kp.gui_kinstype >= kins_count) {
         emsg = "bogus gui_kinstype"; goto error;
     }
 
-    if (!ksetup0 || !ksetup1 || !ksetup2) {
-        emsg = "Missing setup function"; goto error;
-    }
-    if (!kfwd0 || !kfwd1 || !kfwd2) {
-        emsg = "Missing fwd functionn"; goto error;
-    }
-    if (!kinv0 || !kinv1 || !kinv2) {
-        emsg =  "Missing inv function"; goto error;
+    for (i=0; i < kins_count; i++) {
+        if (!ksetups[i]) { emsg = "Missing setup function"; goto error; }
+        if (!kfwds[i])   { emsg = "Missing fwd function";   goto error; }
+        if (!kinvs[i])   { emsg = "Missing inv function";   goto error; }
     }
 
     comp_id = hal_init(kp.kinsname);
@@ -308,9 +304,10 @@ int rtapi_app_main(void)
     swdata = hal_malloc(sizeof(struct swdata));
     if (!swdata) goto error;
 
-    res += hal_pin_new_bool(comp_id, HAL_OUT, &(swdata->kinstype_is_0), 0, "kinstype.is-0");
-    res += hal_pin_new_bool(comp_id, HAL_OUT, &(swdata->kinstype_is_1), 0, "kinstype.is-1");
-    res += hal_pin_new_bool(comp_id, HAL_OUT, &(swdata->kinstype_is_2), 0, "kinstype.is-2");
+    for (i=0; i < kins_count; i++) {
+        res += hal_pin_new_bool(comp_id, HAL_OUT, &(swdata->kinstype_is[i]),
+                                0, "kinstype.is-%d", i);
+    }
 
     if (kp.gui_kinstype >=0) {
         res += hal_pin_new_real(comp_id, HAL_IN, &swdata->gui_x, 0.0, "skgui.x");
@@ -327,9 +324,9 @@ int rtapi_app_main(void)
 
     if (!coordinates) {coordinates = kp.required_coordinates;}
 
-    ksetup0(comp_id,coordinates,&kp);
-    ksetup1(comp_id,coordinates,&kp);
-    ksetup2(comp_id,coordinates,&kp);
+    for (i=0; i < kins_count; i++) {
+        ksetups[i](comp_id,coordinates,&kp);
+    }
 
     hal_ready(comp_id);
     return 0;

--- a/src/emc/kinematics/switchkins.c
+++ b/src/emc/kinematics/switchkins.c
@@ -43,8 +43,9 @@ static KS ksetups[SWITCHKINS_MAX_TYPES] = {NULL};
 static KF kfwds[SWITCHKINS_MAX_TYPES]   = {NULL};
 static KI kinvs[SWITCHKINS_MAX_TYPES]   = {NULL};
 
-// types provided: 3 from switchkinsSetup(), more from switchkinsRegister()
-static int kins_count = 3;
+// types provided, counted in rtapi_app_main() once they are all in
+static int kins_count;
+static int register_error;
 
 static int switchkins_type;
 static struct swdata {
@@ -218,17 +219,24 @@ KINEMATICS_TYPE kinematicsType()
 
 int switchkinsRegister(int ktype, KS kset, KF kfwd, KI kinv)
 {
-    if (ktype < 3 || ktype >= SWITCHKINS_MAX_TYPES) {
+    if (ktype < 0 || ktype >= SWITCHKINS_MAX_TYPES) {
         rtapi_print_msg(RTAPI_MSG_ERR,
                         "switchkinsRegister: BAD switchkins_type <%d>"
-                        " (must be 3..%d)\n",
+                        " (must be 0..%d)\n",
                         ktype, SWITCHKINS_MAX_TYPES - 1);
+        register_error = 1;
+        return -1;
+    }
+    if (ksetups[ktype] || kfwds[ktype] || kinvs[ktype]) {
+        rtapi_print_msg(RTAPI_MSG_ERR,
+                        "switchkinsRegister: switchkins-type %d"
+                        " already provided\n", ktype);
+        register_error = 1;
         return -1;
     }
     ksetups[ktype] = kset;
     kfwds[ktype]   = kfwd;
     kinvs[ktype]   = kinv;
-    if (ktype >= kins_count) { kins_count = ktype + 1; }
     return 0;
 } // switchkinsRegister()
 
@@ -264,12 +272,19 @@ int rtapi_app_main(void)
 
     kp.sparm = sparm; // module parm passed to kins
 
-    // may call switchkinsRegister() for types above 2
+    // may also call switchkinsRegister()
     res = switchkinsSetup(&kp,
                           &ksetups[0], &ksetups[1], &ksetups[2],
                           &kfwds[0],   &kfwds[1],   &kfwds[2],
                           &kinvs[0],   &kinvs[1],   &kinvs[2]);
     if (res) {emsg="switchkinsSetp FAIL"; goto error;}
+    if (register_error) {emsg="switchkinsRegister FAIL"; goto error;}
+
+    // the highest type provided by either route sets the count
+    for (i=0; i < SWITCHKINS_MAX_TYPES; i++) {
+        if (ksetups[i] || kfwds[i] || kinvs[i]) { kins_count = i + 1; }
+    }
+    if (!kins_count) { emsg = "no switchkins-types provided"; goto error; }
 
     for (i=0; i < SWITCHKINS_MAX_TYPES; i++) {
        if (kp.fwd_iterates_mask & (1<<i)) {
@@ -292,10 +307,16 @@ int rtapi_app_main(void)
         emsg = "bogus gui_kinstype"; goto error;
     }
 
+    // a type left out below the highest one provided is a gap, not a count
     for (i=0; i < kins_count; i++) {
-        if (!ksetups[i]) { emsg = "Missing setup function"; goto error; }
-        if (!kfwds[i])   { emsg = "Missing fwd function";   goto error; }
-        if (!kinvs[i])   { emsg = "Missing inv function";   goto error; }
+        if (ksetups[i] && kfwds[i] && kinvs[i]) { continue; }
+        rtapi_print_msg(RTAPI_MSG_ERR,
+                        "switchkins: switchkins-type %d incomplete:%s%s%s\n",
+                        i,
+                        ksetups[i] ? "" : " no setup",
+                        kfwds[i]   ? "" : " no forward",
+                        kinvs[i]   ? "" : " no inverse");
+        emsg = "incomplete switchkins-type"; goto error;
     }
 
     comp_id = hal_init(kp.kinsname);

--- a/src/emc/kinematics/switchkins.c
+++ b/src/emc/kinematics/switchkins.c
@@ -128,6 +128,15 @@ int kinematicsSwitchable() {return 1;}
 int kinematicsSwitch(int new_switchkins_type)
 {
     int k;
+
+    // reject first, so a bad request leaves the running kinematics alone
+    if (new_switchkins_type < 0 || new_switchkins_type >= SWITCHKINS_MAX_TYPES) {
+        rtapi_print_msg(RTAPI_MSG_ERR,
+                        "kinematicsSwitch:BAD VALUE <%d>\n",
+                        new_switchkins_type);
+        return -1; // FAIL
+    }
+
     for (k=0; k< SWITCHKINS_MAX_TYPES; k++) { use_lastpose[k] = 0;}
 
     switchkins_type = new_switchkins_type;
@@ -150,13 +159,6 @@ int kinematicsSwitch(int new_switchkins_type)
                 hal_set_bool(swdata->kinstype_is_1, 0);
                 hal_set_bool(swdata->kinstype_is_2, 1);
                 break;
-       default: rtapi_print_msg(RTAPI_MSG_ERR,
-                "kinematicsSwitch:BAD VALUE <%d>\n",
-                switchkins_type);
-                hal_set_bool(swdata->kinstype_is_1, 0);
-                hal_set_bool(swdata->kinstype_is_0, 0);
-                hal_set_bool(swdata->kinstype_is_2, 0);
-                return -1; // FAIL
     }
     if (fwd_iterates[switchkins_type]) {
         use_lastpose[switchkins_type] = 1; // restarting a kins types

--- a/src/emc/kinematics/switchkins.c
+++ b/src/emc/kinematics/switchkins.c
@@ -27,7 +27,6 @@
 *  Using modules must supply function: switchkinsSetup()
 */
 #include <rtapi.h>
-#include <rtapi_app.h>
 #include <hal.h>
 #include <emcmotcfg.h>
 #include <kinematics.h>
@@ -240,47 +239,31 @@ int switchkinsRegister(int ktype, KS kset, KF kfwd, KI kinv)
     return 0;
 } // switchkinsRegister()
 
-//*********************************************************************
-static char *coordinates;
-RTAPI_MP_STRING(coordinates, "Axes-to-joints-ordering");
-static char *sparm;
-RTAPI_MP_STRING(sparm,  "switchkins module-specific parameter");
-
 EXPORT_SYMBOL(kinematicsSwitchable);
 EXPORT_SYMBOL(kinematicsSwitch);
 EXPORT_SYMBOL(kinematicsType);
 EXPORT_SYMBOL(kinematicsForward);
 EXPORT_SYMBOL(kinematicsInverse);
 EXPORT_SYMBOL(switchkinsRegister);
-MODULE_LICENSE("GPL");
+EXPORT_SYMBOL(switchkinsInit);
 
-static int    comp_id;
 //*********************************************************************
-int rtapi_app_main(void)
+// The caller owns the hal component: it does hal_init() before this and
+// hal_ready() after it.  Every switchkins-type must be registered by
+// now.
+int switchkinsInit(const int   comp_id,
+                   kparms*     ksetup_parms,
+                   const char* coordinates)
 {
-    int i,res;
-    char* emsg="other";
+    int i;
+    int res = 0;
+    char* emsg = "other";
 
-    // defaults prior to switchkinsSetup() call
-    kp.kinsname   = NULL;
-    kp.halprefix  = NULL;
-    kp.required_coordinates = "";
-    kp.max_joints        =  0; // Setup must supply
-    kp.allow_duplicates  =  0;
-    kp.fwd_iterates_mask =  0;
-    kp.gui_kinstype      = -1; // negative means: not used
+    kp = *ksetup_parms; // kinematics parms are needed after this returns
 
-    kp.sparm = sparm; // module parm passed to kins
+    if (register_error) {emsg = "switchkinsRegister FAIL"; goto error;}
 
-    // may also call switchkinsRegister()
-    res = switchkinsSetup(&kp,
-                          &ksetups[0], &ksetups[1], &ksetups[2],
-                          &kfwds[0],   &kfwds[1],   &kfwds[2],
-                          &kinvs[0],   &kinvs[1],   &kinvs[2]);
-    if (res) {emsg="switchkinsSetp FAIL"; goto error;}
-    if (register_error) {emsg="switchkinsRegister FAIL"; goto error;}
-
-    // the highest type provided by either route sets the count
+    // the highest type registered sets the count
     for (i=0; i < SWITCHKINS_MAX_TYPES; i++) {
         if (ksetups[i] || kfwds[i] || kinvs[i]) { kins_count = i + 1; }
     }
@@ -319,11 +302,8 @@ int rtapi_app_main(void)
         emsg = "incomplete switchkins-type"; goto error;
     }
 
-    comp_id = hal_init(kp.kinsname);
-    if(comp_id < 0) goto error;
-
     swdata = hal_malloc(sizeof(struct swdata));
-    if (!swdata) goto error;
+    if (!swdata) {emsg = "hal_malloc fail"; goto error;}
 
     for (i=0; i < kins_count; i++) {
         res += hal_pin_new_bool(comp_id, HAL_OUT, &(swdata->kinstype_is[i]),
@@ -337,8 +317,8 @@ int rtapi_app_main(void)
         res += hal_pin_new_real(comp_id, HAL_IN, &swdata->gui_a, 0.0, "skgui.a");
         res += hal_pin_new_real(comp_id, HAL_IN, &swdata->gui_b, 0.0, "skgui.b");
         res += hal_pin_new_real(comp_id, HAL_IN, &swdata->gui_c, 0.0, "skgui.c");
-        if (res) {emsg = "hal pin create fail";goto error;}
     }
+    if (res) {emsg = "hal pin create fail"; goto error;}
 
     switchkins_type = 0; // startup with default type
     kinematicsSwitch(switchkins_type);
@@ -349,14 +329,10 @@ int rtapi_app_main(void)
         ksetups[i](comp_id,coordinates,&kp);
     }
 
-    hal_ready(comp_id);
     return 0;
 
 error:
     rtapi_print_msg(RTAPI_MSG_ERR,
         "\nSwitchkins FAIL %s:<%s>\n",kp.kinsname,emsg);
-    hal_exit(comp_id);
     return -1;
-} // rtapi_app_main()
-
-void rtapi_app_exit(void) { hal_exit(comp_id); }
+} // switchkinsInit()

--- a/src/emc/kinematics/switchkins.h
+++ b/src/emc/kinematics/switchkins.h
@@ -28,13 +28,20 @@ typedef int (*KS)(const int   comp_id,     // halpins
                  );
 
 //*********************************************************************
-// supplied by the using module, provides types 0,1,2
+// supplied by a module using switchkins_main.c, provides types 0,1,2
 extern int switchkinsSetup(kparms* ksetup_parms,
                            KS* kset0, KS* kset1, KS* kset2,
                            KF* kfwd0, KF* kfwd1, KF* kfwd2,
                            KI* kinv0, KI* kinv1, KI* kinv2
                           );
 
-// called from switchkinsSetup(), once per type it does not provide itself
+// provide one switchkins-type, before switchkinsInit()
 extern int switchkinsRegister(int ktype, KS kset, KF kfwd, KI kinv);
+
+// create the hal pins and start on type 0; the caller owns the hal
+// component and does hal_init() before and hal_ready() after
+extern int switchkinsInit(const int   comp_id,
+                          kparms*     ksetup_parms,
+                          const char* coordinates
+                         );
 #endif // }

--- a/src/emc/kinematics/switchkins.h
+++ b/src/emc/kinematics/switchkins.h
@@ -6,8 +6,8 @@
 
 #include <kinematics.h>
 
-//hardcoded number of switchkins types (KS,KF,KI):
-#define SWITCHKINS_MAX_TYPES 3
+//max number of switchkins types (KS,KF,KI) a module may provide:
+#define SWITCHKINS_MAX_TYPES 9
 
 // KinematicsFORWARD functions
 typedef int (*KF)(const double *joint,
@@ -28,9 +28,13 @@ typedef int (*KS)(const int   comp_id,     // halpins
                  );
 
 //*********************************************************************
+// supplied by the using module, provides types 0,1,2
 extern int switchkinsSetup(kparms* ksetup_parms,
                            KS* kset0, KS* kset1, KS* kset2,
                            KF* kfwd0, KF* kfwd1, KF* kfwd2,
                            KI* kinv0, KI* kinv1, KI* kinv2
                           );
+
+// called from switchkinsSetup() for each type above 2
+extern int switchkinsRegister(int ktype, KS kset, KF kfwd, KI kinv);
 #endif // }

--- a/src/emc/kinematics/switchkins.h
+++ b/src/emc/kinematics/switchkins.h
@@ -35,6 +35,6 @@ extern int switchkinsSetup(kparms* ksetup_parms,
                            KI* kinv0, KI* kinv1, KI* kinv2
                           );
 
-// called from switchkinsSetup() for each type above 2
+// called from switchkinsSetup(), once per type it does not provide itself
 extern int switchkinsRegister(int ktype, KS kset, KF kfwd, KI kinv);
 #endif // }

--- a/src/emc/kinematics/switchkins_main.c
+++ b/src/emc/kinematics/switchkins_main.c
@@ -1,0 +1,94 @@
+/*
+  Copyright 2019 Dewey Garrett <dgarrett@panix.com>
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+/* switchkins_main.c provides rtapi_app_main() for kinematics modules
+*  built around switchkins.c.  A module that gets its rtapi_app_main()
+*  from somewhere else (a halcompile component, for instance) links
+*  switchkins.c alone and calls switchkinsInit() itself.
+*
+*  Using modules must supply function: switchkinsSetup()
+*/
+#include <rtapi.h>
+#include <rtapi_app.h>
+#include <hal.h>
+
+#include "switchkins.h"
+
+static char *coordinates;
+RTAPI_MP_STRING(coordinates, "Axes-to-joints-ordering");
+static char *sparm;
+RTAPI_MP_STRING(sparm,  "switchkins module-specific parameter");
+
+MODULE_LICENSE("GPL");
+
+static int comp_id = -1;
+
+int rtapi_app_main(void)
+{
+    kparms kp;
+    KS ksetup[3] = {NULL};
+    KF kfwd[3]   = {NULL};
+    KI kinv[3]   = {NULL};
+    int i;
+
+    // defaults prior to switchkinsSetup() call
+    kp.kinsname   = NULL;
+    kp.halprefix  = NULL;
+    kp.required_coordinates = "";
+    kp.max_joints        =  0; // Setup must supply
+    kp.allow_duplicates  =  0;
+    kp.fwd_iterates_mask =  0;
+    kp.gui_kinstype      = -1; // negative means: not used
+
+    kp.sparm = sparm; // module parm passed to kins
+
+    // switchkinsSetup() provides types 0,1,2 and may also call
+    // switchkinsRegister() for any others
+    if (switchkinsSetup(&kp,
+                        &ksetup[0], &ksetup[1], &ksetup[2],
+                        &kfwd[0],   &kfwd[1],   &kfwd[2],
+                        &kinv[0],   &kinv[1],   &kinv[2])) {
+        rtapi_print_msg(RTAPI_MSG_ERR,"\nSwitchkins FAIL:<setup>\n");
+        return -1;
+    }
+
+    // the types switchkinsSetup() supplied go in by the same route as
+    // any other, so that providing one twice is caught
+    for (i=0; i < 3; i++) {
+        if (!ksetup[i] && !kfwd[i] && !kinv[i]) { continue; }
+        if (switchkinsRegister(i, ksetup[i], kfwd[i], kinv[i])) { return -1; }
+    }
+
+    if (!kp.kinsname) {
+        rtapi_print_msg(RTAPI_MSG_ERR,"\nSwitchkins FAIL:<Missing kinsname>\n");
+        return -1;
+    }
+
+    comp_id = hal_init(kp.kinsname);
+    if (comp_id < 0) return comp_id;
+
+    if (switchkinsInit(comp_id, &kp, coordinates)) {
+        hal_exit(comp_id);
+        return -1;
+    }
+
+    hal_ready(comp_id);
+    return 0;
+} // rtapi_app_main()
+
+void rtapi_app_exit(void) { hal_exit(comp_id); }

--- a/src/hal/components/Submakefile
+++ b/src/hal/components/Submakefile
@@ -92,11 +92,20 @@ endif
 
 obj-m += $(patsubst hal/drivers/%.comp, %.o, $(patsubst hal/components/%.comp, %.o, $(COMPS) $(COMP_DRIVERS)))
 
+# A component that links objects besides its own names them here as
+# <component>-extra-objs.  The list is expanded when the .mak is written,
+# so it has to be defined in this file (which the .mak depends on).
+SWITCHKINS_OBJS := emc/kinematics/switchkins.o emc/kinematics/kins_util.o
+millturn-extra-objs       := $(SWITCHKINS_OBJS)
+xyzab_tdr_kins-extra-objs := $(SWITCHKINS_OBJS)
+xyzacb_trsrn-extra-objs   := $(SWITCHKINS_OBJS)
+xyzbca_trsrn-extra-objs   := $(SWITCHKINS_OBJS)
+
 objects/%.mak: %.comp hal/components/Submakefile
 	$(ECHO) "Creating $(notdir $@)"
 	@mkdir -p $(dir $@)
-	$(Q)echo $(notdir $*)-objs := objects/$*.o > $@.tmp
-	$(Q)echo ../rtlib/$(notdir $*)$(MODULE_EXT): objects/rtobjects/$*.o >> $@.tmp
+	$(Q)echo $(notdir $*)-objs := objects/$*.o $($(notdir $*)-extra-objs) > $@.tmp
+	$(Q)echo ../rtlib/$(notdir $*)$(MODULE_EXT): objects/rtobjects/$*.o $(addprefix objects/rt,$($(notdir $*)-extra-objs)) >> $@.tmp
 	$(Q)mv -f $@.tmp $@
 
 objects/%.c: %.comp ../bin/halcompile

--- a/src/hal/components/Submakefile
+++ b/src/hal/components/Submakefile
@@ -1,5 +1,5 @@
 ifneq ($(KERNELRELEASE),)
-COMPS := $(filter-out %/tpcomp.comp, $(patsubst $(BASEPWD)/%,%,$(wildcard $(BASEPWD)/hal/components/*.comp $(BASEPWD)/hal/drivers/*.comp)))
+COMPS := $(filter-out %/tpcomp.comp %/switchkinscomp.comp, $(patsubst $(BASEPWD)/%,%,$(wildcard $(BASEPWD)/hal/components/*.comp $(BASEPWD)/hal/drivers/*.comp)))
 include $(patsubst %.comp, $(BASEPWD)/objects/%.mak, $(COMPS))
 else
 CONVERTERS :=  \
@@ -32,8 +32,8 @@ CONVERTERS :=  \
     conv_u64_s32.comp \
     conv_u64_u32.comp \
     conv_u64_s64.comp
-COMPS := $(filter-out hal/components/tpcomp.comp, $(sort $(wildcard hal/components/*.comp) $(addprefix hal/components/, $(CONVERTERS))))
-COMP_MANPAGES := $(patsubst hal/components/%.comp, ../docs/build/man/man9/%.9, $(COMPS)) ../docs/build/man/man9/tpcomp.9
+COMPS := $(filter-out hal/components/tpcomp.comp hal/components/switchkinscomp.comp, $(sort $(wildcard hal/components/*.comp) $(addprefix hal/components/, $(CONVERTERS))))
+COMP_MANPAGES := $(patsubst hal/components/%.comp, ../docs/build/man/man9/%.9, $(COMPS)) ../docs/build/man/man9/tpcomp.9 ../docs/build/man/man9/switchkinscomp.9
 ifeq ($(BUILD_SYS),uspace)
 COMP_DRIVERS += hal/drivers/serport.comp
 COMP_DRIVERS += hal/drivers/mesa_7i65.comp
@@ -56,7 +56,7 @@ endif
 # wildcard that mixes hal/components and hal/drivers, so deriving the adoc
 # targets from it there yields hal/drivers/*.comp entries that fail the
 # hal/components/%.comp static pattern rule.
-COMP_MANPAGE_ADOCS := $(patsubst hal/components/%.comp, objects/man/man9/%.9.adoc, $(COMPS)) objects/man/man9/tpcomp.9.adoc
+COMP_MANPAGE_ADOCS := $(patsubst hal/components/%.comp, objects/man/man9/%.9.adoc, $(COMPS)) objects/man/man9/tpcomp.9.adoc objects/man/man9/switchkinscomp.9.adoc
 COMP_DRIVER_MANPAGE_ADOCS := $(patsubst hal/drivers/%.comp, objects/man/man9/%.9.adoc, $(COMP_DRIVERS))
 
 # Extract adoc from .comp via halcompile --adoc.  Only needs Python +

--- a/src/hal/components/millturn.comp
+++ b/src/hal/components/millturn.comp
@@ -10,15 +10,14 @@ rotary axis.
 
 type1 is a turn (Z-YX) configuration with A configured to be a spindle.
 
+The kinematics-type switching, the *kinstype.is-N* pins and the
+joints-to-coordinates mapping are provided by switchkins.c, so the
+*coordinates=* module parameter and the kinematics switching described in
+the switchkins document chapter apply here too.
+
 For an example configuration, run the sim config: 'configs/sim/axis/vismach/millturn/millturn.ini'.
 
 Further explanations can be found in the README in 'configs/sim/axis/vismach/millturn'.
-
-millturn.comp was constructed by modifying the template file:
-userkins.comp.
-
-For more information on how to modify userkins.comp run: $ man
-userkins.   Also, see additional information inside: 'userkins.comp'.
 
 For information on kinematics in general see the kinematics
 document chapter (docs/src/motion/kinematics.txt) and for
@@ -30,26 +29,16 @@ chapter (docs/src/motion/switchkins.txt)
 // Use the *_setup() function for pins and params used by kinematics.
 pin out si32 fpin=0"pin to demonstrate use of a conventional (non-kinematics) function fdemo";
 option period no;
+option extra_setup;
 function fdemo;
 license "GPL";
 author "David Mueller";
 ;;
 
-#include <rtapi_math.h>
-#include <kinematics.h>
+#include <switchkins.h>
 
-static struct haldata {
-  // Example pin pointers:
-  hal_uint_t in;
-  hal_uint_t out;
-  // Example parameters:
-  //hal_real_t param_rw;
-  //hal_real_t param_ro;
-
-  //Declare hal pin pointers used for switchable kinematics
-  hal_bool_t kinstype_is_0;
-  hal_bool_t kinstype_is_1;
-} *haldata;
+static char *coordinates;
+RTAPI_MP_STRING(coordinates, "Axes-to-joints-ordering");
 
 FUNCTION(fdemo) {
    // This function can be added to a thread (addf) for
@@ -60,112 +49,30 @@ FUNCTION(fdemo) {
    fpin_set(fpin + 1);
 }
 
-static int millturn_setup(void) {
-#define HAL_PREFIX "millturn"
-    int res=0;
-
-    // inherit comp_id from rtapi_main()
-    if (comp_id < 0) goto error;
-    // set unready to allow creation of pins
-    if (hal_set_unready(comp_id)) goto error;
-
-    haldata = hal_malloc(sizeof(*haldata));
-    if (!haldata) goto error;
-
-    // hal pin examples:
-    res += hal_pin_new_ui32(comp_id, HAL_IN,  &haldata->in,  0, "%s.in",  HAL_PREFIX);
-    res += hal_pin_new_ui32(comp_id, HAL_OUT, &haldata->out, 0, "%s.out", HAL_PREFIX);
-    // hal parameter examples:
-    //res += hal_param_new_real(comp_id, HAL_RW, &haldata->param_rw, 0.0, "%s.param-rw", HAL_PREFIX);
-    //res += hal_param_new_real(comp_id, HAL_RO, &haldata->param_ro, 0.0, "%s.param-ro", HAL_PREFIX);
-
-    // hal pins required for switchable kinematics:
-    //default at startup -> mill configuration
-    //-> turn configuration
-    res += hal_pin_new_bool(comp_id, HAL_OUT, &haldata->kinstype_is_0, 1, "kinstype.is-0");
-    res += hal_pin_new_bool(comp_id, HAL_OUT, &haldata->kinstype_is_1, 0, "kinstype.is-1");
-
-    if (res) goto error;
-    hal_ready(comp_id);
-    rtapi_print("*** %s setup ok\n",__FILE__);
+// the turn kinematics need no hal pins of their own
+static int turnKinematicsSetup(const int   comp_id,
+                               const char* coords,
+                               kparms*     kp)
+{
+    (void)comp_id;
+    (void)coords;
+    (void)kp;
     return 0;
-error:
-    rtapi_print("\n!!! %s setup failed res=%d\n\n",__FILE__,res);
-    return -1;
-#undef HAL_PREFIX
-}
+} // turnKinematicsSetup()
 
-EXPORT_SYMBOL(kinematicsType);
-EXPORT_SYMBOL(kinematicsSwitchable);
-EXPORT_SYMBOL(kinematicsSwitch);
-EXPORT_SYMBOL(kinematicsInverse);
-EXPORT_SYMBOL(kinematicsForward);
-
-static rtapi_u32 switchkins_type;
-
-int kinematicsSwitchable() {return 1;}
-
-int kinematicsSwitch(int new_switchkins_type)
-{
-    switchkins_type = new_switchkins_type;
-    rtapi_print("kinematicsSwitch(): type=%d\n",switchkins_type);
-    // create case structure for switchable kinematics
-    switch (switchkins_type) {
-        case 0: rtapi_print_msg(RTAPI_MSG_INFO,
-                "kinematicsSwitch:TYPE0\n");
-                hal_set_bool(haldata->kinstype_is_0, 1);
-                hal_set_bool(haldata->kinstype_is_1, 0);
-                break;
-        case 1: rtapi_print_msg(RTAPI_MSG_INFO,
-                "kinematicsSwitch:TYPE1\n");
-                hal_set_bool(haldata->kinstype_is_0, 0);
-                hal_set_bool(haldata->kinstype_is_1, 1);
-                break;
-       default: rtapi_print_msg(RTAPI_MSG_ERR,
-                "kinematicsSwitch:BAD VALUE <%d>\n",
-                switchkins_type);
-                hal_set_bool(haldata->kinstype_is_1, 0);
-                hal_set_bool(haldata->kinstype_is_0, 0);
-                return -1; // FAIL
-    }
-    return 0; // ok
-}
-
-KINEMATICS_TYPE kinematicsType()
-{
-static bool is_setup=0;
-    if (!is_setup) millturn_setup();
-    return KINEMATICS_BOTH; // set as required
-           // Note: If kinematics are identity, using KINEMATICS_BOTH
-           //       may be used in order to allow a gui to display
-           //       joint values in preview prior to homing
-} // kinematicsType()
-
-static bool is_ready=0;
-int kinematicsForward(const double *j,
-                      EmcPose * pos,
-                      const KINEMATICS_FORWARD_FLAGS * fflags,
-                      KINEMATICS_INVERSE_FLAGS * iflags)
+static int turnKinematicsForward(const double *j,
+                                 EmcPose * pos,
+                                 const KINEMATICS_FORWARD_FLAGS * fflags,
+                                 KINEMATICS_INVERSE_FLAGS * iflags)
 {
     (void)fflags;
     (void)iflags;
-    static bool gave_msg;
-    // define forward kinematic models using case structure for
-    // for switchable kinematics
-    switch (switchkins_type) {
-        case 0:
-            pos->tran.x = j[0];
-            pos->tran.y = j[1];
-            pos->tran.z = j[2];
-            pos->a      = j[3];
-            break;
-        case 1:
-            pos->tran.x = j[2];
-            pos->tran.y = -j[1];
-            pos->tran.z = j[0];
-            pos->a      = j[3];
-            break;
-    }
+
+    pos->tran.x =  j[2];
+    pos->tran.y = -j[1];
+    pos->tran.z =  j[0];
+    pos->a      =  j[3];
+
     // unused coordinates:
     pos->b = 0;
     pos->c = 0;
@@ -173,46 +80,46 @@ int kinematicsForward(const double *j,
     pos->v = 0;
     pos->w = 0;
 
-    if (hal_get_ui32(haldata->in) && !is_ready && !gave_msg) {
-       rtapi_print_msg(RTAPI_MSG_ERR,
-                       "%s the 'in' pin not echoed until Inverse called\n",
-                      __FILE__);
-       gave_msg=1;
-    }
     return 0;
-} // kinematicsForward()
+} // turnKinematicsForward()
 
-int kinematicsInverse(const EmcPose * pos,
-                      double *j,
-                      const KINEMATICS_INVERSE_FLAGS * iflags,
-                      KINEMATICS_FORWARD_FLAGS * fflags)
+static int turnKinematicsInverse(const EmcPose * pos,
+                                 double *j,
+                                 const KINEMATICS_INVERSE_FLAGS * iflags,
+                                 KINEMATICS_FORWARD_FLAGS * fflags)
 {
     (void)iflags;
     (void)fflags;
-    is_ready = 1; // Inverse is not called until homed for KINEMATICS_BOTH
 
-    // Update the kinematic joints specified by the
-    // [KINS]JOINTS setting (4 required for this template).
-    // define forward kinematic models using case structure for
-    // for switchable kinematics
-    switch (switchkins_type) {
-        case 0:
-            j[0] = pos->tran.x;
-            j[1] = pos->tran.y;
-            j[2] = pos->tran.z;
-            j[3] = pos->a;
-            break;
-        case 1:
-            j[2] = pos->tran.x;
-            j[1] = -pos->tran.y;
-            j[0] = pos->tran.z;
-            j[3] = pos->a;
-            break;
-    }
-
-    //example hal pin update (homing reqd before kinematicsInverse)
-    hal_set_ui32(haldata->out, hal_get_ui32(haldata->in)); //dereference
-    //read from param example: *haldata->out = hal_get_real(haldata->param_rw);
+    j[0] =  pos->tran.z;
+    j[1] = -pos->tran.y;
+    j[2] =  pos->tran.x;
+    j[3] =  pos->a;
 
     return 0;
-} // kinematicsInverse()
+} // turnKinematicsInverse()
+
+// halcompile has done hal_init() and does hal_ready() after this returns,
+// which is what switchkinsInit() expects
+EXTRA_SETUP() {
+    kparms kp;
+    (void)__comp_inst; (void)prefix; (void)extra_arg;
+
+    kp.kinsname    = "millturn";
+    kp.halprefix   = "millturn";
+    kp.required_coordinates = "xyza";
+    kp.allow_duplicates     = 0;
+    kp.fwd_iterates_mask    = 0;
+    kp.gui_kinstype         = -1;
+    kp.sparm                = NULL;
+    kp.max_joints           = strlen(kp.required_coordinates);
+
+    if (switchkinsRegister(0, identityKinematicsSetup,
+                              identityKinematicsForward,
+                              identityKinematicsInverse)) { return -1; }
+    if (switchkinsRegister(1, turnKinematicsSetup,
+                              turnKinematicsForward,
+                              turnKinematicsInverse))     { return -1; }
+
+    return switchkinsInit(comp_id, &kp, coordinates);
+} // EXTRA_SETUP()

--- a/src/hal/components/switchkinscomp.comp
+++ b/src/hal/components/switchkinscomp.comp
@@ -1,0 +1,167 @@
+component switchkinscomp "switchable kinematics module template";
+// NOTE: component name must agree with filename
+
+description """
+Example of a switchable kinematics module buildable with halcompile.
+
+The switchkinscomp.comp file (src/hal/components/switchkinscomp.comp)
+illustrates a method to use halcompile to build a kinematics module
+on top of the switchkins implementation used by the in-tree kinematics
+modules, so an out-of-tree module gets the same kinematics switching,
+the same 'kinstype.is-N' pins, the same 'coordinates=' identity
+mapping, and the same G-code and HAL controls, without reimplementing
+any of it.
+
+The example switchkinscomp.comp is not usable until modified for the
+user environment.  To create a runnable switchkinscomp module, the
+file must be edited to supply a valid '#define TOPDIR' pointing at a
+LinuxCNC source tree.
+
+To avoid updates that overwrite switchkinscomp.comp, best practice is
+to rename the file and its component name (example:
+*user_switchkins.comp* creates module: *user_switchkins*).
+
+The (renamed) component can be built and installed with halcompile
+and then used as the kinematics module by inifile setting:
+
+[source,ini]
+----
+[KINS]
+KINEMATICS = user_switchkins
+JOINTS = 3
+----
+
+*Note:* If using a deb install:
+
+1. halcompile is provided by the deb package linuxcnc-dev
+2. This source file for BRANCHNAME (master, 2.9, etc) is downloadable from github:
+
+https://github.com/LinuxCNC/linuxcnc/blob/BRANCHNAME/src/hal/components/switchkinscomp.comp
+
+For information on switchable kinematics see the switchkins document
+chapter (docs/src/motion/switchkins.txt).
+""";
+
+pin out bit is_module=1; //one pin is required to use halcompile
+
+license "GPL";
+option  extra_setup;
+;;
+
+//=====================================================================
+/* To use the switchkins implementation from a local git src tree:
+** set TOPDIR to the git tree top directory
+** (Edit 'myname' as required)
+*/
+
+//#define TOPDIR /home/myname/linuxcnc-dev
+
+#ifdef TOPDIR // {
+
+#define STR(s)        #s
+#define XSTR(s)       STR(s)
+#define USE_TOPDIR(b) XSTR(TOPDIR/b)
+
+// switchkins.c provides kinematicsForward(), kinematicsInverse(),
+// kinematicsSwitch() and the rest of the kinematics interface, and
+// dispatches each call to the currently selected switchkins-type.
+// kins_util.c provides the identity kinematics and the coordinates
+// letters-to-joints mapping they use.
+#include USE_TOPDIR(src/emc/kinematics/switchkins.c)
+#include USE_TOPDIR(src/emc/kinematics/kins_util.c)
+
+#else
+#error No TOPDIR defined, skeleton component provides no kinematics functions.
+#endif // }
+//=====================================================================
+
+// module parameter naming the joint order for the identity type
+static char *coordinates;
+RTAPI_MP_STRING(coordinates, "Axes-to-joints-ordering");
+
+//---------------------------------------------------------------------
+// Example switchkins-type.  A setup routine creating whatever hal pins
+// the kinematics need, plus a forward and an inverse routine.  Replace
+// the arithmetic with the real kinematics.
+
+static struct {
+    hal_real_t x_offset;
+} *mydata;
+
+static int myKinematicsSetup(const int   comp_id,
+                             const char* coords,
+                             kparms*     kp)
+{
+    (void)coords; // this type does not use the coordinates mapping
+
+    mydata = hal_malloc(sizeof(*mydata));
+    if (!mydata) return -1;
+
+    return hal_pin_new_real(comp_id, HAL_IN, &mydata->x_offset, 0.0,
+                            "%s.x-offset", kp->halprefix);
+} // myKinematicsSetup()
+
+static int myKinematicsForward(const double *j,
+                               EmcPose * pos,
+                               const KINEMATICS_FORWARD_FLAGS * fflags,
+                               KINEMATICS_INVERSE_FLAGS * iflags)
+{
+    (void)fflags;
+    (void)iflags;
+
+    pos->tran.x = j[0] + hal_get_real(mydata->x_offset);
+    pos->tran.y = j[1];
+    pos->tran.z = j[2];
+
+    // unused coordinates:
+    pos->a = pos->b = pos->c = 0;
+    pos->u = pos->v = pos->w = 0;
+
+    return 0;
+} // myKinematicsForward()
+
+static int myKinematicsInverse(const EmcPose * pos,
+                               double *j,
+                               const KINEMATICS_INVERSE_FLAGS * iflags,
+                               KINEMATICS_FORWARD_FLAGS * fflags)
+{
+    (void)iflags;
+    (void)fflags;
+
+    j[0] = pos->tran.x - hal_get_real(mydata->x_offset);
+    j[1] = pos->tran.y;
+    j[2] = pos->tran.z;
+
+    return 0;
+} // myKinematicsInverse()
+
+//---------------------------------------------------------------------
+// rtapi_app_main() is supplied by halcompile, which calls hal_init()
+// before EXTRA_SETUP() and hal_ready() after it.  That is what
+// switchkinsInit() expects, so the switchkins-types are registered and
+// the implementation started from here.
+
+EXTRA_SETUP() {
+    kparms kp;
+    (void)__comp_inst; (void)prefix; (void)extra_arg;
+
+    kp.kinsname    = "switchkinscomp"; // must agree with the module name
+    kp.halprefix   = "switchkinscomp"; // hal pin names
+    kp.required_coordinates = "xyz";
+    kp.allow_duplicates     = 0;
+    kp.fwd_iterates_mask    = 0;       // set bit N if type N iterates
+    kp.gui_kinstype         = -1;      // negative means: not used
+    kp.sparm                = NULL;
+    kp.max_joints           = strlen(kp.required_coordinates);
+
+    // switchkins-type 0 is the startup default.  Types run from 0 to
+    // SWITCHKINS_MAX_TYPES-1 with no gaps.
+    if (switchkinsRegister(0, identityKinematicsSetup,
+                              identityKinematicsForward,
+                              identityKinematicsInverse)) { return -1; }
+    if (switchkinsRegister(1, myKinematicsSetup,
+                              myKinematicsForward,
+                              myKinematicsInverse))       { return -1; }
+
+    return switchkinsInit(comp_id, &kp, coordinates);
+} // EXTRA_SETUP()

--- a/src/hal/components/xyzab_tdr_kins.comp
+++ b/src/hal/components/xyzab_tdr_kins.comp
@@ -13,15 +13,14 @@ axes XYZAB respectively.
 
 type1 is a XYZAB configuration with tool center point (TCP) compensation.
 
+The kinematics-type switching, the *kinstype.is-N* pins and the
+joints-to-coordinates mapping are provided by switchkins.c, so the
+*coordinates=* module parameter and the kinematics switching described in
+the switchkins document chapter apply here too.
+
 For an example configuration, run the sim config: '/configs/sim/axis/vismach/5axis/table-dual-rotary/xyzab-tdr.ini'.
 
 Further explanations can be found in the README in '/configs/sim/axis/vismach/5axis/table-dual-rotary/'.
-
-xyzab_tdr_kins.comp was constructed by modifying the template file:
-userkins.comp.
-
-For more information on how to modify userkins.comp run: $ man
-userkins.   Also, see additional information inside: 'userkins.comp'.
 
 For information on kinematics in general see the kinematics
 document chapter (docs/src/motion/kinematics.txt) and for
@@ -32,123 +31,68 @@ chapter (docs/src/motion/switchkins.txt)
 
 pin out si32 dummy=0"one pin needed to satisfy halcompile requirement";
 
+option extra_setup;
+
 license "GPL";
 author "David Mueller";
 ;;
 
 #include <rtapi_math.h>
-#include <kinematics.h>
+
+#include <switchkins.h>
+
+static char *coordinates;
+RTAPI_MP_STRING(coordinates, "Axes-to-joints-ordering");
 
 static struct haldata {
-
-  // Declare hal pin pointers used for xyzab_tdr kinematics:
   hal_real_t tool_offset_z;
   hal_real_t x_offset;
   hal_real_t z_offset;
   hal_real_t x_rot_point;
   hal_real_t y_rot_point;
   hal_real_t z_rot_point;
+} *tdrdata;
 
-  //Declare hal pin pointers used for switchable kinematics
-  hal_bool_t kinstype_is_0;
-  hal_bool_t kinstype_is_1;
-} *haldata;
+static int tdrKinematicsSetup(const int   comp_id,
+                              const char* coords,
+                              kparms*     kp)
+{
+    int res = 0;
+    (void)coords;
 
-static int xyzab_tdr_setup(void) {
-#define HAL_PREFIX "xyzab_tdr_kins"
-    int res=0;
-    // inherit comp_id from rtapi_main()
-    if (comp_id < 0) goto error;
-    // set unready to allow creation of pins
-    if (hal_set_unready(comp_id)) goto error;
+    tdrdata = hal_malloc(sizeof(*tdrdata));
+    if (!tdrdata) return -1;
 
-    haldata = hal_malloc(sizeof(*haldata));
-    if (!haldata) goto error;
+    res += hal_pin_new_real(comp_id, HAL_IN, &tdrdata->tool_offset_z, 0.0,
+                            "%s.tool-offset-z", kp->halprefix);
+    res += hal_pin_new_real(comp_id, HAL_IN, &tdrdata->x_offset,      0.0,
+                            "%s.x-offset",      kp->halprefix);
+    res += hal_pin_new_real(comp_id, HAL_IN, &tdrdata->z_offset,      0.0,
+                            "%s.z-offset",      kp->halprefix);
+    res += hal_pin_new_real(comp_id, HAL_IN, &tdrdata->x_rot_point,   0.0,
+                            "%s.x-rot-point",   kp->halprefix);
+    res += hal_pin_new_real(comp_id, HAL_IN, &tdrdata->y_rot_point,   0.0,
+                            "%s.y-rot-point",   kp->halprefix);
+    res += hal_pin_new_real(comp_id, HAL_IN, &tdrdata->z_rot_point,   0.0,
+                            "%s.z-rot-point",   kp->halprefix);
+    if (res) return -1;
 
-    // hal pins required for xyzab_tdr kinematics:
-    res += hal_pin_new_real(comp_id, HAL_IN, &haldata->tool_offset_z, 0.0, "%s.tool-offset-z", HAL_PREFIX);
-    res += hal_pin_new_real(comp_id, HAL_IN, &haldata->x_offset,      0.0, "%s.x-offset", HAL_PREFIX);
-    res += hal_pin_new_real(comp_id, HAL_IN, &haldata->z_offset,      0.0, "%s.z-offset", HAL_PREFIX);
-    res += hal_pin_new_real(comp_id, HAL_IN, &haldata->x_rot_point,   0.0, "%s.x-rot-point", HAL_PREFIX);
-    res += hal_pin_new_real(comp_id, HAL_IN, &haldata->y_rot_point,   0.0, "%s.y-rot-point", HAL_PREFIX);
-    res += hal_pin_new_real(comp_id, HAL_IN, &haldata->z_rot_point,   0.0, "%s.z-rot-point", HAL_PREFIX);
-
-    // hal pins required for switchable kinematics:
-    //default at startup -> identity kinematics
-    //-> XYZAB TCP
-    res += hal_pin_new_bool(comp_id, HAL_OUT, &haldata->kinstype_is_0, 1, "kinstype.is-0");
-    res += hal_pin_new_bool(comp_id, HAL_OUT, &haldata->kinstype_is_1, 0, "kinstype.is-1");
-
-    if (res) goto error;
-    hal_ready(comp_id);
-    rtapi_print("*** %s setup ok\n",__FILE__);
     return 0;
-error:
-    rtapi_print("\n!!! %s setup failed res=%d\n\n",__FILE__,res);
-    return -1;
-#undef HAL_PREFIX
-}
+} // tdrKinematicsSetup()
 
-EXPORT_SYMBOL(kinematicsType);
-EXPORT_SYMBOL(kinematicsSwitchable);
-EXPORT_SYMBOL(kinematicsSwitch);
-EXPORT_SYMBOL(kinematicsInverse);
-EXPORT_SYMBOL(kinematicsForward);
-
-static rtapi_u32 switchkins_type;
-
-int kinematicsSwitchable() {return 1;}
-
-int kinematicsSwitch(int new_switchkins_type)
-{
-    switchkins_type = new_switchkins_type;
-    rtapi_print("kinematicsSwitch(): type=%d\n",switchkins_type);
-    // create case structure for switchable kinematics
-    switch (switchkins_type) {
-        case 0: rtapi_print_msg(RTAPI_MSG_INFO,
-                "kinematicsSwitch:TYPE0\n");
-                hal_set_bool(haldata->kinstype_is_0, 1);
-                hal_set_bool(haldata->kinstype_is_1, 0);
-                break;
-        case 1: rtapi_print_msg(RTAPI_MSG_INFO,
-                "kinematicsSwitch:TYPE1\n");
-                hal_set_bool(haldata->kinstype_is_0, 0);
-                hal_set_bool(haldata->kinstype_is_1, 1);
-                break;
-       default: rtapi_print_msg(RTAPI_MSG_ERR,
-                "kinematicsSwitch:BAD VALUE <%d>\n",
-                switchkins_type);
-                hal_set_bool(haldata->kinstype_is_1, 0);
-                hal_set_bool(haldata->kinstype_is_0, 0);
-                return -1; // FAIL
-    }
-    return 0; // ok
-}
-
-KINEMATICS_TYPE kinematicsType()
-{
-static bool is_setup=0;
-    if (!is_setup)  xyzab_tdr_setup();
-    return KINEMATICS_BOTH; // set as required
-           // Note: If kinematics are identity, using KINEMATICS_BOTH
-           //       may be used in order to allow a gui to display
-           //       joint values in preview prior to homing
-} // kinematicsType()
-
-int kinematicsForward(const double *j,
-                      EmcPose * pos,
-                      const KINEMATICS_FORWARD_FLAGS * fflags,
-                      KINEMATICS_INVERSE_FLAGS * iflags)
-
+static int tdrKinematicsForward(const double *j,
+                                EmcPose * pos,
+                                const KINEMATICS_FORWARD_FLAGS * fflags,
+                                KINEMATICS_INVERSE_FLAGS * iflags)
 {
     (void)fflags;
     (void)iflags;
-    double x_rot_point = hal_get_real(haldata->x_rot_point);
-    double y_rot_point = hal_get_real(haldata->y_rot_point);
-    double z_rot_point = hal_get_real(haldata->z_rot_point);
+    double x_rot_point = hal_get_real(tdrdata->x_rot_point);
+    double y_rot_point = hal_get_real(tdrdata->y_rot_point);
+    double z_rot_point = hal_get_real(tdrdata->z_rot_point);
 
-    double dz = hal_get_real(haldata->z_offset);
-    double dt = hal_get_real(haldata->tool_offset_z);
+    double dz = hal_get_real(tdrdata->z_offset);
+    double dt = hal_get_real(tdrdata->tool_offset_z);
 
     // substitutions as used in mathematical documentation
     // including degree -> radians angle conversion
@@ -158,39 +102,22 @@ int kinematicsForward(const double *j,
     double       cb = cos(j[4]*TO_RAD);
 
     // used to be consistent with math in the documentation
-    double       px = 0;
-    double       py = 0;
-    double       pz = 0;
+    double       px = j[0] - x_rot_point;
+    double       py = j[1] - y_rot_point;
+    double       pz = j[2] - z_rot_point - dt;
 
-    // define forward kinematic models using case structure for
-    // for switchable kinematics
-    switch (switchkins_type) {
-        case 0: // ====================== IDENTITY kinematics FORWARD ====================
-            pos->tran.x = j[0];
-            pos->tran.y = j[1];
-            pos->tran.z = j[2];
-            pos->a      = j[3];
-            pos->b      = j[4];
-            break;
-        case 1: // ========================= TCP kinematics FORWARD ======================
-            px          = j[0] - x_rot_point;
-            py          = j[1] - y_rot_point;
-            pz          = j[2] - z_rot_point - dt;
+    pos->tran.x =   cb*px + sb*pz
+                  + x_rot_point;
 
-            pos->tran.x =   cb*px + sb*pz
-                          + x_rot_point;
+    pos->tran.y =   sa*sb*px + ca*py - cb*sa*pz + sa*dz
+                  + y_rot_point;
 
-            pos->tran.y =   sa*sb*px + ca*py - cb*sa*pz + sa*dz
-                          + y_rot_point;
+    pos->tran.z = - ca*sb*px + sa*py + ca*cb*pz - ca*dz
+                  + z_rot_point + dz + dt;
 
-            pos->tran.z = - ca*sb*px + sa*py + ca*cb*pz - ca*dz
-                          + z_rot_point + dz + dt;
+    pos->a      = j[3];
+    pos->b      = j[4];
 
-            pos->a      = j[3];
-            pos->b      = j[4];
-            pos->c      = j[5];
-            break;
-    }
     // unused coordinates:
     pos->c = 0;
     pos->u = 0;
@@ -198,22 +125,22 @@ int kinematicsForward(const double *j,
     pos->w = 0;
 
     return 0;
-} // kinematicsForward()
+} // tdrKinematicsForward()
 
-int kinematicsInverse(const EmcPose * pos,
-                      double *j,
-                      const KINEMATICS_INVERSE_FLAGS * iflags,
-                      KINEMATICS_FORWARD_FLAGS * fflags)
+static int tdrKinematicsInverse(const EmcPose * pos,
+                                double *j,
+                                const KINEMATICS_INVERSE_FLAGS * iflags,
+                                KINEMATICS_FORWARD_FLAGS * fflags)
 {
     (void)iflags;
     (void)fflags;
-    double x_rot_point = hal_get_real(haldata->x_rot_point);
-    double y_rot_point = hal_get_real(haldata->y_rot_point);
-    double z_rot_point = hal_get_real(haldata->z_rot_point);
+    double x_rot_point = hal_get_real(tdrdata->x_rot_point);
+    double y_rot_point = hal_get_real(tdrdata->y_rot_point);
+    double z_rot_point = hal_get_real(tdrdata->z_rot_point);
 
-    double dx = hal_get_real(haldata->x_offset);
-    double dz = hal_get_real(haldata->z_offset);
-    double dt = hal_get_real(haldata->tool_offset_z);
+    double dx = hal_get_real(tdrdata->x_offset);
+    double dz = hal_get_real(tdrdata->z_offset);
+    double dt = hal_get_real(tdrdata->tool_offset_z);
 
     // substitutions as used in mathematical documentation
     // including degree -> radians angle conversion
@@ -223,36 +150,46 @@ int kinematicsInverse(const EmcPose * pos,
     double       cb = cos(pos->b*TO_RAD);
 
     // used to be consistent with math in the documentation
-    double       qx = 0;
-    double       qy = 0;
-    double       qz = 0;
+    double       qx = pos->tran.x - x_rot_point - dx;
+    double       qy = pos->tran.y - y_rot_point;
+    double       qz = pos->tran.z - z_rot_point - dz - dt;
 
-    switch (switchkins_type) {
-        case 0:// ====================== IDENTITY kinematics INVERSE =====================
-            j[0] = pos->tran.x;
-            j[1] = pos->tran.y;
-            j[2] = pos->tran.z;
-            j[3] = pos->a;
-            j[4] = pos->b;
-            break;
-        case 1: // ========================= TCP kinematics INVERSE ======================
-            qx   = pos->tran.x - x_rot_point - dx;
-            qy   = pos->tran.y - y_rot_point;
-            qz   = pos->tran.z - z_rot_point - dz - dt;
+    j[0] =   cb*qx + sa*sb*qy - ca*sb*qz + cb*dx - sb*dz
+           + x_rot_point;
 
-            j[0] =   cb*qx + sa*sb*qy - ca*sb*qz + cb*dx - sb*dz
-                   + x_rot_point;
+    j[1] =   ca*qy + sa*qz
+           + y_rot_point;
 
-            j[1] =   ca*qy + sa*qz
-                   + y_rot_point;
+    j[2] =   sb*qx - sa*cb*qy + ca*cb*qz + sb*dx + cb*dz
+           + z_rot_point + dt;
 
-            j[2] =   sb*qx - sa*cb*qy + ca*cb*qz + sb*dx + cb*dz
-                   + z_rot_point + dt;
-
-            j[3] = pos->a;
-            j[4] = pos->b;
-            break;
-    }
+    j[3] = pos->a;
+    j[4] = pos->b;
 
     return 0;
-} // kinematicsInverse()
+} // tdrKinematicsInverse()
+
+// halcompile has done hal_init() and does hal_ready() after this returns,
+// which is what switchkinsInit() expects
+EXTRA_SETUP() {
+    kparms kp;
+    (void)__comp_inst; (void)prefix; (void)extra_arg;
+
+    kp.kinsname    = "xyzab_tdr_kins";
+    kp.halprefix   = "xyzab_tdr_kins";
+    kp.required_coordinates = "xyzab";
+    kp.allow_duplicates     = 0;
+    kp.fwd_iterates_mask    = 0;
+    kp.gui_kinstype         = -1;
+    kp.sparm                = NULL;
+    kp.max_joints           = strlen(kp.required_coordinates);
+
+    if (switchkinsRegister(0, identityKinematicsSetup,
+                              identityKinematicsForward,
+                              identityKinematicsInverse)) { return -1; }
+    if (switchkinsRegister(1, tdrKinematicsSetup,
+                              tdrKinematicsForward,
+                              tdrKinematicsInverse))      { return -1; }
+
+    return switchkinsInit(comp_id, &kp, coordinates);
+} // EXTRA_SETUP()

--- a/src/hal/components/xyzacb_trsrn.comp
+++ b/src/hal/components/xyzacb_trsrn.comp
@@ -4,17 +4,26 @@ description
 """
 FIXME
 
+The kinematics-type switching, the *kinstype.is-N* pins and the
+joints-to-coordinates mapping are provided by switchkins.c, so the
+*coordinates=* module parameter and the kinematics switching described in
+the switchkins document chapter apply here too.
+
 """;
 pin out si32 dummy=0 "dummy pin to satisfy halcompile";
 option period no;
+option extra_setup;
 
 license "GPL";
 author "David Mueller";
 ;;
 
 #include <rtapi_math.h>
-#include <kinematics.h>
 
+#include <switchkins.h>
+
+static char *coordinates;
+RTAPI_MP_STRING(coordinates, "Axes-to-joints-ordering");
 
 static struct haldata {
   // these should be parameters really but we want to be able to
@@ -35,122 +44,50 @@ static struct haldata {
   // Declare hal pin pointers used for xyzacb_trsrn kinematics:
 
   hal_real_t tool_offset_z;
-
-  //Declare hal pin pointers used for switchable kinematics
-  hal_bool_t kinstype_is_0;
-  hal_bool_t kinstype_is_1;
-  hal_bool_t kinstype_is_2;
 } *haldata;
 
-
-static int xyzacb_trsrn_setup(void) {
-#define HAL_PREFIX "xyzacb_trsrn_kins"
-    int res=0;
-    // inherit comp_id from rtapi_main()
-    if (comp_id < 0) goto error;
-    // set unready to allow creation of pins
-    if (hal_set_unready(comp_id)) goto error;
+// the pins are shared by the TCP and TOOL kinematics; the TOOL type has
+// no setup routine of its own
+static int trsrnKinematicsSetup(const int   comp_id,
+                                const char* coords,
+                                kparms*     kp)
+{
+    int res = 0;
+    (void)coords;
 
     haldata = hal_malloc(sizeof(struct haldata));
-    if (!haldata) goto error;
+    if (!haldata) return -1;
 
-    // hal pins required for xyzacb_trsrn kinematics:
-    res += hal_pin_new_real(comp_id, HAL_IN, &haldata->tool_offset_z, 0.0, "%s.tool-offset-z" ,HAL_PREFIX);
-    res += hal_pin_new_real(comp_id, HAL_IN, &haldata->y_pivot,    0.0, "%s.y-pivot" ,HAL_PREFIX);
-    res += hal_pin_new_real(comp_id, HAL_IN, &haldata->z_pivot,    0.0, "%s.z-pivot" ,HAL_PREFIX);
-    res += hal_pin_new_real(comp_id, HAL_IN, &haldata->x_offset,   0.0, "%s.x-offset" ,HAL_PREFIX);
-    res += hal_pin_new_real(comp_id, HAL_IN, &haldata->y_offset,   0.0, "%s.y-offset" ,HAL_PREFIX);
-    res += hal_pin_new_real(comp_id, HAL_IN, &haldata->y_rot_axis, 0.0, "%s.y-rot-axis" ,HAL_PREFIX);
-    res += hal_pin_new_real(comp_id, HAL_IN, &haldata->z_rot_axis, 0.0, "%s.z-rot-axis" ,HAL_PREFIX);
-    res += hal_pin_new_real(comp_id, HAL_IN, &haldata->pre_rot,    0.0, "%s.pre-rot" ,HAL_PREFIX);
-    res += hal_pin_new_real(comp_id, HAL_IN, &haldata->nut_angle,  0.0, "%s.nut-angle" ,HAL_PREFIX);
-    res += hal_pin_new_real(comp_id, HAL_IN, &haldata->prim_angle, 0.0, "%s.primary-angle" ,HAL_PREFIX);
-    res += hal_pin_new_real(comp_id, HAL_IN, &haldata->sec_angle,  0.0, "%s.secondary-angle" ,HAL_PREFIX);
+    res += hal_pin_new_real(comp_id, HAL_IN, &haldata->tool_offset_z, 0.0, "%s.tool-offset-z" ,kp->halprefix);
+    res += hal_pin_new_real(comp_id, HAL_IN, &haldata->y_pivot,    0.0, "%s.y-pivot" ,kp->halprefix);
+    res += hal_pin_new_real(comp_id, HAL_IN, &haldata->z_pivot,    0.0, "%s.z-pivot" ,kp->halprefix);
+    res += hal_pin_new_real(comp_id, HAL_IN, &haldata->x_offset,   0.0, "%s.x-offset" ,kp->halprefix);
+    res += hal_pin_new_real(comp_id, HAL_IN, &haldata->y_offset,   0.0, "%s.y-offset" ,kp->halprefix);
+    res += hal_pin_new_real(comp_id, HAL_IN, &haldata->y_rot_axis, 0.0, "%s.y-rot-axis" ,kp->halprefix);
+    res += hal_pin_new_real(comp_id, HAL_IN, &haldata->z_rot_axis, 0.0, "%s.z-rot-axis" ,kp->halprefix);
+    res += hal_pin_new_real(comp_id, HAL_IN, &haldata->pre_rot,    0.0, "%s.pre-rot" ,kp->halprefix);
+    res += hal_pin_new_real(comp_id, HAL_IN, &haldata->nut_angle,  0.0, "%s.nut-angle" ,kp->halprefix);
+    res += hal_pin_new_real(comp_id, HAL_IN, &haldata->prim_angle, 0.0, "%s.primary-angle" ,kp->halprefix);
+    res += hal_pin_new_real(comp_id, HAL_IN, &haldata->sec_angle,  0.0, "%s.secondary-angle" ,kp->halprefix);
+    if (res) return -1;
 
-    // hal pins required for switchable kinematics:
-    //default at startup -> identity kinematics
-    //-> xyzabc TCP
-    //-> xyzabc TOOL
-    res += hal_pin_new_bool(comp_id, HAL_OUT, &haldata->kinstype_is_0, 1, "kinstype.is-0");
-    res += hal_pin_new_bool(comp_id, HAL_OUT, &haldata->kinstype_is_1, 0, "kinstype.is-1");
-    res += hal_pin_new_bool(comp_id, HAL_OUT, &haldata->kinstype_is_2, 0, "kinstype.is-2");
-
-    if (res) goto error;
-    hal_ready(comp_id);
-    rtapi_print("*** %s setup ok\n",__FILE__);
     return 0;
-error:
-    rtapi_print("\n!!! %s setup failed res=%d\n\n",__FILE__,res);
-    return -1;
-#undef HAL_PREFIX
-}
+} // trsrnKinematicsSetup()
 
-EXPORT_SYMBOL(kinematicsType);
-EXPORT_SYMBOL(kinematicsSwitchable);
-EXPORT_SYMBOL(kinematicsSwitch);
-EXPORT_SYMBOL(kinematicsInverse);
-EXPORT_SYMBOL(kinematicsForward);
-
-static rtapi_u32 switchkins_type;
-
-int kinematicsSwitchable() {return 1;}
-
-
-
-int kinematicsSwitch(int new_switchkins_type)
+static int toolKinematicsSetup(const int   comp_id,
+                               const char* coords,
+                               kparms*     kp)
 {
-    switchkins_type = new_switchkins_type;
-    rtapi_print("kinematicsSwitch(): type=%d\n",switchkins_type);
-    // create case structure for switchable kinematics
-    switch (switchkins_type) {
-        case 0: rtapi_print_msg(RTAPI_MSG_INFO,
-                "kinematicsSwitch:TYPE0\n");
-                hal_set_bool(haldata->kinstype_is_0, 1);
-                hal_set_bool(haldata->kinstype_is_1, 0);
-                hal_set_bool(haldata->kinstype_is_2, 0);
-                break;
-        case 1: rtapi_print_msg(RTAPI_MSG_INFO,
-                "kinematicsSwitch:TYPE1\n");
-                hal_set_bool(haldata->kinstype_is_0, 0);
-                hal_set_bool(haldata->kinstype_is_1, 1);
-                hal_set_bool(haldata->kinstype_is_2, 0);
-                break;
-        case 2: rtapi_print_msg(RTAPI_MSG_INFO,
-                "kinematicsSwitch:TYPE1\n");
-                hal_set_bool(haldata->kinstype_is_0, 0);
-                hal_set_bool(haldata->kinstype_is_1, 0);
-                hal_set_bool(haldata->kinstype_is_2, 1);
-                break;
-      default: rtapi_print_msg(RTAPI_MSG_ERR,
-                "kinematicsSwitch:BAD VALUE <%d>\n",
-                switchkins_type);
-                hal_set_bool(haldata->kinstype_is_1, 0);
-                hal_set_bool(haldata->kinstype_is_0, 0);
-                hal_set_bool(haldata->kinstype_is_2, 0);
-                return -1; // FAIL
-    }
-    return 0; // ok
-}
+    (void)comp_id;
+    (void)coords;
+    (void)kp;
+    return 0; // pins created by trsrnKinematicsSetup()
+} // toolKinematicsSetup()
 
-KINEMATICS_TYPE kinematicsType()
+// tool_kins==0: TCP kinematics, using the current spindle joint positions
+// tool_kins==1: TOOL kinematics, using the angles calculated in remap.py
+static int trsrnForward(const double *j, EmcPose * pos, int tool_kins)
 {
-static bool is_setup=0;
-    if (!is_setup)  xyzacb_trsrn_setup();
-    return KINEMATICS_BOTH; // set as required
-           // Note: If kinematics are identity, using KINEMATICS_BOTH
-           //       may be used in order to allow a gui to display
-           //       joint values in preview prior to homing
-} // kinematicsType()
-
-
-int kinematicsForward(const double *j,
-                      EmcPose * pos,
-                      const KINEMATICS_FORWARD_FLAGS * fflags,
-                      KINEMATICS_INVERSE_FLAGS * iflags)
-{
-    (void)fflags;
-    (void)iflags;
-
     // START of custom variable declaration for Forward kinematics
 
     // geometric offsets of the universal spindle head as defined in the ini file
@@ -195,20 +132,7 @@ int kinematicsForward(const double *j,
 
     // END of custom variable declaration for Forward kinematics
 
-    // define forward kinematic models using case structure for
-    // for switchable kinematics
-    switch (switchkins_type) {
-        case 0: // ========================= IDENTITY kinematics FORWARD ======================
-            pos->tran.x = j[0];
-            pos->tran.y = j[1];
-            pos->tran.z = j[2];
-            pos->a      = j[3];
-            pos->b      = j[4];
-            pos->c      = j[5];
-
-            break;
-
-        case 1: // ========================= TCP kinematics FORWARD 
+    if (!tool_kins) { // ========================= TCP kinematics FORWARD
             // in TCP we use the current positions of the spindle joints
               Ss = sin(j[4]*TO_RAD);
               Cs = cos(j[4]*TO_RAD);
@@ -251,9 +175,7 @@ int kinematicsForward(const double *j,
             pos->b      = j[4];
             pos->c      = j[5];
 
-            break;
-
-      case 2: // ========================= TOOL kinematics FORWARD 
+    } else { // ========================= TOOL kinematics FORWARD
             // in TOOL kinematics we use the articulated joint positions from the TWP
               Ss = sin(theta_2*TO_RAD);
               Cs = cos(theta_2*TO_RAD);
@@ -291,10 +213,6 @@ int kinematicsForward(const double *j,
             pos->a      = j[3];
             pos->b      = j[4];
             pos->c      = j[5];
-
-            break;
-
-
     }
     // unused coordinates:
     pos->u = 0;
@@ -302,16 +220,30 @@ int kinematicsForward(const double *j,
     pos->w = 0;
 
     return 0;
-} // kinematicsForward()
+} // trsrnForward()
 
-int kinematicsInverse(const EmcPose * pos,
-                      double *j,
-                      const KINEMATICS_INVERSE_FLAGS * iflags,
-                      KINEMATICS_FORWARD_FLAGS * fflags)
+static int tcpKinematicsForward(const double *j,
+                                EmcPose * pos,
+                                const KINEMATICS_FORWARD_FLAGS * fflags,
+                                KINEMATICS_INVERSE_FLAGS * iflags)
 {
-    (void)iflags;
     (void)fflags;
+    (void)iflags;
+    return trsrnForward(j, pos, 0);
+} // tcpKinematicsForward()
 
+static int toolKinematicsForward(const double *j,
+                                 EmcPose * pos,
+                                 const KINEMATICS_FORWARD_FLAGS * fflags,
+                                 KINEMATICS_INVERSE_FLAGS * iflags)
+{
+    (void)fflags;
+    (void)iflags;
+    return trsrnForward(j, pos, 1);
+} // toolKinematicsForward()
+
+static int trsrnInverse(const EmcPose * pos, double *j, int tool_kins)
+{
     // START of custom variable declaration for Forward kinematics
 
     // geometric offsets of the universal spindle head as defined in the ini file
@@ -359,23 +291,7 @@ int kinematicsInverse(const EmcPose * pos,
 
     // END of custom variable declaration for Forward kinematics
 
-    // Update the kinematic joints specified by the
-    // [KINS]JOINTS setting (4 required for this template).
-    // define forward kinematic models using case structure for
-    // for switchable kinematics
-    switch (switchkins_type) {
-
-        case 0: // ========================= IDENTITY kinematics INVERSE ======================
-            j[0] = pos->tran.x;
-            j[1] = pos->tran.y;
-            j[2] = pos->tran.z;
-            j[3] = pos->a;
-            j[4] = pos->b;
-            j[5] = pos->c;
-
-            break;
-
-        case 1: // ========================= TCP kinematics INVERSE 
+    if (!tool_kins) { // ========================= TCP kinematics INVERSE
             // in TCP we use the current positions of the spindle joints
               Ss = sin(j[4]*TO_RAD);
               Cs = cos(j[4]*TO_RAD);
@@ -412,9 +328,7 @@ int kinematicsInverse(const EmcPose * pos,
             j[4] = pos->b;
             j[5] = pos->c;
 
-            break;
-
-        case 2: // ========================= TOOL  kinematics INVERSE
+    } else { // ========================= TOOL  kinematics INVERSE
                 // in TOOL kinematics we use the articulated joint positions from the TWP
                   Ss = sin(theta_2*TO_RAD);
                   Cs = cos(theta_2*TO_RAD);
@@ -456,9 +370,55 @@ int kinematicsInverse(const EmcPose * pos,
                 j[3] = pos->a;
                 j[4] = pos->b;
                 j[5] = pos->c;
-
-                break;
     }
 
     return 0;
-} // kinematicsInverse()
+} // trsrnInverse()
+
+static int tcpKinematicsInverse(const EmcPose * pos,
+                                double *j,
+                                const KINEMATICS_INVERSE_FLAGS * iflags,
+                                KINEMATICS_FORWARD_FLAGS * fflags)
+{
+    (void)iflags;
+    (void)fflags;
+    return trsrnInverse(pos, j, 0);
+} // tcpKinematicsInverse()
+
+static int toolKinematicsInverse(const EmcPose * pos,
+                                 double *j,
+                                 const KINEMATICS_INVERSE_FLAGS * iflags,
+                                 KINEMATICS_FORWARD_FLAGS * fflags)
+{
+    (void)iflags;
+    (void)fflags;
+    return trsrnInverse(pos, j, 1);
+} // toolKinematicsInverse()
+
+// halcompile has done hal_init() and does hal_ready() after this returns,
+// which is what switchkinsInit() expects
+EXTRA_SETUP() {
+    kparms kp;
+    (void)__comp_inst; (void)prefix; (void)extra_arg;
+
+    kp.kinsname    = "xyzacb_trsrn";
+    kp.halprefix   = "xyzacb_trsrn_kins";
+    kp.required_coordinates = "xyzabc";
+    kp.allow_duplicates     = 0;
+    kp.fwd_iterates_mask    = 0;
+    kp.gui_kinstype         = -1;
+    kp.sparm                = NULL;
+    kp.max_joints           = strlen(kp.required_coordinates);
+
+    if (switchkinsRegister(0, identityKinematicsSetup,
+                              identityKinematicsForward,
+                              identityKinematicsInverse)) { return -1; }
+    if (switchkinsRegister(1, trsrnKinematicsSetup,
+                              tcpKinematicsForward,
+                              tcpKinematicsInverse))      { return -1; }
+    if (switchkinsRegister(2, toolKinematicsSetup,
+                              toolKinematicsForward,
+                              toolKinematicsInverse))     { return -1; }
+
+    return switchkinsInit(comp_id, &kp, coordinates);
+} // EXTRA_SETUP()

--- a/src/hal/components/xyzbca_trsrn.comp
+++ b/src/hal/components/xyzbca_trsrn.comp
@@ -4,17 +4,26 @@ description
 """
 FIXME
 
+The kinematics-type switching, the *kinstype.is-N* pins and the
+joints-to-coordinates mapping are provided by switchkins.c, so the
+*coordinates=* module parameter and the kinematics switching described in
+the switchkins document chapter apply here too.
+
 """;
 pin out si32 dummy=0 "dummy pin to satisfy halcompile";
 option period no;
+option extra_setup;
 
 license "GPL";
 author "David Mueller";
 ;;
 
 #include <rtapi_math.h>
-#include <kinematics.h>
 
+#include <switchkins.h>
+
+static char *coordinates;
+RTAPI_MP_STRING(coordinates, "Axes-to-joints-ordering");
 
 static struct haldata {
   // these should be parameters really but we want to be able to
@@ -35,122 +44,50 @@ static struct haldata {
   // Declare hal pin pointers used for xyzbca_trsrn kinematics:
 
   hal_real_t tool_offset_z;
-
-  //Declare hal pin pointers used for switchable kinematics
-  hal_bool_t kinstype_is_0;
-  hal_bool_t kinstype_is_1;
-  hal_bool_t kinstype_is_2;
 } *haldata;
 
-
-static int xyzbca_trsrn_setup(void) {
-#define HAL_PREFIX "xyzbca_trsrn_kins"
-    int res=0;
-    // inbherit comp_id from rtapi_main()
-    if (comp_id < 0) goto error;
-    // set unready to allow creation of pins
-    if (hal_set_unready(comp_id)) goto error;
+// the pins are shared by the TCP and TOOL kinematics; the TOOL type has
+// no setup routine of its own
+static int trsrnKinematicsSetup(const int   comp_id,
+                                const char* coords,
+                                kparms*     kp)
+{
+    int res = 0;
+    (void)coords;
 
     haldata = hal_malloc(sizeof(struct haldata));
-    if (!haldata) goto error;
+    if (!haldata) return -1;
 
-    // hal pins required for xyzbca_trsrn kinematics:
-    res += hal_pin_new_real(comp_id, HAL_IN, &haldata->tool_offset_z, 0.0, "%s.tool-offset-z", HAL_PREFIX);
-    res += hal_pin_new_real(comp_id, HAL_IN, &haldata->x_pivot,    0.0, "%s.x-pivot", HAL_PREFIX);
-    res += hal_pin_new_real(comp_id, HAL_IN, &haldata->z_pivot,    0.0, "%s.z-pivot", HAL_PREFIX);
-    res += hal_pin_new_real(comp_id, HAL_IN, &haldata->x_offset,   0.0, "%s.x-offset", HAL_PREFIX);
-    res += hal_pin_new_real(comp_id, HAL_IN, &haldata->y_offset,   0.0, "%s.y-offset", HAL_PREFIX);
-    res += hal_pin_new_real(comp_id, HAL_IN, &haldata->x_rot_axis, 0.0, "%s.x-rot-axis", HAL_PREFIX);
-    res += hal_pin_new_real(comp_id, HAL_IN, &haldata->z_rot_axis, 0.0, "%s.z-rot-axis", HAL_PREFIX);
-    res += hal_pin_new_real(comp_id, HAL_IN, &haldata->pre_rot,    0.0, "%s.pre-rot", HAL_PREFIX);
-    res += hal_pin_new_real(comp_id, HAL_IN, &haldata->nut_angle,  0.0, "%s.nut-angle", HAL_PREFIX);
-    res += hal_pin_new_real(comp_id, HAL_IN, &haldata->prim_angle, 0.0, "%s.primary-angle", HAL_PREFIX);
-    res += hal_pin_new_real(comp_id, HAL_IN, &haldata->sec_angle,  0.0, "%s.secondary-angle", HAL_PREFIX);
+    res += hal_pin_new_real(comp_id, HAL_IN, &haldata->tool_offset_z, 0.0, "%s.tool-offset-z", kp->halprefix);
+    res += hal_pin_new_real(comp_id, HAL_IN, &haldata->x_pivot,    0.0, "%s.x-pivot", kp->halprefix);
+    res += hal_pin_new_real(comp_id, HAL_IN, &haldata->z_pivot,    0.0, "%s.z-pivot", kp->halprefix);
+    res += hal_pin_new_real(comp_id, HAL_IN, &haldata->x_offset,   0.0, "%s.x-offset", kp->halprefix);
+    res += hal_pin_new_real(comp_id, HAL_IN, &haldata->y_offset,   0.0, "%s.y-offset", kp->halprefix);
+    res += hal_pin_new_real(comp_id, HAL_IN, &haldata->x_rot_axis, 0.0, "%s.x-rot-axis", kp->halprefix);
+    res += hal_pin_new_real(comp_id, HAL_IN, &haldata->z_rot_axis, 0.0, "%s.z-rot-axis", kp->halprefix);
+    res += hal_pin_new_real(comp_id, HAL_IN, &haldata->pre_rot,    0.0, "%s.pre-rot", kp->halprefix);
+    res += hal_pin_new_real(comp_id, HAL_IN, &haldata->nut_angle,  0.0, "%s.nut-angle", kp->halprefix);
+    res += hal_pin_new_real(comp_id, HAL_IN, &haldata->prim_angle, 0.0, "%s.primary-angle", kp->halprefix);
+    res += hal_pin_new_real(comp_id, HAL_IN, &haldata->sec_angle,  0.0, "%s.secondary-angle", kp->halprefix);
+    if (res) return -1;
 
-    // hal pins required for switchable kinematics:
-    //default at startup -> identity kinematics
-    //-> xyzabc TCP
-    //-> xyzabc TOOL
-    res += hal_pin_new_bool(comp_id, HAL_OUT, &haldata->kinstype_is_0, 1, "kinstype.is-0");
-    res += hal_pin_new_bool(comp_id, HAL_OUT, &haldata->kinstype_is_1, 0, "kinstype.is-1");
-    res += hal_pin_new_bool(comp_id, HAL_OUT, &haldata->kinstype_is_2, 0, "kinstype.is-2");
-
-    if (res) goto error;
-    hal_ready(comp_id);
-    rtapi_print("*** %s setup ok\n",__FILE__);
     return 0;
-error:
-    rtapi_print("\n!!! %s setup failed res=%d\n\n",__FILE__,res);
-    return -1;
-#undef HAL_PREFIX
-}
+} // trsrnKinematicsSetup()
 
-EXPORT_SYMBOL(kinematicsType);
-EXPORT_SYMBOL(kinematicsSwitchable);
-EXPORT_SYMBOL(kinematicsSwitch);
-EXPORT_SYMBOL(kinematicsInverse);
-EXPORT_SYMBOL(kinematicsForward);
-
-static rtapi_u32 switchkins_type;
-
-int kinematicsSwitchable() {return 1;}
-
-
-
-int kinematicsSwitch(int new_switchkins_type)
+static int toolKinematicsSetup(const int   comp_id,
+                               const char* coords,
+                               kparms*     kp)
 {
-    switchkins_type = new_switchkins_type;
-    rtapi_print("kinematicsSwitch(): type=%d\n",switchkins_type);
-    // create case structure for switchable kinematics
-    switch (switchkins_type) {
-        case 0: rtapi_print_msg(RTAPI_MSG_INFO,
-                "kinematicsSwitch:TYPE0\n");
-                hal_set_bool(haldata->kinstype_is_0, 1);
-                hal_set_bool(haldata->kinstype_is_1, 0);
-                hal_set_bool(haldata->kinstype_is_2, 0);
-                break;
-        case 1: rtapi_print_msg(RTAPI_MSG_INFO,
-                "kinematicsSwitch:TYPE1\n");
-                hal_set_bool(haldata->kinstype_is_0, 0);
-                hal_set_bool(haldata->kinstype_is_1, 1);
-                hal_set_bool(haldata->kinstype_is_2, 0);
-                break;
-        case 2: rtapi_print_msg(RTAPI_MSG_INFO,
-                "kinematicsSwitch:TYPE1\n");
-                hal_set_bool(haldata->kinstype_is_0, 0);
-                hal_set_bool(haldata->kinstype_is_1, 0);
-                hal_set_bool(haldata->kinstype_is_2, 1);
-                break;
-      default: rtapi_print_msg(RTAPI_MSG_ERR,
-                "kinematicsSwitch:BAD VALUE <%d>\n",
-                switchkins_type);
-                hal_set_bool(haldata->kinstype_is_1, 0);
-                hal_set_bool(haldata->kinstype_is_0, 0);
-                hal_set_bool(haldata->kinstype_is_2, 0);
-                return -1; // FAIL
-    }
-    return 0; // ok
-}
+    (void)comp_id;
+    (void)coords;
+    (void)kp;
+    return 0; // pins created by trsrnKinematicsSetup()
+} // toolKinematicsSetup()
 
-KINEMATICS_TYPE kinematicsType()
+// tool_kins==0: TCP kinematics, using the current spindle joint positions
+// tool_kins==1: TOOL kinematics, using the angles calculated in remap.py
+static int trsrnForward(const double *j, EmcPose * pos, int tool_kins)
 {
-static bool is_setup=0;
-    if (!is_setup)  xyzbca_trsrn_setup();
-    return KINEMATICS_BOTH; // set as required
-           // Note: If kinematics are identity, using KINEMATICS_BOTH
-           //       may be used in order to allow a gui to display
-           //       joint values in preview prior to homing
-} // kinematicsType()
-
-
-int kinematicsForward(const double *j,
-                      EmcPose * pos,
-                      const KINEMATICS_FORWARD_FLAGS * fflags,
-                      KINEMATICS_INVERSE_FLAGS * iflags)
-{
-    (void)fflags;
-    (void)iflags;
-
     // START of custom variable declaration for Forward kinematics
 
     // geometric offsets of the universal spindle head as defined in the ini file
@@ -196,20 +133,7 @@ int kinematicsForward(const double *j,
     // END of custom variable declaration for Forward kinematics
 
 
-    // define forward kinematic models using case structure for
-    // for switchable kinematics
-    switch (switchkins_type) {
-        case 0: // ========================= IDENTITY kinematics FORWARD ======================
-            pos->tran.x = j[0];
-            pos->tran.y = j[1];
-            pos->tran.z = j[2];
-            pos->a      = j[3];
-            pos->b      = j[4];
-            pos->c      = j[5];
-
-            break;
-
-       case 1: // ========================= TCP kinematics FORWARD 
+    if (!tool_kins) { // ========================= TCP kinematics FORWARD
             // in TCP we use the current positions of the spindle joints
               Ss = sin(j[3]*TO_RAD);
               Cs = cos(j[3]*TO_RAD);
@@ -256,9 +180,7 @@ int kinematicsForward(const double *j,
             pos->b      = j[4];
             pos->c      = j[5];
 
-            break;
-
-      case 2: // ========================= TOOL kinematics FORWARD 
+    } else { // ========================= TOOL kinematics FORWARD
             // in TOOL kinematics we use the articulated joint positions from the TWP
               Ss = sin(theta_2*TO_RAD);
               Cs = cos(theta_2*TO_RAD);
@@ -296,10 +218,6 @@ int kinematicsForward(const double *j,
             pos->a      = j[3];
             pos->b      = j[4];
             pos->c      = j[5];
-
-            break;
-
-
     }
     // unused coordinates:
     pos->u = 0;
@@ -307,16 +225,30 @@ int kinematicsForward(const double *j,
     pos->w = 0;
 
     return 0;
-} // kinematicsForward()
+} // trsrnForward()
 
-int kinematicsInverse(const EmcPose * pos,
-                      double *j,
-                      const KINEMATICS_INVERSE_FLAGS * iflags,
-                      KINEMATICS_FORWARD_FLAGS * fflags)
+static int tcpKinematicsForward(const double *j,
+                                EmcPose * pos,
+                                const KINEMATICS_FORWARD_FLAGS * fflags,
+                                KINEMATICS_INVERSE_FLAGS * iflags)
 {
-    (void)iflags;
     (void)fflags;
+    (void)iflags;
+    return trsrnForward(j, pos, 0);
+} // tcpKinematicsForward()
 
+static int toolKinematicsForward(const double *j,
+                                 EmcPose * pos,
+                                 const KINEMATICS_FORWARD_FLAGS * fflags,
+                                 KINEMATICS_INVERSE_FLAGS * iflags)
+{
+    (void)fflags;
+    (void)iflags;
+    return trsrnForward(j, pos, 1);
+} // toolKinematicsForward()
+
+static int trsrnInverse(const EmcPose * pos, double *j, int tool_kins)
+{
     // START of custom variable declaration for Forward kinematics
 
     // geometric offsets of the universal spindle head as defined in the ini file
@@ -362,23 +294,7 @@ int kinematicsInverse(const EmcPose * pos,
     // END of custom variable declaration for Forward kinematics
 
 
-    // Update the kinematic joints specified by the
-    // [KINS]JOINTS setting (4 required for this template).
-    // define forward kinematic models using case structure for
-    // for switchable kinematics
-    switch (switchkins_type) {
-
-        case 0: // ========================= IDENTITY kinematics INVERSE ======================
-            j[0] = pos->tran.x;
-            j[1] = pos->tran.y;
-            j[2] = pos->tran.z;
-            j[3] = pos->a;
-            j[4] = pos->b;
-            j[5] = pos->c;
-
-            break;
-
-       case 1: // ========================= TCP kinematics INVERSE 
+    if (!tool_kins) { // ========================= TCP kinematics INVERSE
             // in TCP we use the current positions of the spindle joints
               Ss = sin(j[3]*TO_RAD);
               Cs = cos(j[3]*TO_RAD);
@@ -415,9 +331,7 @@ int kinematicsInverse(const EmcPose * pos,
             j[4] = pos->b;
             j[5] = pos->c;
 
-            break;
-
-        case 2: // ========================= TOOL  kinematics INVERSE
+    } else { // ========================= TOOL  kinematics INVERSE
             // in TOOL kinematics we use the articulated joint positions from the TWP
               Ss = sin(theta_2*TO_RAD);
               Cs = cos(theta_2*TO_RAD);
@@ -459,9 +373,55 @@ int kinematicsInverse(const EmcPose * pos,
             j[3] = pos->a;
             j[4] = pos->b;
             j[5] = pos->c;
-
-            break;
     }
 
     return 0;
-} // kinematicsInverse()
+} // trsrnInverse()
+
+static int tcpKinematicsInverse(const EmcPose * pos,
+                                double *j,
+                                const KINEMATICS_INVERSE_FLAGS * iflags,
+                                KINEMATICS_FORWARD_FLAGS * fflags)
+{
+    (void)iflags;
+    (void)fflags;
+    return trsrnInverse(pos, j, 0);
+} // tcpKinematicsInverse()
+
+static int toolKinematicsInverse(const EmcPose * pos,
+                                 double *j,
+                                 const KINEMATICS_INVERSE_FLAGS * iflags,
+                                 KINEMATICS_FORWARD_FLAGS * fflags)
+{
+    (void)iflags;
+    (void)fflags;
+    return trsrnInverse(pos, j, 1);
+} // toolKinematicsInverse()
+
+// halcompile has done hal_init() and does hal_ready() after this returns,
+// which is what switchkinsInit() expects
+EXTRA_SETUP() {
+    kparms kp;
+    (void)__comp_inst; (void)prefix; (void)extra_arg;
+
+    kp.kinsname    = "xyzbca_trsrn";
+    kp.halprefix   = "xyzbca_trsrn_kins";
+    kp.required_coordinates = "xyzabc";
+    kp.allow_duplicates     = 0;
+    kp.fwd_iterates_mask    = 0;
+    kp.gui_kinstype         = -1;
+    kp.sparm                = NULL;
+    kp.max_joints           = strlen(kp.required_coordinates);
+
+    if (switchkinsRegister(0, identityKinematicsSetup,
+                              identityKinematicsForward,
+                              identityKinematicsInverse)) { return -1; }
+    if (switchkinsRegister(1, trsrnKinematicsSetup,
+                              tcpKinematicsForward,
+                              tcpKinematicsInverse))      { return -1; }
+    if (switchkinsRegister(2, toolKinematicsSetup,
+                              toolKinematicsForward,
+                              toolKinematicsInverse))     { return -1; }
+
+    return switchkinsInit(comp_id, &kp, coordinates);
+} // EXTRA_SETUP()


### PR DESCRIPTION
Draft. This is where the multiaxis kinematics work is going, open early so it can be argued with. The first three commits are #4372, review those there. As pieces are agreed I will split them into small PRs, rebase this, and carry on, so nothing stalls behind it.

Plan, in order:

1. Switchkins: one implementation, used by `.comp`, `.c`, in tree and out of tree.
2. Tool length, oriented and integrated: a real tool vector in the machine's orientation, agreed on by the interpreter, the kinematics and the limits, instead of a scalar Z offset that each kinematics model re-derives for itself and that X and Y never get at all.
3. Forward and inverse kinematics earlier in the pipeline.
4. Velocity, acceleration, jerk and position limits, for every TP and every UI.

G12.1 and G13.1 sit on top of 1.

## In this branch now

- `separate the dispatch from rtapi_app_main()`: switchkins.c keeps the kinematics interface and the type dispatch and gains `switchkinsInit()`; the new switchkins_main.c takes `rtapi_app_main()` and the module parameters. The eight existing modules link both and are unchanged.
- `let halcompile components use the switchkins core`: millturn, xyzab_tdr_kins, xyzacb_trsrn and xyzbca_trsrn drop their private copy of the dispatch and call `switchkinsInit()` from `EXTRA_SETUP()`, which halcompile runs between `hal_init()` and `hal_ready()`. They could not link switchkins.o before, because switchkins.c supplied `rtapi_app_main()` and so does halcompile. The generated per-comp .mak now takes a `<component>-extra-objs` list, and switchkins.h is installed.
- `add an out-of-tree module template`: switchkinscomp.comp, `TOPDIR` plus `#include` of switchkins.c and kins_util.c, the same pattern tpcomp and homecomp use. No ABI, since the sources compile into the module.

## User visible

- The four components gain the `coordinates=` module parameter, their identity type now coming from kins_util.c.
- A bad `motion.switchkins-type` is rejected and leaves the running kinematics alone, instead of switching to a type that does not exist and clearing every `kinstype.is-N` pin.
- millturn loses its `in` and `out` example pins, template scaffolding referenced by no config. `fpin` and `fdemo` stay.
- All other pin names unchanged.

All four sim configs give identical positions to master through the same MDI sequence, in every kinematics type.
