### PR TITLE
tp: rate-limit Ruckig plan-failure logging to once per segment

### DIFF
--- a/src/emc/tp/tc.c
+++ b/src/emc/tp/tc.c
@@ -750,6 +750,11 @@ int tcInit(TC_STRUCT * const tc,
     tc->ruckig_last_use_velocity_control = 0;
     tc->ruckig_last_req_pos = 0.0;
     tc->ruckig_last_feed_override = 0.0;
+    tc->ruckig_fail_logged_pool = 0;
+    tc->ruckig_fail_logged_vel_replan = 0;
+    tc->ruckig_fail_logged_vel_first = 0;
+    tc->ruckig_fail_logged_pos_replan = 0;
+    tc->ruckig_fail_logged_pos_first = 0;
 
     return TP_ERR_OK;
 }

--- a/src/emc/tp/tc_types.h
+++ b/src/emc/tp/tc_types.h
@@ -210,6 +210,16 @@ typedef struct {
     int ruckig_last_use_velocity_control;  // control mode used in last planning (1=velocity, 0=position)
     double ruckig_last_req_pos;        // last req_pos value from Ruckig (for velocity control incremental calc)
     double ruckig_last_feed_override;  // feed override value at last planning (for debug and change detection)
+    // One flag per Ruckig plan-failure site in tpCalculateSCurveAccel. Set
+    // once a failure of that kind has been logged for this segment, so a
+    // segment Ruckig can never solve logs ONCE per failure site instead of
+    // every servo cycle (1kHz) -> avoids a multi-GB log flood on long soak
+    // runs. Cleared by tcInit on every new segment.
+    int ruckig_fail_logged_pool;        // pool acquire returned NULL
+    int ruckig_fail_logged_vel_replan;  // velocity control, replan failed
+    int ruckig_fail_logged_vel_first;   // velocity control, first attempt failed
+    int ruckig_fail_logged_pos_replan;  // position control, replan failed
+    int ruckig_fail_logged_pos_first;   // position control, first attempt failed
 } TC_STRUCT;
 
 #endif				/* TC_TYPES_H */

--- a/src/emc/tp/tp.c
+++ b/src/emc/tp/tp.c
@@ -2827,7 +2827,14 @@ int tpCalculateSCurveAccel(TP_STRUCT const * const tp, TC_STRUCT * const tc, TC_
         // Borrow a Ruckig planner from the preallocated pool (no RT-cycle alloc)
         tc->ruckig_planner = ruckig_pool_acquire(tc->cycle_time);
         if (!tc->ruckig_planner) {
-            rtapi_print_msg(RTAPI_MSG_ERR, "tpCalculateSCurveAccel: failed to create Ruckig planner\n");
+            // Same rate-limit as the plan-failure paths below: the pool is
+            // retried every servo cycle for as long as it stays exhausted.
+            if (!tc->ruckig_fail_logged_pool) {
+                tc->ruckig_fail_logged_pool = 1;
+                rtapi_print_msg(RTAPI_MSG_ERR,
+                    "tpCalculateSCurveAccel: failed to acquire a Ruckig planner from the pool"
+                    " (segment %d, reported once)\n", tc->id);
+            }
             return TP_SCURVE_ACCEL_ERROR;
         }
         tc->ruckig_planned = 0;
@@ -2884,10 +2891,27 @@ int tpCalculateSCurveAccel(TP_STRUCT const * const tp, TC_STRUCT * const tc, TC_
                                                   maxjerk);      // max jerk
 
             if (plan_result != 0) {
+                // Guarded exactly like the position-control paths below: both
+                // branches are re-entered every servo cycle while the segment
+                // keeps failing (the caller reverts to trapezoidal for that
+                // cycle only, then calls back in). Each site has its own flag,
+                // cleared by tcInit on every new segment, so each distinct
+                // failure mode still logs once per segment.
                 if (tc->ruckig_planned) {
-                    rtapi_print_msg(RTAPI_MSG_WARN, "tpCalculateSCurveAccel: Ruckig velocity control replanning failed, using previous trajectory\n");
+                    if (!tc->ruckig_fail_logged_vel_replan) {
+                        tc->ruckig_fail_logged_vel_replan = 1;
+                        rtapi_print_msg(RTAPI_MSG_WARN,
+                            "tpCalculateSCurveAccel: Ruckig velocity control replanning failed,"
+                            " using previous trajectory (segment %d, reported once)\n", tc->id);
+                    }
                 } else {
-                    rtapi_print_msg(RTAPI_MSG_WARN, "tpCalculateSCurveAccel: Ruckig velocity control planning failed, falling back to tp 0\n");
+                    if (!tc->ruckig_fail_logged_vel_first) {
+                        tc->ruckig_fail_logged_vel_first = 1;
+                        rtapi_print_msg(RTAPI_MSG_WARN,
+                            "tpCalculateSCurveAccel: Ruckig velocity control planning failed"
+                            " with result %d, falling back to tp 0 (segment %d, reported once)\n",
+                            plan_result, tc->id);
+                    }
                     return TP_SCURVE_ACCEL_ERROR;
                 }
             } else {
@@ -2950,25 +2974,38 @@ int tpCalculateSCurveAccel(TP_STRUCT const * const tp, TC_STRUCT * const tc, TC_
                                           maxjerk);              // max jerk
 
             if (plan_result != 0) {
-                rtapi_print_msg(RTAPI_MSG_INFO, "tpCalculateSCurveAccel: ruckig_plan_position failed with result %d\n", plan_result);
                 if (tc->ruckig_planned) {
                     // Keep using previous trajectory
+                    if (!tc->ruckig_fail_logged_pos_replan) {
+                        tc->ruckig_fail_logged_pos_replan = 1;
+                        rtapi_print_msg(RTAPI_MSG_INFO, "tpCalculateSCurveAccel: ruckig_plan_position failed with result %d (segment %d, reported once)\n", plan_result, tc->id);
+                    }
                 } else {
-                    // First planning attempt failed, fall back
-                    rtapi_print_msg(RTAPI_MSG_ERR,
-                        "Ruckig planning failed (first attempt), Back to tp 0\n"
-                        "  feed_override: %.6f \n"
-                        "  max_vel: %.6f\n"
-                        "  cpos: %.6f, tpos: %.6f, dx: %.6f\n"
-                        "  cvel: %.6f, tvel: %.6f\n"
-                        "  cacc: %.6f\n"
-                        "  maxa: %.6f, maxj: %.6f\n",
-                        emcmotStatus->net_feed_scale,
-                        effective_max_vel,
-                        replan_pos, target_pos, dx,
-                        replan_vel, effective_target_vel,
-                        replan_acc,
-                        maxaccel, maxjerk);
+                    // First planning attempt failed, fall back to trapezoidal.
+                    // Guarded so a segment Ruckig can never solve logs ONCE, not
+                    // every servo cycle (the retry loop re-enters here each cycle
+                    // until ruckig_planned flips). The flag is cleared by tcInit
+                    // on every new segment, so each distinct failure still logs.
+                    if (!tc->ruckig_fail_logged_pos_first) {
+                        tc->ruckig_fail_logged_pos_first = 1;
+                        rtapi_print_msg(RTAPI_MSG_ERR,
+                            "Ruckig planning failed (first attempt), Back to tp 0 (segment %d, reported once)\n"
+                            "  plan_result: %d\n"
+                            "  feed_override: %.6f \n"
+                            "  max_vel: %.6f\n"
+                            "  cpos: %.6f, tpos: %.6f, dx: %.6f\n"
+                            "  cvel: %.6f, tvel: %.6f\n"
+                            "  cacc: %.6f\n"
+                            "  maxa: %.6f, maxj: %.6f\n",
+                            tc->id,
+                            plan_result,
+                            emcmotStatus->net_feed_scale,
+                            effective_max_vel,
+                            replan_pos, target_pos, dx,
+                            replan_vel, effective_target_vel,
+                            replan_acc,
+                            maxaccel, maxjerk);
+                    }
                     return TP_SCURVE_ACCEL_ERROR;
                 }
             } else {


### PR DESCRIPTION
## Problem

When Ruckig cannot plan a segment, `tpCalculateSCurveAccel()` logs the failure
and falls back to trapezoidal motion for that cycle. The caller then calls
straight back in on the next servo cycle, and — because `ruckig_planned` only
flips to 1 on success — the planning branch is re-entered and fails again. A
segment Ruckig can never solve therefore logs **every servo cycle**, i.e. at
1 kHz on a typical machine, for as long as that segment is being executed.

The fallback itself is graceful; the logging is not. On a long run this
produces a log measured in gigabytes and buries anything else in it.

Note that the S-curve path is the default (`mode = 1` unless the move is an
abort), so this is reachable on a stock machine with jerk limits configured.

## Fix

Add per-segment "already logged" flags to `TC_STRUCT`, cleared in `tcInit()`,
and guard each of the five failure sites in `tpCalculateSCurveAccel()`: the
pool-acquire failure, both velocity-control failures, and both position-control
failures. Each distinct segment still reports its first failure — and the
messages now carry `tc->id`, so you can tell *which* segment — but a segment
that keeps failing reports once instead of once per cycle.

One flag per site, not one shared flag: a segment that hits more than one
failure mode (say a pool-acquire failure, then a plan failure once a planner
frees up) still logs each mode once. A single shared flag would report only
whichever fired first.

The first-attempt position-control ERR dump also carries `plan_result` again
(it had been left only on the replan branch), so the give-up path shows which
limit Ruckig objected to; the velocity-control first-attempt warning carries
it too.

Nothing about the motion changes: the trapezoidal fallback, the return codes
and the retry behaviour are all untouched. This is a logging change only.

**Precedent:** master's own `tpCalculateSCurveAccel()` already carries a
`scurve_jerk_warned` guard for the adjacent "max jerk < 1" warning, with the
same rationale in its comment ("warn ONCE instead of storming the log at servo
rate"). This applies that treatment to the Ruckig failure paths, per-segment
rather than per-process, so each new bad segment is still surfaced.

## Testing

Build clean (RIP, `--with-realtime=uspace`), no warnings. `cppcheck` clean on
all three changed files. `tests/motion` + `tests/motion-logger` +
`tests/interp`: 91/91 pass, 1 skipped (`tests/interp/compile`, disabled
upstream).

Measured with fault injection — forcing the first-attempt position-planning
failure (`plan_result = -1` right after `ruckig_plan_position()`) and running a
five-move G-code program on `configs/sim/axis/axis_mm_scurve.ini` (which the
arc blender expands to nine queued segments):

| build | `Ruckig planning failed (first attempt)` lines | total stderr lines |
|---|---|---|
| master `tp.c`, same injection | **9427** | 65996 |
| this branch | **9** | 80 |

The nine remaining lines on the branch are one per queued segment that hits the
site (five moves plus four arc-blend segments, each its own `TC_STRUCT`), each
tagged `reported once` and naming its `tc->id`. With the injection removed the
branch logs **zero** Ruckig-failure lines on the same program, so nothing that
should be reported is being suppressed.
