### PR TITLE
rtapi: define the math constants that are missing in kernel space

### DIFF
--- a/src/rtapi/rtapi_math.h
+++ b/src/rtapi/rtapi_math.h
@@ -19,14 +19,54 @@
 #include "rtapi.h"  /* Because of all the rtapi refs */
 #include <float.h>  /* DBL_MAX and other FP goodies */
 
+/* The math constants are not in ISO C.  Userspace gets them from math.h,
+   where glibc keeps the long double ones behind _GNU_SOURCE, and a kernel
+   build includes no math.h at all, so define whatever is missing.  Values
+   are the ones glibc uses. */
 #ifndef M_PIl
 #define M_PIl		3.1415926535897932384626433832795029L  /* pi */
 #endif
 #ifndef M_PI_2l
 #define M_PI_2l        1.570796326794896619231321691639751442L /* pi/2 */
 #endif
+#ifndef M_E
+#define M_E		2.7182818284590452354	/* e */
+#endif
+#ifndef M_LOG2E
+#define M_LOG2E		1.4426950408889634074	/* log_2 e */
+#endif
+#ifndef M_LOG10E
+#define M_LOG10E	0.43429448190325182765	/* log_10 e */
+#endif
+#ifndef M_LN2
+#define M_LN2		0.69314718055994530942	/* log_e 2 */
+#endif
+#ifndef M_LN10
+#define M_LN10		2.30258509299404568402	/* log_e 10 */
+#endif
 #ifndef M_PI
-#define M_PI		3.1415926535897932384626433832795029   /* pi */
+#define M_PI		3.14159265358979323846	/* pi */
+#endif
+#ifndef M_PI_2
+#define M_PI_2		1.57079632679489661923	/* pi/2 */
+#endif
+#ifndef M_PI_4
+#define M_PI_4		0.78539816339744830962	/* pi/4 */
+#endif
+#ifndef M_1_PI
+#define M_1_PI		0.31830988618379067154	/* 1/pi */
+#endif
+#ifndef M_2_PI
+#define M_2_PI		0.63661977236758134308	/* 2/pi */
+#endif
+#ifndef M_2_SQRTPI
+#define M_2_SQRTPI	1.12837916709551257390	/* 2/sqrt(pi) */
+#endif
+#ifndef M_SQRT2
+#define M_SQRT2		1.41421356237309504880	/* sqrt(2) */
+#endif
+#ifndef M_SQRT1_2
+#define M_SQRT1_2	0.70710678118654752440	/* 1/sqrt(2) */
 #endif
 
 #if defined(__KERNEL__)


### PR DESCRIPTION
Follows from the review discussion in #4387, on whether posemath's PM_PI and friends should just be the libc constants.

The math constants are not in ISO C. Userspace gets them from math.h, where glibc keeps the long double spellings behind _GNU_SOURCE, and a kernel build takes the other branch of rtapi_math.h, which includes no math.h at all. The header already fills in M_PI, M_PIl and M_PI_2l for that case, which are the three the tree happens to use.

The other twelve of glibc's set are absent in kernel space, M_PI_2 and M_PI_4 among them, so real time code using one builds on uspace and fails on RTAI. Nothing in tree uses them today, which is the only reason it has never shown. This defines them under the same #ifndef guard with glibc's values, and rewrites M_PI's literal, which was the long double spelling truncated, the way glibc writes it.

The typed variants, the f, f32, f64, f128 and l suffixes, are left out apart from the two already there.

**Testing.**

Preprocessing rtapi_math.h down both branches: kernel space goes from 3 names to the same 15 userspace has. Each of the 15 compares equal to the glibc value in its own type, the two long double ones included, so the truncated digits were cosmetic rather than a difference in value.

Including math.h before or after rtapi_math.h is clean under -Wall -Wextra -Werror in both orders, so the guards do not fight libc either way round.

Full build clean, no errors and no warnings. runtests over blendmath, realtime-math and interp: 84 run, 84 successful, 0 failed, 1 skipped.

One to remember when the PM_ names map across: M_2_PI is 2/pi in libm, not 2*pi, so PM_2_PI becomes 2*M_PI.
