### PR TITLE
emc: cut the nml_intf dependency on tooldata

### DIFF
--- a/src/emc/nml_intf/emc_nml.hh
+++ b/src/emc/nml_intf/emc_nml.hh
@@ -1638,7 +1638,7 @@ class EMC_TOOL_STAT:public EMC_TOOL_STAT_MSG {
     // Sub-class update() calls base-class update()
     // cppcheck-suppress duplInheritedMember
     void update(CMS * cms);
-    EMC_TOOL_STAT& operator =(const EMC_TOOL_STAT &s);	// need this for [] members
+    EMC_TOOL_STAT& operator =(const EMC_TOOL_STAT &) = delete; // No copy assignment
 
     int pocketPrepped;		// idx ready for loading from
     int toolInSpindle;		// tool loaded, 0 is no tool

--- a/src/emc/nml_intf/emcops.cc
+++ b/src/emc/nml_intf/emcops.cc
@@ -15,10 +15,8 @@
 * Last change:
 ********************************************************************/
 
-#include "libnml/rcs/rcs_print.hh"
 #include "emc.hh"
 #include "emc_nml.hh"
-#include "tooldata/tooldata.hh"
 
 EMC_AXIS_STAT::EMC_AXIS_STAT()
   : EMC_AXIS_STAT_MSG(EMC_AXIS_STAT_TYPE, sizeof(EMC_AXIS_STAT)),
@@ -159,13 +157,14 @@ EMC_TOOL_STAT::EMC_TOOL_STAT()
     toolInSpindle(0), // toolno
     toolFromPocket(0) // tool_from_pocket
 #ifndef TOOL_NML // {
-    , toolTableCurrent(tooldata_entry_init())
+    , toolTableCurrent CANON_TOOL_TABLE_INIT
 #endif
 {
 #ifdef TOOL_NML //{
+    const struct CANON_TOOL_TABLE tdata = CANON_TOOL_TABLE_INIT;
     int idx;
     for (idx = 0; idx < CANON_POCKETS_MAX; idx++) {
-        toolTable[idx] = tooldata_entry_init();
+        toolTable[idx] = tdata;
     }
 #endif //}
 }
@@ -199,35 +198,6 @@ EMC_COOLANT_STAT::EMC_COOLANT_STAT()
     mist(0),
     flood(0)
 {
-}
-
-// overload = , since class has array elements
-EMC_TOOL_STAT& EMC_TOOL_STAT::operator =(const EMC_TOOL_STAT& s)
-{
-    pocketPrepped = s.pocketPrepped; // idx
-    toolInSpindle = s.toolInSpindle; // toolno
-    toolFromPocket = s.toolFromPocket; // tool_from_pocket
-
-#ifdef TOOL_NML //{
-    int idx;
-    for (idx = 0; idx < CANON_POCKETS_MAX; idx++) {
-        toolTable[idx].toolno = s.toolTable[idx].toolno;
-        toolTable[idx].pocketno = s.toolTable[idx].pocketno;
-        toolTable[idx].offset = s.toolTable[idx].offset;
-        toolTable[idx].diameter = s.toolTable[idx].diameter;
-        toolTable[idx].frontangle = s.toolTable[idx].frontangle;
-        toolTable[idx].backangle = s.toolTable[idx].backangle;
-        toolTable[idx].orientation = s.toolTable[idx].orientation;
-    }
-#else //}{
-    struct CANON_TOOL_TABLE tdata;
-    if (tooldata_get(&tdata,0) != IDX_OK) {
-        rcs_print_error("UNEXPECTED idx %s %d\n",__FILE__,__LINE__);
-    }
-    toolTableCurrent = tdata;
-#endif //}
-
-    return *this;
 }
 
 EMC_STAT::EMC_STAT()

--- a/src/emc/nml_intf/emctool.h
+++ b/src/emc/nml_intf/emctool.h
@@ -37,4 +37,8 @@ struct CANON_TOOL_TABLE {
     char comment[CANON_TOOL_COMMENT_SIZE];
 };
 
+/* default state of an entry: no tool, no pocket, zero geometry */
+#define CANON_TOOL_TABLE_INIT \
+    { -1, -1, { { 0, 0, 0 }, 0, 0, 0, 0, 0, 0 }, 0, 0, 0, 0, { 0 } }
+
 #endif

--- a/src/emc/tooldata/tooldata_common.cc
+++ b/src/emc/tooldata/tooldata_common.cc
@@ -40,16 +40,7 @@ void tooldata_init(bool random_toolchanger)
 
 struct CANON_TOOL_TABLE tooldata_entry_init()
 {
-    struct CANON_TOOL_TABLE tdata;
-    tdata.toolno      = -1;
-    tdata.pocketno    = -1;
-    tdata.diameter    =  0;
-    tdata.frontangle  =  0;
-    tdata.backangle   =  0;
-    tdata.orientation =  0;
-    ZERO_EMC_POSE(tdata.offset);
-    tdata.comment[0]  =  0;
-
+    struct CANON_TOOL_TABLE tdata = CANON_TOOL_TABLE_INIT;
     return tdata;
 } // tooldata_entry_init()
 


### PR DESCRIPTION
`emc/nml_intf` and `emc/tooldata` include each other. The reverse edge is one line, `emcops.cc:21`, held by two calls in `EMC_TOOL_STAT`.

`operator=` has no caller: marking it `= delete` builds the tree in both the default and `--enable-toolnml` configurations. Its comment claims array members need it, but implicit copy assignment copies those, and the default build has no array member. The copy constructor is already deleted.

The constructor call is a plain initializer for nml_intf's own `CANON_TOOL_TABLE`, so the default state moves next to the type as `CANON_TOOL_TABLE_INIT`. Default member initializers would read better, but they make the struct non-POD and clang then rejects `tooldata_entry_init()`, which is declared `extern "C"` and returns it by value. The struct itself is untouched, which matters because it lands in the mmapped tool store.

`scripts/include-dep-report.py` goes from three cycles over nine directories to two over seven.

Part of the dependency work behind #4375.
