### PR TITLE
docs: fix the two remaining htmldocs CI warnings

### DIFF
--- a/docs/src/config/python-hal-interface.adoc
+++ b/docs/src/config/python-hal-interface.adoc
@@ -157,9 +157,9 @@ System information:
 * `hal.kernel_version` - A string specifying the real-time kernel version if `hal.is_kernelspace` is one.
   Otherwise it specifies `"Not Available"`.
 * `hal.is_rt` - One (1) if the system runs in real-time, otherwise zero (0) *DEPRECATED*:
-  Use xref:python-lcnc_realtime.adoc[`lcnc_realtime.verify()`]
+  Use <<cha:python-lcnc_realtime,`lcnc_realtime.verify()`>>
 * `hal.is_sim` - Inverted `hal.is_rt` *DEPRECATED*:
-  Use xref:python-lcnc_realtime.adoc[`lcnc_realtime.verify()`]
+  Use <<cha:python-lcnc_realtime,`lcnc_realtime.verify()`>>
 
 
 === hal methods
@@ -180,7 +180,7 @@ hal.get_realtime_type() -> hal.RTType::
 Returns the type of the running realtime system.
 Might return `hal.RTType.UNINITIALIZED` if `rtapi_app` is not running.
 See xref:halconstantsrt[realtime type constants].
-See also xref:python-lcnc_realtime.adoc[LinuxCNC Realtime check].
+See also <<cha:python-lcnc_realtime,LinuxCNC Realtime check>>.
 
 hal.component_exists(_name_:string) -> bool::
 Returns a boolean to indicate whether or not the specified component exist at this time.

--- a/docs/src/man/man9/hm2_rpspi.9.adoc
+++ b/docs/src/man/man9/hm2_rpspi.9.adoc
@@ -178,10 +178,10 @@ throwing off the SoC's PLL(s), resulting in strange behaviour.
 For optimal performance on the RPi3, you must disable the "ondemand" CPU
 frequency governor. You may add the following to your /etc/rc.local file:
 
-```
+----
 echo -n 1200000 > /sys/devices/system/cpu/cpufreq/policy0/scaling_min_freq
 echo -n performance > /sys/devices/system/cpu/cpufreq/policy0/scaling_governor
-```
+----
 
 Be sure to have a proper heatsink mounted on the SoC or it will get too warm and crashes.
 


### PR DESCRIPTION
Clears the two remaining `htmldocs` CI warnings.

`python-hal-interface.adoc` used inter-document xref syntax, `xref:python-lcnc_realtime.adoc[]`. The docs build as one book, so it renders as `href="#python-lcnc_realtime.adoc"`, a fragment that does not exist; `htmlcheck.sh` flagged it in all eight languages. Now `<<cha:python-lcnc_realtime>>`, the anchor the target chapter declares.

The rc.local example in `hm2_rpspi.9.adoc` used a markdown ``` fence. po4a does not recognise fences and reflows the block onto one line, so every translated build hit `unterminated listing block` and lost the rest of the page (the German manpage drops NOTE, AUTHOR and LICENSE). A plain `----` listing block fixes it; po4a then keeps the line breaks.
