### PR TITLE
docs: Architecture C1 context diagram - halcmd and halshow attach to HAL

### DIFF
--- a/docs/src/getting-started/images/LCNC_Architecture_C1.drawio
+++ b/docs/src/getting-started/images/LCNC_Architecture_C1.drawio
@@ -256,13 +256,28 @@
             <mxPoint x="1100" y="500" as="sourcePoint" />
           </mxGeometry>
         </mxCell>
-        <mxCell id="XWJ5TldJVoNbO8orDr2t-41" parent="1" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#dae8fc;strokeColor=#6c8ebf;dashed=1;" value="Terminal&lt;br&gt;halcmd / halshow / linuxcncrsh&amp;nbsp;" vertex="1">
-          <mxGeometry height="80" width="200" x="1600" y="240" as="geometry" />
+        <mxCell id="XWJ5TldJVoNbO8orDr2t-41" parent="1" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#dae8fc;strokeColor=#6c8ebf;dashed=1;" value="Terminal&lt;br&gt;linuxcncrsh&amp;nbsp;" vertex="1">
+          <mxGeometry height="35" width="200" x="1600" y="235" as="geometry" />
+        </mxCell>
+        <mxCell id="XWJ5TldJVoNbO8orDr2t-49" parent="1" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#dae8fc;strokeColor=#6c8ebf;dashed=1;" value="Terminal&lt;br&gt;halcmd / halshow&amp;nbsp;" vertex="1">
+          <mxGeometry height="38" width="200" x="1600" y="282" as="geometry" />
+        </mxCell>
+        <mxCell id="XWJ5TldJVoNbO8orDr2t-50" edge="1" parent="1" source="XWJ5TldJVoNbO8orDr2t-49" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;entryX=1;entryY=0.5;entryDx=0;entryDy=0;startArrow=classic;startFill=1;dashed=1;exitX=0.5;exitY=1;exitDx=0;exitDy=0;" target="XWJ5TldJVoNbO8orDr2t-4">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="XWJ5TldJVoNbO8orDr2t-51" edge="1" parent="1" source="XWJ5TldJVoNbO8orDr2t-29" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;dashed=1;startArrow=classic;startFill=1;exitX=0.65;exitY=1;exitDx=0;exitDy=0;exitPerimeter=0;entryX=1;entryY=0.5;entryDx=0;entryDy=0;" target="XWJ5TldJVoNbO8orDr2t-49">
+          <mxGeometry relative="1" as="geometry">
+            <Array as="points">
+              <mxPoint x="1450" y="160" />
+              <mxPoint x="1860" y="160" />
+              <mxPoint x="1860" y="301" />
+            </Array>
+          </mxGeometry>
         </mxCell>
         <mxCell id="XWJ5TldJVoNbO8orDr2t-42" edge="1" parent="1" source="XWJ5TldJVoNbO8orDr2t-41" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;entryX=1;entryY=0.5;entryDx=0;entryDy=0;startArrow=classic;startFill=1;dashed=1;exitX=0;exitY=0.5;exitDx=0;exitDy=0;" target="XWJ5TldJVoNbO8orDr2t-3">
           <mxGeometry relative="1" as="geometry">
             <Array as="points">
-              <mxPoint x="1569" y="280" />
+              <mxPoint x="1569" y="252" />
             </Array>
           </mxGeometry>
         </mxCell>

--- a/docs/src/getting-started/images/LCNC_Architecture_C1.drawio.svg
+++ b/docs/src/getting-started/images/LCNC_Architecture_C1.drawio.svg
@@ -202,16 +202,28 @@
            id="rect109-2" />
         <rect
            x="568.5"
-           y="227.5"
+           y="222.5"
            width="200"
-           height="80"
-           rx="12"
-           ry="12"
+           height="35"
+           rx="5.25"
+           ry="5.25"
            fill="#dae8fc"
            style="fill:#dae8fc;stroke:#6c8ebf"
            stroke="#6c8ebf"
            stroke-dasharray="3, 3"
            id="rect117-8" />
+        <rect
+           x="568.5"
+           y="269.5"
+           width="200"
+           height="38"
+           rx="5.7"
+           ry="5.7"
+           fill="#dae8fc"
+           style="fill:#dae8fc;stroke:#6c8ebf"
+           stroke="#6c8ebf"
+           stroke-dasharray="3, 3"
+           id="rect117-8-hal" />
         <rect
            x="88.5"
            y="128.5"
@@ -366,14 +378,14 @@
              transform="translate(0.5,0.5)"
              id="g123-8">
             <path
-               d="M 561.63,267 H 537 L 534.36,267.15"
+               d="M 561.63,240 H 537 L 534.36,240.15"
                id="path121-8" />
             <path
-               d="M 566.88,267 L 559.88,270.5 L 561.63,267 L 559.88,263.5 Z"
+               d="M 566.88,240 L 559.88,243.5 L 561.63,240 L 559.88,236.5 Z"
                id="path122-5"
                style="stroke-dasharray:none" />
             <path
-               d="M 529.12,267.44 L 535.91,263.56 L 534.36,267.15 L 536.3,270.54 Z"
+               d="M 529.12,240.44 L 535.91,236.56 L 534.36,240.15 L 536.3,243.54 Z"
                id="path123-0"
                style="stroke-dasharray:none" />
           </g>
@@ -384,7 +396,7 @@
              transform="translate(0.5,0.5)"
              id="g126-6">
             <path
-               d="M 408.4,113.37 L 408.42,157 H 668 V 220.63"
+               d="M 408.4,113.37 L 408.42,157 H 668 V 215.63"
                id="path124-3"
                style="fill:none" />
             <path
@@ -392,8 +404,46 @@
                id="path125-8"
                style="stroke-dasharray:none" />
             <path
-               d="M 668,225.88 L 664.5,218.88 L 668,220.63 L 671.5,218.88 Z"
+               d="M 668,220.88 L 664.5,213.88 L 668,215.63 L 671.5,213.88 Z"
                id="path126-5"
+               style="stroke-dasharray:none" />
+          </g>
+        </g>
+        <g
+           id="g124-0-hal">
+          <g
+             transform="translate(0.5,0.5)"
+             id="g123-8-hal">
+            <path
+               d="M 668,313.37 V 397 H 643.87"
+               id="path121-8-hal"
+               style="fill:none" />
+            <path
+               d="M 668,308.12 L 671.5,315.12 L 668,313.37 L 664.5,315.12 Z"
+               id="path122-5-hal"
+               style="stroke-dasharray:none" />
+            <path
+               d="M 638.62,397 L 645.62,393.5 L 643.87,397 L 645.62,400.5 Z"
+               id="path123-0-hal"
+               style="stroke-dasharray:none" />
+          </g>
+        </g>
+        <g
+           id="g127-9-hal">
+          <g
+             transform="translate(0.5,0.5)"
+             id="g126-6-hal">
+            <path
+               d="M 418.4,113.37 L 418.4,147 H 828.5 V 288.5 H 774.37"
+               id="path124-3-hal"
+               style="fill:none" />
+            <path
+               d="M 418.4,108.12 L 421.9,115.12 L 418.4,113.37 L 414.9,115.12 Z"
+               id="path125-8-hal"
+               style="stroke-dasharray:none" />
+            <path
+               d="M 769.12,288.5 L 776.12,285 L 774.37,288.5 L 776.12,292 Z"
+               id="path126-5-hal"
                style="stroke-dasharray:none" />
           </g>
         </g>
@@ -738,14 +788,24 @@
              id="tspan156">(machine builder)</tspan></text>
         <text
            x="667.9780273"
-           y="266.1189575"
+           y="238.6189575"
            id="text153-9-1"><tspan
              id="tspan153-6-5"
              x="667.9780273"
-             y="266.1189575">Terminal</tspan><tspan
+             y="238.6189575">Terminal</tspan><tspan
              x="667.9780273"
-             y="280.1310425"
-             id="tspan157">halcmd / halshow / linuxcncrsh</tspan></text>
+             y="252.6310425"
+             id="tspan157">linuxcncrsh</tspan></text>
+        <text
+           x="667.9780273"
+           y="287.1189575"
+           id="text153-9-1-hal"><tspan
+             id="tspan153-6-5-hal"
+             x="667.9780273"
+             y="287.1189575">Terminal</tspan><tspan
+             x="667.9780273"
+             y="301.1310425"
+             id="tspan157-hal">halcmd / halshow</tspan></text>
         <text
            x="147.7854919"
            y="264.6559753"


### PR DESCRIPTION
@zz912 — the separate PR for the context diagram I promised in #3718, and only for it.
It carries the correction you accepted there.

## What changes

The Terminal box holds `halcmd`, `halshow` and `linuxcncrsh` and draws one link, to the
Core Runtime.

The box is split in two inside its own footprint: `linuxcncrsh` keeps the link to the
core, `halcmd / halshow` gain a dashed link to the HAL Interface Boundary. The
*Developers / Testers* link is drawn to both halves, so the split does not narrow it to
`linuxcncrsh` alone.

## Whose file this is

The published SVG is not an export of the `.drawio` beside it. It is the file
**@BsAtHome** rebuilt by hand in Inkscape and offered in #4057, which **@grandixximo**
merged there.

The second commit puts the same split in the `.drawio`, so the source does not contradict
the figure. The two have already drifted since #4057: the SVG reads
`(joints, spindles, IO, safety)`, `PNConf` and full stops where the source reads
`(axes, spindle, IO, safety)`, `PNCconf` and middle dots. None of the three is touched
here — but a re-export would revert all of them, so it is worth saying which file is
authoritative from now on.
