### PR TITLE
axis: jog increments follow the selected axis type (degrees vs linear)

### DIFF
--- a/src/emc/usr_intf/axis/scripts/axis.py
+++ b/src/emc/usr_intf/axis/scripts/axis.py
@@ -1480,19 +1480,39 @@ def set_first_line(lineno):
         t.tag_add("ignored", "0.0", "%d.end" % (lineno-1))
 
 def parse_increment(jogincr):
-    if jogincr.endswith("mm"):
+    jogincr = jogincr.strip()
+    low = jogincr.lower()
+    scale = 1
+    # angular units first: the jog increment of an angular joint/axis is
+    # commanded in degrees ("grad" before "rad" - suffix containment)
+    if low.endswith("grad"):
+        scale = 0.9
+        jogincr = jogincr[:-4]
+    elif low.endswith("rad"):
+        scale = 180.0 / pi
+        jogincr = jogincr[:-3]
+    elif low.endswith("deg"):
+        scale = 1.
+        jogincr = jogincr[:-3]
+    elif low.endswith("mm"):
         scale = from_internal_linear_unit(1/25.4)
-    elif jogincr.endswith("cm"):
+        jogincr = jogincr[:-2]
+    elif low.endswith("cm"):
         scale = from_internal_linear_unit(10/25.4)
-    elif jogincr.endswith("um"):
+        jogincr = jogincr[:-2]
+    elif low.endswith("um"):
         scale = from_internal_linear_unit(.001/25.4)
-    elif jogincr.endswith("in") or jogincr.endswith("inch"):
+        jogincr = jogincr[:-2]
+    elif low.endswith("inch"):
         scale = from_internal_linear_unit(1.)
-    elif jogincr.endswith("mil"):
+        jogincr = jogincr[:-4]
+    elif low.endswith("in"):
+        scale = from_internal_linear_unit(1.)
+        jogincr = jogincr[:-2]
+    elif low.endswith("mil"):
         scale = from_internal_linear_unit(.001)
-    else:
-        scale = 1
-    jogincr = jogincr.rstrip(" inchmuil")
+        jogincr = jogincr[:-3]
+    jogincr = jogincr.strip()
     if "/" in jogincr:
         p, q = jogincr.split("/")
         jogincr = float(p) / float(q)
@@ -3758,10 +3778,89 @@ if increments:
         increments = [i.strip() for i in increments.split(",")]
     else:
         increments = increments.split()
-    root_window.call(widgets.jogincr._w, "list", "delete", "1", "end")
-    root_window.call(widgets.jogincr._w, "list", "insert", "end", *increments)
+else:
+    # the tcl default list (unitless numbers, valid for mm and deg alike)
+    increments = ["0.1000", "0.0100", "0.0010", "0.0001"]
+
+_LINEAR_SUFFIXES = ("um", "mm", "cm", "mil", "inch", "in")
+_ANGULAR_SUFFIXES = ("deg", "grad", "rad")
+
+def _incr_split_suffix(entry):
+    t = entry.strip()
+    low = t.lower()
+    for s in _ANGULAR_SUFFIXES + _LINEAR_SUFFIXES:
+        if low.endswith(s):
+            return t[:-len(s)].strip(), s
+    return t, ""
+
+# jog increments are per axis TYPE: a linear-united entry makes no sense
+# on an angular axis (historically "10mm" silently jogged C by its bare
+# number - 10 degrees on metric, 0.39 "degrees" on inch configs). Classify
+# the ini entries; unitless entries serve both kinds; if the ini lists
+# only one kind, derive the other from the numeric parts (10mm -> 10 deg)
+# so angular axes always get sensible, honestly-labelled degree steps.
+jogincr_lists = {"linear": [], "angular": []}
+for _e in increments:
+    _num, _suf = _incr_split_suffix(_e)
+    if _suf in _ANGULAR_SUFFIXES:
+        jogincr_lists["angular"].append(_e.strip())
+    elif _suf in _LINEAR_SUFFIXES:
+        jogincr_lists["linear"].append(_e.strip())
+    else:
+        jogincr_lists["linear"].append(_e.strip())
+        jogincr_lists["angular"].append(_e.strip())
+if not jogincr_lists["angular"]:
+    jogincr_lists["angular"] = [
+        _incr_split_suffix(_e)[0] + " deg" for _e in jogincr_lists["linear"]]
+if not jogincr_lists["linear"]:
+    jogincr_lists["linear"] = [
+        _incr_split_suffix(_e)[0] for _e in jogincr_lists["angular"]]
+jogincr_kind_shown = "linear"
+
+root_window.call(widgets.jogincr._w, "list", "delete", "1", "end")
+root_window.call(widgets.jogincr._w, "list", "insert", "end",
+                 *jogincr_lists["linear"])
 widgets.jogincr.configure(command= jogspeed_listbox_change)
 root_window.call(widgets.jogincr._w, "select", 0)
+
+def selected_ja_is_angular():
+    ja = vars.ja_rbutton.get()
+    try:
+        return joint_type[int(ja)] == "ANGULAR"
+    except ValueError:
+        try:
+            return axis_type["xyzabcuvw".index(ja.lower())] == "ANGULAR"
+        except (ValueError, IndexError):
+            return False
+
+def update_jogincr_for_selection(*_args):
+    global jogincr_kind_shown
+    kind = "angular" if selected_ja_is_angular() else "linear"
+    if kind == jogincr_kind_shown:
+        return
+    # keep the selected SLOT across the swap (Continuous stays index 0)
+    cur = widgets.jogincr.get()
+    old = [_("Continuous")] + jogincr_lists[jogincr_kind_shown]
+    try:
+        idx = old.index(cur)
+    except ValueError:
+        idx = 0
+    root_window.call(widgets.jogincr._w, "list", "delete", "1", "end")
+    root_window.call(widgets.jogincr._w, "list", "insert", "end",
+                     *jogincr_lists[kind])
+    idx = min(idx, len(jogincr_lists[kind]))
+    root_window.call(widgets.jogincr._w, "select", idx)
+    jogincr_kind_shown = kind
+    set_hal_jogincrement()
+
+# vars.* are nf.makevar instances (not plain tkinter Vars) and lack the
+# _root that Variable.trace_add() needs - register through nf.makecommand,
+# which carries the proper master, and trace at the tcl level.
+_jogincr_trace_cmd = nf.makecommand(
+    root_window, "update_jogincr_for_selection", update_jogincr_for_selection)
+root_window.tk.call("trace", "add", "variable",
+                    vars.ja_rbutton._name, "write", _jogincr_trace_cmd)
+update_jogincr_for_selection()   # in case the initial selection is angular
 
 vcp = inifile.find("DISPLAY", "PYVCP")
 


### PR DESCRIPTION
## Problem

AXIS keeps a single `[DISPLAY]INCREMENTS` list and shows it for every axis,
whatever that axis's type. The entries carry unit suffixes (`mm`, `cm`, `um`,
`in`, `mil`) and `parse_increment()` scales by the suffix — but it only knows
*linear* units. Nothing expresses that an ANGULAR axis should be jogged in
degrees.

On a machine with a rotary axis and a linear-labelled increment list, two
things go wrong:

1. **Mislabel (metric configs).** Picking `10mm` jogs the rotary 10 units =
   10 degrees, which is numerically fine, but the dropdown says millimetres
   for a degrees move. This is the confusing symptom operators report: *"I
   selected C and the step still says mm."*
2. **Wrong distance (inch configs).** `parse_increment("1 mm")` scales by
   `from_internal_linear_unit(1/25.4)`, so the rotary is jogged ~0.0394
   "degrees" instead of a sensible step. Label wrong *and* motion wrong.

The stock default list is unitless (`0.1 0.01 0.001 0.0001`), which sidesteps
the mislabel by never showing a unit — so this bites configs that reasonably
give their increments explicit linear units *and* have a rotary axis.

## Fix

Make the increment list follow the **type** of the selected axis/joint.

- `parse_increment()` learns angular units: `deg`, `grad`, `rad`, scaled to
  degrees (`deg`→×1, `grad`→×0.9, `rad`→×180/π). Suffix order matters and is
  handled: `grad` before `rad`, `inch` before `in`. The old
  `rstrip(" inchmuil")` is replaced by exact suffix slicing — it stripped
  characters, so e.g. a trailing `l`/`i`/`n` could be eaten from a bare
  number.
- The `[DISPLAY]INCREMENTS` entries are classified once at startup into a
  `linear` and an `angular` list. A unitless entry serves both. If the ini
  lists only linear entries (the common case), the angular list is *derived*
  from the numeric parts with a `deg` label (`1 mm` → `1 deg`), so a rotary
  axis gets sensible, honestly-labelled degree steps with no config change.
  An angular-only list derives the linear one symmetrically.
- The combobox swaps to the matching list live when the selected axis/joint
  changes, preserving the selected slot.

No INI change is required, and a config without a rotary axis sees exactly
what it sees today.

## Testing

Driven on a headless display through Tk `send` — the channel `axis-remote`
already uses — selecting axes exactly as the radiobuttons do (set
`::ja_rbutton`, call `axis_activated`), then reading back the combobox labels
and sampling the `axisui.jog.increment` HAL pin for every slot.

Stock config `configs/sim/axis/axis_9axis.ini` (A/B/C ANGULAR,
`LINEAR_UNITS = inch`, `INCREMENTS = 1 mm, .01 in, .1mm, 1 mil, .1 mil,
1/8000 in` — an all-linear list). Selecting the rotary **A** axis:

| slot | before | after |
|---|---|---|
| 1 | `1 mm` → **0.03937008** | `1 deg` → **1.0** |
| 3 | `.1mm` → 0.003937008 | `.1 deg` → 0.1 |
| 6 | `1/8000 in` → 0.000125 | `1/8000 deg` → 0.000125 |

So before this change, asking for "1 mm" on the rotary axis commands 0.0394
degrees. After it, 1.0 degree, labelled as such.

The linear axis is unchanged in both builds (X slot 1 = 0.03937008, i.e. 1 mm
in this machine's inch units), and switching back from A to X restores the
ini's own list.

`py_compile` clean; `tests/interp`, `tests/motion` and `tests/motion-logger`
unaffected.

One note for anyone re-running this on an inch config: slot 2 is degenerate,
because `.01 in` and `.01 deg` both parse to 0.01. Compare slot 1 or 3.
