### PR TITLE
tree: remove includes that nothing in the file uses

### DIFF
--- a/src/emc/canterp/canterp.cc
+++ b/src/emc/canterp/canterp.cc
@@ -55,7 +55,6 @@
 #include <limits.h>
 #include <algorithm>
 #include <linuxcnc.h>
-#include "config.h"
 #include "nml_intf/interp_return.hh"
 #include "nml_intf/canon.hh"
 #include "rs274ngc/interp_base.hh"

--- a/src/emc/ini/inihal.cc
+++ b/src/emc/ini/inihal.cc
@@ -27,7 +27,6 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #include <rtapi_math.h>
 #include "inihal.hh"
 #include "iniaxis.hh"
-#include "inispindle.hh"
 
 static int debug=0;
 static int comp_id;

--- a/src/emc/motion-logger/motion-logger.c
+++ b/src/emc/motion-logger/motion-logger.c
@@ -33,7 +33,6 @@
 #include <hal.h>
 #include "motion/motion.h"
 #include "motion/motion_struct.h"
-#include "motion_types.h"
 #include "motion/mot_priv.h"
 #include "motion/axis.h"
 

--- a/src/emc/motion/control.c
+++ b/src/emc/motion/control.c
@@ -31,7 +31,6 @@
 #include "simple_tp.h"
 #include "motion.h"
 #include "mot_priv.h"
-#include "config.h"
 #include "homing.h"
 #include "axis.h"
 #include "../nml_intf/state_tag.h"

--- a/src/emc/nml_intf/emc.cc
+++ b/src/emc/nml_intf/emc.cc
@@ -22,10 +22,8 @@
 
 // Include command and status message definitions
 #include "canon.hh"
-#include "canon_position.hh"
 #include "emc.hh"
 #include "emc_nml.hh"
-#include "emcglb.h"
 #include "emcpos.h"
 #include "libnml/cms/cms.hh"
 

--- a/src/emc/nml_intf/emcargs.cc
+++ b/src/emc/nml_intf/emcargs.cc
@@ -17,7 +17,6 @@
 #include <stdio.h>		/* fgets() */
 #include "libnml/nml/nml.hh"               /* nmlSetHostAlias */
 #include "emcglb.h"		/* these decls */
-#include "emccfg.h"		/* their initial values */
 #include "libnml/rcs/rcs_print.hh"
 #include <rtapi_string.h>
 

--- a/src/emc/rs274ngc/gcodemodule.cc
+++ b/src/emc/rs274ngc/gcodemodule.cc
@@ -49,8 +49,6 @@
 #include "rs274ngc_interp.hh"
 #include "nml_intf/interp_return.hh"
 #include "nml_intf/canon.hh"
-#include "config.h"		// LINELEN
-#include "units.h"
 
 int _task = 0; // control preview behaviour when remapping
 

--- a/src/emc/rs274ngc/interp_array.cc
+++ b/src/emc/rs274ngc/interp_array.cc
@@ -11,7 +11,6 @@
 * Copyright (c) 2004 All rights reserved.
 ********************************************************************/
 
-#include "rs274ngc_return.hh"
 #include "rs274ngc_interp.hh"
 
 using namespace interp_param_global;

--- a/src/emc/rs274ngc/interp_g7x.cc
+++ b/src/emc/rs274ngc/interp_g7x.cc
@@ -915,10 +915,8 @@ void g7x::add_distance(double distance) {
 #include <cstring>
 #include <string>
 #include "rs274ngc.hh"
-#include "rs274ngc_return.hh"
 #include "rs274ngc_interp.hh"
 #include "interp_internal.hh"
-#include "units.h"
 
 class motion_machine:public motion_base {
     Interp *interp;

--- a/src/emc/rs274ngc/interp_python.cc
+++ b/src/emc/rs274ngc/interp_python.cc
@@ -38,7 +38,6 @@ namespace bp = boost::python;
 #include "nml_intf/interp_return.hh"
 #include "interp_internal.hh"
 #include "rs274ngc_interp.hh"
-#include "units.h"
 
 extern    PythonPlugin *python_plugin;
 

--- a/src/emc/rs274ngc/interp_queue.cc
+++ b/src/emc/rs274ngc/interp_queue.cc
@@ -14,7 +14,6 @@
 #include <math.h>
 
 #include "rs274ngc.hh"
-#include "rs274ngc_return.hh"
 #include "interp_queue.hh"
 #include "interp_internal.hh"
 #include "rs274ngc_interp.hh"

--- a/src/emc/rs274ngc/interp_remap.cc
+++ b/src/emc/rs274ngc/interp_remap.cc
@@ -27,7 +27,6 @@ namespace bp = boost::python;
 #include <sys/types.h>
 #include <sys/stat.h>
 #include "rs274ngc.hh"
-#include "rs274ngc_return.hh"
 #include "rs274ngc_interp.hh"
 #include "interp_internal.hh"
 #include <rtapi_string.h>

--- a/src/emc/rs274ngc/pyarrays.cc
+++ b/src/emc/rs274ngc/pyarrays.cc
@@ -31,7 +31,6 @@ namespace bp = boost::python;
 #include "array1.hh"
 
 namespace pp = pyplusplus::containers::static_sized;
-#include "interp_array_types.hh"
 
 
 void export_Arrays()

--- a/src/emc/sai/driver.cc
+++ b/src/emc/sai/driver.cc
@@ -35,7 +35,6 @@
 #include <histedit.h>
 #include <glob.h>
 #include <wordexp.h>
-#include <rtapi_string.h>
 
 #include "saicanon.hh"
 #include "tooldata/tooldata.hh"

--- a/src/emc/sai/dummyemcstat.cc
+++ b/src/emc/sai/dummyemcstat.cc
@@ -18,7 +18,6 @@
 // keep linker happy so TaskMod can be resolved
 
 #include <stdio.h>
-#include "libnml/rcs/rcs.hh"		// NML classes, nmlErrorFormat()
 #include "nml_intf/emc.hh"		// EMC NML
 #include "nml_intf/emc_nml.hh"
 #include "rs274ngc/rs274ngc.hh"

--- a/src/emc/sai/saicanon.cc
+++ b/src/emc/sai/saicanon.cc
@@ -41,7 +41,6 @@
 #include <stdarg.h>
 #include <stdlib.h>
 #include <errno.h>
-#include <rtapi_string.h>
 
 #define UNEXPECTED_MSG fprintf(stderr,"UNEXPECTED %s %d\n",__FILE__,__LINE__);
 

--- a/src/emc/task/emccanon.cc
+++ b/src/emc/task/emccanon.cc
@@ -48,7 +48,6 @@
   The code from University of Palermo is modified to work on planes xy, yz and zx by Joachim Franek
   */
 
-#include "config.h"
 #include <stdio.h>
 #include <stdarg.h>
 #include <math.h>
@@ -61,7 +60,6 @@
 #include "nml_intf/canon_position.hh"		// data type for a machine position
 #include "nml_intf/interpl.hh"		// interp_list
 #include "nml_intf/emcglb.h"		// TRAJ_MAX_VELOCITY
-#include <rtapi_string.h>
 #include "nml_intf/modal_state.hh"
 #include "tooldata/tooldata.hh"
 #include <algorithm>

--- a/src/emc/task/taskclass.cc
+++ b/src/emc/task/taskclass.cc
@@ -26,7 +26,6 @@
 
 #include "pythonplugin/python_plugin.hh"
 #include "taskclass.hh"
-#include <rtapi_string.h>
 
 using namespace linuxcnc;
 

--- a/src/emc/tooldata/tooldata_common.cc
+++ b/src/emc/tooldata/tooldata_common.cc
@@ -23,7 +23,6 @@
 */
 #include <stdio.h>
 #include <string.h>
-#include <rtapi_string.h>
 #include "tooldata.hh"
 
 #define UNEXPECTED_MSG fprintf(stderr,"UNEXPECTED %s %d\n",__FILE__,__LINE__);

--- a/src/emc/tp/blendmath.c
+++ b/src/emc/tp/blendmath.c
@@ -22,7 +22,6 @@
 #include "tp_debug.h"
 #include "../motion/motion.h"
 #include "../motion/mot_priv.h"
-#include "sp_scurve.h"
 
 /** @section utilityfuncs Utility functions */
 

--- a/src/emc/tp/cruckig/calculator.c
+++ b/src/emc/tp/cruckig/calculator.c
@@ -8,7 +8,6 @@
 #include "calculator.h"
 #include "position.h"
 #include "velocity.h"
-#include "utils.h"
 
 
 static const double eps = DBL_EPSILON;

--- a/src/emc/tp/cruckig/position_first_step1.c
+++ b/src/emc/tp/cruckig/position_first_step1.c
@@ -7,7 +7,6 @@
  */
 
 #include "position.h"
-#include "block.h"
 #include "profile.h"
 
 void cruckig_pos1_step1_init(CRuckigPositionFirstOrderStep1 *s,

--- a/src/emc/tp/cruckig/position_first_step2.c
+++ b/src/emc/tp/cruckig/position_first_step2.c
@@ -7,9 +7,7 @@
  */
 
 #include "position.h"
-#include "block.h"
 #include "profile.h"
-#include "roots.h"
 
 void cruckig_pos1_step2_init(CRuckigPositionFirstOrderStep2 *s,
                      double tf, double p0, double pf, double vMax, double vMin)

--- a/src/emc/tp/cruckig/position_second_step2.c
+++ b/src/emc/tp/cruckig/position_second_step2.c
@@ -7,9 +7,7 @@
  */
 
 #include "position.h"
-#include "block.h"
 #include "profile.h"
-#include "roots.h"
 
 void cruckig_pos2_step2_init(CRuckigPositionSecondOrderStep2 *s,
                      double tf, double p0, double v0, double pf, double vf,

--- a/src/emc/tp/cruckig/position_third_step2.c
+++ b/src/emc/tp/cruckig/position_third_step2.c
@@ -7,7 +7,6 @@
  */
 
 #include "position.h"
-#include "block.h"
 #include "profile.h"
 #include "roots.h"
 #include "utils.h"

--- a/src/emc/tp/cruckig/velocity_second_step1.c
+++ b/src/emc/tp/cruckig/velocity_second_step1.c
@@ -6,7 +6,6 @@
  * License: MIT, see the LICENSE file in this directory.
  */
 #include "velocity.h"
-#include "block.h"
 #include "profile.h"
 
 void cruckig_vel2_step1_init(CRuckigVelocitySecondOrderStep1 *s,

--- a/src/emc/tp/cruckig/velocity_second_step2.c
+++ b/src/emc/tp/cruckig/velocity_second_step2.c
@@ -6,7 +6,6 @@
  * License: MIT, see the LICENSE file in this directory.
  */
 #include "velocity.h"
-#include "block.h"
 #include "profile.h"
 
 void cruckig_vel2_step2_init(CRuckigVelocitySecondOrderStep2 *s,

--- a/src/emc/tp/cruckig/velocity_third_step2.c
+++ b/src/emc/tp/cruckig/velocity_third_step2.c
@@ -7,7 +7,6 @@
  */
 
 #include "velocity.h"
-#include "block.h"
 #include "profile.h"
 
 /* ---- Internal helper functions ---- */

--- a/src/emc/tp/tc.c
+++ b/src/emc/tp/tc.c
@@ -18,7 +18,6 @@
 #include <rtapi_math.h>
 #include <posemath.h>
 #include <emcpose.h>
-#include <motion_types.h>
 
 #include "blendmath.h"
 #include "tc.h"

--- a/src/emc/tp/tp.c
+++ b/src/emc/tp/tp.c
@@ -17,7 +17,6 @@
 #include <motion_types.h>
 #include "../motion/motion.h"
 #include "../motion/mot_priv.h"
-#include "../motion/axis.h"
 #include "tp.h"
 #include "tc.h"
 #include "spherical_arc.h"

--- a/src/emc/usr_intf/axis/extensions/togl.c
+++ b/src/emc/usr_intf/axis/extensions/togl.c
@@ -14,7 +14,6 @@
 #define X11
 #endif
 
-#include "config.h"
 
 /*** Windows headers ***/
 #if defined(WIN32) && !defined(X11) && !defined(macintosh)

--- a/src/emc/usr_intf/emclcd.cc
+++ b/src/emc/usr_intf/emclcd.cc
@@ -44,7 +44,6 @@
 #include <string.h>
 
 #include <rtapi_string.h>
-#include <linuxcnc.h>
 #include <posemath.h>		// PM_POSE, TO_RAD
 #include "libnml/rcs/rcs.hh"
 #include "nml_intf/emc.hh"		// EMC NML

--- a/src/emc/usr_intf/emcsched.cc
+++ b/src/emc/usr_intf/emcsched.cc
@@ -26,13 +26,11 @@
 #include <stdint.h>
 
 #include "libnml/rcs/rcs.hh"
-#include <posemath.h>		// PM_POSE, TO_RAD
 #include "nml_intf/emc.hh"		// EMC NML
 #include "nml_intf/emc_nml.hh"
 #include "nml_intf/canon.hh"		// CANON_UNITS, CANON_UNITS_INCHES,MM,CM
 #include "nml_intf/emcglb.h"		// EMC_NMLFILE, TRAJ_MAX_VELOCITY, etc.
 #include "nml_intf/emccfg.h"		// DEFAULT_TRAJ_MAX_VELOCITY
-#include "libnml/nml/nml_oi.hh"            // nmlErrorFormat, NML_ERROR, etc
 #include "libnml/rcs/rcs_print.hh"
 #include "libnml/os_intf/timer.hh"             // esleep
 #include "shcom.hh"             // Common NML communications functions

--- a/src/emc/usr_intf/shcom.cc
+++ b/src/emc/usr_intf/shcom.cc
@@ -19,7 +19,6 @@
 #include <fmt/format.h>
 
 #include <rtapi_string.h>
-#include <posemath.h>		// PM_POSE, TO_RAD
 #include <inifile.hh>
 #include "libnml/rcs/rcs.hh"
 #include "nml_intf/emc.hh"		// EMC NML

--- a/src/emc/usr_intf/sockets.c
+++ b/src/emc/usr_intf/sockets.c
@@ -13,7 +13,6 @@
 * Last change:
 ********************************************************************/
 
-#include "config.h"
 #include <unistd.h>
 #include <stddef.h>
 #include <stdio.h>

--- a/src/hal/components/div2.comp
+++ b/src/hal/components/div2.comp
@@ -40,7 +40,6 @@ function _;
 
 ;;
 
-#include <rtapi_math.h>
 
 static bool error_msg = 0;
 

--- a/src/hal/components/invert.comp
+++ b/src/hal/components/invert.comp
@@ -29,7 +29,6 @@ author "Stephen Wille Padnos";
 see_also " invert(9), div2(9) ";
 ;;
 
-#include <rtapi_math.h>
 
 FUNCTION(_) {
     rtapi_real tmp = in;

--- a/src/hal/components/millturn.comp
+++ b/src/hal/components/millturn.comp
@@ -35,7 +35,6 @@ license "GPL";
 author "David Mueller";
 ;;
 
-#include <rtapi_math.h>
 #include <kinematics.h>
 
 static struct haldata {

--- a/src/hal/components/ohmic.comp
+++ b/src/hal/components/ohmic.comp
@@ -65,7 +65,6 @@ option period no;
 function _;
 license "GPL";
 ;;
-#include <rtapi_math.h>
 
 FUNCTION(_) {
     rtapi_real thcad_vel_scale = 1/((thcad_max_volt_freq - thcad_0_volt_freq)/thcad_fullscale/thcad_divide);

--- a/src/hal/components/thc.comp
+++ b/src/hal/components/thc.comp
@@ -92,7 +92,6 @@ function _;
 
 ;;
 
-#include <rtapi_math.h>
 
 FUNCTION(_) {
     // convert encoder velocity to volts

--- a/src/hal/components/thcud.comp
+++ b/src/hal/components/thcud.comp
@@ -97,7 +97,6 @@ function _;
 
 ;;
 
-#include <rtapi_math.h>
 
 FUNCTION(_) {
     if(enable){

--- a/src/hal/components/time.comp
+++ b/src/hal/components/time.comp
@@ -116,7 +116,6 @@ function _;
 
 ;;
 
-#include <rtapi_math.h>
 
 FUNCTION(_) {
     rtapi_u32 totalseconds;

--- a/src/hal/components/userkins.comp
+++ b/src/hal/components/userkins.comp
@@ -66,7 +66,6 @@ license "GPL";
 author "Dewey Garrett";
 ;;
 
-#include <rtapi_math.h>
 #include <kinematics.h>
 
 static struct haldata {

--- a/src/hal/drivers/mesa-hostmot2/abs_encoder.c
+++ b/src/hal/drivers/mesa-hostmot2/abs_encoder.c
@@ -4,12 +4,9 @@
 
 
 #include <rtapi_slab.h>
-#include <rtapi_bool.h>
 
 #include <rtapi.h>
 #include <rtapi_string.h>
-#include <rtapi_math.h>
-#include <rtapi_math64.h>
 #include <hal.h>
 #include "hostmot2.h"
 

--- a/src/hal/drivers/mesa-hostmot2/bitfile.c
+++ b/src/hal/drivers/mesa-hostmot2/bitfile.c
@@ -26,8 +26,6 @@
 #include <rtapi_firmware.h>
 
 #include <rtapi.h>
-#include <rtapi_string.h>
-#include <rtapi_math.h>
 
 #include <hal.h>
 

--- a/src/hal/drivers/mesa-hostmot2/bspi.c
+++ b/src/hal/drivers/mesa-hostmot2/bspi.c
@@ -16,11 +16,7 @@
 //    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
 //
 
-#include <rtapi_slab.h>
-#include <rtapi_bool.h>
 #include <rtapi.h>
-#include <rtapi_string.h>
-#include <rtapi_math.h>
 #include <hal.h>
 #include "hostmot2.h"
 

--- a/src/hal/drivers/mesa-hostmot2/dpll.c
+++ b/src/hal/drivers/mesa-hostmot2/dpll.c
@@ -21,11 +21,8 @@
 // other modules. 
 
 
-#include <rtapi_slab.h>
 
 #include <rtapi.h>
-#include <rtapi_string.h>
-#include <rtapi_math.h>
 
 #include <hal.h>
 

--- a/src/hal/drivers/mesa-hostmot2/hm2_eth_net_evl.c
+++ b/src/hal/drivers/mesa-hostmot2/hm2_eth_net_evl.c
@@ -35,7 +35,6 @@
 #include <evl/net/net.h>
 
 #include <rtapi.h>
-#include <rtapi_string.h>
 
 #include "hostmot2-lowlevel.h"
 #include "hm2_eth_net_evl.h"

--- a/src/hal/drivers/mesa-hostmot2/hm2_eth_net_posix.c
+++ b/src/hal/drivers/mesa-hostmot2/hm2_eth_net_posix.c
@@ -28,7 +28,6 @@
 #include <poll.h>
 
 #include <rtapi.h>
-#include <rtapi_string.h>
 
 #include "hostmot2-lowlevel.h"
 #include "hm2_eth_net_posix.h"

--- a/src/hal/drivers/mesa-hostmot2/led.c
+++ b/src/hal/drivers/mesa-hostmot2/led.c
@@ -24,7 +24,6 @@
 
 #include <rtapi.h>
 #include <rtapi_string.h>
-#include <rtapi_math.h>
 
 #include <hal.h>
 

--- a/src/hal/drivers/mesa-hostmot2/oneshot.c
+++ b/src/hal/drivers/mesa-hostmot2/oneshot.c
@@ -21,7 +21,6 @@
 
 #include <rtapi.h>
 #include <rtapi_string.h>
-#include <rtapi_math.h>
 
 #include <hal.h>
 

--- a/src/hal/drivers/mesa-hostmot2/outm.c
+++ b/src/hal/drivers/mesa-hostmot2/outm.c
@@ -30,7 +30,6 @@
 
 
 
-#include <rtapi_slab.h>
 
 #include <rtapi.h>
 #include <hal.h>

--- a/src/hal/drivers/mesa-hostmot2/periodm.c
+++ b/src/hal/drivers/mesa-hostmot2/periodm.c
@@ -21,7 +21,6 @@
 
 #include <rtapi.h>
 #include <rtapi_string.h>
-#include <rtapi_math.h>
 
 #include <hal.h>
 

--- a/src/hal/drivers/mesa-hostmot2/pins.c
+++ b/src/hal/drivers/mesa-hostmot2/pins.c
@@ -21,7 +21,6 @@
 
 #include <rtapi.h>
 #include <rtapi_string.h>
-#include <rtapi_math.h>
 
 #include <hal.h>
 

--- a/src/hal/drivers/mesa-hostmot2/pktuart.c
+++ b/src/hal/drivers/mesa-hostmot2/pktuart.c
@@ -16,10 +16,8 @@
 //    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
 //
 
-#include <rtapi_slab.h>
 #include <rtapi.h>
 #include <rtapi_string.h>
-#include <rtapi_math.h>
 #include <hal.h>
 #include "hostmot2.h"
 #include "hostmot2-serial.h"

--- a/src/hal/drivers/mesa-hostmot2/raw.c
+++ b/src/hal/drivers/mesa-hostmot2/raw.c
@@ -17,11 +17,9 @@
 //    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
 //
 
-#include <rtapi_slab.h>
 
 #include <rtapi.h>
 #include <rtapi_string.h>
-#include <rtapi_math.h>
 
 #include <hal.h>
 

--- a/src/hal/drivers/mesa-hostmot2/sserial.c
+++ b/src/hal/drivers/mesa-hostmot2/sserial.c
@@ -27,7 +27,6 @@
 #include <hal.h>
 
 #include "hostmot2.h"
-#include "bitfile.h"
 
 // Local definition of labs() because RTAI compile barfs on using labs(). It
 // could be optimized using compiler built-ins, but the single use in here is

--- a/src/hal/drivers/mesa-hostmot2/tp_pwmgen.c
+++ b/src/hal/drivers/mesa-hostmot2/tp_pwmgen.c
@@ -22,7 +22,6 @@
 
 #include <rtapi.h>
 #include <rtapi_string.h>
-#include <rtapi_math.h>
 
 #include <hal.h>
 

--- a/src/hal/drivers/mesa-hostmot2/uart.c
+++ b/src/hal/drivers/mesa-hostmot2/uart.c
@@ -16,10 +16,7 @@
 //    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
 //
 
-#include <rtapi_slab.h>
 #include <rtapi.h>
-#include <rtapi_string.h>
-#include <rtapi_math.h>
 #include <hal.h>
 #include "hostmot2.h"
 

--- a/src/hal/drivers/mesa-hostmot2/watchdog.c
+++ b/src/hal/drivers/mesa-hostmot2/watchdog.c
@@ -20,8 +20,6 @@
 #include <rtapi_slab.h>
 
 #include <rtapi.h>
-#include <rtapi_string.h>
-#include <rtapi_math.h>
 
 #include <hal.h>
 

--- a/src/hal/drivers/serport.comp
+++ b/src/hal/drivers/serport.comp
@@ -52,7 +52,6 @@ license "GPL";
 ;;
 
 #include <rtapi_io.h>
-#include <rtapi_errno.h>
 
 #define MAX 8
 int io[MAX] = {0,};

--- a/src/hal/halmodule.cc
+++ b/src/hal/halmodule.cc
@@ -24,11 +24,9 @@
 #include <vector>
 
 #include <rtapi.h>
-#include <rtapi_mutex.h>
 #include <hal.h>
 
 #include "halqrec.hh"
-#include "setps_util.h"
 
 #define EXCEPTION_IF_NOT_LIVE(retval) do { \
         if(self->hal_id <= 0) { \

--- a/src/hal/utils/halcmd.c
+++ b/src/hal/utils/halcmd.c
@@ -42,7 +42,6 @@
     information, go to www.linuxcnc.org.
 */
 
-#include "config.h"
 #include <linuxcnc.h>
 
 #ifndef NO_INI

--- a/src/hal/utils/halcmd_completion.c
+++ b/src/hal/utils/halcmd_completion.c
@@ -41,7 +41,6 @@
 #include "config.h"
 #include <rtapi.h>		/* RTAPI realtime OS API */
 #include <hal.h>		/* HAL public API decls */
-#include <rtapi_mutex.h>
 #include <string.h>
 #include <ctype.h>
 #include <stdlib.h>

--- a/src/hal/utils/halcmd_main.c
+++ b/src/hal/utils/halcmd_main.c
@@ -39,7 +39,6 @@
 
 #include "config.h"
 #include <rtapi.h>
-#include <rtapi_mutex.h>
 #include <hal.h>
 #include <linuxcnc.h>
 #include "halcmd.h"

--- a/src/hal/utils/halrmt.cc
+++ b/src/hal/utils/halrmt.cc
@@ -52,7 +52,6 @@
 #include <fmt/format.h>
 
 #include <rtapi.h>
-#include <rtapi_string.h>
 #include <hal.h>
 #include <inifile.hh>
 

--- a/src/hal/utils/meter.c
+++ b/src/hal/utils/meter.c
@@ -59,7 +59,6 @@
 
 #include <rtapi.h>		/* RTAPI realtime OS API */
 #include <hal.h>		/* HAL public API decls */
-#include <rtapi_mutex.h>
 
 #include <gtk/gtk.h>
 #include "miscgtk.h"		/* generic GTK stuff */

--- a/src/hal/utils/pci_read.c
+++ b/src/hal/utils/pci_read.c
@@ -32,7 +32,6 @@
 #include <unistd.h>
 #include <linux/types.h>
 #include "upci.h"
-#include "bitfile.h"
 
 /* define DEBUG_PRINTS to print info about command line parameters,
    the detected board, etc. */

--- a/src/hal/utils/pci_write.c
+++ b/src/hal/utils/pci_write.c
@@ -32,7 +32,6 @@
 #include <unistd.h>
 #include <linux/types.h>
 #include "upci.h"
-#include "bitfile.h"
 
 /* define DEBUG_PRINTS to print info about command line parameters,
    the detected board, etc. */

--- a/src/hal/utils/scope.c
+++ b/src/hal/utils/scope.c
@@ -54,7 +54,6 @@ static char *license = \
 #include <gtk/gtk.h>
 #include "miscgtk.h"		/* generic GTK stuff */
 #include "scope_usr.h"		/* scope related declarations */
-#include <rtapi_string.h>
 
 /***********************************************************************
 *                         GLOBAL VARIABLES                             *

--- a/src/hal/utils/scope_disp.c
+++ b/src/hal/utils/scope_disp.c
@@ -44,7 +44,6 @@
 #include <hal.h>		/* HAL public API decls */
 
 #include <gtk/gtk.h>
-#include "miscgtk.h"		/* generic GTK stuff */
 #include "scope_usr.h"		/* scope related declarations */
 
 #define BUFLEN 80		/* length for sprintf buffers */

--- a/src/hal/utils/scope_files.c
+++ b/src/hal/utils/scope_files.c
@@ -45,7 +45,6 @@
 #include <hal.h>		/* HAL public API decls */
 
 #include <gtk/gtk.h>
-#include "miscgtk.h"		/* generic GTK stuff */
 #include "scope_usr.h"		/* scope related declarations */
 
 /***********************************************************************

--- a/src/hal/utils/scope_horiz.c
+++ b/src/hal/utils/scope_horiz.c
@@ -45,7 +45,6 @@
 #include <string.h>
 
 #include <rtapi.h>		/* RTAPI realtime OS API */
-#include <rtapi_mutex.h>
 #include <hal.h>		/* HAL public API decls */
 
 #include <gtk/gtk.h>

--- a/src/hal/utils/scope_trig.c
+++ b/src/hal/utils/scope_trig.c
@@ -31,7 +31,6 @@
     information, go to https://linuxcnc.org.
 */
 
-#include "config.h"
 #include <locale.h>
 #include <libintl.h>
 #define _(x) gettext(x)

--- a/src/hal/utils/scope_vert.c
+++ b/src/hal/utils/scope_vert.c
@@ -32,7 +32,6 @@
     information, go to https://linuxcnc.org.
 */
 
-#include "config.h"
 #include <locale.h>
 #include <libintl.h>
 #define _(x) gettext(x)
@@ -45,7 +44,6 @@
 #include <string.h>
 
 #include <rtapi.h>		// RTAPI realtime OS API
-#include <rtapi_mutex.h>
 #include <rtapi_string.h>	// rtapi_strlcpy()
 #include <hal.h>		// HAL public API decls
 

--- a/src/libnml/cms/cms.cc
+++ b/src/libnml/cms/cms.cc
@@ -16,7 +16,6 @@
 * Last change:
 ********************************************************************/
 
-#include "libnml/rcs/rcsversion.h"
 
 #include <stdlib.h>		/* malloc(), free() */
 #include <stddef.h>		/* size_t */

--- a/src/libnml/cms/cms_dup.cc
+++ b/src/libnml/cms/cms_dup.cc
@@ -26,7 +26,6 @@
 #include "cms.hh"		/* class CMS */
 #include "cms_dup.hh"		/* class CMS_DISPLAY_ASCII_UPDATER */
 #include "libnml/rcs/rcs_print.hh"		/* rcs_print_error() */
-#include <rtapi_string.h>
 #define DEFAULT_WARNING_COUNT_MAX 100
 /* Member functions for CMS_DISPLAY_ASCII_UPDATER Class */
     CMS_DISPLAY_ASCII_UPDATER::CMS_DISPLAY_ASCII_UPDATER(CMS * _cms_parent):

--- a/src/libnml/nml/nml.cc
+++ b/src/libnml/nml/nml.cc
@@ -15,7 +15,6 @@
 
 #define __STDC_FORMAT_MACROS
 #include <inttypes.h>
-#include "libnml/rcs/rcsversion.h"
 
 #include <string.h>		// memcpy()
 #include <stdlib.h>		// atexit()

--- a/src/libnml/nml/stat_msg.cc
+++ b/src/libnml/nml/stat_msg.cc
@@ -15,7 +15,6 @@
 #include "nml.hh"
 #include "nmlmsg.hh"
 #include "libnml/cms/cms.hh"
-#include "libnml/buffer/physmem.hh"
 #include "libnml/linklist/linklist.hh"
 
 #include "stat_msg.hh"

--- a/src/libnml/os_intf/_shm.c
+++ b/src/libnml/os_intf/_shm.c
@@ -13,7 +13,6 @@
 * Last change: 
 ********************************************************************/
 
-#include "config.h"
 #include "_shm.h"
 #include "libnml/rcs/rcs_print.hh"
 #include <stdio.h>		/* NULL */

--- a/src/rtapi/uspace_rtapi_main.cc
+++ b/src/rtapi/uspace_rtapi_main.cc
@@ -16,7 +16,6 @@
  */
 
 #include "config.h"
-#include <linuxcnc.h>
 
 #ifdef __linux__
 #include <sys/fsuid.h>

--- a/src/rtapi/uspace_ulapi.c
+++ b/src/rtapi/uspace_ulapi.c
@@ -22,7 +22,6 @@
 #include <string.h>
 #include "rtapi.h"
 #include <unistd.h>
-#include <rtapi_errno.h>
 #include "rtapi/uspace_common.h"
 
 


### PR DESCRIPTION
104 `#include` lines across 82 files, of 30 distinct in-tree headers, that provide nothing the including file mentions. Removals only, no additions and no moves.

This is the sweep referred to in #4411, held back until #4425 landed.

**How they were found.** Take the names each in-tree header declares, macros, typedefs, tags, prototypes, extern variables and enum members, and check whether any of them appears in the file that includes it. That heuristic is going to be wrong somewhere, so nothing rests on it: 209 candidates came out, all 209 were removed at once, the tree was built, and whatever failed had its include put back. What is here is what survived a build with all of them gone together, `--with-realtime=uspace`, no errors and no warnings.

That build does not cover everything. Five of the files are outside what a uspace configuration compiles, so those were read by hand instead, and two keep their include: `rtai_ulapi.c` needs `rtapi_rtai_shm_wrap.h`, which declares nothing itself and only wraps `rtai_shm.h`, and `fifousr.c` takes `FIFO_KEY` and `FIFO_SIZE` from an anonymous enum in its own `common.h`.

**What it buys.** Against current master, `scripts/include-dep-report.py` goes from 137 directory edges and 1287 cross-directory include sites to 131 and 1213.

The cycles do not move: still 3, covering 9 directories and 18 edges. I think that is the honest result and worth stating plainly. Dead includes inflate the picture, they are not what holds the knots together. The three remaining cycles are interface questions, not stray includes.

The ones that repeat are `rtapi_math.h` 21 times, `rtapi_string.h` 15, `config.h` 10, `block.h` 7, `rtapi_slab.h` and `rtapi_mutex.h` 6 each.
