### PR TITLE
mb2hal: Fix module info placement and cppcheck problem

### DIFF
--- a/src/hal/user_comps/mb2hal/mb2hal.h
+++ b/src/hal/user_comps/mb2hal/mb2hal.h
@@ -7,9 +7,6 @@
 #include <pthread.h>
 
 #include <rtapi.h>
-#ifdef RTAPI
-#include <rtapi_app.h>
-#endif
 #include <rtapi_string.h>
 #include <rtapi_errno.h>
 #include <hal.h>
@@ -31,12 +28,6 @@
 #define MB2HAL_MAX_FNCT06_ELEMENTS 1
 #define MB2HAL_MAX_FNCT15_ELEMENTS 100
 #define MB2HAL_MAX_FNCT16_ELEMENTS 100
-
-#ifdef MODULE_VERBOSE
-MODULE_VERBOSE(emc2, "component:mb2hal:Userspace HAL component to communicate with one or more Modbus devices");
-MODULE_VERBOSE(emc2, "license:LGPL");
-MODULE_LICENSE("LGPL");
-#endif
 
 typedef enum { linkRTU,
                linkTCP


### PR DESCRIPTION
The new cppcheck in Ubuntu 26.04 (for future CI, see #4477) would trip on a define test of `MODULE_VERBOSE`. The placement was wrong in the header and the usage should be replaced with `MODULE_INFO` as used everywhere else.

This PR addresses the issue. It also removes the `RTAPI` dependent inclusion check of `rtapi_app.h` (probably copy-pasted from a compiled component). This is a user-space program that does not need `rtapi_app_main()` and uses plain `main()`.