### PR TITLE
interp: don't restore spindle speed on abort state restore

### DIFF
--- a/src/emc/rs274ngc/interp_convert.cc
+++ b/src/emc/rs274ngc/interp_convert.cc
@@ -3452,7 +3452,8 @@ int Interp::convert_length_units(int g_code,     //!< g_code being executed (mus
 int Interp::gen_settings(
     int *int_current, int *int_saved,            // G-codes
     double * /*float_current*/, double *float_saved,  // S, F, other
-    std::string &cmd)                            // command buffer
+    std::string &cmd,                            // command buffer
+    bool include_spindle_speed)
 {
     FORCE_LC_NUMERIC_C;
     int i, val;
@@ -3473,8 +3474,11 @@ int Interp::gen_settings(
                 cmd += buf;
 		break;
 	    case GM_FIELD_FLOAT_SPEED:
-		snprintf(buf,sizeof(buf)," S%.0f", float_saved[i]);
-                cmd += buf;
+		// No S word on abort restore: the spindle was just stopped
+		if (include_spindle_speed) {
+		    snprintf(buf,sizeof(buf)," S%.0f", float_saved[i]);
+		    cmd += buf;
+		}
 		break;
 	    case GM_FIELD_FLOAT_PATH_TOLERANCE:
 	    case GM_FIELD_FLOAT_NAIVE_CAM_TOLERANCE:
@@ -3663,13 +3667,13 @@ int Interp::gen_restore_cmd(int *current_g,
 	     cmd.c_str());
     }
 
+    // M codes and spindle speed should not be restored during an abort
     if ((res = gen_settings(
-	     current_g, saved_g, current_settings, saved_settings, cmd))) {
+	     current_g, saved_g, current_settings, saved_settings, cmd, false))) {
 	logStateTags("gen_restore_cmd():  error restoring settings (%d)",
 		     res);
         return INTERP_ERROR;
     }
-    // M codes should not be restored during an abort with gen_m_codes()
 
     return INTERP_OK;
 }
@@ -3737,7 +3741,7 @@ int Interp::restore_settings(setup_pointer settings,
 	(int *)settings->sub_context[from_level].saved_g_codes,
 	(double *)settings->active_settings,
 	(double *)settings->sub_context[from_level].saved_settings,
-	cmd);
+	cmd, true);
     gen_m_codes(
 	(int *) settings->active_m_codes,
 	(int *)settings->sub_context[from_level].saved_m_codes,

--- a/src/emc/rs274ngc/rs274ngc_interp.hh
+++ b/src/emc/rs274ngc/rs274ngc_interp.hh
@@ -477,7 +477,8 @@ int read_dollar(char *line, int *counter, block_pointer block,
  int gen_settings(
      int *int_current, int *int_saved,
      double *float_current, double *float_saved,
-     std::string &cmd);
+     std::string &cmd,
+     bool include_spindle_speed);
  int gen_m_codes(int *current, int *saved, std::string &cmd);
     int gen_restore_cmd(int *current_g,
 			int *current_m,


### PR DESCRIPTION
Fixes #4465.

On abort, `emcTaskStateRestore()` runs `restore_from_tag()`, which executes a G-code string built from the difference between the motion state tag and the interpreter readahead state, to sync the interpreter to the machine at the abort point. `gen_settings()` unconditionally appends the saved S word to that string, so after an early abort the restore queued `EMC_SPINDLE_SPEED` onto the interp_list and it was issued after the abort's spindle stop, turning the spindle back on (speed display drops to 0, then returns to the previous speed). Aborting late in a program was unaffected because tag and readahead state agree by then, so no restore command is generated. This matches the readahead correlation reported in the issue.

Fix: exclude the spindle speed setting from the abort restore, as is already done for M codes. The M72 `restore_settings()` path keeps restoring it, since there the S word must take effect mid-program.

Reproduced headless on a sim config with the test program from the forum thread: abort near the start of the program restarted the spindle to 3000 rpm before the fix, stays off after. Also verified idle abort and late-program abort. Regression-tested: tests/abort (4/4, incl. the g64 state-tag test), interp, interp_initcode, m70-m73, oword, remap, spindle_limits: 110/110 pass.
