### PR TITLE
hal: Make including HAL's private header issue a compiler warning

### DIFF
--- a/src/hal/hal.h
+++ b/src/hal/hal.h
@@ -58,6 +58,10 @@
     information, go to www.linuxcnc.org.
 */
 
+#if defined(HAL_PRIV_H) || defined(__HAL_LIBRARY_INTERNAL_ONLY)
+#error "Including hal.h after hal_priv.h"
+#endif
+
 /***********************************************************************
 *                   GENERAL NOTES AND DOCUMENTATION                    *
 ************************************************************************/

--- a/src/hal/hal_lib.c
+++ b/src/hal/hal_lib.c
@@ -69,6 +69,7 @@
 
 #include <rtapi.h>		/* RTAPI realtime OS API */
 #include "hal.h"		/* HAL public API decls */
+#define __HAL_LIBRARY_INTERNAL_ONLY 1
 #include "hal_priv.h"		/* HAL private decls */
 
 #include <rtapi_string.h>

--- a/src/hal/hal_lib_extra.c
+++ b/src/hal/hal_lib_extra.c
@@ -16,6 +16,7 @@
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 #include "hal.h"
+#define __HAL_LIBRARY_INTERNAL_ONLY 1
 #include "hal_priv.h"
 
 //

--- a/src/hal/hal_lib_query.c
+++ b/src/hal/hal_lib_query.c
@@ -16,6 +16,7 @@
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 #include "hal.h"
+#define __HAL_LIBRARY_INTERNAL_ONLY 1
 #include "hal_priv.h"
 
 //=====================================================

--- a/src/hal/hal_priv.h
+++ b/src/hal/hal_priv.h
@@ -57,6 +57,12 @@
 
 */
 
+#if !defined(__HAL_LIBRARY_INTERNAL_ONLY) || !defined(__LINUXCNC_HAL_H)
+// This also warns when you include the private header
+// before the normal header.
+#warning "You should not be including HAL's private hal_priv.h. Please use the HAL query API."
+#endif
+
 /***********************************************************************
 *                       GENERAL INFORMATION                            *
 ************************************************************************/


### PR DESCRIPTION
With this PR, the compiler will issue a warning when you (casually) try to include the private HAL header. All HAL internals are now private and they should stay private.

All in-tree use has been cleaned up and migrated to the query API. Any outside builders using the header will now get this warning. This does not affect out-of-tree builds because the private HAL header has not been exported in either 2.9 or master.