### PR TITLE
tests: Fix RT/non-RT race in raster checking output after setting input

### DIFF
--- a/tests/raster/rastertest.py
+++ b/tests/raster/rastertest.py
@@ -4,8 +4,24 @@ import time
 import os
 from raster import *
 
+BEATTIMEOUT = 10.0
+
 theta = 0.005
 timeout = 0.25
+
+# RT to non-RT synchronized wait to prevent race condition
+# Especially important in CI where RT is not running realtime
+# The minimum wait should normally be >= 2 because you can catch the threadbeat
+# variable's increment event, which in itself does not run the cycle. When you
+# see an increment by 2, then you can be sure that the cycle ran at least once.
+def waitThreadBeat(n):
+    assert n > 0, "Number of threadbeat wait cycles must be >= 1"
+    beat = hal.get_p('fast.threadbeat')
+    starttime = time.time()
+    while hal.get_p('fast.threadbeat') - beat < n:
+        time.sleep(0.001)
+        if time.time() - starttime > BEATTIMEOUT:
+            raise RuntimeError("waitThreadBeat: Timeout after {} seconds".format(BEATTIMEOUT))
 
 def fleq(a, b):
     return abs(a - b) < theta
@@ -159,7 +175,7 @@ def testProgram(prog, pin, pos, offset, bpp, dpu, program, data):
     prog.start()
     for (pos, pwr) in data:
         pin['position'].value = pos
-        time.sleep(0.001)
+        waitThreadBeat(2)
         assert (pin['output'].value - pwr) < theta, \
             "output at position {0} should be {1}. Got {2}".format(pos, pwr, pin['output'].value)
         #once position is exceeded the program should be finished and raster should reset


### PR DESCRIPTION
There was yet another (local) CI failure on the raster test and it happened when the test set a pin, did a 1ms wait and read a result pin. However, the RT thread had not yet run its cycle and the pin read gave the wrong value.
The assumption in the test was that the 1ms wait would be enough to have the RT thread run a cycle. This assumption does never really hold and is a RT-to-non-RT race.

The getter/setter changes also included a thread beat counter, which can be read to retrieve the actual thread cycle activity. This PR adds a 1 thread cycle wait on the thread's beat counter with a 10 seconds timeout if things are really stalled.