### PR TITLE
classicladder: give the headers include guards and their own dependencies

### DIFF
--- a/src/hal/classicladder/arithm_eval.h
+++ b/src/hal/classicladder/arithm_eval.h
@@ -14,6 +14,9 @@
 //    along with this program; if not, write to the Free Software
 //    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
+#ifndef CLASSICLADDER_ARITHM_EVAL_H
+#define CLASSICLADDER_ARITHM_EVAL_H
+
 #define arithmtype int
 
 
@@ -26,3 +29,5 @@ char * VerifySyntaxForEvalCompare(char * StringToVerify);
 char * VerifySyntaxForMakeCalc(char * StringToVerify);
 
 
+
+#endif

--- a/src/hal/classicladder/calc.h
+++ b/src/hal/classicladder/calc.h
@@ -14,6 +14,11 @@
 //    along with this program; if not, write to the Free Software
 //    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
+#ifndef CLASSICLADDER_CALC_H
+#define CLASSICLADDER_CALC_H
+
+#include "classicladder.h"
+
 void InitRungs(void);
 void PrepareRungs(void);
 void InitTimers(void);
@@ -32,3 +37,5 @@ void WriteVarForElement( StrElement *pElem, int Value );
 void RefreshASection( StrSection * pSection );
 void ClassicLadder_RefreshAllSections(void);
 void CopyRungToRung(StrRung * RungSrc,StrRung * RungDest);
+
+#endif

--- a/src/hal/classicladder/calc_sequential.h
+++ b/src/hal/classicladder/calc_sequential.h
@@ -13,6 +13,11 @@
 //    You should have received a copy of the GNU General Public License
 //    along with this program; if not, write to the Free Software
 //    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#ifndef CLASSICLADDER_CALC_SEQUENTIAL_H
+#define CLASSICLADDER_CALC_SEQUENTIAL_H
+
 void InitSequential( void );
 void PrepareSequential( void );
 void RefreshSequentialPage( int PageNbr );
+
+#endif

--- a/src/hal/classicladder/classicladder.h
+++ b/src/hal/classicladder/classicladder.h
@@ -19,6 +19,9 @@
 /* Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
 /* if GTK not included before */
+#ifndef CLASSICLADDER_H
+#define CLASSICLADDER_H
+
 #ifndef TRUE
 #define TRUE 1
 #endif
@@ -521,3 +524,5 @@ extern int modslave;
 //#define DBG_HEADER_ERR "ClassicLadder Error --- "
 #define DBG_HEADER_INFO ""
 #define DBG_HEADER_ERR ""
+
+#endif

--- a/src/hal/classicladder/classicladder_gtk.h
+++ b/src/hal/classicladder/classicladder_gtk.h
@@ -14,8 +14,8 @@
 //    along with this program; if not, write to the Free Software
 //    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-#ifndef _CLASSICLADDER_GTK_H
-#define _CLASSICLADDER_GTK_H
+#ifndef CLASSICLADDER_CLASSICLADDER_GTK_H
+#define CLASSICLADDER_CLASSICLADDER_GTK_H
 
 //For i18n
 #define _(STRING) gettext(STRING)

--- a/src/hal/classicladder/config_gtk.h
+++ b/src/hal/classicladder/config_gtk.h
@@ -13,4 +13,9 @@
 //    You should have received a copy of the GNU General Public License
 //    along with this program; if not, write to the Free Software
 //    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#ifndef CLASSICLADDER_CONFIG_GTK_H
+#define CLASSICLADDER_CONFIG_GTK_H
+
 void OpenConfigWindowGtk( );
+
+#endif

--- a/src/hal/classicladder/drawing.h
+++ b/src/hal/classicladder/drawing.h
@@ -13,6 +13,13 @@
 //    You should have received a copy of the GNU General Public License
 //    along with this program; if not, write to the Free Software
 //    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#ifndef CLASSICLADDER_DRAWING_H
+#define CLASSICLADDER_DRAWING_H
+
+#include <stddef.h>
+#include <cairo.h>
+#include "classicladder.h"
+
 #define DRAW_NORMAL 0
 #define DRAW_FOR_TOOLBAR 1
 #define DRAW_FOR_PRINT 2
@@ -31,3 +38,5 @@ void DrawRung( cairo_t * cr, StrRung * Rung, int OffX, int PosiY, int BlockWidth
 void DrawRungs( cairo_t * cr );
 void DrawCurrentSection( cairo_t * cr );
 
+
+#endif

--- a/src/hal/classicladder/drawing_sequential.h
+++ b/src/hal/classicladder/drawing_sequential.h
@@ -13,9 +13,17 @@
 //    You should have received a copy of the GNU General Public License
 //    along with this program; if not, write to the Free Software
 //    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#ifndef CLASSICLADDER_DRAWING_SEQUENTIAL_H
+#define CLASSICLADDER_DRAWING_SEQUENTIAL_H
+
+#include <cairo.h>
+#include "sequential.h"
+
 void DrawSeqStep( cairo_t * cr,int x,int y,int Size,StrStep * pStep,char DrawingOption );
 void DrawSeqTransition( cairo_t * cr,int x,int y,int Size,StrTransition * pTransi,char DrawingOption );
 
 void DrawSequentialPage( cairo_t * cr, int PageNbr, int SeqPxSize, char DrawingOption );
 
 void DrawSeqElementForToolBar( cairo_t * cr, int x, int y, int Size, int NumElement );
+
+#endif

--- a/src/hal/classicladder/edit.h
+++ b/src/hal/classicladder/edit.h
@@ -13,6 +13,11 @@
 //    You should have received a copy of the GNU General Public License
 //    along with this program; if not, write to the Free Software
 //    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#ifndef CLASSICLADDER_EDIT_H
+#define CLASSICLADDER_EDIT_H
+
+#include "classicladder.h"
+
 #define MODE_MODIFY 0
 #define MODE_ADD 1
 #define MODE_INSERT 2
@@ -43,3 +48,5 @@ char * ConvVarNameToHalSigName (char *);
 char * FirstVariableInArithm(char *);
 int SetDefaultVariableType(int NumElement);
 
+
+#endif

--- a/src/hal/classicladder/edit_copy.h
+++ b/src/hal/classicladder/edit_copy.h
@@ -1,3 +1,6 @@
+#ifndef CLASSICLADDER_EDIT_COPY_H
+#define CLASSICLADDER_EDIT_COPY_H
+
 void StartOrMotionPartSelection(double x,double y, char StartToClick);
 void EndPartSelection( );
 void GetSizesOfTheSelectionToCopy( int * pSizeX, int * pSizeY );
@@ -5,3 +8,5 @@ char GetIsOutputEleLastColumnSelection( );
 void CopyNowPartSelected( double x,double y );
 
 
+
+#endif

--- a/src/hal/classicladder/edit_gtk.h
+++ b/src/hal/classicladder/edit_gtk.h
@@ -13,8 +13,10 @@
 //    You should have received a copy of the GNU General Public License
 //    along with this program; if not, write to the Free Software
 //    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
-#ifndef _EDIT_GTK_H
-#define _EDIT_GTK_H
+#ifndef CLASSICLADDER_EDIT_GTK_H
+#define CLASSICLADDER_EDIT_GTK_H
+#include <gtk/gtk.h>
+
 void EditorButtonsAccordingSectionType( );
 void ButtonCancelCurrentRung();
 void OpenEditWindow( GtkAction * ActionOpen, gboolean OpenIt );

--- a/src/hal/classicladder/edit_sequential.h
+++ b/src/hal/classicladder/edit_sequential.h
@@ -13,9 +13,14 @@
 //    You should have received a copy of the GNU General Public License
 //    along with this program; if not, write to the Free Software
 //    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#ifndef CLASSICLADDER_EDIT_SEQUENTIAL_H
+#define CLASSICLADDER_EDIT_SEQUENTIAL_H
+
 void SaveSeqElementProperties( void );
 void ModifyCurrentSeqPage(void);
 void CancelSeqPageEdited(void);
 void ApplySeqPageEdited(void);
 void EditElementInSeqPage(double x,double y);
 
+
+#endif

--- a/src/hal/classicladder/editproperties_gtk.h
+++ b/src/hal/classicladder/editproperties_gtk.h
@@ -13,7 +13,12 @@
 //    You should have received a copy of the GNU General Public License
 //    along with this program; if not, write to the Free Software
 //    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#ifndef CLASSICLADDER_EDITPROPERTIES_GTK_H
+#define CLASSICLADDER_EDITPROPERTIES_GTK_H
+
 void SetProperty(int NumParam,char * LblParam,char * ValParam,char SetFocus);
 char * GetProperty(int NumParam);
 void ShowPropertiesWindow( int Visible );
 void PropertiesInitGtk();
+
+#endif

--- a/src/hal/classicladder/emc_mods.h
+++ b/src/hal/classicladder/emc_mods.h
@@ -13,6 +13,11 @@
 //    You should have received a copy of the GNU General Public License
 //    along with this program; if not, write to the Free Software
 //    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#ifndef CLASSICLADDER_EMC_MODS_H
+#define CLASSICLADDER_EMC_MODS_H
+
 char * ConvVarNameToHalSigName( char * VarNameParam );
 char * FirstVariableInArithm(char * Expr);
 void SymbolsAutoAssign (void);
+
+#endif

--- a/src/hal/classicladder/files.h
+++ b/src/hal/classicladder/files.h
@@ -13,6 +13,11 @@
 //    You should have received a copy of the GNU General Public License
 //    along with this program; if not, write to the Free Software
 //    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#ifndef CLASSICLADDER_FILES_H
+#define CLASSICLADDER_FILES_H
+
+#include "classicladder.h"
+
 #include <stdio.h>		// FILE
 
 #ifndef S_LINE
@@ -66,3 +71,5 @@ void LoadAllLadderDatas(char * DatasDirectory);
 void SaveAllLadderDatas(char * DatasDirectory);
 
 void CleanTmpLadderDirectory( char DestroyDir );
+
+#endif

--- a/src/hal/classicladder/files_project.h
+++ b/src/hal/classicladder/files_project.h
@@ -14,6 +14,9 @@
 //    along with this program; if not, write to the Free Software
 //    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
+#ifndef CLASSICLADDER_FILES_PROJECT_H
+#define CLASSICLADDER_FILES_PROJECT_H
+
 void VerifyDirectorySelected( char * NewDir );
 void InitTempDir( void );
 char LoadProjectFiles( char * FileProject );
@@ -21,3 +24,5 @@ char LoadGeneralParamsOnlyFromProject( char * FileProject );
 char SaveProjectFiles( char * FileProject );
 char JoinFiles( char * DirAndNameOfProject, char * TmpDirectoryFiles );
 char SplitFiles( char * DirAndNameOfProject, char * TmpDirectoryFiles );
+
+#endif

--- a/src/hal/classicladder/files_sequential.h
+++ b/src/hal/classicladder/files_sequential.h
@@ -14,5 +14,10 @@
 //    along with this program; if not, write to the Free Software
 //    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
+#ifndef CLASSICLADDER_FILES_SEQUENTIAL_H
+#define CLASSICLADDER_FILES_SEQUENTIAL_H
+
 char LoadSequential(char * FileName);
 char SaveSequential(char * FileName);
+
+#endif

--- a/src/hal/classicladder/global.h
+++ b/src/hal/classicladder/global.h
@@ -18,6 +18,11 @@
 /* License along with this library; if not, write to the Free Software */
 /* Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
+#ifndef CLASSICLADDER_GLOBAL_H
+#define CLASSICLADDER_GLOBAL_H
+
+#include "classicladder.h"
+
 #ifdef MAT_CONNECTION
 #include "../../lib/plc.h"
 #define TYPE_FOR_BOOL_VAR plc_pt_t
@@ -82,3 +87,5 @@ extern char * ErrorMessageVarParser;
 //extern int ListCurrentDefParam[ NBR_CURRENT_DEFS_MAX ];
 
 
+
+#endif

--- a/src/hal/classicladder/manager.h
+++ b/src/hal/classicladder/manager.h
@@ -13,6 +13,9 @@
 //    You should have received a copy of the GNU General Public License
 //    along with this program; if not, write to the Free Software
 //    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#ifndef CLASSICLADDER_MANAGER_H
+#define CLASSICLADDER_MANAGER_H
+
 void InitSections( void );
 int SearchSubRoutineWithItsNumber( int SubRoutineNbrToFind );
 int SearchSectionWithName( char * SectionNameToFind );
@@ -27,3 +30,5 @@ int GetPrevNextSection( int RefSectionNbr, char NextSearch );
 void SwapSections( int SectionNbr1, int SectionNbr2 /*char * SectionName1, char * SectionName2*/ );
 int FindFreeSequentialPage( void );
 
+
+#endif

--- a/src/hal/classicladder/manager_gtk.h
+++ b/src/hal/classicladder/manager_gtk.h
@@ -13,7 +13,14 @@
 //    You should have received a copy of the GNU General Public License
 //    along with this program; if not, write to the Free Software
 //    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#ifndef CLASSICLADDER_MANAGER_GTK_H
+#define CLASSICLADDER_MANAGER_GTK_H
+
+#include <gtk/gtk.h>
+
 void ManagerDisplaySections( char ForgetSectionSelected );
 void OpenManagerWindow( GtkAction * ActionOpen, gboolean OpenIt );
 void ManagerEnableActionsSectionsList( char cState );
 void ManagerInitGtk();
+
+#endif

--- a/src/hal/classicladder/menu_and_toolbar_gtk.h
+++ b/src/hal/classicladder/menu_and_toolbar_gtk.h
@@ -1,5 +1,10 @@
 
 
+#ifndef CLASSICLADDER_MENU_AND_TOOLBAR_GTK_H
+#define CLASSICLADDER_MENU_AND_TOOLBAR_GTK_H
+
+#include <gtk/gtk.h>
+
 GtkUIManager * InitMenusAndToolBar( GtkWidget *vbox );
 void SetToogleMenuForSectionsManagerWindow( gboolean OpenedWin );
 void SetToggleMenuForEditorWindow( gboolean OpenedWin );
@@ -9,3 +14,5 @@ void SetToggleMenuForFreeVarsWindow( gboolean OpenedWin );
 void SetToggleMenuForLogWindow( gboolean OpenedWin );
 void SetMenuStateForRunStopSwitch( gboolean Running );
 
+
+#endif

--- a/src/hal/classicladder/print_gtk.h
+++ b/src/hal/classicladder/print_gtk.h
@@ -1,3 +1,8 @@
 
+#ifndef CLASSICLADDER_PRINT_GTK_H
+#define CLASSICLADDER_PRINT_GTK_H
+
 void PrintGtk( );
 void PrintPreviewGtk( );
+
+#endif

--- a/src/hal/classicladder/protocol_modbus_defines.h
+++ b/src/hal/classicladder/protocol_modbus_defines.h
@@ -14,8 +14,8 @@
 //    along with this program; if not, write to the Free Software
 //    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-#ifndef _PROTOCOL_MODBUS_DEFINES_H
-#define _PROTOCOL_MODBUS_DEFINES_H
+#ifndef CLASSICLADDER_PROTOCOL_MODBUS_DEFINES_H
+#define CLASSICLADDER_PROTOCOL_MODBUS_DEFINES_H
 
 /* To set/reset single coil with function 5 */
 #define MODBUS_BIT_OFF 0x0000

--- a/src/hal/classicladder/protocol_modbus_master.h
+++ b/src/hal/classicladder/protocol_modbus_master.h
@@ -14,8 +14,8 @@
 //    along with this program; if not, write to the Free Software
 //    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-#ifndef _PROTOCOL_MODBUS_MASTER_H
-#define _PROTOCOL_MODBUS_MASTER_H
+#ifndef CLASSICLADDER_PROTOCOL_MODBUS_MASTER_H
+#define CLASSICLADDER_PROTOCOL_MODBUS_MASTER_H
 
 /* Modbus requests list available for the user */
 #define MODBUS_REQ_INPUTS_READ 0

--- a/src/hal/classicladder/protocol_modbus_slave.h
+++ b/src/hal/classicladder/protocol_modbus_slave.h
@@ -14,8 +14,13 @@
 //    along with this program; if not, write to the Free Software
 //    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
+#ifndef CLASSICLADDER_PROTOCOL_MODBUS_SLAVE_H
+#define CLASSICLADDER_PROTOCOL_MODBUS_SLAVE_H
+
 int ModbusRequestToRespond( unsigned char * Question, int LgtQuestion, unsigned char * Response );
 int GetMobdusSlaveNbrVars( unsigned char FunctCode );
 void SetVarFromModbusSlave( unsigned char FunctCode, int ModbusNum, int Value );
 int GetVarForModbusSlave( unsigned char FunctCode, int ModbusNum );
 
+
+#endif

--- a/src/hal/classicladder/sequential.h
+++ b/src/hal/classicladder/sequential.h
@@ -19,6 +19,9 @@
 /* Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
 
+#ifndef CLASSICLADDER_SEQUENTIAL_H
+#define CLASSICLADDER_SEQUENTIAL_H
+
 #define NBR_SEQUENTIAL_PAGES 5
 
 #define NBR_STEPS 128
@@ -117,3 +120,5 @@ typedef struct StrSequential
 }StrSequential;
 
 
+
+#endif

--- a/src/hal/classicladder/serial_common.h
+++ b/src/hal/classicladder/serial_common.h
@@ -14,6 +14,9 @@
 //    along with this program; if not, write to the Free Software
 //    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
+#ifndef CLASSICLADDER_SERIAL_COMMON_H
+#define CLASSICLADDER_SERIAL_COMMON_H
+
 char SerialOpen( );
 void SerialClose( );
 char SerialPortIsOpened( void );
@@ -22,3 +25,5 @@ void SerialSetResponseSize( int Size, int TimeOutResp );
 int SerialReceive( char * Buff, int MaxBuffLength );
 void SerialPurge( void );
 
+
+#endif

--- a/src/hal/classicladder/socket_modbus_master.h
+++ b/src/hal/classicladder/socket_modbus_master.h
@@ -13,9 +13,14 @@
 //    You should have received a copy of the GNU General Public License
 //    along with this program; if not, write to the Free Software
 //    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#ifndef CLASSICLADDER_SOCKET_MODBUS_MASTER_H
+#define CLASSICLADDER_SOCKET_MODBUS_MASTER_H
+
 void InitSocketModbusMaster( void );
 void ConfigSerialModbusMaster( void );
 void CloseSocketModbusMaster( void );
 void SocketModbusMasterLoop( void );
 //void GetSocketModbusMasterStats( char * Buff );
 
+
+#endif

--- a/src/hal/classicladder/socket_server.h
+++ b/src/hal/classicladder/socket_server.h
@@ -15,7 +15,12 @@
 //    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 
+#ifndef CLASSICLADDER_SOCKET_SERVER_H
+#define CLASSICLADDER_SOCKET_SERVER_H
+
 void InitSocketServer( int UseUdpMode, int PortNbr );
 void SocketServerTcpMainLoop( void );
 void CloseSocketServer( void );
 
+
+#endif

--- a/src/hal/classicladder/spy_vars_gtk.h
+++ b/src/hal/classicladder/spy_vars_gtk.h
@@ -14,8 +14,15 @@
 //    along with this program; if not, write to the Free Software
 //    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
+#ifndef CLASSICLADDER_SPY_VARS_GTK_H
+#define CLASSICLADDER_SPY_VARS_GTK_H
+
+#include <gtk/gtk.h>
+
 void RefreshAllBoolsVars( );
 void OpenSpyBoolVarsWindow( GtkAction * ActionOpen, gboolean OpenIt );
 void DisplayFreeVarSpy( );
 void OpenSpyFreeVarsWindow( GtkAction * ActionOpen, gboolean OpenIt );
 void VarsWindowInitGtk( );
+
+#endif

--- a/src/hal/classicladder/symbols.h
+++ b/src/hal/classicladder/symbols.h
@@ -14,7 +14,14 @@
 //    along with this program; if not, write to the Free Software
 //    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
+#ifndef CLASSICLADDER_SYMBOLS_H
+#define CLASSICLADDER_SYMBOLS_H
+
+#include "classicladder.h"
+
 void InitSymbols( void );
 StrSymbol * ConvVarNameInSymbolPtr( char * tcVarNameVar );
 char * ConvVarNameToSymbol( char * VarNameParam );
 char * ConvSymbolToVarName( char * SymbolParam );
+
+#endif

--- a/src/hal/classicladder/symbols_gtk.h
+++ b/src/hal/classicladder/symbols_gtk.h
@@ -14,7 +14,14 @@
 //    along with this program; if not, write to the Free Software
 //    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
+#ifndef CLASSICLADDER_SYMBOLS_GTK_H
+#define CLASSICLADDER_SYMBOLS_GTK_H
+
+#include <gtk/gtk.h>
+
 void DisplaySymbols( );
 void OpenSymbolsWindow( GtkAction * ActionOpen, gboolean OpenIt );
 void SymbolsInitGtk();
 
+
+#endif

--- a/src/hal/classicladder/vars_access.h
+++ b/src/hal/classicladder/vars_access.h
@@ -13,6 +13,9 @@
 //    You should have received a copy of the GNU General Public License
 //    along with this program; if not, write to the Free Software
 //    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#ifndef CLASSICLADDER_VARS_ACCESS_H
+#define CLASSICLADDER_VARS_ACCESS_H
+
 void InitVars(void);
 int ReadVar(int TypeVar,int Offset);
 void WriteVar(int TypeVar,int NumVar,int Value);
@@ -21,3 +24,5 @@ void WriteVar(int TypeVar,int NumVar,int Value);
 void DoneVars(void);
 void CycleStart(void);
 void CycleEnd(void);
+
+#endif

--- a/src/hal/classicladder/vars_names.h
+++ b/src/hal/classicladder/vars_names.h
@@ -15,8 +15,13 @@
 //    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 
+#ifndef CLASSICLADDER_VARS_NAMES_H
+#define CLASSICLADDER_VARS_NAMES_H
+
 int GetSizeVarsForTypeVar( int iTypeVarToSearch );
 char * CreateVarName(int Type, int Offset, char SymbolNameIfAvail);
 char TextParserForAVar( char * TextToParse, int * VarTypeFound, int * VarOffsetFound, int * pNumberOfChars, char PartialNames );
 char TestVarIsReadWrite( int TypeVarTested, int OffsetVarTested );
 
+
+#endif


### PR DESCRIPTION
30 of the 34 headers in `hal/classicladder` have no include guard, and 12 do not compile on their own. They name `StrRung`, `StrStep`, `cairo_t` or the gtk types without including whatever declares them, and build only because the file that included them had already got there.

Guards go in first, since including `classicladder.h` from twelve places without them redefines everything. Then the twelve name what they use.

The guards are `CLASSICLADDER_<FILE>_H`. The four that had one already used a leading underscore, which is reserved to the implementation, so they are renamed rather than left as a second convention in one directory.

**Testing.** All 34 compile standalone afterwards, one translation unit per header, where 22 did before. Built clean with `--with-realtime=uspace`, no errors and no warnings.

**Is it worth having?** @BsAtHome this is your point from #4425, that a header needing something should be the one to say so, applied to a subsystem you did not ask about. classicladder is old code nobody is working on, so if 34 files of churn reads as noise, say so and I will close it.

Independent of #4425, overlapping by one line, the `<stdio.h>` in `files.h`.
