### PR TITLE
motion: remove dead commands ENABLE_WATCHDOG, DISABLE_WATCHDOG, SET_TELEOP_VECTOR

### DIFF
--- a/docs/src/code/code-notes.adoc
+++ b/docs/src/code/code-notes.adoc
@@ -241,12 +241,6 @@ More on that function later.
 There are approximately 44 commands - this list is still under
 construction.
 
-[NOTE]
-The cmd_code_t enumeration, in motion.h, contains 73 commands, but the switch
-statement in command.c contemplates only 70 commands (as of 6/5/2020).
-ENABLE_WATCHDOG / DISABLE_WATCHDOG commands are in motion-logger.c. Maybe they are obsolete.
-The SET_TELEOP_VECTOR command only appears in motion-logger.c, with no effect other than its own log.
-
 === ABORT
 
 The ABORT command simply stops all motion. It can be issued at any
@@ -468,38 +462,6 @@ Calculations for the specified joint are enabled. The amp enable pin
 is not changed, and subsequent ENABLE or DISABLE commands will not
 modify the joint's amp enable pin.
 
-=== ENABLE_WATCHDOG
-
-The ENABLE_WATCHDOG command enables a hardware based watchdog (if
-present).
-
-==== Requirements
-
-None. The command can be issued at any time, and will always be
-accepted.
-
-==== Results
-
-Currently nothing. The old watchdog was a strange thing that used a
-specific sound card. A new watchdog interface may be designed in the
-future.
-
-=== DISABLE_WATCHDOG
-
-The DISABLE_WATCHDOG command disables a hardware based watchdog (if
-present).
-
-==== Requirements
-
-None. The command can be issued at any time, and will always be
-accepted.
-
-==== Results
-
-Currently nothing. The old watchdog was a strange thing that used a
-specific sound card. A new watchdog interface may be designed in the
-future.
-
 === PAUSE
 
 The PAUSE command stops the trajectory planner. It has no effect in
@@ -704,13 +666,6 @@ queue.
 
 The SET_CIRCLE command adds a circular move to the trajectory planner
 queue.
-
-(More later)
-
-=== SET_TELEOP_VECTOR
-
-The SET_TELEOP_VECTOR command instructs the motion controller to move
-along a specific vector in Cartesian space.
 
 (More later)
 

--- a/src/emc/motion-logger/motion-logger.c
+++ b/src/emc/motion-logger/motion-logger.c
@@ -353,14 +353,6 @@ int main(int argc, char* argv[]) {
                 update_motion_state();
                 break;
 
-            case EMCMOT_ENABLE_WATCHDOG:
-                log_print("ENABLE_WATCHDOG\n");
-                break;
-
-            case EMCMOT_DISABLE_WATCHDOG:
-                log_print("DISABLE_WATCHDOG\n");
-                break;
-
             case EMCMOT_JOINT_ACTIVATE:
                 log_print("JOINT_ACTIVATE joint=%d\n", c->joint);
                 break;
@@ -489,10 +481,6 @@ int main(int argc, char* argv[]) {
                     c->vel, c->ini_maxvel,
                     c->acc, c->turn
                 );
-                break;
-
-            case EMCMOT_SET_TELEOP_VECTOR:
-                log_print("SET_TELEOP_VECTOR\n");
                 break;
 
             case EMCMOT_CLEAR_PROBE_FLAGS:

--- a/src/emc/motion/motion.h
+++ b/src/emc/motion/motion.h
@@ -116,9 +116,6 @@ extern "C" {
 
 	EMCMOT_SET_LINE,	/* queue up a linear move */
 	EMCMOT_SET_CIRCLE,	/* queue up a circular move */
-	EMCMOT_SET_TELEOP_VECTOR,	/* Move at a given velocity but in
-					   world cartesian coordinates, not
-					   in joint space like EMCMOT_JOG_* */
 	EMCMOT_CLEAR_PROBE_FLAGS,	/* clears probeTripped flag */
 	EMCMOT_PROBE,		/* go to pos, stop if probe trips, record
 				   trip pos */
@@ -151,8 +148,6 @@ extern "C" {
         EMCMOT_SETUP_ARC_BLENDS,
 
 	EMCMOT_SET_PROBE_ERR_INHIBIT,
-	EMCMOT_ENABLE_WATCHDOG,         /* enable watchdog sound, parport */
-	EMCMOT_DISABLE_WATCHDOG,        /* enable watchdog sound, parport */
 	EMCMOT_JOG_CONT,	/* continuous jog */
 	EMCMOT_JOG_INCR,	/* incremental jog */
 	EMCMOT_JOG_ABS,		/* absolute jog */


### PR DESCRIPTION
Fixes #4359.

The three commands have had no handler since 1adc33f11c (the old sound-card watchdog cleanup); SET_TELEOP_VECTOR never had one. Nothing in the tree sends any of them, so the motion-logger cases removed here could never be reached. Code Notes has carried a "73 vs 70 commands" note about this since 2020; with the commands gone there is nothing left to count, so the note and the three command sections go too.

One caveat: removing enum entries shifts the numeric values of later `cmd_code_t` commands. The enum is only exchanged between in-tree components built from the same sources (task, motion, motion-logger), so this is safe in-tree. An out-of-tree sender of these commands would already be a no-op today.

This conflicts with the code-notes.adoc hunk in #4349, which rewords the count note instead of deleting it. Whichever merges second needs the hunk dropped.
