### PR TITLE
ini: warn when PLANNER_TYPE=1 falls back to trapezoidal due to low jerk

### DIFF
--- a/src/emc/ini/inihal.cc
+++ b/src/emc/ini/inihal.cc
@@ -243,6 +243,18 @@ static void copy_hal_data(const ptr_inihal_data &i, value_inihal_data &j)
 #undef ARRAY
 } // copy_hal_data()
 
+// S-curve planner requires max jerk >= 1.0; when a HAL pin change forces
+// the planner back to trapezoidal, warn once instead of on every change.
+static void warn_planner_fallback_once(void)
+{
+    static bool warned = false;
+    if (!warned) {
+        rcs_print_error("S-curve planner (planner type 1) requires max jerk >= 1.0; "
+                        "using trapezoidal planner\n");
+        warned = true;
+    }
+}
+
 int check_ini_hal_items(int numjoints)
 {
     value_inihal_data new_inihal_data_mutable = {};
@@ -300,6 +312,9 @@ int check_ini_hal_items(int numjoints)
         }
         // Force planner type 0 if max_jerk < 1 (S-curve needs valid jerk)
         if (NEW(traj_max_jerk) < 1.0) {
+            if (old_inihal_data.traj_planner_type == 1) {
+                warn_planner_fallback_once();
+            }
             if (0 != emcTrajPlannerType(0)) {
                 if (emc_debug & EMC_DEBUG_CONFIG) {
                     rcs_print("check_ini_hal_items:bad return value from emcTrajPlannerType\n");
@@ -318,6 +333,7 @@ int check_ini_hal_items(int numjoints)
             planner_type = 0;
         }
         if (planner_type == 1 && NEW(traj_max_jerk) < 1.0) {
+            warn_planner_fallback_once();
             planner_type = 0;
         }
         if (0 != emcTrajPlannerType(planner_type)) {

--- a/src/emc/ini/initraj.cc
+++ b/src/emc/ini/initraj.cc
@@ -157,7 +157,9 @@ static int loadTraj(const IniFile &ini)
     int planner_type = ini.findIntV("PLANNER_TYPE", "TRAJ", 0, 0, 1);
     // Also force planner type 0 if max_jerk < 1 (S-curve needs valid jerk)
     if (planner_type == 1 && jerk < 1.0) {
-        // FIXME: Should write a warning message to the user
+        rcs_print_error("[TRAJ]PLANNER_TYPE = 1 (S-curve) requires "
+                        "[TRAJ]MAX_LINEAR_JERK >= 1.0 (got %g); "
+                        "using trapezoidal planner\n", jerk);
         planner_type = 0;
     }
     if (0 != emcTrajPlannerType(planner_type)) {


### PR DESCRIPTION
`PLANNER_TYPE = 1` with `MAX_LINEAR_JERK < 1.0` silently forced the trapezoidal planner, both at startup (`loadTraj()`, which carried a FIXME asking for this warning) and at runtime via the inihal HAL pins. Users who requested S-curve planning got no indication their setting was ignored.

This prints a warning in both paths: at startup, and once per session for HAL-pin-triggered fallbacks.

```
[TRAJ]PLANNER_TYPE = 1 (S-curve) requires [TRAJ]MAX_LINEAR_JERK >= 1.0 (got 0.5); using trapezoidal planner
```

Note: #4349 documents the old silent behavior in `ini-config.adoc`; that sentence becomes stale if this merges first.
