### PR TITLE
include-dep-report: fold a subdirectory that has no Submakefile

### DIFF
--- a/scripts/include-dep-report.py
+++ b/scripts/include-dep-report.py
@@ -108,18 +108,15 @@ def folded_dirs():
 
     A directory whose sources are listed by its parent's Submakefile compiles and
     links as part of the parent, so an include crossing that boundary crosses
-    nothing.  libnml is the case in the tree: SUBDIRS names its six
-    subdirectories and each has an empty Submakefile purely to satisfy
-    SUBMAKEFILES, while libnml/Submakefile lists every source and links them into
-    one libnml.so.  Reporting those as separate nodes invents a cycle out of a
-    directory layout.  Subdirectories the top-level Makefile builds on their own,
-    emc/tp into tpmod for one, are not folded.
+    nothing.  libnml is the case in the tree: libnml/Submakefile lists every
+    source under its six subdirectories and links them into one libnml.so.
+    Reporting those as separate nodes invents a cycle out of a directory layout.
+    Subdirectories the top-level Makefile builds on their own, emc/tp into tpmod
+    for one, are not folded.
     """
     fold = {}
-    for cur, dirs, files in os.walk(SRC):
+    for cur, dirs, unused_files in os.walk(SRC):
         dirs[:] = [d for d in dirs if d not in SKIP_DIRS and not d.startswith(".")]
-        if "Submakefile" not in files:
-            continue
         rel = os.path.relpath(cur, SRC)
         if rel == ".":
             continue


### PR DESCRIPTION
`folded_dirs()` only looked at directories carrying a Submakefile of their own, which the six libnml subdirectories stopped doing when #4456 retired their zero-byte ones, so the report invents the five-way libnml cycle again. Whether the parent's Submakefile lists the sources is the real test and stands on its own, so dropping the guard folds libnml again, picks up `emc/usr_intf/axis/extensions`, leaves `emc/tp` unfolded, and the report goes back to one cycle.
