### PR TITLE
hal_glib: defer file-loaded when the interp is already running

### DIFF
--- a/lib/python/common/hal_glib.py
+++ b/lib/python/common/hal_glib.py
@@ -330,6 +330,7 @@ class _GStat(GObject.GObject):
         self._status_active = False
         self.old = {}
         self.old['tool-prep-number'] = 0
+        self._file_load_pending = False
         self.previous_mode = self.MANUAL
         try:
             self.stat.poll()
@@ -677,6 +678,17 @@ class _GStat(GObject.GObject):
             # a reload of the preview and sourceview widgets
             if self.stat.interp_state == linuxcnc.INTERP_IDLE and file_new != "":
                 self.emit('file-loaded', file_new)
+            elif file_new != "":
+                # also defer a legit program that was opened and started
+                # before this poll saw it, or the GUI never shows it
+                self._file_load_pending = True
+            else:
+                self._file_load_pending = False
+        if self._file_load_pending and \
+                self.stat.interp_state == linuxcnc.INTERP_IDLE and \
+                self.old['file']:
+            self._file_load_pending = False
+            self.emit('file-loaded', self.old['file'])
 
         #ToDo : Find a way to avoid signal when the line changed due to
         #       a remap procedure, because the signal do highlight a wrong


### PR DESCRIPTION
GSTAT only emits 'file-loaded' if the poll that first sees stat.file change finds the interp IDLE; the guard exists to skip reloads when the "new file" is a remap procedure. A client doing program_open + AUTO_RUN back to back starts the program within a few ms, so every ~100 ms poll sees the new file with the interp busy, the change is swallowed, and the signal never fires: gmoccapy sits at "No Program loaded" with an empty editor and preview after an externally driven run. Seen in the ui-smoke CI screenshots (#4136), where it flip-flopped with runner timing.

Fix: emit a skipped change on the first poll with the interp back at IDLE. Remap protection unchanged (merge() ignores the file name at call level != 0). qtvcp inherits via Status(GStat). Verified locally: gmoccapy shows the program after a run that previously left it empty.
