### PR TITLE
tests: detect Tcl HAL extensions functionally in skip scripts

### DIFF
--- a/tests/tclsh-extensions/skip
+++ b/tests/tclsh-extensions/skip
@@ -1,8 +1,8 @@
 #!/bin/bash
-# This test exercises the Tcl HAL extensions (tcl/hal.so,
-# tcl/linuxcnc.so), which are only built in GUI builds (BUILD_GUI);
-# skip in headless builds.  The tcl dir is taken from TCLLIBPATH
-# (exported by rip-environment).
+# This test needs the Tcl HAL extensions, only built in GUI builds.
+# Ask tclsh to load them like the test does; works for run-in-place
+# (TCLLIBPATH) and installed packages (auto_path).  catch is needed
+# because tclsh reads stdin interactively and exits 0 even on error.
 set -u
 
 if ! command -v tclsh >/dev/null 2>&1; then
@@ -10,8 +10,8 @@ if ! command -v tclsh >/dev/null 2>&1; then
     exit 1
 fi
 
-read -r tcldir _ <<< "${TCLLIBPATH:-}"
-if ! [ -f "${tcldir:-/nonexistent}/linuxcnc.so" ]; then
+if ! echo 'exit [catch {package require Linuxcnc
+package require Hal}]' | tclsh >/dev/null 2>&1; then
     echo "skip: Tcl HAL extensions not built (headless build)" >&2
     exit 1
 fi

--- a/tests/twopass-personality/skip
+++ b/tests/twopass-personality/skip
@@ -1,7 +1,8 @@
 #!/bin/bash
-# haltcl needs the Tcl HAL extension (tcl/hal.so), which is only built
-# in GUI builds (BUILD_GUI); skip in headless builds.  The tcl dir is
-# taken from TCLLIBPATH (exported by rip-environment).
+# haltcl needs the Tcl HAL extension, only built in GUI builds.  Ask
+# tclsh to load it like the test does; works for run-in-place
+# (TCLLIBPATH) and installed packages (auto_path).  catch is needed
+# because tclsh reads stdin interactively and exits 0 even on error.
 set -u
 
 if ! command -v tclsh >/dev/null 2>&1; then
@@ -9,8 +10,7 @@ if ! command -v tclsh >/dev/null 2>&1; then
     exit 1
 fi
 
-read -r tcldir _ <<< "${TCLLIBPATH:-}"
-if ! [ -f "${tcldir:-/nonexistent}/hal.so" ]; then
+if ! echo 'exit [catch {package require Hal}]' | tclsh >/dev/null 2>&1; then
     echo "skip: Tcl HAL extension not built (headless build)" >&2
     exit 1
 fi

--- a/tests/twopass/skip
+++ b/tests/twopass/skip
@@ -1,7 +1,8 @@
 #!/bin/bash
-# haltcl needs the Tcl HAL extension (tcl/hal.so), which is only built
-# in GUI builds (BUILD_GUI); skip in headless builds.  The tcl dir is
-# taken from TCLLIBPATH (exported by rip-environment).
+# haltcl needs the Tcl HAL extension, only built in GUI builds.  Ask
+# tclsh to load it like the test does; works for run-in-place
+# (TCLLIBPATH) and installed packages (auto_path).  catch is needed
+# because tclsh reads stdin interactively and exits 0 even on error.
 set -u
 
 if ! command -v tclsh >/dev/null 2>&1; then
@@ -9,8 +10,7 @@ if ! command -v tclsh >/dev/null 2>&1; then
     exit 1
 fi
 
-read -r tcldir _ <<< "${TCLLIBPATH:-}"
-if ! [ -f "${tcldir:-/nonexistent}/hal.so" ]; then
+if ! echo 'exit [catch {package require Hal}]' | tclsh >/dev/null 2>&1; then
     echo "skip: Tcl HAL extension not built (headless build)" >&2
     exit 1
 fi


### PR DESCRIPTION
The skip scripts for twopass, twopass-personality and tclsh-extensions located `tcl/hal.so` via `TCLLIBPATH`, which is only exported by `rip-environment`. Package-arch CI runs `runtests` with `SYSTEM_BUILD=1` and no `TCLLIBPATH`, so the three tests were wrongly skipped even though the installed extensions load fine (the installed tcltk dir is on tclsh's `auto_path`).

Ask tclsh to load the package instead, the same way the tests use it. This skips headless (`--disable-gui`) builds where the extension is missing and runs wherever it exists. Note: tclsh reads stdin interactively and exits 0 even when a command fails, so `catch` is used to turn a missing package into a nonzero exit status.

Verified both directions: passes (runs) in a run-in-place tree with the extension built, skips in an environment without it.

The fourth test listed in the issue, blendmath, is a different case: its skip is intentional. The test compiles `src/emc/tp/blendmath.c` from the source tree, which does not exist for installed packages, and the skip landed together with the test itself in #4281, so it never ran in package-arch.

Fixes #4460
