### PR TITLE
build: export headers with one rule instead of ten

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -184,7 +184,7 @@ SUBDIRS := \
     rtapi/examples/timer rtapi/examples/semaphore rtapi/examples/shmem \
     rtapi/examples/extint rtapi/examples/fifo rtapi/examples rtapi \
     \
-    hal/components hal/drivers hal/drivers/mesa-hostmot2 \
+    hal/components hal/drivers \
     hal/user_comps/devices hal/user_comps/mb2hal \
     hal/user_comps hal/user_comps/vismach hal/user_comps/vfs11_vfd hal/classicladder hal/utils hal \
     hal/user_comps/vfdb_vfd hal/user_comps/wj200_vfd \
@@ -437,9 +437,16 @@ SRCHEADERS := \
     rtapi/rtapi_string.h \
     rtapi/rtapi_vsnprintf.h
 
-# the "headers" target installs all the header files in ../include
+# the "headers" target installs all the header files in ../include.  One rule
+# does the copying for every entry in SRCHEADERS, so a directory that exports a
+# header does not carry a recipe of its own.  Two headers sharing a basename
+# would collide here, and make says so rather than letting one cp win.
 .PHONY: headers
-HEADERS := $(patsubst %,../include/%,$(foreach h,$(SRCHEADERS),$(notdir $h)))
+HEADERS := $(patsubst %,../include/%,$(notdir $(SRCHEADERS)))
+$(foreach h,$(SRCHEADERS),$(eval ../include/$(notdir $(h)): $(h)))
+$(HEADERS):
+	$(ECHO) Exporting $(notdir $@)
+	$(Q)cp $< $@
 headers: $(HEADERS)
 
 # install header files as part of the build
@@ -507,8 +514,10 @@ python: $(PYTARGETS)
 userspace: python
 inclean:
 	$(RM) $(INFILES)
+# Not just $(HEADERS): a header that has been dropped from SRCHEADERS still has
+# a copy sitting in ../include, and that copy is what an angled include finds.
 headersclean:
-	$(RM) $(HEADERS)
+	$(RM) ../include/*.h ../include/*.hh
 clean: docclean pythonclean cscopeclean headersclean
 distclean: clean inclean
 
@@ -601,14 +610,6 @@ ifeq ($(BUILD_SYS),uspace)
 else
 	@echo "setcap target is only supported for uspace builds" >&2; exit 1
 endif
-
-# These rules allows a header file from this directory to be installed into
-# ../include.  A pair of rules like these will exist in the Submakefile
-# of each file that contains headers.
-#$(patsubst %,../include/%,$(wildcard *.h)): ../include/%.h: %.h
-#	$(Q)-cp $^ $@
-#$(patsubst %,../include/%,$(wildcard *.hh)): ../include/%.hh: %.hh
-#	$(Q)-cp $^ $@
 
 INSTALL=install -o root
 DIR=$(INSTALL) -d -m 0755

--- a/src/emc/Submakefile
+++ b/src/emc/Submakefile
@@ -1,5 +1,1 @@
 INCLUDES += emc
-
-# linuxcnc.h has some generic defines for many interfaces
-../include/linuxcnc.h: ./emc/linuxcnc.h
-	cp $^ $@

--- a/src/emc/ini/Submakefile
+++ b/src/emc/ini/Submakefile
@@ -5,17 +5,6 @@ $(call TOOBJSDEPS, $(LIBLCNCINISRCS)) : EXTRAFLAGS=-fPIC
 USERSRCS += $(LIBLCNCINISRCS)
 TARGETS += ../lib/liblinuxcncini.so ../lib/liblinuxcncini.so.1
 
-LIBLCNCINICCINCS = \
-    ./emc/ini/inifile.h
-LIBLCNCINICXINCS = \
-    ./emc/ini/inifile.hh
-
-# The ini-file headers are needed to build against the liblinuxcncini.so
-$(patsubst ./emc/ini/%,../include/%,$(LIBLCNCINICCINCS)): ../include/%.h: ./emc/ini/%.h
-	cp $^ $@
-$(patsubst ./emc/ini/%,../include/%,$(LIBLCNCINICXINCS)): ../include/%.hh: ./emc/ini/%.hh
-	cp $^ $@
-
 ../lib/liblinuxcncini.so.1: $(call TOOBJS,$(LIBLCNCINISRCS))
 	$(ECHO) Creating shared library $(notdir $@)
 	@mkdir -p ../lib

--- a/src/emc/kinematics/Submakefile
+++ b/src/emc/kinematics/Submakefile
@@ -33,9 +33,3 @@ $(RDELTAMODULE): $(call TOOBJS, $(RDELTAMODULESRCS))
 	$(ECHO) Linking python module $(notdir $@)
 	$(CXX) $(LDFLAGS) -shared -o $@ $^ $(BOOST_PYTHON_LIB)
 PYTARGETS += $(RDELTAMODULE)
-
-EMCKINEMATICSINCS = \
-	./emc/kinematics/kinematics.h
-
-$(patsubst ./emc/kinematics/%,../include/%,$(EMCKINEMATICSINCS)): ../include/%.h: ./emc/kinematics/%.h
-	cp $^ $@

--- a/src/emc/nml_intf/Submakefile
+++ b/src/emc/nml_intf/Submakefile
@@ -23,11 +23,3 @@ TARGETS += ../lib/liblinuxcnc.a
 	@mkdir -p ../lib
 	@rm -f $@
 	@$(AR) $(ARFLAGS) $@ $^
-
-EMCNMLINTFINCS = \
-	./emc/nml_intf/emcmotcfg.h \
-	./emc/nml_intf/emcpos.h \
-	./emc/nml_intf/motion_types.h
-
-$(patsubst ./emc/nml_intf/%,../include/%,$(EMCNMLINTFINCS)): ../include/%.h: ./emc/nml_intf/%.h
-	cp $^ $@

--- a/src/hal/Submakefile
+++ b/src/hal/Submakefile
@@ -1,8 +1,4 @@
 
-# hal.h is need for halcompile/RT-components
-../include/hal.h: ./hal/hal.h
-	cp $^ $@
-
 HALLIBSRCS := hal/hal_lib.c hal/hal_lib_query.c hal/hal_lib_extra.c $(ULAPISRCS)
 $(call TOOBJSDEPS, $(HALLIBSRCS)): EXTRAFLAGS += -fPIC $(ULAPI_CFLAGS)
 USERSRCS += $(HALLIBSRCS)

--- a/src/hal/drivers/mesa-hostmot2/Submakefile
+++ b/src/hal/drivers/mesa-hostmot2/Submakefile
@@ -1,4 +1,0 @@
-
-# hostmot2-serial.h is need for some external hostmot2 RT-components
-../include/hostmot2-serial.h: ./hal/drivers/mesa-hostmot2/hostmot2-serial.h
-	cp $^ $@

--- a/src/libposemath/Submakefile
+++ b/src/libposemath/Submakefile
@@ -8,16 +8,3 @@ TARGETS += ../lib/libposemath.so ../lib/libposemath.so.0
 	@mkdir -p ../lib
 	@rm -f $@
 	@$(CXX) $(LDFLAGS) -Wl,-soname,$(notdir $@) -shared -o $@ $^
-
-POSEMATHINCS = \
-    ./libposemath/emcpose.h \
-    ./libposemath/posemath.h \
-    ./libposemath/posemath_types.h
-
-POSEMATHCXXINCS = \
-    ./libposemath/posemath.hh
-
-$(patsubst ./libposemath/%,../include/%,$(POSEMATHINCS)): ../include/%.h: ./libposemath/%.h
-	cp $^ $@
-$(patsubst ./libposemath/%,../include/%,$(POSEMATHCXXINCS)): ../include/%.hh: ./libposemath/%.hh
-	cp $^ $@

--- a/src/rtapi/Submakefile
+++ b/src/rtapi/Submakefile
@@ -1,34 +1,4 @@
 
-RTAPIINCS = \
-    ./rtapi/rtapi.h \
-    ./rtapi/rtapi_app.h \
-    ./rtapi/rtapi_atomic.h \
-    ./rtapi/rtapi_bitops.h \
-    ./rtapi/rtapi_bool.h \
-    ./rtapi/rtapi_byteorder.h \
-    ./rtapi/rtapi_ctype.h \
-    ./rtapi/rtapi_device.h \
-    ./rtapi/rtapi_errno.h \
-    ./rtapi/rtapi_firmware.h \
-    ./rtapi/rtapi_gfp.h \
-    ./rtapi/rtapi_io.h \
-    ./rtapi/rtapi_limits.h \
-    ./rtapi/rtapi_list.h \
-    ./rtapi/rtapi_math.h \
-    ./rtapi/rtapi_math_i386.h \
-    ./rtapi/rtapi_math64.h \
-    ./rtapi/rtapi_mutex.h \
-    ./rtapi/rtapi_parport.h \
-    ./rtapi/rtapi_pci.h \
-    ./rtapi/rtapi_slab.h \
-    ./rtapi/rtapi_stdint.h \
-    ./rtapi/rtapi_string.h \
-    ./rtapi/rtapi_vsnprintf.h
-
-# The rtapi headers are needed for halcompile/RT-components
-$(patsubst ./rtapi/%,../include/%,$(RTAPIINCS)): ../include/%.h: ./rtapi/%.h
-	cp $^ $@
-
 ifeq ($(BUILD_SYS),uspace)
 
 RTAPI_APP_SRCS := \


### PR DESCRIPTION
@BsAtHome One variable, one rule, as you suggested.

Every exported header was declared twice, once in `SRCHEADERS` and once in a per-directory `*INCS` list or a one-off rule that carried the `cp`. `SRCHEADERS` is already the variable, so one rule copies from it and the ten recipes across eight Submakefiles go.

`headersclean` now empties `../include` instead of removing `$(HEADERS)`, so a header dropped from `SRCHEADERS` stops being exported. It removes `*.h` and `*.hh` rather than the directory, since `include/.gitignore` is tracked.

`hal/drivers/mesa-hostmot2/Submakefile` held nothing but its copy rule, so I deleted it rather than leave an empty file behind, and its `SUBDIRS` entry with it since `SUBDIRS` exists only to name the Submakefiles. The build still produces `hostmot2.so` and still exports `hostmot2-serial.h`.

The single rule also means two headers sharing a basename would collide on one target and make would say so, where before one `cp` quietly won. There are none today.

Ordering is untouched. `build-software: headers userspace modules` does not serialise under `-j`, but that is no different after this.

From a clean tree: configure and build with `--enable-werror`, 37 headers in `include/`, a planted `stale.h` gone after `make headersclean` with `.gitignore` still there, and `make headers` putting all 37 back.
