### PR TITLE
gladevcp: fix velocity DRO row position on non-lathes

### DIFF
--- a/lib/python/gladevcp/hal_gremlin.py
+++ b/lib/python/gladevcp/hal_gremlin.py
@@ -261,7 +261,7 @@ class HAL_Gremlin(gremlin.Gremlin, _EMC_ActionBase):
                 pos=0
                 for i in range(9):
                     if s.axis_mask & (1<<i): pos +=1
-                if self.is_lathe:
+                if self.is_lathe():
                     pos +=1
                 droposstrs.insert(pos, " " + format % ("Vel", spd))
 


### PR DESCRIPTION
`hal_gremlin`'s `dro_format` computes where to insert the `Vel` row in the DRO offsets column, and the lathe test guarding that index referenced the bound method rather than calling it:

```python
if self.is_lathe:
    pos +=1
```

A bound method is always truthy, so every machine got the lathe offset. On a mill the `Vel` row was inserted one slot too low, below the blank separator that precedes the G5x offset block, instead of directly under the axis rows.

XYZ mill, before:

```
      X:    1.000
      Y:    1.000
      Z:    1.000

    Vel:   12.500
  G53 X:    0.000  G92 X:    0.000
```

after:

```
      X:    1.000
      Y:    1.000
      Z:    1.000
    Vel:   12.500

  G53 X:    0.000  G92 X:    0.000
```

Lathe output is unchanged. There the blanked X slot plus the inserted Rad/Dia row is exactly what the extra `+1` accounts for, so the index lands in the same place before and after.

I checked the rest of the tree for the same pattern; this was the only paren-less `self.is_lathe` reference.
