### PR TITLE
libnml: Remove the RTAPI/HAL dependency

### DIFF
--- a/src/emc/nml_intf/emcargs.cc
+++ b/src/emc/nml_intf/emcargs.cc
@@ -18,7 +18,6 @@
 #include "libnml/nml/nml.hh"               /* nmlSetHostAlias */
 #include "emcglb.h"		/* these decls */
 #include "libnml/rcs/rcs_print.hh"
-#include <rtapi_string.h>
 
 int emcGetArgs(int argc, char *argv[])
 {
@@ -35,7 +34,7 @@ int emcGetArgs(int argc, char *argv[])
                     fprintf(stderr, "    %s\n", argv[t+1]);
                     return -1;
                 }
-		rtapi_strxcpy(emc_inifile, argv[t + 1]);
+		nml_strxcpy(emc_inifile, argv[t + 1]);
 		t++;
 	    }
 	    continue;

--- a/src/emc/usr_intf/emclcd.cc
+++ b/src/emc/usr_intf/emclcd.cc
@@ -43,7 +43,6 @@
 #include <getopt.h>
 #include <string.h>
 
-#include <rtapi_string.h>
 #include <posemath.h>		// PM_POSE, TO_RAD
 #include "libnml/rcs/rcs.hh"
 #include "nml_intf/emc.hh"		// EMC NML
@@ -1070,8 +1069,8 @@ static int enterEvent()
   char *pch;
 
   pch = strtok(NULL, delims);
-  rtapi_strxcpy(menu1, menu2);
-  rtapi_strxcpy(menu2, pch);
+  nml_strxcpy(menu1, menu2);
+  nml_strxcpy(menu2, pch);
   printf("menuevent enter %s\n", pch);
 
   return 0;
@@ -1107,8 +1106,8 @@ static void parseConnect()
   pch = strtok(NULL, delims);
   while (pch != NULL) {
     switch (lookupConnect(pch)) {
-      case cpVersion: rtapi_strxcpy(lcdParms.version, strtok(NULL, delims)); break;
-      case cpProtocol: rtapi_strxcpy(lcdParms.protocol, strtok(NULL, delims)); break;
+      case cpVersion: nml_strxcpy(lcdParms.version, strtok(NULL, delims)); break;
+      case cpProtocol: nml_strxcpy(lcdParms.protocol, strtok(NULL, delims)); break;
       case cpLCD: break;
       case cpWidth: 
         pch = strtok(NULL, delims);
@@ -1463,8 +1462,8 @@ static void slowLoop()
   if (emcStatus->task.file[0] != 0) {
     fname = extractFileName(emcStatus->task.file);
     if (strcmp(fname, programName) != 0) {
-      rtapi_strxcpy(programName, widgetSetStr(PROG_WIDGET1, fname, programName));
-      rtapi_strxcpy(programName, widgetSetStr(PROG_WIDGET2, fname, programName));
+      nml_strxcpy(programName, widgetSetStr(PROG_WIDGET1, fname, programName));
+      nml_strxcpy(programName, widgetSetStr(PROG_WIDGET2, fname, programName));
       totalSteps = stepCount(emcStatus->task.file);
       }
     }
@@ -1480,32 +1479,32 @@ static void slowLoop()
   switch (emcStatus->task.interpState) {
       case EMC_TASK_INTERP::READING:
       case EMC_TASK_INTERP::WAITING: 
-        rtapi_strxcpy(status, widgetSetStr(STATUSWIDGET, "  Run", status));
+        nml_strxcpy(status, widgetSetStr(STATUSWIDGET, "  Run", status));
         if (runStatus != rsRun)
           widgetSetStr(JOG_WIDGET, "Step", "");
         runStatus = rsRun;
         break;
       case EMC_TASK_INTERP::PAUSED: 
-        rtapi_strxcpy(status, widgetSetStr(STATUSWIDGET, "Pause", status));
+        nml_strxcpy(status, widgetSetStr(STATUSWIDGET, "Pause", status));
         runStatus = rsPause;
         break;
       default:
         if (emcStatus->task.state == EMC_TASK_STATE::ESTOP) {
-          rtapi_strxcpy(status, widgetSetStr(STATUSWIDGET, "EStop", status));
+          nml_strxcpy(status, widgetSetStr(STATUSWIDGET, "EStop", status));
           widgetSetStr(JOG_WIDGET, "    ", "");
           }
         else
           if (emcStatus->task.state != EMC_TASK_STATE::ON) {
-            rtapi_strxcpy(status, widgetSetStr(STATUSWIDGET, "  Off", status));
+            nml_strxcpy(status, widgetSetStr(STATUSWIDGET, "  Off", status));
             widgetSetStr(JOG_WIDGET, "    ", "");
             }
           else
             if (emcStatus->task.mode == EMC_TASK_MODE::MANUAL) {          
-              rtapi_strxcpy(status, widgetSetStr(STATUSWIDGET, "  Man", status));
+              nml_strxcpy(status, widgetSetStr(STATUSWIDGET, "  Man", status));
               widgetSetStr(JOG_WIDGET, "Jog ", "");
               }
             else {
-              rtapi_strxcpy(status, widgetSetStr(STATUSWIDGET, " Idle", status));
+              nml_strxcpy(status, widgetSetStr(STATUSWIDGET, " Idle", status));
               widgetSetStr(JOG_WIDGET, "    ", "");
               }
         displayJogMode(jogMode);

--- a/src/emc/usr_intf/emcsched.cc
+++ b/src/emc/usr_intf/emcsched.cc
@@ -35,7 +35,6 @@
 #include "libnml/os_intf/timer.hh"             // esleep
 #include "shcom.hh"             // Common NML communications functions
 #include "emcsched.hh"          // Common scheduling functions
-#include <rtapi_string.h>
 
 #define MAX_PRIORITY 0x80000000
 #define POLYNOMIAL 0xD8  /* 11011 followed by 0's */
@@ -298,8 +297,8 @@ void updateQueue() {
             queueStatus = qsError;
             }
           sendAuto();
-          rtapi_strxcpy(fileStr, defaultPath.c_str());
-          rtapi_strxcat(fileStr, q.front().getFileName().c_str());
+          nml_strxcpy(fileStr, defaultPath.c_str());
+          nml_strxcat(fileStr, q.front().getFileName().c_str());
           if (sendProgramOpen(fileStr) != 0) {
             queueStatus = qsError;
             return;
@@ -371,7 +370,7 @@ int getProgramById(int id, qRecType *qRec) {
   qRec->tagId = i->getTagId();
   i->getOffsets(qRec->xpos, qRec->ypos, qRec->zpos);
   qRec->zone = i->getZone();
-  rtapi_strxcpy(qRec->fileName,  i->getFileName().c_str());
+  nml_strxcpy(qRec->fileName,  i->getFileName().c_str());
   qRec->feedOverride = i->getFeedOverride();
   qRec->spindleOverride = i->getSpindleOverride();
   qRec->tool = i->getTool();
@@ -390,7 +389,7 @@ int getProgramByIndex(int idx, qRecType *qRec) {
   qRec->tagId = i->getTagId();
   i->getOffsets(qRec->xpos, qRec->ypos, qRec->zpos);
   qRec->zone = i->getZone();
-  rtapi_strxcpy(qRec->fileName,  i->getFileName().c_str());
+  nml_strxcpy(qRec->fileName,  i->getFileName().c_str());
   qRec->feedOverride = i->getFeedOverride();
   qRec->spindleOverride = i->getSpindleOverride();
   qRec->tool = i->getTool();

--- a/src/emc/usr_intf/emcsh.cc
+++ b/src/emc/usr_intf/emcsh.cc
@@ -22,7 +22,6 @@
 #include <tcl.h>
 #include <tk.h>
 
-#include <rtapi_string.h>
 #include <linuxcnc.h>
 #include <posemath.h>		// PM_POSE, TO_RAD
 #include "libnml/rcs/rcs.hh"
@@ -692,7 +691,7 @@ static int emc_ini_load(ClientData /*clientdata*/,
 	// call or any internals previously set to change. We only want to be
 	// able to query the new ini-file.
         // Set the global filename
-        rtapi_strxcpy(emc_inifile, fname);
+        nml_strxcpy(emc_inifile, fname);
         // Update Tcl's filename variable
         Tcl_SetVar(interp, "EMC_INIFILE", emc_inifile, TCL_GLOBAL_ONLY);
         Tcl_SetObjResult(interp, Tcl_NewBooleanObj(1));
@@ -1942,10 +1941,10 @@ static int emc_mdi(ClientData /*clientdata*/,
 	return TCL_ERROR;
     }
     // bug-- check for string overflow
-    rtapi_strxcpy(string, Tcl_GetStringFromObj(objv[1], NULL));
+    nml_strxcpy(string, Tcl_GetStringFromObj(objv[1], NULL));
     for (t = 2; t < objc; t++) {
-	rtapi_strxcat(string, " ");
-	rtapi_strxcat(string, Tcl_GetStringFromObj(objv[t], NULL));
+	nml_strxcat(string, " ");
+	nml_strxcat(string, Tcl_GetStringFromObj(objv[t], NULL));
     }
 
     if (0 != sendMdiCmd(string)) {
@@ -2482,7 +2481,7 @@ static int emc_program_codes(ClientData /*clientdata*/,
 	} else {
 	    snprintf(string, sizeof(string), "G%d ", code / 10);
 	}
-	rtapi_strxcat(codes_string, string);
+	nml_strxcat(codes_string, string);
     }
 
     // fill in the active M codes, settings too
@@ -2492,14 +2491,14 @@ static int emc_program_codes(ClientData /*clientdata*/,
 	    continue;
 	}
 	snprintf(string, sizeof(string), "M%d ", code);
-	rtapi_strxcat(codes_string, string);
+	nml_strxcat(codes_string, string);
     }
 
     // fill in F and S codes also
     snprintf(string, sizeof(string), "F%.0f ", emcStatus->task.activeSettings[1]);
-    rtapi_strxcat(codes_string, string);
+    nml_strxcat(codes_string, string);
     snprintf(string, sizeof(string), "S%.0f", fabs(emcStatus->task.activeSettings[2]));
-    rtapi_strxcat(codes_string, string);
+    nml_strxcat(codes_string, string);
 
     setresult(interp,codes_string);
     return TCL_OK;
@@ -3257,7 +3256,7 @@ static int emc_joint_load_comp(ClientData /*clientdata*/,
 	return TCL_ERROR;
     }
     // copy objv[1] to file arg, to make sure it's not modified
-    rtapi_strxcpy(file, Tcl_GetStringFromObj(objv[2], NULL));
+    nml_strxcpy(file, Tcl_GetStringFromObj(objv[2], NULL));
 
     if (0 != Tcl_GetIntFromObj(NULL, objv[3], &type)) {
 	setresult(interp,"emc_joint_load_comp: <type> must be an int");
@@ -3532,10 +3531,10 @@ static int localint(ClientData /*clientdata*/,
 
     if (0 != Tcl_GetDoubleFromObj(NULL, objv[1], &val)) {
 	resstring[0] = 0;
-	rtapi_strxcat(resstring, "expected number but got \"");
+	nml_strxcat(resstring, "expected number but got \"");
 	strncat(resstring, Tcl_GetStringFromObj(objv[1], NULL),
 		sizeof(resstring) - strlen(resstring) - 2);
-	rtapi_strxcat(resstring, "\"");
+	nml_strxcat(resstring, "\"");
 	setresult(interp, resstring);
 	return TCL_ERROR;
     }
@@ -3567,10 +3566,10 @@ static int localround(ClientData /*clientdata*/,
 
     if (0 != Tcl_GetDoubleFromObj(NULL, objv[1], &val)) {
 	resstring[0] = 0;
-	rtapi_strxcat(resstring, "expected number but got \"");
+	nml_strxcat(resstring, "expected number but got \"");
 	strncat(resstring, Tcl_GetStringFromObj(objv[1], NULL),
 		sizeof(resstring) - strlen(resstring) - 2);
-	rtapi_strxcat(resstring, "\"");
+	nml_strxcat(resstring, "\"");
 	setresult(interp,resstring);
 	return TCL_ERROR;
     }

--- a/src/emc/usr_intf/schedrmt.cc
+++ b/src/emc/usr_intf/schedrmt.cc
@@ -42,7 +42,6 @@
 #include "libnml/os_intf/timer.hh"             // etime()
 #include "shcom.hh"             // NML Messaging functions
 #include "emcsched.hh"
-#include <rtapi_string.h>
 
 /*
   Using schedrmt:
@@ -335,7 +334,7 @@ static void sigQuit(int /*sig*/)
 
 static int sockWrite(connectionRecType *context)
 {
-   rtapi_strxcat(context->outBuf, "\r\n");
+   nml_strxcat(context->outBuf, "\r\n");
    return write(context->cliSock, context->outBuf, strlen(context->outBuf));
 }
 
@@ -363,11 +362,11 @@ static int commandHello(connectionRecType *context)
   if (strcmp(pch, pwd) != 0) return -1;
   pch = strtok(NULL, delims);
   if (pch == NULL) return -1;
-  rtapi_strxcpy(context->hostName, pch);  
+  nml_strxcpy(context->hostName, pch);
   pch = strtok(NULL, delims);
   if (pch == NULL) return -1;
   context->linked = true;    
-  rtapi_strxcpy(context->version, pch);
+  nml_strxcpy(context->version, pch);
   printf("Connected to %s\n", context->hostName);
   return 0;
 }
@@ -482,7 +481,7 @@ static cmdResponseType setCommProt(char * /*s*/, connectionRecType *context)
   
   pVersion = strtok(NULL, delims);
   if (pVersion == NULL) return rtStandardError;
-  rtapi_strxcpy(context->version, pVersion);
+  nml_strxcpy(context->version, pVersion);
   return rtNoError;
 }
 
@@ -720,7 +719,7 @@ static cmdResponseType getConfig(char * /*s*/, connectionRecType *context)
 {
   const char *pConfigStr = "CONFIG";
 
-  rtapi_strxcpy(context->outBuf, pConfigStr);
+  nml_strxcpy(context->outBuf, pConfigStr);
   return rtNoError;
 }
 
@@ -950,11 +949,11 @@ int commandShutdown(connectionRecType *context)
 static int helpGeneral(connectionRecType *context)
 {
   snprintf(context->outBuf, sizeof(context->outBuf), "Available commands:\n\r");
-  rtapi_strxcat(context->outBuf, "  Hello <password> <client name> <protocol version>\n\r");
-  rtapi_strxcat(context->outBuf, "  Get <emc command>\n\r");
-  rtapi_strxcat(context->outBuf, "  Set <emc command>\n\r");
-  rtapi_strxcat(context->outBuf, "  Shutdown\n\r");
-  rtapi_strxcat(context->outBuf, "  Help <command>\n\r");
+  nml_strxcat(context->outBuf, "  Hello <password> <client name> <protocol version>\n\r");
+  nml_strxcat(context->outBuf, "  Get <emc command>\n\r");
+  nml_strxcat(context->outBuf, "  Set <emc command>\n\r");
+  nml_strxcat(context->outBuf, "  Shutdown\n\r");
+  nml_strxcat(context->outBuf, "  Help <command>\n\r");
   sockWrite(context);
   return 0;
 }
@@ -962,18 +961,18 @@ static int helpGeneral(connectionRecType *context)
 static int helpHello(connectionRecType *context)
 {
   snprintf(context->outBuf, sizeof(context->outBuf), "Usage:\n\r");
-  rtapi_strxcat(context->outBuf, "  Hello <Password> <Client Name> <Protocol Version>\n\rWhere:\n\r");
-  rtapi_strxcat(context->outBuf, "  Password is the connection password to allow communications with the CNC server.\n\r");
-  rtapi_strxcat(context->outBuf, "  Client Name is the name of client trying to connect, typically the network name of the client.\n\r");
-  rtapi_strxcat(context->outBuf, "  Protocol Version is the version of the protocol with which the client wishes to use.\n\r\n\r");
-  rtapi_strxcat(context->outBuf, "  With valid password, server responds with:\n\r");
-  rtapi_strxcat(context->outBuf, "  Hello Ack <Server Name> <Protocol Version>\n\rWhere:\n\r");
-  rtapi_strxcat(context->outBuf, "  Ack is acknowledging the connection has been made.\n\r");
-  rtapi_strxcat(context->outBuf, "  Server Name is the name of the EMC Server to which the client has connected.\n\r");
-  rtapi_strxcat(context->outBuf, "  Protocol Version is the client requested version or latest version support by server if");
-  rtapi_strxcat(context->outBuf, "  the client requests a version later than that supported by the server.\n\r\n\r");
-  rtapi_strxcat(context->outBuf, "  With invalid password, the server responds with:\n\r");
-  rtapi_strxcat(context->outBuf, "  Hello Nak\n\r");
+  nml_strxcat(context->outBuf, "  Hello <Password> <Client Name> <Protocol Version>\n\rWhere:\n\r");
+  nml_strxcat(context->outBuf, "  Password is the connection password to allow communications with the CNC server.\n\r");
+  nml_strxcat(context->outBuf, "  Client Name is the name of client trying to connect, typically the network name of the client.\n\r");
+  nml_strxcat(context->outBuf, "  Protocol Version is the version of the protocol with which the client wishes to use.\n\r\n\r");
+  nml_strxcat(context->outBuf, "  With valid password, server responds with:\n\r");
+  nml_strxcat(context->outBuf, "  Hello Ack <Server Name> <Protocol Version>\n\rWhere:\n\r");
+  nml_strxcat(context->outBuf, "  Ack is acknowledging the connection has been made.\n\r");
+  nml_strxcat(context->outBuf, "  Server Name is the name of the EMC Server to which the client has connected.\n\r");
+  nml_strxcat(context->outBuf, "  Protocol Version is the client requested version or latest version support by server if");
+  nml_strxcat(context->outBuf, "  the client requests a version later than that supported by the server.\n\r\n\r");
+  nml_strxcat(context->outBuf, "  With invalid password, the server responds with:\n\r");
+  nml_strxcat(context->outBuf, "  Hello Nak\n\r");
   sockWrite(context);
   return 0;
 }
@@ -981,24 +980,24 @@ static int helpHello(connectionRecType *context)
 static int helpGet(connectionRecType *context)
 {
   snprintf(context->outBuf, sizeof(context->outBuf), "Usage:\n\rGet <emc command>\n\r");
-  rtapi_strxcat(context->outBuf, "  Get commands require that a hello has been successfully negotiated.\n\r");
-  rtapi_strxcat(context->outBuf, "  Emc command may be one of:\n\r");
-  rtapi_strxcat(context->outBuf, "    AutoTagId\n\r");
-  rtapi_strxcat(context->outBuf, "    Comm_mode\n\r");
-  rtapi_strxcat(context->outBuf, "    Comm_prot\n\r");
-  rtapi_strxcat(context->outBuf, "    Debug\n\r");
-  rtapi_strxcat(context->outBuf, "    Echo\n\r");
-  rtapi_strxcat(context->outBuf, "    Enable\n\r");
-  rtapi_strxcat(context->outBuf, "    Inifile\n\r");
-  rtapi_strxcat(context->outBuf, "    PgmById <Tag Id>\n\r");
-  rtapi_strxcat(context->outBuf, "    PgmByIndex <Index>\n\r");
-  rtapi_strxcat(context->outBuf, "    PriorityById <Tag Id>\n\r");
-  rtapi_strxcat(context->outBuf, "    PriorityByIndex <Tag Index>\n\r");
-  rtapi_strxcat(context->outBuf, "    Plat\n\r");
-  rtapi_strxcat(context->outBuf, "    QMode\n\r");
-  rtapi_strxcat(context->outBuf, "    QStatus\n\r");
-  rtapi_strxcat(context->outBuf, "    Verbose\n\r");
-//  rtapi_strxcat(context->outBuf, "CONFIG\n\r");
+  nml_strxcat(context->outBuf, "  Get commands require that a hello has been successfully negotiated.\n\r");
+  nml_strxcat(context->outBuf, "  Emc command may be one of:\n\r");
+  nml_strxcat(context->outBuf, "    AutoTagId\n\r");
+  nml_strxcat(context->outBuf, "    Comm_mode\n\r");
+  nml_strxcat(context->outBuf, "    Comm_prot\n\r");
+  nml_strxcat(context->outBuf, "    Debug\n\r");
+  nml_strxcat(context->outBuf, "    Echo\n\r");
+  nml_strxcat(context->outBuf, "    Enable\n\r");
+  nml_strxcat(context->outBuf, "    Inifile\n\r");
+  nml_strxcat(context->outBuf, "    PgmById <Tag Id>\n\r");
+  nml_strxcat(context->outBuf, "    PgmByIndex <Index>\n\r");
+  nml_strxcat(context->outBuf, "    PriorityById <Tag Id>\n\r");
+  nml_strxcat(context->outBuf, "    PriorityByIndex <Tag Index>\n\r");
+  nml_strxcat(context->outBuf, "    Plat\n\r");
+  nml_strxcat(context->outBuf, "    QMode\n\r");
+  nml_strxcat(context->outBuf, "    QStatus\n\r");
+  nml_strxcat(context->outBuf, "    Verbose\n\r");
+//  nml_strxcat(context->outBuf, "CONFIG\n\r");
   sockWrite(context);
   return 0;
 }
@@ -1006,22 +1005,22 @@ static int helpGet(connectionRecType *context)
 static int helpSet(connectionRecType *context)
 {
   snprintf(context->outBuf, sizeof(context->outBuf), "Usage:\n\r  Set <emc command>\n\r");
-  rtapi_strxcat(context->outBuf, "  Set commands require that a hello has been successfully negotiated,\n\r");
-  rtapi_strxcat(context->outBuf, "  in most instances requires that control be enabled by the connection.\n\r");
-  rtapi_strxcat(context->outBuf, "  The set commands not requiring control enabled are:\n\r");
-  rtapi_strxcat(context->outBuf, "    Comm_mode <mode>\n\r");
-  rtapi_strxcat(context->outBuf, "    Comm_prot <protocol>\n\r");
-  rtapi_strxcat(context->outBuf, "    Echo <On | Off>\n\r");
-  rtapi_strxcat(context->outBuf, "    Enable <Pwd | Off>\n\r");
-  rtapi_strxcat(context->outBuf, "    Verbose <On | Off>\n\r\n\r");
-  rtapi_strxcat(context->outBuf, "  The set commands requiring control enabled are:\n\r");
-  rtapi_strxcat(context->outBuf, "    AutoTagId <Start Id>\n\r");
-  rtapi_strxcat(context->outBuf, "    PgmAdd <Priority> <Tag Id> <X> <Y> <Z> <Zone> <File Name> <Feed Override> <Spindle Override> <Tool No>\n\r");
-  rtapi_strxcat(context->outBuf, "    PriorityById <Tag Id> <Priority>\n\r");
-  rtapi_strxcat(context->outBuf, "    PriorityByIndex <Index> <Priority>\n\r");
-  rtapi_strxcat(context->outBuf, "    DeleteById <Tag Id> \n\r");
-  rtapi_strxcat(context->outBuf, "    DeleteByIndex <Index> \n\r");
-  rtapi_strxcat(context->outBuf, "    QMode <stop | run | pause | resume>\n\r");
+  nml_strxcat(context->outBuf, "  Set commands require that a hello has been successfully negotiated,\n\r");
+  nml_strxcat(context->outBuf, "  in most instances requires that control be enabled by the connection.\n\r");
+  nml_strxcat(context->outBuf, "  The set commands not requiring control enabled are:\n\r");
+  nml_strxcat(context->outBuf, "    Comm_mode <mode>\n\r");
+  nml_strxcat(context->outBuf, "    Comm_prot <protocol>\n\r");
+  nml_strxcat(context->outBuf, "    Echo <On | Off>\n\r");
+  nml_strxcat(context->outBuf, "    Enable <Pwd | Off>\n\r");
+  nml_strxcat(context->outBuf, "    Verbose <On | Off>\n\r\n\r");
+  nml_strxcat(context->outBuf, "  The set commands requiring control enabled are:\n\r");
+  nml_strxcat(context->outBuf, "    AutoTagId <Start Id>\n\r");
+  nml_strxcat(context->outBuf, "    PgmAdd <Priority> <Tag Id> <X> <Y> <Z> <Zone> <File Name> <Feed Override> <Spindle Override> <Tool No>\n\r");
+  nml_strxcat(context->outBuf, "    PriorityById <Tag Id> <Priority>\n\r");
+  nml_strxcat(context->outBuf, "    PriorityByIndex <Index> <Priority>\n\r");
+  nml_strxcat(context->outBuf, "    DeleteById <Tag Id> \n\r");
+  nml_strxcat(context->outBuf, "    DeleteByIndex <Index> \n\r");
+  nml_strxcat(context->outBuf, "    QMode <stop | run | pause | resume>\n\r");
  
   sockWrite(context);
   return 0;
@@ -1030,9 +1029,9 @@ static int helpSet(connectionRecType *context)
 static int helpQuit(connectionRecType *context)
 {
   snprintf(context->outBuf, sizeof(context->outBuf), "Usage:\n\r");
-  rtapi_strxcat(context->outBuf, "  The quit command has the server initiate a disconnect from the client,\n\r");
-  rtapi_strxcat(context->outBuf, "  the command has no parameters and no requirements to have negotiated\n\r");
-  rtapi_strxcat(context->outBuf, "  a hello, or be in control.");
+  nml_strxcat(context->outBuf, "  The quit command has the server initiate a disconnect from the client,\n\r");
+  nml_strxcat(context->outBuf, "  the command has no parameters and no requirements to have negotiated\n\r");
+  nml_strxcat(context->outBuf, "  a hello, or be in control.");
   sockWrite(context);
   return 0;
 }
@@ -1040,9 +1039,9 @@ static int helpQuit(connectionRecType *context)
 static int helpShutdown(connectionRecType *context)
 {
   snprintf(context->outBuf, sizeof(context->outBuf), "Usage:\n\r");
-  rtapi_strxcat(context->outBuf, "  The shutdown command terminates the connection with all clients,\n\r");
-  rtapi_strxcat(context->outBuf, "  and initiates a shutdown of EMC. The command has no parameters, and\n\r");
-  rtapi_strxcat(context->outBuf, "  can only be issued by the connection having control.\n\r");
+  nml_strxcat(context->outBuf, "  The shutdown command terminates the connection with all clients,\n\r");
+  nml_strxcat(context->outBuf, "  and initiates a shutdown of EMC. The command has no parameters, and\n\r");
+  nml_strxcat(context->outBuf, "  can only be issued by the connection having control.\n\r");
   sockWrite(context);
   return 0;
 }
@@ -1161,8 +1160,8 @@ void *readClient(void * /*arg*/)
   context->linked = false;
   context->echo = true;
   context->verbose = false;
-  rtapi_strxcpy(context->version, "1.0");
-  rtapi_strxcpy(context->hostName, "Default");
+  nml_strxcpy(context->version, "1.0");
+  nml_strxcpy(context->hostName, "Default");
   context->enabled = false;
   context->commMode = 0;
   context->commProt = 0;
@@ -1173,7 +1172,7 @@ void *readClient(void * /*arg*/)
     len = read(context->cliSock, &str, 1600);
     if (len <= 0) goto finished;
     str[len] = 0;
-    rtapi_strxcat(buf, str);
+    nml_strxcat(buf, str);
     if (!memchr(str, 0x0d, strlen(str))) continue;
     if (context->echo && context->linked)
       if(write(context->cliSock, buf, strlen(buf)) != (ssize_t)strlen(buf)) {

--- a/src/emc/usr_intf/shcom.cc
+++ b/src/emc/usr_intf/shcom.cc
@@ -18,7 +18,6 @@
 #include <unistd.h>
 #include <fmt/format.h>
 
-#include <rtapi_string.h>
 #include <inifile.hh>
 #include "libnml/rcs/rcs.hh"
 #include "nml_intf/emc.hh"		// EMC NML
@@ -762,7 +761,7 @@ int sendProgramOpen(const char *program)
     /* save this to run again */
     lastProgramFile = program;
     /* store filename in message */
-    rtapi_strxcpy(msg.file, program);
+    nml_strxcpy(msg.file, program);
     /* clear optional fields */
     msg.remote_buffersize = 0;
     msg.remote_filesize = 0;
@@ -877,7 +876,7 @@ int sendMdiCmd(const char *mdi)
 {
     EMC_TASK_PLAN_EXECUTE emc_task_plan_execute_msg;
 
-    rtapi_strxcpy(emc_task_plan_execute_msg.command, mdi);
+    nml_strxcpy(emc_task_plan_execute_msg.command, mdi);
     return emcSendCommandAndWait(emc_task_plan_execute_msg);
 }
 
@@ -885,7 +884,7 @@ int sendLoadToolTable(const char *file)
 {
     EMC_TOOL_LOAD_TOOL_TABLE emc_tool_load_tool_table_msg;
 
-    rtapi_strxcpy(emc_tool_load_tool_table_msg.file, file);
+    nml_strxcpy(emc_tool_load_tool_table_msg.file, file);
     return emcSendCommandAndWait(emc_tool_load_tool_table_msg);
 }
 
@@ -931,7 +930,7 @@ int sendJointLoadComp(int /*joint*/, const char *file, int type)
 {
     EMC_JOINT_LOAD_COMP emc_joint_load_comp_msg;
 
-    rtapi_strxcpy(emc_joint_load_comp_msg.file, file);
+    nml_strxcpy(emc_joint_load_comp_msg.file, file);
     emc_joint_load_comp_msg.type = type;
     return emcSendCommandAndWait(emc_joint_load_comp_msg);
 }
@@ -1013,7 +1012,7 @@ int iniLoad(const char *filename)
 
     if (auto inistring = inifile.findString("NML_FILE", "EMC")) {
 	// copy to global
-	rtapi_strxcpy(emc_nmlfile, inistring->c_str());
+	nml_strxcpy(emc_nmlfile, inistring->c_str());
     } // else not found, use default or previously set
 
     if (auto inival = mapLinearUnits(inifile, "LINEAR_UNITS", "DISPLAY")) {

--- a/src/libnml/Submakefile
+++ b/src/libnml/Submakefile
@@ -23,7 +23,7 @@ USERSRCS += $(LIBNMLSRCS)
 
 TARGETS += ../lib/libnml.so ../lib/libnml.so.0
 
-../lib/libnml.so.0: $(call TOOBJS,$(LIBNMLSRCS)) ../lib/liblinuxcnchal.so
+../lib/libnml.so.0: $(call TOOBJS,$(LIBNMLSRCS))
 	$(ECHO) Creating shared library $(notdir $@)
 	@mkdir -p ../lib
 	@rm -f $@

--- a/src/libnml/buffer/locmem.cc
+++ b/src/libnml/buffer/locmem.cc
@@ -22,18 +22,10 @@
 #include "libnml/cms/cms.hh"		// class CMS
 #include "libnml/linklist/linklist.hh"		// class LinkedList
 #include "libnml/rcs/rcs_print.hh"		// rcs_print_error()
-#include <rtapi_string.h>
-
-#ifdef __cplusplus
-extern "C" {
-#endif
 
 #include <stdlib.h>		// malloc()
 #include <string.h>		// strcpy(), strcmp()
 
-#ifdef __cplusplus
-}
-#endif
 LinkedList *LOCMEM::buffers_list = (LinkedList *) NULL;
 
 LOCMEM::LOCMEM(const char *bufline, const char *procline, int set_to_server,
@@ -66,7 +58,7 @@ LOCMEM::LOCMEM(const char *bufline, const char *procline, int set_to_server,
 	    return;
 	}
 	my_node->size = size;
-	rtapi_strxcpy(my_node->name, BufferName);
+	nml_stracpy(my_node->name, BufferName);
 	memset(my_node->addr, 0, size);
 	buffer_id = buffers_list->store_at_tail(my_node, sizeof(my_node), 0);
 	return;

--- a/src/libnml/buffer/shmem.cc
+++ b/src/libnml/buffer/shmem.cc
@@ -26,7 +26,6 @@
 #include <math.h>
 
 #include "physmem.hh"           /* PHYSMEM_HANDLE */
-#include <rtapi_string.h>	/* rtapi_strlcpy */
 #include "libnml/rcs/rcs_print.hh"		/* rcs_print_error() */
 #include "libnml/cms/cms.hh"		/* class CMS */
 #include "shmem.hh"		/* class SHMEM */
@@ -314,7 +313,10 @@ int SHMEM::open()
 		rcs_print_error
 		    ("Shared memory buffers %s and %s may conflict. (key=%d(0x%X))\n",
 		    BufferName, cptr, key, key);
-		rtapi_strlcpy(cptr, BufferName, 32);
+		size_t l = strlen(BufferName);
+		if(l > 31) l = 31;
+		memcpy(cptr, BufferName, l);
+		cptr[l] = 0;
 	    }
 	}
 	if (master) {
@@ -326,7 +328,10 @@ int SHMEM::open()
 		memset(autokey_table_end, 0, size - 32 - autokey_table_size);
 	    }
 #endif
-	    rtapi_strlcpy((char *) shm->addr, BufferName, 32);
+	    size_t l = strlen(BufferName);
+	    if(l > 31) l = 31;
+	    memcpy(shm->addr, BufferName, l);
+	    ((char *)shm->addr)[l] = 0;
 	}
 /*! \todo Another #if 0 */
 #if 0				// PC Do we need to use autokey ?

--- a/src/libnml/cms/cms.cc
+++ b/src/libnml/cms/cms.cc
@@ -25,7 +25,6 @@
 #include <errno.h>		/* errno, ERANGE */
 
 #include <string>
-#include <rtapi_string.h>
 #include "cms_cfg.hh"
 #include "cms.hh"		/* class CMS */
 #include "cms_up.hh"		/* class CMS_UPDATER */
@@ -266,8 +265,8 @@ CMS::CMS(const char *bufline_in, const char *procline_in, int set_to_server)
     remote_port_type = CMS_NO_REMOTE_PORT_TYPE;
 
     /* Store the bufline and procline for debugging later. */
-    rtapi_strxcpy(BufferLine, bufline);
-    rtapi_strxcpy(ProcessLine, procline);
+    nml_strxcpy(BufferLine, bufline);
+    nml_strxcpy(ProcessLine, procline);
 
     /* Get parameters from the buffer's line in the config file. */
     if (separate_words(word, 9, bufline) != 9) {
@@ -279,7 +278,7 @@ CMS::CMS(const char *bufline_in, const char *procline_in, int set_to_server)
 
     /* Use the words from the buffer line to initialize some class variables. 
      */
-    rtapi_strxcpy(BufferName, word[1]);
+    nml_strxcpy(BufferName, word[1]);
     rcs_print_debug(PRINT_CMS_CONSTRUCTORS, "new CMS (%s)\n", BufferName);
 
     /* Clear errno so we can determine if all of the parameters in the */
@@ -289,9 +288,9 @@ CMS::CMS(const char *bufline_in, const char *procline_in, int set_to_server)
     }
     char *realname = cms_check_for_host_alias(word[3]);
     if (realname == NULL) {
-	rtapi_strxcpy(BufferHost, word[3]);
+	nml_strxcpy(BufferHost, word[3]);
     } else {
-	rtapi_strxcpy(BufferHost, realname);
+	nml_strxcpy(BufferHost, realname);
     }
 
     buffer_type_name = word[2];
@@ -451,8 +450,8 @@ CMS::CMS(const char *bufline_in, const char *procline_in, int set_to_server)
 	errno = 0;
     }
 
-    rtapi_strxcpy(ProcessName, word[1]);
-    rtapi_strxcpy(ProcessHost, word[4]);
+    nml_strxcpy(ProcessName, word[1]);
+    nml_strxcpy(ProcessHost, word[4]);
 
     /* Clear errno so we can determine if all of the parameters in the */
     /* buffer line were in an acceptable form. */
@@ -461,7 +460,7 @@ CMS::CMS(const char *bufline_in, const char *procline_in, int set_to_server)
     }
 
     proc_type_name = word[3];
-    rtapi_strxcpy(PermissionString, word[5]);
+    nml_strxcpy(PermissionString, word[5]);
     spawn_server = atoi(word[6]);
 
     /* Compute timeout. */

--- a/src/libnml/cms/cms_cfg.cc
+++ b/src/libnml/cms/cms_cfg.cc
@@ -27,7 +27,6 @@ extern int verbose_nml_error_messages;
 #include <netinet/in.h>		/* sockaddr_in */
 #include <stdlib.h>
 
-#include <rtapi_string.h>
 #include "cms.hh"		/* class CMS */
 #include "cms_cfg.hh"
 
@@ -115,7 +114,7 @@ int load_nml_config_file(const char *file)
 	delete info;
         return -1;
     }
-    rtapi_strlcpy(info->file_name, file, 80);
+    nml_strlcpy(info->file_name, file, 80);
     FILE *fp;
     fp = fopen(file, "r");
     if (fp == NULL) {
@@ -369,13 +368,13 @@ int cms_config(CMS ** cms, const char *bufname, const char *procname, const char
 	    strncpy(buf, search.proc_line, LINELEN);
 	    default_ptr = strstr(buf, "default");
 	    if (default_ptr) {
-		rtapi_strxcpy(buf2, default_ptr + 7);
+		nml_strxcpy(buf2, default_ptr + 7);
 		strcpy(default_ptr, bufname);
 		default_ptr += strlen(bufname);
 		strcpy(default_ptr, buf2);
-		rtapi_strlcpy(search.proc_line, buf, LINELEN);
+		nml_strlcpy(search.proc_line, buf, LINELEN);
 	    }
-	    rtapi_strxcat(search.proc_line, " defaultbuf");
+	    nml_strxcat(search.proc_line, " defaultbuf");
 	}
     }
     if (NO_PROCESS_LINE == search.error_type) {
@@ -386,20 +385,20 @@ int cms_config(CMS ** cms, const char *bufname, const char *procname, const char
 	    strncpy(buf, search.proc_line, LINELEN);
 	    default_ptr = strstr(buf, "default");
 	    if (default_ptr) {
-		rtapi_strxcpy(buf2, default_ptr + 7);
+		nml_strxcpy(buf2, default_ptr + 7);
 		strcpy(default_ptr, procname);
 		default_ptr += strlen(procname);
 		strcpy(default_ptr, buf2);
 		default_ptr = strstr(buf, "default");
 	    }
 	    if (default_ptr) {
-		rtapi_strxcpy(buf2, default_ptr + 7);
+		nml_strxcpy(buf2, default_ptr + 7);
 		strcpy(default_ptr, bufname);
 		default_ptr += strlen(bufname);
 		strcpy(default_ptr, buf2);
-		rtapi_strlcpy(search.proc_line, buf, LINELEN);
+		nml_strlcpy(search.proc_line, buf, LINELEN);
 	    }
-	    rtapi_strxcat(search.proc_line, " defaultproc defaultbuf");
+	    nml_strxcat(search.proc_line, " defaultproc defaultbuf");
 	}
     }
     if (CONFIG_SEARCH_OK == search.error_type) {
@@ -626,19 +625,19 @@ void find_proc_and_buffer_lines(CONFIG_SEARCH_STRUCT * s)
 			return;
 		    }
 		    if (hostname_matches_bufferline(s->buffer_line)) {
-			rtapi_strxcpy(s->proc_type, "LOCAL");
+			nml_strxcpy(s->proc_type, "LOCAL");
 		    } else {
-			rtapi_strxcpy(s->proc_type, "REMOTE");
+			nml_strxcpy(s->proc_type, "REMOTE");
 		    }
 		}
 		break;
 
 	    case CMS_FORCE_LOCAL_CONNECTION_MODE:
-		rtapi_strxcpy(s->proc_type, "LOCAL");
+		nml_strxcpy(s->proc_type, "LOCAL");
 		break;
 
 	    case CMS_FORCE_REMOTE_CONNECTION_MODE:
-		rtapi_strxcpy(s->proc_type, "REMOTE");
+		nml_strxcpy(s->proc_type, "REMOTE");
 		break;
 	    }
 	    s->procline_found = 1;

--- a/src/libnml/cms/cms_srv.cc
+++ b/src/libnml/cms/cms_srv.cc
@@ -335,7 +335,7 @@ void CMS_SERVER::read_passwd_file()
 	if (NULL == user_info) {
 	    break;
 	}
-	rtapi_strxcpy(user_info->passwd_file_line, buf);
+	nml_strxcpy(user_info->passwd_file_line, buf);
 	memcpy(user_info->name, buf, user_name_length);
 	passwd_length = strcspn(buf + user_name_length + 1, "\n\r \t:");
 	if (passwd_length > 16) {
@@ -354,7 +354,7 @@ void CMS_SERVER::read_passwd_file()
 	    user_info->has_passwd = 0;
 	}
 	gen_random_key(user_info->key2, 2);
-	rtapi_strxcpy(user_info->epasswd,
+	nml_strxcpy(user_info->epasswd,
 	    crypt(user_info->passwd, user_info->key2));
 	user_info->allow_read = (NULL != strstr(buf, "read=true"));
 	user_info->allow_write = (NULL != strstr(buf, "write=true"));
@@ -412,15 +412,15 @@ int CMS_SERVER::get_user_keys(const char *name, char *key1, char *key2)
 	gen_random_key(key2, 2);
 	return -1;
     }
-    rtapi_strxcpy(key1, user_info->key1);
+    nml_strxcpy(key1, user_info->key1);
     if (fabs(etime() - time_of_last_key_request) > 30.0) {
 	memset(user_info->key2, 0, 8);
 	memset(user_info->epasswd, 0, 16);
 	gen_random_key(user_info->key2, 2);
-	rtapi_strxcpy(user_info->epasswd,
+	nml_strxcpy(user_info->epasswd,
 	    crypt(user_info->passwd, user_info->key2));
     }
-    rtapi_strxcpy(key2, user_info->key2);
+    nml_strxcpy(key2, user_info->key2);
     time_of_last_key_request = etime();
     return 0;
 }

--- a/src/libnml/cms/cmsdiag.cc
+++ b/src/libnml/cms/cmsdiag.cc
@@ -14,11 +14,11 @@
 
 #include "cmsdiag.hh"
 #include "libnml/rcs/rcsversion.h"
+#include "libnml/rcs/rcs_print.hh"
 #include <sys/types.h>
 #include <unistd.h>		/* getpid() */
 #include "libnml/os_intf/timer.hh"		// etime()
 #include <stdlib.h>		// memset()
-#include <rtapi_string.h> 	// strncpy() -> rtapi_strlcpy()
 #include <time.h>		// time_t, time()
 #include <math.h>		// floor()
 #include "libnml/linklist/linklist.hh"          // LinkedList
@@ -61,7 +61,7 @@ void CMS::setup_diag_proc_info()
     if (NULL == dpi) {
 	dpi = new CMS_DIAG_PROC_INFO();
     }
-    rtapi_strlcpy(dpi->name, ProcessName, 16);	// process name
+    nml_stracpy(dpi->name, ProcessName);	// process name
     int sysinfo_len = 0;
     memset(dpi->host_sysinfo, 0, 32);
     gethostname(dpi->host_sysinfo, 31);

--- a/src/libnml/cms/tcp_srv.cc
+++ b/src/libnml/cms/tcp_srv.cc
@@ -30,8 +30,6 @@
 #include <errno.h>		/* errno */
 #include <signal.h>		// SIGPIPE, signal()
 
-#include <rtapi_string.h>	// rtapi_strlcpy
-
 #include <sys/types.h>
 #include <sys/wait.h>		// waitpid
 
@@ -955,7 +953,8 @@ void CMS_SERVER_REMOTE_TCP_PORT::switch_function(CLIENT_TCP_PORT *
 	    if (NULL != namereply) {
 		putbe32(temp_buffer, _client_tcp_port->serial_number);
 		putbe32(temp_buffer + 4, namereply->status);
-		rtapi_strlcpy(temp_buffer + 8, namereply->name, 31);
+		size_t l = strlen(namereply->name);
+		memcpy(temp_buffer + 8, namereply->name, l > 31 ? 31 : l);
 		if (sendn
 		    (_client_tcp_port->socket_fd, temp_buffer, 40, 0,
 			dtimeout) < 0) {

--- a/src/libnml/nml/nml.cc
+++ b/src/libnml/nml/nml.cc
@@ -22,7 +22,6 @@
 #include <netdb.h>
 #include <arpa/inet.h>		// inet_ntoa
 
-#include <rtapi_string.h>	// rtapi_strlcpy()
 #include "nml.hh"		// class NML
 #include "nmlmsg.hh"		// class NMLmsg
 #include "libnml/cms/cms.hh"		// class CMS
@@ -177,10 +176,10 @@ NML::NML(NML_FORMAT_PTR f_ptr, const char *buf, const char *proc, const char *fi
     snprintf(bufname, 40, "%s", buf);
     snprintf(procname, 40, "%s", proc);
     if (NULL == file) {
-	rtapi_strlcpy(cfgfilename, default_nml_config_file, 160);
+	nml_strlcpy(cfgfilename, default_nml_config_file, 160);
     }
     else {
-	rtapi_strlcpy(cfgfilename, file, 160);
+	nml_strlcpy(cfgfilename, file, 160);
     }
 
     if (rcs_errors_printed >= max_rcs_errors_to_print

--- a/src/libnml/nml/nml_srv.cc
+++ b/src/libnml/nml/nml_srv.cc
@@ -20,7 +20,6 @@
 #include <sys/wait.h>		// waitpid()
 #include <stdlib.h>		// atexit()
 
-#include <rtapi_string.h>	// rtapi_strlcpy()
 #include "nml.hh"
 #include "nmlmsg.hh"
 #include "libnml/cms/cms.hh"
@@ -314,8 +313,8 @@ set_diag_info(REMOTE_SET_DIAG_INFO_REQUEST * _req)
 	orig_info = new CMS_DIAG_PROC_INFO();
 	*orig_info = *dpi;
     }
-    rtapi_strlcpy(dpi->name, _req->process_name, 16);
-    rtapi_strlcpy(dpi->host_sysinfo, _req->host_sysinfo, 32);
+    nml_stracpy(dpi->name, _req->process_name);
+    nml_stracpy(dpi->host_sysinfo, _req->host_sysinfo);
     if (cms->total_connections > _req->c_num && _req->c_num >= 0) {
 	cms->connection_number = _req->c_num;
     }

--- a/src/libnml/rcs/rcs_print.cc
+++ b/src/libnml/rcs/rcs_print.cc
@@ -22,7 +22,6 @@
 #include <sys/types.h>
 #include <unistd.h>		/* getpid() */
 
-#include <rtapi_string.h>
 #include "libnml/rcs/rcs_print.hh"
 #include "libnml/linklist/linklist.hh"
 #ifndef _TIMER_H
@@ -164,7 +163,7 @@ void convert_print_list_to_lines()
 	    if (NULL == next_line) {
 		if (NULL == temp_buf) {
 		    temp_buf = (char *) malloc(strlen(string_from_list) + 1);
-		    rtapi_strlcpy(temp_buf, string_from_list, strlen(string_from_list) + 1);
+		    nml_strlcpy(temp_buf, string_from_list, strlen(string_from_list) + 1);
 		} else {
 		    char *ra = (char *) realloc(temp_buf, strlen(temp_buf) + strlen(string_from_list) + 1);
 		    if(ra) {
@@ -231,7 +230,7 @@ char *strip_control_characters(char *_dest, char *_src)
     if (NULL == _dest) {
 	destination = line_buffer;
 	if (strlen(_src) < 255) {
-	    rtapi_strxcpy(line_buffer, _src);
+	    nml_strxcpy(line_buffer, _src);
 	} else {
 	    if (NULL == strpbrk(_src, "\n\r\t\b")) {
 		return (_src);
@@ -271,7 +270,7 @@ int separate_words(char **_dest, int _max, char *_src)
     if (strlen(_src) > 255) {
 	return -1;
     }
-    rtapi_strxcpy(word_buffer, _src);
+    nml_strxcpy(word_buffer, _src);
     char* saveptr;
     _dest[0] = strtok_r(word_buffer, " \n\r\t", &saveptr);
     for (i = 0; i < _max - 1 && NULL != _dest[i]; i++) {
@@ -303,7 +302,7 @@ int rcs_vprint(const char *_fmt, va_list _args, int save_string)
     if (save_string) {
         last_error_buf_filled++;
         last_error_buf_filled %= 4;
-        rtapi_strlcpy(last_error_bufs[last_error_buf_filled], tmpstr.data(), error_buf_size-1);
+        nml_strlcpy(last_error_bufs[last_error_buf_filled], tmpstr.data(), error_buf_size-1);
     }
     return rcs_fputs(tmpstr.data());
 }
@@ -407,10 +406,10 @@ int set_rcs_print_file(char *_file_name)
     if (_file_name == NULL) {
 	return -1;
     }
-    if (strlen(_file_name) > 80) {
+    if (strlen(_file_name) >= sizeof(rcs_print_file_name)) {
 	return -1;
     }
-    rtapi_strxcpy(rcs_print_file_name, _file_name);
+    nml_strxcpy(rcs_print_file_name, _file_name);
     if (NULL != rcs_print_file_stream) {
 	fclose(rcs_print_file_stream);
     }

--- a/src/libnml/rcs/rcs_print.hh
+++ b/src/libnml/rcs/rcs_print.hh
@@ -195,4 +195,54 @@ enum { error_buf_size = 256 };
 extern char last_error_bufs[4][error_buf_size];
 extern int last_error_buf_filled;
 
+#ifdef __cplusplus
+#include <type_traits>
+#include <cstdio>
+#include <cstring>
+
+//
+// nml_stracpy(dst,src) - Copy 'src' char buffer array to 'dst' char buffer array
+// nml_strxcpy(dst,src) - Copy 'src' char pointer to 'dst' char buffer array
+// nml_strxcat(dst,src) - Append 'src' char pointer to 'dst' char buffer array
+// nml_strlcpy(dst,src,size) - Print-copy 'src' char pointer to 'dst' char pointer
+// nml_strlcat(dst,src,size) - Print-append 'src' char pointer to 'dst' char pointer
+//
+static inline int nml_strlcpy(char *dst, const char *src, size_t dstsize) {
+    return std::snprintf(dst, dstsize, "%s", src);
+}
+
+static inline int nml_strlcat(char *dst, const char *src, size_t dstsize) {
+    size_t l = std::strlen(dst);
+    if(l >= dstsize)
+        return 0;
+    return std::snprintf(dst + l, dstsize - l, "%s", src);
+}
+
+#define nml_strxcpy(dst,src) do { \
+        static_assert(std::is_array<decltype(dst)>::value, "dst must be non-const array"); \
+        static_assert(sizeof((dst)[0]) == 1, "dst must be char array"); \
+        static_assert(sizeof((src)[0]) == 1, "dst must be char array"); \
+        nml_strlcpy((dst), (src), sizeof(dst)); \
+    } while(0)
+
+#define nml_stracpy(dst,src) do { \
+        static_assert(std::is_array<decltype(dst)>::value, "dst must be non-const array"); \
+        static_assert(std::is_array<decltype(src)>::value, "dst must be array"); \
+        static_assert(sizeof((dst)[0]) == 1, "dst must be char array"); \
+        static_assert(sizeof((src)[0]) == 1, "src must be char array"); \
+        size_t l = std::strlen(src); \
+	if(l >= sizeof(dst)) { \
+            std::memcpy((dst), (src), sizeof(dst)); \
+            (dst)[sizeof(dst) - 1] = 0; \
+        } else { \
+            std::memcpy((dst), (src), l + 1); \
+        } \
+    } while(0)
+
+#define nml_strxcat(dst,src) do { \
+        static_assert(std::is_array<decltype(dst)>::value, "dst must be non-const array"); \
+        nml_strlcat((dst), (src), sizeof(dst)); \
+    } while(0)
+#endif
+
 #endif


### PR DESCRIPTION
There was a dependency on the `liblinuxcnchal.so` library in `libnml.so` because it used the `rtapi_str*` API. That pulls in `rtapi_snprintf` and this requires linking to a library that can resolve the symbol. However, libnml is completely non-RT and it should be able to use the standard libc version of snprintf.

Removing the HAL dependency in NML exposed another indirect dependency in the Tcl library `linuxcnc.so` and via `liblinuxcnc.a`. But that is also non-RT and it too should be using the libc version.

An adapted re-implementation of the `rtapi_strxcpy`, `rtapi_strlcpy`, `rtapi_strxcat` and `rtapi_strlcat` functions was created with the `nml_` prefix instead on the `rtapi_` prefix and placed in `libnml/rcs/rcs_print.hh`. An added `nml_stracpy` (array-to-array copy) foregoes the snprintf completely. The changes are not 1-to-1 because the compiler is very good at finding format truncation (with a very verbose warning). These places were adapted to use a method that gives the same intended result without a warning.

Smaller note: there is still a rtapi_print_msg reference in liblinuxcnc.a due to inihal.cc. However, that has no consequences for the problem here and it is linked to task, which needs HAL anyway.