### PR TITLE
hm2_modbus: Don't complain about relative paths, it is up to the user

### DIFF
--- a/docs/src/man/man9/hm2_modbus.9.adoc
+++ b/docs/src/man/man9/hm2_modbus.9.adoc
@@ -15,9 +15,8 @@ PktUART ports.
   parameter. Example: `ports="hm2_7i96s.0.pktuart.0","hm2_5i25.0.pktuart.2"`
 *mbccbs* [default: <empty>]::
   A comma separated list of "Modbus Command Control Binary" (MBCCB) file paths
-  to use for each PktUART port as specified in the *ports* parameter. The path
-  should be an absolute path to prevent nasty surprises.
-  Example: `mbccbs="/path/to/rly-and-spindle.mbccb","/path/to/lightsparks.mbccb"`
+  to use for each PktUART port as specified in the *ports* parameter.
+  Example: `mbccbs="rly-and-spindle.mbccb","lightsparks.mbccb"`
 *debug* [default: -1]::
   Set the message level of the running process. The message level is set
   if *debug* is set to a positive value between 0 and 5, where 0 means no

--- a/src/hal/drivers/mesa-hostmot2/hm2_modbus.c
+++ b/src/hal/drivers/mesa-hostmot2/hm2_modbus.c
@@ -316,11 +316,11 @@ RTAPI_MP_ARRAY_STRING(ports, MAX_PORTS, "PktUART HAL names");
 /*
  * The Modbus configuration and command structure files for each PktUART
  * interface to be read by the hm2_modbus module. This should be a list of
- * absolute path file names like:
- *   files="/usr/share/linuxcnc/modbus/spindle.mbccb","/home/test/xyz.mbccb"
+ * path file names like:
+ *   files="spindle.mbccb","xyz.mbccb"
  */
 static char *mbccbs[MAX_PORTS];
-RTAPI_MP_ARRAY_STRING(mbccbs, MAX_PORTS, "Binary Modbus configuration and command sequence absolute path file names");
+RTAPI_MP_ARRAY_STRING(mbccbs, MAX_PORTS, "Binary Modbus configuration and command sequence path file names");
 
 /*
  * Set the message level for debugging purpose. This has the (side-)effect that
@@ -2748,9 +2748,6 @@ int rtapi_app_main(void)
 			MSG_ERR("%s: error: Missing mbccb file path for instance %d in 'mbccbs' argument\n", inst->name, i);
 			retval = -EINVAL;
 			goto errout;
-		}
-		if('/' != mbccbs[i][0]) {
-			MSG_ERR("%s: warning: The 'mbccb' file path '%s' for instance %d in 'mbccbs' argument is not absolute\n", inst->name, mbccbs[i], i);
 		}
 
 		if((retval = load_mbccb(inst, mbccbs[i])) < 0) {


### PR DESCRIPTION
This PR removes the absolute path check in the hm2_modbus driver.

The default is to cd into the directory where the INI-file lives. And, if your mbccb file(s) live in there, then there is no need to complain. Therefore, the path is now fully up to the user to make it work.