### PR TITLE
  sai: give rs274 its own tool mmap instead of truncating $HOME/.tool.mmap

### DIFF
--- a/.github/scripts/install-deps.sh
+++ b/.github/scripts/install-deps.sh
@@ -3,6 +3,8 @@
 set -eu #Needed so CI fails when anything is wrong
 set -x
 
+.github/scripts/use-main-ubuntu-mirror.sh
+
 sudo apt-get --quiet update
 sudo apt-get install --yes --no-install-recommends devscripts equivs build-essential lintian clang
 debian/configure

--- a/.github/scripts/use-main-ubuntu-mirror.sh
+++ b/.github/scripts/use-main-ubuntu-mirror.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+# The azure.archive.ubuntu.com apt mirror on GitHub-hosted runners
+# regularly degrades to trickle speeds for extended periods, which stalls
+# package downloads until the job hits its timeout. apt retries do not
+# help because the connection stays alive, only slow. Switch to the main
+# Ubuntu archive, which is consistently fast from Azure.
+
+set -eu #Needed so CI fails when anything is wrong
+set -x
+
+for f in /etc/apt/sources.list /etc/apt/sources.list.d/*.list /etc/apt/sources.list.d/*.sources; do
+    [ -e "$f" ] || continue
+    sudo sed -i 's|http://azure\.archive\.ubuntu\.com/ubuntu|http://archive.ubuntu.com/ubuntu|g' "$f"
+done

--- a/.github/scripts/use-main-ubuntu-mirror.sh
+++ b/.github/scripts/use-main-ubuntu-mirror.sh
@@ -1,15 +1,22 @@
 #!/bin/sh
 
 # The azure.archive.ubuntu.com apt mirror on GitHub-hosted runners
-# regularly degrades to trickle speeds for extended periods, which stalls
-# package downloads until the job hits its timeout. apt retries do not
-# help because the connection stays alive, only slow. Switch to the main
-# Ubuntu archive, which is consistently fast from Azure.
+# regularly degrades to trickle speeds, stalling jobs until they time
+# out. Switch to archive.ubuntu.com, which is consistently fast.
 
 set -eu #Needed so CI fails when anything is wrong
 set -x
 
-for f in /etc/apt/sources.list /etc/apt/sources.list.d/*.list /etc/apt/sources.list.d/*.sources; do
+# apt-mirrors.txt must be included: the runner image points apt at it
+# via mirror+file:// in ubuntu.sources, so the azure URL lives there.
+for f in /etc/apt/sources.list /etc/apt/sources.list.d/*.list /etc/apt/sources.list.d/*.sources /etc/apt/apt-mirrors.txt; do
     [ -e "$f" ] || continue
     sudo sed -i 's|http://azure\.archive\.ubuntu\.com/ubuntu|http://archive.ubuntu.com/ubuntu|g' "$f"
 done
+
+# Fail if azure is still referenced, so an image layout change cannot
+# turn this script into a silent no-op.
+if grep -rsq 'azure\.archive\.ubuntu\.com' /etc/apt; then
+    echo "error: azure.archive.ubuntu.com still referenced under /etc/apt after mirror switch" >&2
+    exit 1
+fi

--- a/docs/src/gcode/m-code.adoc
+++ b/docs/src/gcode/m-code.adoc
@@ -233,7 +233,7 @@ M19 R- Q- [P-] [$-]
 M19 is a command of modal group 7, like M3, M4 and M5.
 M19 is cleared by any of M3,M4,M5.
 
-Spindle orientation requires a quadrature encoder with an index to sense the
+Spindle orientation requires a quadrature encoder to sense the
 spindle shaft position and direction of rotation.
 
 INI Settings in the [RS274NGC] section:

--- a/docs/src/man/man9/hm2_modbus.9.adoc
+++ b/docs/src/man/man9/hm2_modbus.9.adoc
@@ -15,9 +15,8 @@ PktUART ports.
   parameter. Example: `ports="hm2_7i96s.0.pktuart.0","hm2_5i25.0.pktuart.2"`
 *mbccbs* [default: <empty>]::
   A comma separated list of "Modbus Command Control Binary" (MBCCB) file paths
-  to use for each PktUART port as specified in the *ports* parameter. The path
-  should be an absolute path to prevent nasty surprises.
-  Example: `mbccbs="/path/to/rly-and-spindle.mbccb","/path/to/lightsparks.mbccb"`
+  to use for each PktUART port as specified in the *ports* parameter.
+  Example: `mbccbs="rly-and-spindle.mbccb","lightsparks.mbccb"`
 *debug* [default: -1]::
   Set the message level of the running process. The message level is set
   if *debug* is set to a positive value between 0 and 5, where 0 means no

--- a/src/emc/motion/command.c
+++ b/src/emc/motion/command.c
@@ -1381,7 +1381,10 @@ void emcmotCommandHandler_locked(void *arg, long servo_period)
 	                   joint_num);
                 return;
 	    }
-
+	    if ( get_homing_is_active() ) {
+	        reportError("Homing not possible until current homing process is finished.\n");
+	        return;
+	    }
 	    if (!GET_MOTION_ENABLE_FLAG()) {
 		break;
 	    }

--- a/src/emc/sai/driver.cc
+++ b/src/emc/sai/driver.cc
@@ -567,7 +567,17 @@ int main (int argc, char ** argv)
   tool_nml_register((CANON_TOOL_TABLE*)& _sai._tools);
 #else //}{
   const int random_toolchanger = 0;
+  // sai gets its OWN mmap. tool_mmap_creator() opens the file O_TRUNC, and it
+  // runs before getopt() below, so every rs274 invocation -- including --help,
+  // and including one given -t -- emptied $HOME/.tool.mmap. That file is the
+  // live tool table, shared MAP_SHARED with io/milltask/halui, so an offline
+  // parse silently replaced the tool table of a running machine.
+  char sai_mmap_fname[LINELEN];
+  snprintf(sai_mmap_fname,sizeof(sai_mmap_fname),
+           "/tmp/rs274.%d.tool.mmap",(int)getpid());
+  tool_mmap_set_fname(sai_mmap_fname);
   tool_mmap_creator((EMC_TOOL_STAT*)NULL,random_toolchanger);
+  atexit(tool_mmap_close);  // tool_mmap_close() unlinks the file
   /* Notes:
   **   1) sai does not use toolInSpindle,pocketPrepped
   **   2) sai does not distinguish changer type

--- a/src/emc/tooldata/tooldata.hh
+++ b/src/emc/tooldata/tooldata.hh
@@ -83,6 +83,7 @@ int tooldata_save(const char *filename,
 
 //----------------------------------------------------------
 //mmap specific
+void tool_mmap_set_fname(const char* fname);
 int  tool_mmap_creator(EMC_TOOL_STAT const  *ptr,int random_toolchanger);
 int  tool_mmap_user(void);
 void tool_mmap_close(void);

--- a/src/emc/tooldata/tooldata_mmap.cc
+++ b/src/emc/tooldata/tooldata_mmap.cc
@@ -71,6 +71,13 @@ typedef struct {
 **       DEFAULT_EMC_IO_CYCLE_TIME   0.100
 */
 
+void tool_mmap_set_fname(const char* fname) {
+    // Let a standalone user of the tooldata mmap (sai/rs274) choose a private
+    // file. Without this every process uses $HOME/.tool.mmap, so an offline
+    // parse truncates the tool table of a session that is already running.
+    snprintf(filename,sizeof(filename),"%s",fname);
+}
+
 static char* tool_mmap_fname(void) {
     if (*filename) {return filename;}
     char* hdir = secure_getenv("HOME");

--- a/src/emc/usr_intf/axis/scripts/axis.py
+++ b/src/emc/usr_intf/axis/scripts/axis.py
@@ -1952,6 +1952,11 @@ def all_homed():
     return isHomed
 
 def go_home(num):
+    s.poll()
+    for j in range(s.joints):
+        if s.joint[j]["homing"]:
+            print(_("Homing not possible until current homing process is finished."))
+            return
     set_motion_teleop(0)
     c.home(num)
     c.wait_complete()

--- a/src/emc/usr_intf/gmoccapy/gmoccapy.py
+++ b/src/emc/usr_intf/gmoccapy/gmoccapy.py
@@ -3857,6 +3857,11 @@ class gmoccapy(object):
     def _on_btn_home_clicked(self, widget):
         # home axis or joint?
         LOG.debug("on button home clicked = {0}".format(widget.get_property("name")))
+        self.stat.poll()
+        for j in range(self.stat.joints):
+            if self.stat.joint[j]["homing"]:
+                self._show_error((13, _("Homing not possible until current homing process is finished.")))
+                return
         if "axis" in widget.get_property("name"):
             value = widget.get_property("name")[-1]
             # now get the joint from directory by the value

--- a/src/hal/components/orient.comp
+++ b/src/hal/components/orient.comp
@@ -25,10 +25,7 @@ command value, and fit with the motion spindle-orient support pins to support th
 The spindle is assumed to have stopped in an arbitrary position. The spindle
 encoder position is linked to the  \\fBposition\\fR pin.
 The  current value of the position pin is sampled on a positive edge on the \\fBenable\\fR pin, and 
-\\fBcommand\\fR is computed and set as follows: floor(number of 
-full spindle revolutions 
-in the \\fBposition\\fR sampled on positive edge) 
-plus \\fBangle\\fR/360 (the fractional revolution) +1/-1/0 depending on \\fBmode\\fR.
+\\fBcommand\\fR is computed and set depending on \\fBmode\\fR.
 
 The \\fBmode\\fR pin is interpreted as follows:
 

--- a/src/hal/drivers/mesa-hostmot2/hm2_modbus.c
+++ b/src/hal/drivers/mesa-hostmot2/hm2_modbus.c
@@ -316,11 +316,11 @@ RTAPI_MP_ARRAY_STRING(ports, MAX_PORTS, "PktUART HAL names");
 /*
  * The Modbus configuration and command structure files for each PktUART
  * interface to be read by the hm2_modbus module. This should be a list of
- * absolute path file names like:
- *   files="/usr/share/linuxcnc/modbus/spindle.mbccb","/home/test/xyz.mbccb"
+ * path file names like:
+ *   files="spindle.mbccb","xyz.mbccb"
  */
 static char *mbccbs[MAX_PORTS];
-RTAPI_MP_ARRAY_STRING(mbccbs, MAX_PORTS, "Binary Modbus configuration and command sequence absolute path file names");
+RTAPI_MP_ARRAY_STRING(mbccbs, MAX_PORTS, "Binary Modbus configuration and command sequence path file names");
 
 /*
  * Set the message level for debugging purpose. This has the (side-)effect that
@@ -2661,11 +2661,6 @@ int rtapi_app_main(void)
 			retval = -EINVAL;
 			goto errout;
 		}
-/*
-		if('/' != mbccbs[i][0]) {
-			MSG_PRINT("%s: warning: The 'mbccb' file path '%s' for instance %d in 'mbccbs' argument is not absolute\n", inst->name, mbccbs[i], i);
-		}
-*/
 
 		if((retval = load_mbccb(inst, mbccbs[i])) < 0) {
 			// Messages printed in load function


### PR DESCRIPTION
 at driver.cc:570, before `getopt()` at :578; `-t` is not read until :583.

  That file is not scratch space. `tool_mmap_fname()` builds it from
  `secure_getenv("HOME")` with a fixed name, and io, milltask, halui and the
  Python bindings all map the same inode `MAP_SHARED`. So an offline parse run
  beside a live session replaces that session's tool table with the compiled-in
  sample table. `O_TRUNC` preserves the inode, so nothing re-maps and nothing
  errors — the running session simply observes its tools change.

  Observed on 2.9.8 with `[EMCIO]DB_PROGRAM`: 15 tools became the 4 sample
  entries mid-session, `G43` applied 0.0000 for a tool no longer in the table,
  and the tool-number/drawbar guard inhibited jog and feed. `DB_PROGRAM` neither
  prevents nor repairs it — ioControl.cc creates the mmap before the `DB_ACTIVE`
  branch, and io does not re-read afterwards. The code is unchanged at v2.9.10.

  This gives sai a private, pid-qualified file and unlinks it on exit.
  `tool_mmap_close()` already unlinks, and `tool_mmap_fname()` already honours a
  preset filename — the patch only adds the setter needed to reach it. io and
  milltask are untouched and remain the only creators of the shared file.

  Reproduce before the change:

      rm -rf /tmp/rsx && mkdir -p /tmp/rsx
      HOME=/tmp/rsx rs274 -g /dev/null
      # /tmp/rsx/.tool.mmap now exists, last_index=4, holding
      # T1 z0.511 d0.125 / T2 z0.100 d0.0625 / T3 z1.273 d0.201 / T99999 P123

  After: rs274 writes `/tmp/rs274.<pid>.tool.mmap` and removes it on exit;
  `$HOME/.tool.mmap` is never opened.

  Branched from 2.9; happy to forward-port to master.