### PR TITLE
interp: don't restore spindle speed on abort state restore

### DIFF
--- a/src/emc/rs274ngc/interp_convert.cc
+++ b/src/emc/rs274ngc/interp_convert.cc
@@ -2850,7 +2850,8 @@ int Interp::convert_length_units(int g_code,     //!< g_code being executed (mus
 int Interp::gen_settings(
     int *int_current, int *int_saved,            // G-codes
     double *float_current, double *float_saved,  // S, F, other
-    std::string &cmd)                            // command buffer
+    std::string &cmd,                            // command buffer
+    bool include_spindle_speed)
 {
     FORCE_LC_NUMERIC_C;
     int i, val;
@@ -2871,8 +2872,11 @@ int Interp::gen_settings(
                 cmd += buf;
 		break;
 	    case GM_FIELD_FLOAT_SPEED:
-		snprintf(buf,sizeof(buf)," S%.0f", float_saved[i]);
-                cmd += buf;
+		// No S word on abort restore: the spindle was just stopped
+		if (include_spindle_speed) {
+		    snprintf(buf,sizeof(buf)," S%.0f", float_saved[i]);
+		    cmd += buf;
+		}
 		break;
 	    case GM_FIELD_FLOAT_PATH_TOLERANCE:
 	    case GM_FIELD_FLOAT_NAIVE_CAM_TOLERANCE:
@@ -3061,13 +3065,13 @@ int Interp::gen_restore_cmd(int *current_g,
 	     cmd.c_str());
     }
 
+    // M codes and spindle speed should not be restored during an abort
     if ((res = gen_settings(
-	     current_g, saved_g, current_settings, saved_settings, cmd))) {
+	     current_g, saved_g, current_settings, saved_settings, cmd, false))) {
 	logStateTags("gen_restore_cmd():  error restoring settings (%d)",
 		     res);
         return INTERP_ERROR;
     }
-    // M codes should not be restored during an abort with gen_m_codes()
 
     return INTERP_OK;
 }
@@ -3135,7 +3139,7 @@ int Interp::restore_settings(setup_pointer settings,
 	(int *)settings->sub_context[from_level].saved_g_codes,
 	(double *)settings->active_settings,
 	(double *)settings->sub_context[from_level].saved_settings,
-	cmd);
+	cmd, true);
     gen_m_codes(
 	(int *) settings->active_m_codes,
 	(int *)settings->sub_context[from_level].saved_m_codes,

--- a/src/emc/rs274ngc/rs274ngc_interp.hh
+++ b/src/emc/rs274ngc/rs274ngc_interp.hh
@@ -475,7 +475,8 @@ int read_dollar(char *line, int *counter, block_pointer block,
  int gen_settings(
      int *int_current, int *int_saved,
      double *float_current, double *float_saved,
-     std::string &cmd);
+     std::string &cmd,
+     bool include_spindle_speed);
  int gen_m_codes(int *current, int *saved, std::string &cmd);
     int gen_restore_cmd(int *current_g,
 			int *current_m,


### PR DESCRIPTION
Backport of #4467 to the 2.9 branch.

On abort, `emcTaskStateRestore()` runs `restore_from_tag()`, which builds a G-code restore string from the difference between the motion state tag and the interpreter readahead state. `gen_settings()` unconditionally appends the saved S word, so after an early abort the restore queued `EMC_SPINDLE_SPEED` after the abort's spindle stop, turning the spindle back on. Aborting late in a program was unaffected because tag and readahead agree by then.

Fix: exclude the spindle speed setting from the abort restore, as is already done for M codes. The M72 `restore_settings()` path keeps restoring it, since there the S word must take effect mid-program.

Verified headless on a 2.9 sim with the program from the issue's forum thread: abort near the start restarted the spindle to 3000 rpm before the fix and stays off after.
