### PR TITLE
docs: add the missing blank line before * bullets in source

### DIFF
--- a/docs/src/config/core-components.adoc
+++ b/docs/src/config/core-components.adoc
@@ -203,6 +203,7 @@ The __N__ (integer between 0 and 7) substitutes the spindle number.
 === Pins
 
 (((HAL,pins,spindle)))
+
 * 'spindle.__N__.at-speed' - (bit, in)
   Motion will pause until this pin is TRUE, under the following conditions:
 ** before the first feed move after each spindle start or speed change;
@@ -311,6 +312,7 @@ iocontrol's HAL pins are turned on and off in non-realtime context.  If you have
 
 === Pins
 (((HAL,pins,iocontrol)))
+
 * 'iocontrol.0.coolant-flood' (bit, out) TRUE when flood coolant is requested.
 * 'iocontrol.0.coolant-mist' (bit, out) TRUE when mist coolant is requested.
 * 'iocontrol.0.emc-enable-in' (bit, in) Should be driven FALSE when an external E-Stop condition exists.

--- a/docs/src/config/ini-config.adoc
+++ b/docs/src/config/ini-config.adoc
@@ -223,6 +223,7 @@ Do _not_ use a file extension of '.ini' for included files.
 === [EMC] Section
 
 (((INI File, Sections, [EMC] Section)))
+
 * `VERSION = 1.1` - The version number for the configuration.
   Any value other than 1.1 will cause the configuration checker to run and try to update the configuration to the new style joint axes type of configuration.
 * `MACHINE = My Controller` - This is the name of the controller, which is printed out at the top of most graphical interfaces.
@@ -500,6 +501,7 @@ if __name__ == "__main__":
 === [RS274NGC] Section
 
 (((INI File, Sections, [RS274NGC] Section)))
+
 * `PARAMETER_FILE = myfile.var` - (((PARAMETER FILE)))
   The file located in the same directory as the INI file which contains the parameters used by the interpreter (saved between runs).
 * `ORIENT_OFFSET = 0` - (((ORIENT OFFSET)))
@@ -606,6 +608,7 @@ For more information on the motion controller see the <<sec:motion,Motion>> sect
 === [TASK] Section
 
 (((INI File, Sections, [TASK] Section)))
+
 * `TASK = milltask` -
   Specifies the name of the 'task' executable.
   The 'task' executable does various things, such as
@@ -622,6 +625,7 @@ For more information on the motion controller see the <<sec:motion,Motion>> sect
 === [HAL] section
 
 (((INI File, Sections, [HAL] Section)))
+
 * `HALFILE = example.hal` - Execute the file 'example.hal' at start up.
 +
 --
@@ -698,6 +702,7 @@ For more information see the <<cha:hal-twopass,HAL TWOPASS>> chapter.
 === [HALUI] section
 
 (((INI File, Sections, [HALUI] Section)))
+
 * `MDI_COMMAND = G53 G0 X0 Y0 Z0` -
   An MDI command can be executed by using `halui.mdi-command-00`. Increment the number for each command listed in the [HALUI] section.
 
@@ -800,6 +805,7 @@ If you want to travel along a path at 1 IPS = 60 IPM, and your servo period 
 If you set Naive CAM tolerance to around this min length, overly short segments will be combined together to eliminate this bottleneck.
 Of course, setting the tolerance too high means big path deviations, so you have to play with it a bit to find a good value.
 I'd start at 1/2 of the min_length, then work up as needed.
+
 * `ARC_BLEND_GAP_CYCLES = 4` How short the previous segment must be before the trajectory planner 'consumes' it.
 +
 Often, a circular arc blend will leave short line segments in between the blends.
@@ -808,6 +814,7 @@ Since the trajectory planner has to touch each segment at least once, it means t
 My fix to this way to "consume" the short segment by making it a part of the blend arc.
 Since the line+blend is one segment, we don't have to slow down to hit the very short segment.
 Likely, you won't need to touch this setting.
+
 * `ARC_BLEND_RAMP_FREQ = 20` - This is a 'cutoff' frequency for using ramped velocity.
 +
 'Ramped velocity' in this case just means constant acceleration over the whole segment.
@@ -893,6 +900,7 @@ LinuxCNC will not know your joint travel limits when using `NO_FORCE_HOMING = 1`
 === [KINS] Section
 
 (((INI File, Sections, KINS Section)))
+
 * `JOINTS = 3` - Specifies the number of joints (motors) in the system.
   For example, a trivkins XYZ machine with a single motor for each axis has 3 joints.
   A gantry machine with one motor on each of two of the axes, and two motors on the third axis, has 4 joints.
@@ -1366,6 +1374,7 @@ Control screens can limit these settings further.
 === [EMCIO] Section
 
 (((INI File, Sections, [EMCIO] Section)))
+
 * `EMCIO = io` - Name of IO controller program.
 * `CYCLE_TIME = 0.100` - The period, in seconds, at which EMCIO will run.
   Making it 0.0 or a negative number will tell EMCIO not to sleep at all.

--- a/docs/src/config/stepconf.adoc
+++ b/docs/src/config/stepconf.adoc
@@ -84,6 +84,7 @@ to those of the driver. You may find it necessary to add some time to the
 drive requirements to allow for this.
 +
 The LinuxCNC Configuration Selector has configs for Sherline already configured.
+
 * 'Step Time' - How long the step pulse is 'on' in nano seconds. If your not
   sure about this setting a value of 20,000 will work with most drives.
 * 'Step Space' - Minimum time between step pulses in nano seconds. If your

--- a/docs/src/gcode/m-code.adoc
+++ b/docs/src/gcode/m-code.adoc
@@ -42,6 +42,7 @@
 == M0, M1 Program Pause
 
 (((M0, M1 Program Pause)))(((M0 Mandatory Program Pause)))(((M1 Optional Program Pause)))
+
 * 'M0' - pause a running program temporarily. LinuxCNC remains in the Auto Mode
   so MDI and other manual actions are not enabled. Pressing the resume
   button will restart the program at the following line.
@@ -60,6 +61,7 @@ to stop after each line of input anyway.
 == M2, M30 Program End
 
 (((M2 Program End)))(((M30 Pallet Exchange and Program End)))
+
 * 'M2' - end the program. Pressing `Cycle Start` ("R" in the Axis GUI)
   will restart the program at the beginning of the file.
 * 'M30' - exchange pallet shuttles and end the program.
@@ -91,6 +93,7 @@ on what using % does not do.
 == M60 Pallet Change Pause
 
 (((M60 Pallet Change Pause)))
+
 * 'M60' - exchange pallet shuttles and then pause a running program
   temporarily (regardless of the setting of the optional stop
   switch). Pressing the cycle start button
@@ -100,6 +103,7 @@ on what using % does not do.
 == M3, M4, M5 Spindle Control
 
 (((M3, M4, M5 Spindle Control)))
+
 * 'M3 [$n]' - start the selected spindle clockwise at the 'S' speed.
 * 'M4 [$n]' - start the selected spindle counterclockwise at the 'S' speed.
 * 'M5 [$n]' - stop the selected spindle.
@@ -199,6 +203,7 @@ ClassicLadder.
 == M7, M8, M9 Coolant Control
 
 (((M7, M8, M9 Coolant Control)))
+
 * 'M7' - turn mist coolant on. M7 controls iocontrol.0.coolant-mist pin.
 * 'M8' - turn flood coolant on. M8 controls iocontrol.0.coolant-flood pin.
 * 'M9' - turn both M7 and M8 off.
@@ -264,6 +269,7 @@ INI Settings in the [RS274NGC] section:
 == M48, M49 Speed and Feed Override Control
 
 (((M48, M49 Speed and Feed Override Control)))
+
 * 'M48' - enable the spindle speed and feed rate override controls.
 * 'M49' - disable both controls.
 
@@ -281,6 +287,7 @@ see below.
 == M50 Feed Override Control
 
 (((M50 Feed Override Control)))
+
 * 'M50 <P1>' - enable the feed rate override control. The P1
   is optional.
 * 'M50 P0' - disable the feed rate control.
@@ -293,6 +300,7 @@ and the motion will be executed at programmed feed rate.
 == M51 Spindle Speed Override Control
 
 (((M51 Spindle Speed Override)))
+
 * 'M51 <P1> <$->'- enable the spindle speed override control for the
   selected spindle. The  P1 is optional.
 * 'M51 P0 <$->'  - disable the spindle speed override control program.
@@ -306,6 +314,7 @@ exact program specified value of the S-word
 == M52 Adaptive Feed Control
 
 (((M52 Adaptive Feed Control)))
+
 * 'M52 <P1>' - use an adaptive feed. The P1 is optional.
 * 'M52 P0' - stop using adaptive feed.
 
@@ -325,6 +334,7 @@ cutters and wire spark eroders but it is not limited to such applications.
 == M53 Feed Stop Control
 
 (((M53 Feed Stop Control)))
+
 * 'M53 <P1>' - enable the feed stop switch. The P1 is optional.
   Enabling the feed stop switch will allow motion to be
   interrupted by means of the feed stop control. In LinuxCNC,
@@ -337,6 +347,7 @@ cutters and wire spark eroders but it is not limited to such applications.
 == M61 Set Current Tool
 
 (((M61 Set Current Tool)))
+
 * 'M61 Q-' - change the current tool number while in MDI or Manual mode without
   a tool change. One use is when you power up LinuxCNC with a tool
   currently in the spindle you can set that tool number without
@@ -354,6 +365,7 @@ It is an error if:
 == M62 - M65 Digital Output Control
 
 (((M62 - M65 Digital Output Control)))
+
 * 'M62 P-' - turn on digital output synchronized with motion.
 * 'M63 P-' - turn off digital output synchronized with motion.
 * 'M64 P-' - turn on digital output immediately.

--- a/docs/src/gcode/overview.adoc
+++ b/docs/src/gcode/overview.adoc
@@ -414,6 +414,7 @@ is written.
 === Subroutine Parameters
 
 (((Subroutine Parameters)))
+
 * '1-30' Subroutine local parameters of call arguments. These parameters are
   local to the subroutine. Volatile. See also the chapter on
   <<cha:o-codes,O-Codes>>.
@@ -572,6 +573,7 @@ can be added easily without changes to the source code.
 === System Parameters
 
 (((System Parameters)))
+
 * '#<_spindle_rpm_mode>' - Return 1 if spindle rpm mode (G97) is on, else 0.
 * '#<_spindle_css_mode>' - Return 1 if constant surface speed mode (G96) is on, else 0.
 * '#<_ijk_absolute_mode>' - Return 1 if Absolute Arc distance mode (G90.1) is on, else 0.
@@ -1067,6 +1069,7 @@ NOTE: Inline comments on O-words should not be used see the O-code
 == Messages
 
 (((Messages)))
+
 * '(MSG,)' - displays message if 'MSG' appears after the left parenthesis
   and before any other printing characters. Variants of 'MSG' which include
   white space and lower case characters are allowed. The rest of the
@@ -1083,6 +1086,7 @@ NOTE: Inline comments on O-words should not be used see the O-code
 == Probe Logging
 
 (((Probe Logging)))
+
 * '(PROBEOPEN filename.txt)' - will open filename.txt and store the 9-number
   coordinate consisting of XYZABCUVW of each successful straight probe in it.
 * '(PROBECLOSE)' - will close the open probelog file.
@@ -1093,6 +1097,7 @@ For more information on probing see the <<gcode:g38,G38>> section.
 == Logging
 
 (((Logging)))
+
 * '(LOGOPEN,filename.txt)' - opens the named log file. If the file already
   exists, it is truncated.
 * '(LOGAPPEND,filename)' - opens the named log file. If the file already
@@ -1108,6 +1113,7 @@ Examples of logging are in 'nc_files/examples/smartprobe.ngc' and in
 == Debug Messages
 
 (((Debug Messages)))
+
 * '(DEBUG,)' - displays a message like '(MSG,)' with the addition of special
   handling for comment parameters as described below.
 
@@ -1115,6 +1121,7 @@ Examples of logging are in 'nc_files/examples/smartprobe.ngc' and in
 == Print Messages
 
 (((Print Messages)))
+
 * '(PRINT,)' - messages are output to 'stderr' with special handling for
   comment parameters as described below.
 

--- a/docs/src/getting-started/about-linuxcnc.adoc
+++ b/docs/src/getting-started/about-linuxcnc.adoc
@@ -7,6 +7,7 @@
 == The Software
 
 (((About LinuxCNC)))
+
 * LinuxCNC (the Enhanced Machine Control) is a software system for computer
   control of machine tools such as milling machines and lathes, robots
   such as puma and scara and other computer controlled machines up to 9 axes.

--- a/docs/src/gui/ngcgui.adoc
+++ b/docs/src/gui/ngcgui.adoc
@@ -16,6 +16,7 @@ image::images/ngcgui.png[align="center"]
 == Overview
 
 (((NGCGUI)))
+
 * 'NGCGUI' is a Tcl application to work with subroutines. It allows you to
   have a conversational interface with LinuxCNC. You can organize the
   subroutines in the order you need them to run and concatenate the

--- a/docs/src/gui/pyvcp.adoc
+++ b/docs/src/gui/pyvcp.adoc
@@ -794,6 +794,7 @@ up or down as the wheel is turned, either by dragging in a circular
 motion, or by rolling the mouse-wheel.
 
 Optional tags:
+
 * '<text>"My Text"</text>' displays text
 * '<bgcolor>"grey"</bgcolor> <fillcolor>"green"</fillcolor>' background & active colors
 * '<scale_pin>1</scale_pin>' creates scale text and a `FLOAT.scale` pin to display jog scale

--- a/docs/src/hal/rtcomps.adoc
+++ b/docs/src/hal/rtcomps.adoc
@@ -81,6 +81,7 @@ On the step type and control type selected.
 === Parameters
 
 (((HAL stepgen parameters)))
+
 * (float) `stepgen.`__<chan>__`.position-scale` - Steps per position unit. This parameter is used for both output and feedback.
 * (float) `stepgen.`__<chan>__`.maxvel` - Maximum velocity, in position units per second. If 0.0, has no effect.
 * (float) `stepgen.`__<chan>__`.maxaccel` - Maximum accel/decel rate, in positions units per second squared.


### PR DESCRIPTION
Fixes #4475.

A column-0 `* ` bullet that directly follows a column-0 paragraph or a standalone `(((index)))` line is folded into that paragraph, so no list is rendered. Whole option lists show up as one run-on paragraph with literal `*` and `+` in them, for example https://linuxcnc.org/docs/stable/html/config/ini-config.html#sub:ini:sec:rs274ngc

Most of these boundaries appeared when the index entries were moved out of the heading lines in fe899f0c73.

Fix is the missing blank line at 35 boundaries in 9 files, no text changed:

```
 (((INI File, Sections, [RS274NGC] Section)))
+
 * `PARAMETER_FILE = myfile.var` - ...
```

Same class of fix as 126049017c on master.

Testing: rendered the 9 changed chapters before and after, paragraphs still holding a literal `*` bullet go from 32 to 0. Done with asciidoctor since asciidoc.py is not installed here, so it checks the source structure; a blank line before a list is valid in both parsers, and each site was confirmed broken in the published 2.9 HTML.

Merge note: master renders these correctly already and needs no follow-up, but 4 of the files conflict on the next `2.9` merge (11 hunks in `config/ini-config.adoc`, `config/core-components.adoc`, `gcode/overview.adoc`, `getting-started/about-linuxcnc.adoc`), because master rewrote that text. Take the master side for all 11, hunk by hunk rather than per file. I checked that this leaves master byte-identical to what it is now.
