### PR TITLE
gmoccapy: Fix reading [DISPLAY]CYCLE_TIME when set as a real

### DIFF
--- a/share/gscreen/skins/silverdragon/silverdragon_handler.py
+++ b/share/gscreen/skins/silverdragon/silverdragon_handler.py
@@ -243,7 +243,7 @@ class HandlerClass:
         self.halcomp["search_vel"] = search_vel
         self.halcomp["sensor_height"] = sensor_height
         self.halcomp["maxprobe"] = maxprobe
-        if not xpos or not ypos or not zpos or not maxprobe:
+        if xpos is None or ypos is None or zpos is None or maxprobe is None:
             self.widgets.chk_use_auto_zref.set_active(False)
             self.widgets.chk_use_auto_zref.set_sensitive(False)
             self.widgets.btn_g30.set_sensitive(False)
@@ -271,7 +271,7 @@ class HandlerClass:
         # set up laser crosshair offsets
         xpos = self.gscreen.inifile.getreal("LASER", "X")
         ypos = self.gscreen.inifile.getreal("LASER", "Y")
-        if not xpos or not ypos:
+        if xpos is None or ypos is None:
             self.widgets.btn_laser_zero.set_sensitive(False)
             self.widgets.tbtn_laser.set_sensitive(False)
         else:

--- a/src/emc/usr_intf/gmoccapy/getiniinfo.py
+++ b/src/emc/usr_intf/gmoccapy/getiniinfo.py
@@ -47,14 +47,20 @@ class GetIniInfo:
             sys.exit()
 
     def get_cycle_time(self):
-        temp = self.inifile.getint("DISPLAY", "CYCLE_TIME")
-        try:
-            return temp
-        except:
-            message = ("Wrong entry [DISPLAY] CYCLE_TIME in INI File! ")
-            message += ("Will use gmoccapy default 150")
-            LOG.warning(message)
-            return 150
+        temp = self.inifile.getreal("DISPLAY", "CYCLE_TIME")
+        if temp is not None:
+            # Can be in seconds or milliseconds and, regardless,
+            # the result must be larger than zero to be valid.
+            # This brings gmoccapy in line with f.ex. AXIS.
+            if temp >= 0.001 and temp < 1.0:
+                return int(temp * 1000.0) # Assume seconds
+            elif temp >= 1.0:
+                return int(temp) # Assume milliseconds
+        # Otherwise, undefined or less or equal to zero
+        message = ("Wrong entry [DISPLAY] CYCLE_TIME in INI File! ")
+        message += ("Will use gmoccapy default 150")
+        LOG.warning(message)
+        return 150
 
     def get_postgui_halfile(self):
         postgui_halfile = self.inifile.findall("HAL", "POSTGUI_HALFILE") or None

--- a/src/emc/usr_intf/gmoccapy/gmoccapy.py
+++ b/src/emc/usr_intf/gmoccapy/gmoccapy.py
@@ -1098,7 +1098,7 @@ class gmoccapy(object):
     def _check_toolmeasurement(self):
         # tool measurement probe settings
         xpos, ypos, zpos, maxprobe = self.get_ini_info.get_tool_sensor_data()
-        if not xpos or not ypos or not zpos or not maxprobe:
+        if xpos is None or ypos is None or zpos is None or maxprobe is None:
             self.widgets.lbl_tool_measurement.show()
             LOG.info(_("No valid probe config in INI file. Tool measurement disabled."))
             self.widgets.chk_use_tool_measurement.set_active(False)


### PR DESCRIPTION
Several sims use the wrong `[DISPLAY]CYCLE_TIME` being set in seconds, whereas the docs say it is in milliseconds. The old INI read would cause an exception, which no longer happens. The new INI-file reader warns of trailing context and return the value zero (0). It will now test for existence and whether it is larger than 0. Otherwise the default is used.

Also, the existence test "not val" should read "val is None", which has been fixed in two places where INI values are read and zero (0) is a valid value.

Fixes #4415

After discussion in #4415 gmoccapy now accepts both seconds and milliseconds bringing it in line with Axis.