### PR TITLE
docs: fix the raster test path in hal_port(3)

### DIFF
--- a/docs/src/man/man3/hal_port.3.adoc
+++ b/docs/src/man/man3/hal_port.3.adoc
@@ -114,7 +114,7 @@ stop::
 == SAMPLE CODE
 
 In the source tree under src/hal/components/raster.comp is a realtime
-component intended for laser control. src/tests/raster is a test program
+component intended for laser control. tests/raster is a test program
 that also programs the raster component from Python.
 
 == REALTIME CONSIDERATIONS


### PR DESCRIPTION
The raster test program is at `tests/raster`, not `src/tests/raster`.
