### PR TITLE
backport: halcmd: Fix auto-complete after change to libedit

### DIFF
--- a/src/hal/utils/halcmd_main.c
+++ b/src/hal/utils/halcmd_main.c
@@ -436,7 +436,7 @@ static void print_help_general(int showR)
     printf("  help command   Prints detailed help for 'command'\n\n");
 }
 
-#ifdef HAVE_READLINE
+#if defined(HAVE_READLINE) || defined(HAVE_EDITLINE_READLINE_H)
 #include "halcmd_completion.h"
 
 static int get_input(FILE *srcfile, char *buf, size_t bufsize) {


### PR DESCRIPTION
The change from libreadline to libedit requires an update to the define test or auto-complete no longer works. This was fixed in master with #4269 but the particular problem was never backported.