### PR TITLE
hal: Stop exporting halpr_*() private functions and shared memory base

### DIFF
--- a/src/hal/hal_lib.c
+++ b/src/hal/hal_lib.c
@@ -4517,14 +4517,6 @@ static bool hal_port_compute_copy(unsigned read,
 }
 
 
-// hal_port_alloc() is DEPRECATED
-// Access to port allocation is done by hal_set_s() on the signal that has the
-// port pins connected.
-int hal_port_alloc(unsigned size, hal_port_t *port)
-{
-    return halpr_port_alloc(size, port);
-}
-
 int halpr_port_alloc(unsigned size, hal_port_t *port) {
     if(!port || size < 1 || size > HAL_PORT_SIZE_MAX)
         return -EINVAL;
@@ -5245,25 +5237,9 @@ EXPORT_SYMBOL(hal_del_funct_from_thread);
 EXPORT_SYMBOL(hal_start_threads);
 EXPORT_SYMBOL(hal_stop_threads);
 
-EXPORT_SYMBOL(hal_shmem_base);
-EXPORT_SYMBOL(halpr_find_comp_by_name);
-EXPORT_SYMBOL(halpr_find_pin_by_name);
-EXPORT_SYMBOL(halpr_find_sig_by_name);
-EXPORT_SYMBOL(halpr_find_param_by_name);
-EXPORT_SYMBOL(halpr_find_thread_by_name);
-EXPORT_SYMBOL(halpr_find_funct_by_name);
-EXPORT_SYMBOL(halpr_find_comp_by_id);
-
-EXPORT_SYMBOL(halpr_find_pin_by_owner);
-EXPORT_SYMBOL(halpr_find_param_by_owner);
-EXPORT_SYMBOL(halpr_find_funct_by_owner);
-
-EXPORT_SYMBOL(halpr_find_pin_by_sig);
-
 EXPORT_SYMBOL(hal_pin_alias);
 EXPORT_SYMBOL(hal_param_alias);
 
-EXPORT_SYMBOL(hal_port_alloc);
 EXPORT_SYMBOL(hal_port_read);
 EXPORT_SYMBOL(hal_port_peek);
 EXPORT_SYMBOL(hal_port_peek_commit);

--- a/src/hal/hal_priv.h
+++ b/src/hal/hal_priv.h
@@ -525,15 +525,11 @@ extern hal_funct_t *halpr_find_funct_by_owner(hal_comp_t * owner,
 extern hal_pin_t *halpr_find_pin_by_sig(hal_sig_t * sig, hal_pin_t * start);
 
 
-/** hal_port_alloc allocates a new empty hal_port having a buffer of size bytes. 
-    Returns a negative value on failure. On success zero (0) is returned and
-    the newly allocated hal_port_t is returned in the port argument and can be
-    used with all other hal_port functions.
-    This is supposed to be private. The public function is deprecated and you
-    should use hal_set_s() to allocate the port once the pins are connected to
-    the signal.
+/** halpr_port_alloc allocates a new empty hal_port having a buffer of size
+    bytes. Returns a negative errno value on failure. On success zero (0) is
+    returned and the newly allocated hal_port_t is returned in the port
+    argument and can be used with all other hal_port functions.
 */
-extern int hal_port_alloc(unsigned size, hal_port_t *port);
 int halpr_port_alloc(unsigned size, hal_port_t *port);
 
 // Recursive HAL mutex (replaces old mutex)


### PR DESCRIPTION
HAL lib is now isolated and its private functions are no longer accessible. This PR removes them from the export statements. It also stops exporting the HAL shared memory segment base address, which is local to each process and handled internally.