### PR TITLE
src: include exported headers with angle brackets where they are used

### DIFF
--- a/src/emc/ini/iniaxis.cc
+++ b/src/emc/ini/iniaxis.cc
@@ -19,7 +19,7 @@
 #include "nml_intf/emcglb.h"
 #include "nml_intf/emccfg.h"
 #include "libnml/rcs/rcs_print.hh"
-#include "inifile.hh"
+#include <inifile.hh>
 
 #include "inihal.hh"
 #include "iniaxis.hh"

--- a/src/emc/ini/inijoint.cc
+++ b/src/emc/ini/inijoint.cc
@@ -17,7 +17,7 @@
 #include "libnml/rcs/rcs_print.hh"
 #include "nml_intf/emcglb.h"
 #include "nml_intf/emccfg.h"
-#include "inifile.hh"
+#include <inifile.hh>
 
 #include "inihal.hh"
 #include "inijoint.hh"

--- a/src/emc/ini/inispindle.cc
+++ b/src/emc/ini/inispindle.cc
@@ -20,7 +20,7 @@
 #include "libnml/rcs/rcs_print.hh"
 #include "nml_intf/emcglb.h"
 #include "nml_intf/emccfg.h"
-#include "inifile.hh"
+#include <inifile.hh>
 
 #include "inihal.hh"
 #include "inispindle.hh"

--- a/src/emc/ini/initraj.cc
+++ b/src/emc/ini/initraj.cc
@@ -18,7 +18,7 @@
 #include <emcpos.h>
 #include "libnml/rcs/rcs_print.hh"
 #include "nml_intf/emcglb.h"
-#include "inifile.hh"
+#include <inifile.hh>
 
 #include "inihal.hh"
 #include "initraj.hh"

--- a/src/emc/ini/inivalue.cc
+++ b/src/emc/ini/inivalue.cc
@@ -22,7 +22,7 @@
 #include <getopt.h>
 #include <locale.h>
 
-#include "inifile.hh"
+#include <inifile.hh>
 
 using namespace linuxcnc;
 

--- a/src/hal/components/matrixkins.comp
+++ b/src/hal/components/matrixkins.comp
@@ -225,8 +225,8 @@ error:
     return -1;
 }
 
-#include "kinematics.h"
-#include "emcmotcfg.h"
+#include <kinematics.h>
+#include <emcmotcfg.h>
 
 KINS_NOT_SWITCHABLE
 EXPORT_SYMBOL(kinematicsType);


### PR DESCRIPTION
@BsAtHome The include-type half of #4375, split out as you asked. The check stays there.

The build copies every `SRCHEADERS` entry into `include/`, so an exported header exists twice, the source under `src/` and the copy modules compile against. A quoted include searches the includer's own directory before the `-I` path and an angled include does not, so the two forms can reach different copies of the same header and both compile.

An exported header keeps the quoted form so it still finds its siblings once it lands in `include/`, and so does its implementation, which wants the source rather than a stale export. The seven files here are users, and build out of tree where only the exported copies exist.
