### PR TITLE
mesa_modbus: deprecate in favor of hm2_modbus

### DIFF
--- a/docs/src/drivers/mesa_modbus.adoc
+++ b/docs/src/drivers/mesa_modbus.adoc
@@ -5,6 +5,8 @@
 
 = Mesa Modbus =
 
+WARNING: The Mesa Modbus framework (modcompile and mesa_modbus) is deprecated and will be removed in a future release. New configurations should use the link:../man/man9/hm2_modbus.9.html[hm2_modbus] driver with link:../man/man1/mesambccc.1.html[mesambccc]-compiled MBCCB files instead.
+
 A framework to create custom, realtime, modbus drivers using the Mesa
 PktUART component.
 

--- a/docs/src/hal/components.adoc
+++ b/docs/src/hal/components.adoc
@@ -157,7 +157,7 @@ To search in the man pages, use the UNIX tool `apropos`.
 | link:../man/man1/latency-plot.1.html[latency-plot] |Another way to view latency numbers ||
 | link:../man/man1/latency-test.1.html[latency-test] |Tests the realtime system latency ||
 | link:../man/man1/linuxcncmkdesktop.1.html[linuxcncmkdesktop] |Create a desktop icon for LinuxCNC ||
-| link:../man/man1/modcompile.1.html[modcompile] |Utility for compiling Modbus drivers||
+| link:../man/man1/modcompile.1.html[modcompile] |Utility for compiling Modbus drivers. Deprecated: use hm2_modbus with mesambccc instead.||
 | link:../man/man1/motion-logger.1.html[motion-logger] |Log motion commands sent from LinuxCNC ||
 | link:../man/man1/pncconf.1.html[pncconf] |Configuration wizard for Mesa cards ||
 | link:../man/man1/sim_pin.1.html[sim_pin] |GUI for displaying and setting one or more HAL inputs ||

--- a/docs/src/index.tmpl
+++ b/docs/src/index.tmpl
@@ -114,7 +114,7 @@
 		<li><a href="drivers/hal_pi_gpio.html">Raspberry Pi GPIO Driver</a></li>
 		<li><a href="drivers/hostmot2.html">Mesa HostMot2 Driver</a></li>
 		<li><a href="drivers/mb2hal.html">Modbus to HAL Driver</a></li>
-		<li><a href="drivers/mesa_modbus.html">Modbus framework for Mesa cards</a></li>
+		<li><a href="drivers/mesa_modbus.html">Modbus framework for Mesa cards (deprecated)</a></li>
 		<li><a href="drivers/mitsub-vfd.html">Mitsubishi VFD Driver</a></li>
 		<li><a href="drivers/motenc.html">Motenc Driver</a></li>
 		<li><a href="drivers/opto22.html">Opto22 Driver</a></li>

--- a/docs/src/man/man1/modcompile.1.adoc
+++ b/docs/src/man/man1/modcompile.1.adoc
@@ -2,7 +2,7 @@
 
 == NAME
 
-modcompile - Utility for compiling Modbus drivers
+modcompile - Utility for compiling Modbus drivers (DEPRECATED)
 
 == SYNOPSIS
 
@@ -13,6 +13,9 @@ modcompile - Utility for compiling Modbus drivers
 *modcompile* [*-k*] [*-n*] [*-v*] module.mod ...
 
 == DESCRIPTION
+
+*modcompile* and the mesa_modbus framework are deprecated and will be removed in a future release.
+New configurations should use the *hm2_modbus* driver with *mesambccc*-compiled MBCCB files instead.
 
 The *modcompile* utility is used to compile modbus drivers that use the PktUART
 interface of Mesa cards.

--- a/src/hal/drivers/mesa-hostmot2/modbus/README.adoc
+++ b/src/hal/drivers/mesa-hostmot2/modbus/README.adoc
@@ -1,3 +1,7 @@
+WARNING: The mesa_modbus framework (this directory and modcompile) is
+deprecated and will be removed in a future release. Use the hm2_modbus
+driver with mesambccc-compiled .mbccb files instead.
+
 Do not edit mesa_modbus.c (Unless you are sure that you want to, of
 course).
 Create a new xxxxx.mod file that describes your particular modbus device

--- a/src/hal/drivers/mesa-hostmot2/modbus/mesa_modbus.c.tmpl
+++ b/src/hal/drivers/mesa-hostmot2/modbus/mesa_modbus.c.tmpl
@@ -185,6 +185,10 @@ int rtapi_app_main(void){
 
     rtapi_set_msg_level(DEBUG);
 
+    rtapi_print_msg(RTAPI_MSG_WARN, COMP_NAME": WARNING: mesa_modbus-based drivers are deprecated"
+            " and will be removed in a future release. Use the hm2_modbus driver with"
+            " mesambccc-compiled MBCCB files instead.\n");
+
     if (!ports[0]) {
         rtapi_print_msg(RTAPI_MSG_ERR, "The "COMP_NAME" component requires at least"
                 " one valid pktuart port, eg ports=\"hm2_5i25.0.pktuart.7\"\n");

--- a/src/hal/drivers/mesa-hostmot2/modbus/modcompile.py
+++ b/src/hal/drivers/mesa-hostmot2/modbus/modcompile.py
@@ -88,6 +88,10 @@ def main():
     if len(args) < 1:
         raise SystemExit("No modules found (*.mod files) to compile.");
 
+    print("WARNING: modcompile and the mesa_modbus framework are deprecated and will be"
+          " removed in a future release. Use the hm2_modbus driver with mesambccc-compiled"
+          " .mbccb files instead.", file=sys.stderr)
+
     # Create a temporary directory and copy the C template into it
     tempdir = tempfile.mkdtemp(prefix="modcompile")
     BASE = os.path.abspath(os.path.join(os.path.dirname(sys.argv[0]), ".."))


### PR DESCRIPTION
Deprecate mesa_modbus in favor of hm2_modbus

Following the discussions on the mailing list about having proper deprecation warnings in place, this marks the mesa_modbus framework (modcompile + mesa_modbus.c.tmpl) as deprecated. The replacement is the hm2_modbus driver with mesambccc-compiled MBCCB files, which already ships in master and 2.9.

Warnings added:

- mesa_modbus.c.tmpl: RTAPI_MSG_WARN at module load, so every modcompile-built driver announces itself at loadrt time
- modcompile.py: stderr warning at build time
- README.adoc in the modbus source directory
- docs: WARNING block in the mesa_modbus driver page, (DEPRECATED) in the modcompile(1) man page, notes in the component list and the docs index

No functional changes; existing configurations keep working unchanged.

Question for reviewers: is a 2.9 back-port wanted? hm2_modbus and mesambccc exist in 2.9, so users there can migrate.
