### PR TITLE
fix safety and correctness bugs in hostmot2 drivers

### DIFF
--- a/docs/src/man/man3/hm2_pktuart.3.adoc
+++ b/docs/src/man/man3/hm2_pktuart.3.adoc
@@ -150,11 +150,13 @@ This is typically a multi-step process:
 1. rxstatus indicates that there are packets of data, but at this point we need to know how big each packet is (and reading two much or two little data from the FIFOs will cause problems).
 2. Queue a read of the frame sizes. **hm2_pktuart_queue_get_frame_sizes(name, fsizes[])**
 On return, the fsizes[] array will have been loaded with the frame sizes (size in bytes).
+The function returns the number of frame-size reads queued, or a negative error code.
 If fsizes are [8] [7] [6] and you only read 1 frame from the data FIFO then on the next call to get_frame_sizes the returned array would be [7] [6].
 3. Wait one thread cycle to get the data.  Note that there is no serial latency here, the data is already on the FPGA but we can only know how much data to request once we know the packet size
 4. Queue enough data reads to get all the data frames that the packet is spread over.
 int hm2_pktuart_queue_read_data(name, data, bytes)
 On return the data[] array will have been loaded with enough 32-bit frames to include "bytes" bytes.
+The function returns the number of 32-bit data reads queued, or a negative error code.
 5. Parse the data.
 
 === Data Formats ===

--- a/src/hal/drivers/mesa-hostmot2/abs_encoder.c
+++ b/src/hal/drivers/mesa-hostmot2/abs_encoder.c
@@ -262,13 +262,20 @@ int hm2_absenc_parse_format(hm2_sserial_remote_t *chan,  hm2_absenc_format_t *de
                         "not get the pins you expected\n");
             }
             else if (strchr("bBuUsSeEfFpPgGhHlLmM", *format)){
+                hm2_sserial_data_t *confs;
                 hm2_sserial_data_t *conf;
-                chan->num_confs++;
-                chan->confs = (hm2_sserial_data_t *)rtapi_krealloc(chan->confs,
-                        chan->num_confs * sizeof(hm2_sserial_data_t),
-                        RTAPI_GFP_KERNEL);
 
-                conf = &(chan->confs[chan->num_confs - 1]);
+                if (q > RTAPI_UINT8_MAX) {
+                    HM2_ERR_NO_LL("Field length %d exceeds the supported maximum\n", q);
+                    return -EINVAL;
+                }
+                confs = rtapi_krealloc(chan->confs,
+                        (chan->num_confs + 1) * sizeof(*confs),
+                        RTAPI_GFP_KERNEL);
+                if (confs == NULL) return -ENOMEM;
+                chan->confs = confs;
+
+                conf = &(chan->confs[chan->num_confs++]);
                 conf->DataDir = LBP_IN;
                 conf->DataLength = q;
                 rtapi_strxcpy(conf->NameString, name);
@@ -357,6 +364,10 @@ int hm2_absenc_parse_format(hm2_sserial_remote_t *chan,  hm2_absenc_format_t *de
         else
         {
             // Not a % format, append name
+            if (nameptr == &name[sizeof(name) - 1]) {
+                HM2_ERR_NO_LL("Absolute encoder field name is too long\n");
+                return -EINVAL;
+            }
             *nameptr++ = *format++;
             *nameptr = 0;
         }
@@ -400,12 +411,6 @@ int hm2_absenc_parse_md(hostmot2_t *hm2, int md_index) {
 
     if (hm2->absenc.num_chans == 0) { // first time though
         hm2->absenc.clock_frequency = md->clock_freq;
-        hm2->absenc.ssi_busy_flags = rtapi_kmalloc(sizeof(rtapi_u32), RTAPI_GFP_KERNEL);
-        *hm2->absenc.ssi_busy_flags = 0;
-        hm2->absenc.biss_busy_flags = rtapi_kmalloc(sizeof(rtapi_u32), RTAPI_GFP_KERNEL);
-        *hm2->absenc.biss_busy_flags = 0;
-        hm2->absenc.fabs_busy_flags = rtapi_kmalloc(sizeof(rtapi_u32), RTAPI_GFP_KERNEL);
-        *hm2->absenc.fabs_busy_flags = 0;
     }
     
     for (index = 0 ; index < md->instances ; index ++){
@@ -422,12 +427,18 @@ int hm2_absenc_parse_md(hostmot2_t *hm2, int md_index) {
                 goto fail1;
             }
             if (index == def->index && md->gtag == def->gtag){
+                hm2_sserial_remote_t *chans;
+
                 has_format = true;
-                hm2->absenc.num_chans += 1;
-                hm2->absenc.chans = rtapi_krealloc(hm2->absenc.chans,
-                        hm2->absenc.num_chans * sizeof(hm2_sserial_remote_t),
+                chans = rtapi_krealloc(hm2->absenc.chans,
+                        (hm2->absenc.num_chans + 1) * sizeof(*chans),
                         RTAPI_GFP_KERNEL);
-                chan = &hm2->absenc.chans[hm2->absenc.num_chans - 1];
+                if (chans == NULL) {
+                    HM2_ERR("out of memory allocating absolute encoder channel\n");
+                    goto fail1;
+                }
+                hm2->absenc.chans = chans;
+                chan = &hm2->absenc.chans[hm2->absenc.num_chans++];
                 memset(chan, 0, sizeof(hm2_sserial_remote_t));
                 chan->index = index;
                 chan->myinst = md->gtag;
@@ -517,6 +528,8 @@ void hm2_absenc_process_tram_read(hostmot2_t *hm2, long period) {
                 err_tag[i] = 1;
             }    
         } 
+        // These pointers are supplied by hm2_absenc_register_tram() whenever
+        // the corresponding global-start address enables this dereference.
         if (((chan->myinst == HM2_GTAG_SSI)
                 && (*hm2->absenc.ssi_busy_flags & (1 << chan->index)))
                 || ((chan->myinst == HM2_GTAG_BISS)

--- a/src/hal/drivers/mesa-hostmot2/bspi.c
+++ b/src/hal/drivers/mesa-hostmot2/bspi.c
@@ -121,6 +121,10 @@ int hm2_tram_add_bspi_frame(char *name, int chan, rtapi_u32 **wbuff, rtapi_u32 *
         HM2_ERR_NO_LL("Can not find BSPI instance %s.\n", name);
         return -1;
     }
+    if (chan < 0 || chan > 15) {
+        HM2_ERR("BSPI %s: channel number %i is out of range\n", name, chan);
+        return -EINVAL;
+    }
     if (hm2->bspi.instance[i].conf_flag[chan] != true){
         HM2_ERR("The selected write channel (%i) on bspi instance %s.\n" 
                 "Has not been configured.\n", chan, name);
@@ -205,6 +209,10 @@ int hm2_bspi_write_chan(char* name, int chan, rtapi_u32 val)
         HM2_ERR_NO_LL("Can not find BSPI instance %s.\n", name);
         return -1;
     }
+    if (chan < 0 || chan > 15) {
+        HM2_ERR("BSPI %s: channel number %i is out of range\n", name, chan);
+        return -EINVAL;
+    }
     if (hm2->bspi.instance[i].conf_flag[chan] != true){
         HM2_ERR("The selected write channel (%i) on bspi instance %s.\n" 
                 "Has not been configured.\n", chan, name);
@@ -246,6 +254,10 @@ int hm2_bspi_setup_chan(char *name, int chan, int cs, int bits, double mhz,
         HM2_ERR("BSPI %s: Number of bits for chan %i (%i) is out of range, "
                 "BSPI only supports 1-64 bits\n", name, chan, bits);
         return -1;
+    }
+    if (mhz <= 0) {
+        HM2_ERR("BSPI %s: clock frequency must be greater than zero\n", name);
+        return -EINVAL;
     }
     if (delay < 0 || delay > 1e6){
         HM2_ERR("The requested frame delay on channel %i of %inS seems "
@@ -388,6 +400,3 @@ void hm2_bspi_write(hostmot2_t *hm2)
 {
     (void)hm2;
 }
-
-
-

--- a/src/hal/drivers/mesa-hostmot2/bspi.c
+++ b/src/hal/drivers/mesa-hostmot2/bspi.c
@@ -123,7 +123,7 @@ int hm2_tram_add_bspi_frame(char *name, int chan, rtapi_u32 **wbuff, rtapi_u32 *
     }
     if (chan < 0 || chan > 15) {
         HM2_ERR("BSPI %s: channel number %i is out of range\n", name, chan);
-        return -EINVAL;
+        return -1;
     }
     if (hm2->bspi.instance[i].conf_flag[chan] != true){
         HM2_ERR("The selected write channel (%i) on bspi instance %s.\n" 
@@ -211,7 +211,7 @@ int hm2_bspi_write_chan(char* name, int chan, rtapi_u32 val)
     }
     if (chan < 0 || chan > 15) {
         HM2_ERR("BSPI %s: channel number %i is out of range\n", name, chan);
-        return -EINVAL;
+        return -1;
     }
     if (hm2->bspi.instance[i].conf_flag[chan] != true){
         HM2_ERR("The selected write channel (%i) on bspi instance %s.\n" 
@@ -257,7 +257,7 @@ int hm2_bspi_setup_chan(char *name, int chan, int cs, int bits, double mhz,
     }
     if (mhz <= 0) {
         HM2_ERR("BSPI %s: clock frequency must be greater than zero\n", name);
-        return -EINVAL;
+        return -1;
     }
     if (delay < 0 || delay > 1e6){
         HM2_ERR("The requested frame delay on channel %i of %inS seems "

--- a/src/hal/drivers/mesa-hostmot2/hm2_eth.c
+++ b/src/hal/drivers/mesa-hostmot2/hm2_eth.c
@@ -1418,23 +1418,8 @@ static int hm2_eth_probe(hm2_eth_t *board) {
         // DB25, 17 pins used, IO 34 to IO 50
         board->llio.ioport_connector_name[0] = "P1";
 
-        // terminal block, 10 pins used, enc 0-2
+        // terminal block
         board->llio.ioport_connector_name[1] = "TB1";
-  
-        // terminal block, 10 pins used, enc 3-5
-        board->llio.ioport_connector_name[2] = "TB2";
-
-        // terminal block, 8 pins used, Step & Dir 0-3
-        board->llio.ioport_connector_name[3] = "TB3";
- 
-        // terminal block, 10 pins used, Step & Dir 4,5, serial Rx/Tx/Txen 0,1
-        board->llio.ioport_connector_name[2] = "TB4";
-
-        // terminal block, 8 inputs, 6 SSR outputs
-        board->llio.ioport_connector_name[3] = "TB5";
-
-        // terminal block, 16 inputs
-        board->llio.ioport_connector_name[2] = "TB6";
 
         board->llio.fpga_part_number = "6slx9tqg144";
         board->llio.num_leds = 4;
@@ -1448,23 +1433,8 @@ static int hm2_eth_probe(hm2_eth_t *board) {
         // DB25, 17 pins used, IO 34 to IO 50
         board->llio.ioport_connector_name[0] = "P1";
 
-        // terminal block, 10 pins used, enc 0-2
+        // terminal block
         board->llio.ioport_connector_name[1] = "TB1";
-  
-        // terminal block, 10 pins used, enc 3-5
-        board->llio.ioport_connector_name[2] = "TB2";
-
-        // terminal block, 8 pins used, Step & Dir 0-3
-        board->llio.ioport_connector_name[3] = "TB3";
- 
-        // terminal block, 10 pins used, Step & Dir 4,5, serial Rx/Tx/Txen 0,1
-        board->llio.ioport_connector_name[2] = "TB4";
-
-        // terminal block, 8 inputs, 6 SSR outputs
-        board->llio.ioport_connector_name[3] = "TB5";
-
-        // terminal block, 16 inputs
-        board->llio.ioport_connector_name[2] = "TB6";
 
         board->llio.fpga_part_number = "T20F256";
         board->llio.num_leds = 4;

--- a/src/hal/drivers/mesa-hostmot2/hm2_eth.c
+++ b/src/hal/drivers/mesa-hostmot2/hm2_eth.c
@@ -71,7 +71,7 @@ static int *kvlist_lookup(struct rtapi_list_head *head, const char *name) {
         struct kvlist *ent = rtapi_list_entry(ptr, struct kvlist, list);
         if(strncmp(name, ent->key, sizeof(ent->key)) == 0) return &ent->value;
     }
-    struct kvlist *ent = rtapi_kzalloc(sizeof(struct kvlist), RTAPI_GPF_KERNEL);
+    struct kvlist *ent = rtapi_kzalloc(sizeof(struct kvlist), RTAPI_GFP_KERNEL);
     if(!ent)
         return NULL;
     strncpy(ent->key, name, sizeof(ent->key)-1);
@@ -680,7 +680,7 @@ static char* inet_ntoa_buf(struct in_addr in, char *buf, size_t n) {
 }
 
 char* fetch_ifname(int sockfd, char *buf, size_t n) {
-    struct sockaddr_in srcaddr;
+    struct sockaddr_in srcaddr = {0};
     struct ifaddrs *ifa, *it;
 
     socklen_t addrlen = sizeof(srcaddr);
@@ -707,7 +707,7 @@ char* fetch_ifname(int sockfd, char *buf, size_t n) {
 }
 
 int install_firewall_board(int sockfd) {
-    struct sockaddr_in srcaddr, dstaddr;
+    struct sockaddr_in srcaddr = {0}, dstaddr = {0};
     char srchost[16], dsthost[16]; // enough for 255.255.255.255\0
     char dport_s[8], sport_s[8];
 
@@ -800,11 +800,11 @@ int fetch_hwaddr(hm2_eth_t *board, unsigned char buf[6]) {
     unsigned char response[6];
     LBP16_INIT_PACKET4(packet, 0x4983, 0x0002);
     int res = eth_socket_send(board, &packet, sizeof(packet));
-    if(res < 0) return -errno;
+    if(res != (int)sizeof(packet)) return res < 0 ? -errno : -EIO;
 
     int i=0;
     res = eth_socket_recv(board, &response, sizeof(response), RECV_TIMEOUT_NON_RT_NS);
-    if(res < 0) return -errno;
+    if(res != (int)sizeof(response)) return res < 0 ? -errno : -EIO;
 
     // eeprom order is backwards from arp AF_LOCAL order
     for(i=0; i<6; i++) buf[i] = response[5-i];
@@ -866,14 +866,24 @@ static inline int eth_socket_recv(hm2_eth_t *board, void *buffer, int len, int r
 
 /// hm2_eth io functions
 
+static bool hm2_eth_valid_transfer_size(int size) {
+    return size > 0
+        && (size % sizeof(rtapi_u32)) == 0
+        && size / (int)sizeof(rtapi_u32) <= LBP16_MAX_PACKET_DATA_SIZE;
+}
+
 static int hm2_eth_read(hm2_lowlevel_io_t *this, rtapi_u32 addr, void *buffer, int size) {
     hm2_eth_t *board = this->private;
     int send, recv;
-    rtapi_u8 tmp_buffer[size + 4];
+    rtapi_u8 tmp_buffer[LBP16_MAX_PACKET_DATA_SIZE * sizeof(rtapi_u32)];
     long long t1, t2;
 
     if (comm_active == 0) return 1;
     if (size == 0) return 1;
+    if (!hm2_eth_valid_transfer_size(size)) {
+        THIS_ERR("hm2_eth_read: invalid transfer size %d\n", size);
+        return 0;
+    }
     board->read_cnt++;
 
     if(rtapi_task_self() >= 0) {
@@ -890,8 +900,12 @@ static int hm2_eth_read(hm2_lowlevel_io_t *this, rtapi_u32 addr, void *buffer, i
     LBP16_INIT_PACKET4(read_packet, CMD_READ_HOSTMOT2_ADDR32_INCR(size/4), addr & 0xFFFF);
 
     send = eth_socket_send(board, (void*) &read_packet, sizeof(read_packet));
-    if(send < 0)
-        LL_PRINT("ERROR: sending packet: %s\n", strerror(errno));
+    if(send != (int)sizeof(read_packet)) {
+        LL_PRINT("ERROR: sending read packet%s%s\n",
+                 send < 0 ? ": " : "",
+                 send < 0 ? strerror(errno) : "");
+        return 0;
+    }
     LL_PRINT_IF(debug, "read(%d) : PACKET SENT [CMD:%02X%02X | ADDR: %02X%02X | SIZE: %d]\n", board->read_cnt, read_packet.cmd_hi, read_packet.cmd_lo,
       read_packet.addr_lo, read_packet.addr_hi, size);
 
@@ -904,7 +918,7 @@ static int hm2_eth_read(hm2_lowlevel_io_t *this, rtapi_u32 addr, void *buffer, i
     } else {
         LL_PRINT_IF(debug, "read(%d) : PACKET RECV [SIZE: %d | TIME: %llu]\n", board->read_cnt, recv, t2 - t1);
     }
-    if (recv < 0)
+    if (recv != size)
         return 0;
     memcpy(buffer, tmp_buffer, size);
     return 1;  // success
@@ -962,9 +976,13 @@ static int hm2_eth_send_queued_reads(hm2_lowlevel_io_t *this) {
     board->queue_reads_count++;
     board->queue_buff_size += sizeof(board->confirm_rw_cnt);
 
-    send = eth_socket_send(board, (void*) &board->read_packet, board->read_packet_ptr - board->read_packet);
-    if(send < 0) {
-        LL_PRINT("ERROR: sending packet: %s\n", strerror(errno));
+    size_t packet_size = board->read_packet_ptr - board->read_packet;
+    send = eth_socket_send(board, (void*) &board->read_packet, packet_size);
+    if(send != (int)packet_size) {
+        LL_PRINT("ERROR: sending queued-read packet%s%s\n",
+                 send < 0 ? ": " : "",
+                 send < 0 ? strerror(errno) : "");
+        hm2_eth_reset_queued_reads(board);
         return 0;
     }
     return 1;
@@ -1067,26 +1085,41 @@ static int hm2_eth_reset(hm2_lowlevel_io_t *this) {
     lbp16_cmd_addr_data32 bite_packet;
     LBP16_INIT_PACKET8(bite_packet, CMD_WRITE_HOSTMOT2_ADDR32_INCR(1), HM2_ADDR_WATCHDOG, 0x0001);
     int ret = eth_socket_send(board, (void*) &bite_packet, sizeof(bite_packet));
-    if(ret < 0) perror("eth_socket_send(bite_packet)");
-    return ret < 0 ? -errno : 0;
+    if(ret != (int)sizeof(bite_packet)) {
+        if (ret < 0) perror("eth_socket_send(bite_packet)");
+        return ret < 0 ? -errno : -EIO;
+    }
+    return 0;
 }
 
 static int hm2_eth_enqueue_read(hm2_lowlevel_io_t *this, rtapi_u32 addr, void *buffer, int size) {
     hm2_eth_t *board = this->private;
     if (comm_active == 0) return 1;
     if (size == 0) return 1;
-    
-    //Check size we are going to write
+    if (!hm2_eth_valid_transfer_size(size)) {
+        THIS_ERR("hm2_eth_enqueue_read: invalid transfer size %d\n", size);
+        return 0;
+    }
+    // hm2_eth_send_queued_reads() appends two internal confirmation reads.
+    if (board->queue_reads_count >= MAX_ETH_READS - 2) {
+        THIS_ERR("hm2_eth_enqueue_read: read queue full (%d)\n", board->queue_reads_count);
+        return 0;
+    }
     size_t read_packet_size = board->read_packet_ptr - board->read_packet;
-    if (read_packet_size + sizeof(lbp16_cmd_addr) > sizeof(board->read_packet)) {
-        LL_PRINT("ERROR: enqueue_read: buffer full\n");
+    size_t read_packet_trailer_size =
+        3 * sizeof(lbp16_cmd_addr) + sizeof(board->read_cnt);
+    if (read_packet_size + sizeof(lbp16_cmd_addr)
+            + read_packet_trailer_size > sizeof(board->read_packet)) {
+        THIS_ERR("hm2_eth_enqueue_read: read packet buffer size exceeded\n");
         return 0;
     }
-    if (board->queue_reads_count + 1 > MAX_ETH_READS) {
-        LL_PRINT("ERROR: enqueue_read: queue_reads full\n");
+    size_t response_trailer_size =
+        sizeof(board->rxudpcount) + sizeof(board->confirm_rw_cnt);
+    if ((size_t)board->queue_buff_size + size + response_trailer_size
+            > HM2_ETH_PACKET_SIZE) {
+        THIS_ERR("hm2_eth_enqueue_read: response packet size exceeded\n");
         return 0;
     }
-
     LBP16_INIT_PACKET4(*(lbp16_cmd_addr*)board->read_packet_ptr, CMD_READ_HOSTMOT2_ADDR32_INCR(size/4), addr);
     board->read_packet_ptr += sizeof(lbp16_cmd_addr);
     board->queue_reads[board->queue_reads_count].buffer = buffer;
@@ -1111,6 +1144,10 @@ static int hm2_eth_write(hm2_lowlevel_io_t *this, rtapi_u32 addr, const void *bu
 
     if (comm_active == 0) return 1;
     if (size == 0) return 1;
+    if (!hm2_eth_valid_transfer_size(size)) {
+        THIS_ERR("hm2_eth_write: invalid transfer size %d\n", size);
+        return 0;
+    }
     hm2_eth_t *board = this->private;
     board->write_cnt++;
 
@@ -1118,8 +1155,12 @@ static int hm2_eth_write(hm2_lowlevel_io_t *this, rtapi_u32 addr, const void *bu
     LBP16_INIT_PACKET4(packet.wr_packet, CMD_WRITE_HOSTMOT2_ADDR32_INCR(size/4), addr & 0xFFFF);
 
     send = eth_socket_send(board, (void*) &packet, sizeof(lbp16_cmd_addr) + size);
-    if(send < 0)
-        LL_PRINT("ERROR: sending packet: %s\n", strerror(errno));
+    if(send != (int)(sizeof(lbp16_cmd_addr) + size)) {
+        LL_PRINT("ERROR: sending write packet%s%s\n",
+                 send < 0 ? ": " : "",
+                 send < 0 ? strerror(errno) : "");
+        return 0;
+    }
     LL_PRINT_IF(debug, "write(%d): PACKET SENT [CMD:%02X%02X | ADDR: %02X%02X | SIZE: %d]\n", board->write_cnt, packet.wr_packet.cmd_hi, packet.wr_packet.cmd_lo,
       packet.wr_packet.addr_lo, packet.wr_packet.addr_hi, size);
 
@@ -1149,28 +1190,36 @@ static int hm2_eth_send_queued_writes(hm2_lowlevel_io_t *this) {
     board->has_written_cnt = 1;
     
     t0 = rtapi_get_time();
-    send = eth_socket_send(board, (void*) &board->write_packet, board->write_packet_ptr - board->write_packet);
-    if(send < 0) {
-        LL_PRINT("ERROR: sending packet: %s\n", strerror(errno));
+    size_t packet_size = board->write_packet_ptr - board->write_packet;
+    send = eth_socket_send(board, (void*) &board->write_packet, packet_size);
+    if(send != (int)packet_size) {
+        LL_PRINT("ERROR: sending queued-write packet%s%s\n",
+                 send < 0 ? ": " : "",
+                 send < 0 ? strerror(errno) : "");
     }
     t1 = rtapi_get_time();
     LL_PRINT_IF(debug, "enqueue_write(%d) : PACKET SEND [SIZE: %d | TIME: %llu]\n", board->write_cnt, send, t1 - t0);
     board->write_packet_ptr = board->write_packet;
-    return send < 0 ? 0 : 1;
+    return send == (int)packet_size;
 }
 
 static int hm2_eth_enqueue_write(hm2_lowlevel_io_t *this, rtapi_u32 addr, const void *buffer, int size) {
     hm2_eth_t *board = this->private;
     if (comm_active == 0) return 1;
     if (size == 0) return 1;
-    lbp16_cmd_addr *packet = (lbp16_cmd_addr *) board->write_packet_ptr;
-
-    //Check size we are going to write
-    size_t write_packet_size = board->write_packet_ptr - board->write_packet;
-    if (write_packet_size + sizeof(*packet) + size > sizeof(board->write_packet)) {
-        LL_PRINT("ERROR: enqueue_write: buffer full\n");
+    if (!hm2_eth_valid_transfer_size(size)) {
+        THIS_ERR("hm2_eth_enqueue_write: invalid transfer size %d\n", size);
         return 0;
     }
+    size_t write_packet_size = board->write_packet_ptr - board->write_packet;
+    size_t write_packet_trailer_size =
+        sizeof(lbp16_cmd_addr) + sizeof(board->write_cnt);
+    if (write_packet_size + sizeof(lbp16_cmd_addr) + size
+            + write_packet_trailer_size > sizeof(board->write_packet)) {
+        THIS_ERR("hm2_eth_enqueue_write: write packet buffer size exceeded\n");
+        return 0;
+    }
+    lbp16_cmd_addr *packet = (lbp16_cmd_addr *) board->write_packet_ptr;
 
     LBP16_INIT_PACKET4_PTR(packet, CMD_WRITE_HOSTMOT2_ADDR32_INCR(size/4), addr);
     board->write_packet_ptr += sizeof(*packet);
@@ -1200,19 +1249,19 @@ static int hm2_eth_probe(hm2_eth_t *board) {
     lbp16_cmd_addr read_packet;
 
     int ret, send, recv;
-    char board_name[16] = {};
-    char llio_name[16] = {};
+    char board_name[16] = {0};
+    char llio_name[16] = {0};
 
     LBP16_INIT_PACKET4(read_packet, CMD_READ_BOARD_INFO_ADDR16_INCR(16/2), 0);
     send = eth_socket_send(board, (void*) &read_packet, sizeof(read_packet));
-    if(send < 0) {
+    if(send != (int)sizeof(read_packet)) {
         LL_PRINT("ERROR: sending packet: %s\n", strerror(errno));
-        return -errno;
+        return send < 0 ? -errno : -EIO;
     }
     recv = eth_socket_recv(board, (void*) &board_name, 16, RECV_TIMEOUT_NON_RT_NS);
-    if(recv < 0) {
+    if(recv != (int)sizeof(board_name)) {
         LL_PRINT("ERROR: receiving packet: %s\n", strerror(errno));
-        return -errno;
+        return recv < 0 ? -errno : -EIO;
     }
 
     board = &boards[boards_count];
@@ -1561,12 +1610,15 @@ static int hm2_eth_probe(hm2_eth_t *board) {
         // (such as 0 or -1) could be passed here and the layer which can
         // legitimately read idroms would read the values and store them, but
         // that wasn't trivial to do.
-        rtapi_u32 read_data;
-        hm2_eth_read(&board->llio, HM2_ADDR_IDROM_OFFSET, &read_data, 4);
+        rtapi_u32 read_data = 0;
+        if (!hm2_eth_read(&board->llio, HM2_ADDR_IDROM_OFFSET,
+                          &read_data, sizeof(read_data)))
+            return -EIO;
         unsigned int idrom_address = read_data & 0xffff;
         hm2_idrom_t idrom;
         memset(&idrom, 0, sizeof(idrom));
-        hm2_eth_read(&board->llio, idrom_address, &idrom, sizeof(idrom));
+        if (!hm2_eth_read(&board->llio, idrom_address, &idrom, sizeof(idrom)))
+            return -EIO;
 
         board->llio.num_ioport_connectors = idrom.io_ports;
         board->llio.pins_per_connector = idrom.port_width;

--- a/src/hal/drivers/mesa-hostmot2/hm2_eth.h
+++ b/src/hal/drivers/mesa-hostmot2/hm2_eth.h
@@ -28,6 +28,7 @@
 #define HM2_LLIO_NAME "hm2_eth"
 
 #define MAX_ETH_READS 64
+#define HM2_ETH_PACKET_SIZE 1400
 
 typedef struct {
     void *buffer;
@@ -57,13 +58,13 @@ struct hm2_eth_t {
     //Only for evl implementation
     bool is_evl_oob_active;
 
-    rtapi_u8 read_packet[1400];
+    rtapi_u8 read_packet[HM2_ETH_PACKET_SIZE];
     rtapi_u8 *read_packet_ptr;
     hm2_read_queue_entry_t queue_reads[MAX_ETH_READS];
     int queue_reads_count;
     int queue_buff_size;
 
-    rtapi_u8 write_packet[1400];
+    rtapi_u8 write_packet[HM2_ETH_PACKET_SIZE];
     rtapi_u8 *write_packet_ptr;
     uint32_t read_cnt, write_cnt;
     struct {

--- a/src/hal/drivers/mesa-hostmot2/inm.c
+++ b/src/hal/drivers/mesa-hostmot2/inm.c
@@ -419,11 +419,24 @@ void hm2_inm_force_write(hostmot2_t *hm2) {
     for (i = 0; i < hm2->inm.num_instances; i ++) {
         hm2_inm_instance_t *inst = &hm2->inm.instance[i];
         scanrate = inst->scanwidth * hal_get_ui32(inst->hal.param.scan_rate);
-	if (scanrate > 10000000) {
+        if (scanrate > 10000000) {
             scanrate = 10000000;
 	    hal_set_ui32(inst->hal.param.scan_rate, scanrate/inst->scanwidth);
         }
-        divisor = (hm2->inm.clock_frequency / (4 * scanrate)) - 1;
+        if (scanrate <= 0) {
+            divisor = 1023;
+            hal_set_ui32(inst->hal.param.scan_rate,
+                    (hm2->inm.clock_frequency / 4) / (divisor + 1)
+                    / inst->scanwidth);
+        } else {
+            divisor = (hm2->inm.clock_frequency / (4 * scanrate)) - 1;
+            if (divisor > 1023) {
+                divisor = 1023;
+                hal_set_ui32(inst->hal.param.scan_rate,
+                        (hm2->inm.clock_frequency / 4) / (divisor + 1)
+                        / inst->scanwidth);
+            }
+        }
         rtapi_u32 fast_scans = hal_get_ui32(inst->hal.param.fast_scans);
 	if (fast_scans > 63) {
             fast_scans = hal_set_ui32(inst->hal.param.fast_scans, 63);
@@ -472,13 +485,22 @@ void hm2_inm_write(hostmot2_t *hm2) {
 	    hal_set_ui32(inst->hal.param.scan_rate, scanrate/inst->scanwidth);
             HM2_ERR("inm %d scanrate too high, resetting to %d \n", i, hal_get_ui32(inst->hal.param.scan_rate));
         }
-        divisor = (hm2->inm.clock_frequency / (4 * scanrate)) - 1;
 //      bound divisor so we dont splatter into other fields
-	if ((divisor > 1023 ) | (scanrate == 0 )) {
+	if (scanrate <= 0) {
             divisor = 1023;
 	    hal_set_ui32(inst->hal.param.scan_rate, (hm2->inm.clock_frequency/4)/(divisor +1)
             /inst->scanwidth);
             HM2_ERR("inm %d scanrate too low, resetting to %d \n", i, hal_get_ui32(inst->hal.param.scan_rate));
+        } else {
+            divisor = (hm2->inm.clock_frequency / (4 * scanrate)) - 1;
+	    if (divisor > 1023) {
+                divisor = 1023;
+	        hal_set_ui32(inst->hal.param.scan_rate,
+                    (hm2->inm.clock_frequency/4)/(divisor +1)
+                    /inst->scanwidth);
+                HM2_ERR("inm %d scanrate too low, resetting to %d \n",
+                        i, hal_get_ui32(inst->hal.param.scan_rate));
+            }
         }
         rtapi_u32 fast_scans = hal_get_ui32(inst->hal.param.fast_scans);
 	if (fast_scans > 63) {
@@ -654,7 +676,6 @@ void hm2_inm_print_module(hostmot2_t *hm2) {
         HM2_PRINT("        mpg_reg = 0x%08X\n", hm2->inm.mpg_read_reg[i]);
     }
 }
-
 
 
 

--- a/src/hal/drivers/mesa-hostmot2/inmux.c
+++ b/src/hal/drivers/mesa-hostmot2/inmux.c
@@ -348,7 +348,20 @@ void hm2_inmux_force_write(hostmot2_t *hm2) {
             muxrate = 5000000;
 	    hal_set_ui32(inst->hal.param.scan_rate, muxrate/inst->scanwidth);
         }
-        divisor = (hm2->inmux.clock_frequency / (4 * muxrate)) - 1;
+        if (muxrate <= 0) {
+            divisor = 1023;
+            hal_set_ui32(inst->hal.param.scan_rate,
+                    (hm2->inmux.clock_frequency / 4) / (divisor + 1)
+                    / inst->scanwidth);
+        } else {
+            divisor = (hm2->inmux.clock_frequency / (4 * muxrate)) - 1;
+            if (divisor > 1023) {
+                divisor = 1023;
+                hal_set_ui32(inst->hal.param.scan_rate,
+                        (hm2->inmux.clock_frequency / 4) / (divisor + 1)
+                        / inst->scanwidth);
+            }
+        }
         rtapi_u32 fast_scans = hal_get_ui32(inst->hal.param.fast_scans);
 	if (fast_scans > 63) {
             fast_scans = hal_set_ui32(inst->hal.param.fast_scans, 63);
@@ -394,13 +407,22 @@ void hm2_inmux_write(hostmot2_t *hm2) {
 	    hal_set_ui32(inst->hal.param.scan_rate, muxrate/inst->scanwidth);
             HM2_ERR("InMux %d scanrate too high, resetting to %d \n", i, hal_get_ui32(inst->hal.param.scan_rate));
         }
-        divisor = (hm2->inmux.clock_frequency / (4 * muxrate)) - 1;
 //      bound divisor so we dont splatter into other fields
-	if ((divisor > 1023 ) | (muxrate == 0 )) {
+	if (muxrate <= 0) {
             divisor = 1023;
 	    hal_set_ui32(inst->hal.param.scan_rate,
                 (hm2->inmux.clock_frequency/4) / (divisor +1) / inst->scanwidth);
             HM2_ERR("InMux %d scanrate too low, resetting to %d \n", i, hal_get_ui32(inst->hal.param.scan_rate));
+        } else {
+            divisor = (hm2->inmux.clock_frequency / (4 * muxrate)) - 1;
+	    if (divisor > 1023) {
+                divisor = 1023;
+	        hal_set_ui32(inst->hal.param.scan_rate,
+                    (hm2->inmux.clock_frequency/4) / (divisor +1)
+                    / inst->scanwidth);
+                HM2_ERR("InMux %d scanrate too low, resetting to %d \n",
+                        i, hal_get_ui32(inst->hal.param.scan_rate));
+            }
         }
         rtapi_u32 fast_scans = hal_get_ui32(inst->hal.param.fast_scans);
 	if (fast_scans > 63) {
@@ -552,7 +574,6 @@ void hm2_inmux_print_module(hostmot2_t *hm2) {
         HM2_PRINT("        mpg_reg = 0x%08X\n", hm2->inmux.mpg_read_reg[i]);
     }
 }
-
 
 
 

--- a/src/hal/drivers/mesa-hostmot2/pins.c
+++ b/src/hal/drivers/mesa-hostmot2/pins.c
@@ -769,7 +769,7 @@ int hm2_read_pin_descriptors(hostmot2_t *hm2) {
         
         if (pin->port_num >= hm2->llio->num_ioport_connectors) {
             HM2_ERR("hm2_read_pin_descriptors: Calculated port number (%d) is "
-                    "invalid\n", pin->port_pin );
+                    "invalid\n", pin->port_num );
             return -EINVAL;
         }
         
@@ -894,7 +894,9 @@ void hm2_print_pin_usage(hostmot2_t *hm2) {
 
         char connector_pin_name[100];
 
-        if (hm2->llio->io_connector_pin_names == NULL) {
+        if (hm2->llio->io_connector_pin_names == NULL
+                || (unsigned)i >= (hm2->llio->num_ioport_connectors
+                    * hm2->llio->pins_per_connector)) {
             snprintf(connector_pin_name, sizeof(connector_pin_name), "%s-%02d", hm2->llio->ioport_connector_name[pin->port_num], pin->port_pin);
         } else {
             if (hm2->llio->io_connector_pin_names[i] == NULL) {

--- a/src/hal/drivers/mesa-hostmot2/pktuart.c
+++ b/src/hal/drivers/mesa-hostmot2/pktuart.c
@@ -871,7 +871,7 @@ int hm2_pktuart_queue_get_frame_sizes(const char *name, rtapi_u32 fsizes[])
 			HM2_ERR("Unable to queue Rx FIFO count read %d of %d (error %d))\n", j, nfs, r);
 		}
 	}
-	return j - 1;
+	return j;
 }
 EXPORT_SYMBOL_GPL(hm2_pktuart_queue_get_frame_sizes);
 
@@ -915,7 +915,7 @@ int hm2_pktuart_queue_read_data(const char *name, rtapi_u32 data[], int bytes)
 			HM2_ERR("Unable to queue Rx FIFO read %d of %d (error %d)\n", i, nrx, r);
 		}
 	}
-	return i - 1;
+	return i;
 }
 EXPORT_SYMBOL_GPL(hm2_pktuart_queue_read_data);
 

--- a/src/hal/drivers/mesa-hostmot2/pktuart.c
+++ b/src/hal/drivers/mesa-hostmot2/pktuart.c
@@ -129,7 +129,8 @@ int hm2_pktuart_parse_md(hostmot2_t *hm2, int md_index)
 		// For the time being we assume that all PktUARTS come on pairs
 		if(inst->clock_freq == 0) {
 			inst->clock_freq = md->clock_freq;
-			r = rtapi_snprintf(inst->name, sizeof(inst->name), "%s.pktuart.%01d", hm2->llio->name, i);
+			rtapi_snprintf(inst->name, sizeof(inst->name),
+					"%s.pktuart.%01d", hm2->llio->name, i);
 			HM2_PRINT("created PktUART Interface function %s.\n", inst->name);
 		}
 		if(md->gtag == HM2_GTAG_PKTUART_TX) {
@@ -613,7 +614,10 @@ int hm2_pktuart_send(const char *name, const unsigned char data[], rtapi_u8 *num
 	for(unsigned i = 0; i < nframes; i++) {
 		count += frame_sizes[i];
 		while(c < count - 3) {
-			rtapi_u32 buff = data[c] + (data[c+1] << 8) + (data[c+2] << 16) + (data[c+3] << 24);
+			rtapi_u32 buff = ((rtapi_u32)data[c]
+					| ((rtapi_u32)data[c+1] << 8)
+					| ((rtapi_u32)data[c+2] << 16)
+					| ((rtapi_u32)data[c+3] << 24));
 			r = hm2->llio->queue_write(hm2->llio, hm2->pktuart.instance[inst].tx_addr, &buff, sizeof(buff));
 			if(r < 0) {
 				HM2_ERR("%s send: hm2->llio->queue_write failure\n", name);
@@ -627,8 +631,15 @@ int hm2_pktuart_send(const char *name, const unsigned char data[], rtapi_u8 *num
 			rtapi_u32 buff;
 			switch(count - c) {
 			case 1: buff = data[c]; break;
-			case 2: buff = (data[c] + (data[c+1] << 8)); break;
-			case 3: buff = (data[c] + (data[c+1] << 8) + (data[c+2] << 16)); break;
+			case 2:
+				buff = ((rtapi_u32)data[c]
+						| ((rtapi_u32)data[c+1] << 8));
+				break;
+			case 3:
+				buff = ((rtapi_u32)data[c]
+						| ((rtapi_u32)data[c+1] << 8)
+						| ((rtapi_u32)data[c+2] << 16));
+				break;
 			default:
 				HM2_ERR("%s send error in buffer parsing: count = %i, i = %i\n", name, count, c);
 				return -1;
@@ -806,8 +817,8 @@ int hm2_pktuart_read(const char *name, unsigned char data[], rtapi_u8 *num_frame
 		if(countb - c) {
 			r = hm2->llio->read(hm2->llio, hm2->pktuart.instance[inst].rx_addr, &buff, sizeof(buff));
 			if(r < 0) {
-				HM2_ERR("%s read: hm2->llio->queue_write failure\n", name);
-				return -1;
+				HM2_ERR("%s read: hm2->llio->read failure\n", name);
+				return r;
 			}
 			switch(countb - c) {
 			case 1:

--- a/src/hal/drivers/mesa-hostmot2/resolver.c
+++ b/src/hal/drivers/mesa-hostmot2/resolver.c
@@ -283,6 +283,12 @@ void hm2_resolver_process_tram_read(hostmot2_t *hm2, long period) {
     for (i = 0; i < hm2->resolver.num_resolvers; i ++) {
         
         res = &hm2->resolver.instance[i];
+        rtapi_u32 index_div = hal_get_ui32(res->hal.param.index_div);
+
+        if (index_div == 0) {
+            HM2_ERR("resolver.%02d.index-div == 0, bogus, setting to 1\n", i);
+            index_div = hal_set_ui32(res->hal.param.index_div, 1);
+        }
         
         scale = hal_get_real(res->hal.param.scale);
         
@@ -326,7 +332,6 @@ void hm2_resolver_process_tram_read(hostmot2_t *hm2, long period) {
         if ((res->old_reg > hm2->resolver.position_reg[i]) && (res->old_reg - hm2->resolver.position_reg[i] > 0x80000000)){
             res->index_cnts++;
             if (hal_get_bool(res->hal.pin.index_enable)){
-                rtapi_u32 index_div = hal_get_ui32(res->hal.param.index_div);
                 int r = (res->index_cnts % index_div);
                 if ((index_div  > 1 && r == 1) 
                  || (index_div == 1 && r == 0)){
@@ -337,7 +342,8 @@ void hm2_resolver_process_tram_read(hostmot2_t *hm2, long period) {
         }
         else if ((res->old_reg < hm2->resolver.position_reg[i]) && (hm2->resolver.position_reg[i] - res->old_reg > 0x80000000)){
             res->index_cnts--;
-            if (hal_get_bool(res->hal.pin.index_enable) && (res->index_cnts % hal_get_ui32(res->hal.param.index_div) == 0)){
+            if (hal_get_bool(res->hal.pin.index_enable)
+                    && (res->index_cnts % index_div == 0)){
                 res->offset = (res->accum - hm2->resolver.position_reg[i] + 0x100000000LL);
                 hal_set_bool(res->hal.pin.index_enable, 0);
             }
@@ -463,4 +469,3 @@ void hm2_resolver_print_module(hostmot2_t *hm2) {
                   (hm2->resolver.velocity_reg[i]));
     }
 }
-

--- a/src/hal/drivers/mesa-hostmot2/setsserial.c
+++ b/src/hal/drivers/mesa-hostmot2/setsserial.c
@@ -176,7 +176,7 @@ int sslbp_read_cookie(void){
     return res;
 }
 
-rtapi_u8 sslbp_read_byte(rtapi_u32 addr){
+int sslbp_read_byte(rtapi_u32 addr){
     rtapi_u32 buff = READ_REM_BYTE_CMD + addr;
     rtapi_u32 res;
     HM2WRITE(remote->reg_cs_addr, buff);
@@ -303,6 +303,7 @@ int sslbp_flash(char *fname){
     struct rtapi_device dev;
     int r;
     unsigned write_sz, erase_sz;
+    int write_exp, erase_exp;
     
     if (strstr("8i20", remote->name)){
         if (hm2->sserial.version < 37){
@@ -348,8 +349,17 @@ int sslbp_flash(char *fname){
     
     if (setup_start() < 0) goto fail0;
     flash_start();
-    write_sz = 1u << sslbp_read_byte(LBPFLASHWRITESIZELOC);
-    erase_sz = 1u << sslbp_read_byte(LBPFLASHERASESIZELOC);
+    write_exp = sslbp_read_byte(LBPFLASHWRITESIZELOC);
+    erase_exp = sslbp_read_byte(LBPFLASHERASESIZELOC);
+    if (write_exp < 3 || write_exp >= (int)(sizeof(write_sz) * 8)
+            || erase_exp < 0 || erase_exp < write_exp
+            || erase_exp >= (int)(sizeof(erase_sz) * 8)) {
+        HM2_ERR("Invalid flash geometry exponents write=%d erase=%d\n",
+                write_exp, erase_exp);
+        goto fail0;
+    }
+    write_sz = 1u << write_exp;
+    erase_sz = 1u << erase_exp;
     HM2_PRINT("Write Size = %x, Erase Size = %x\n", write_sz, erase_sz);
     flash_stop();
     
@@ -412,6 +422,7 @@ int sslbp_flash(char *fname){
     
 fail0:
     flash_stop();
+    rtapi_release_firmware(fw);
     return -1;
 }
 
@@ -494,7 +505,5 @@ void rtapi_app_exit(void)
 {
     hal_exit(comp_id);
 }
-
-
 
 

--- a/src/hal/drivers/mesa-hostmot2/spix_rpi3.c
+++ b/src/hal/drivers/mesa-hostmot2/spix_rpi3.c
@@ -850,8 +850,8 @@ static const spix_port_t *rpi3_open(int port, const spix_args_t *args)
 	if(!rpp->spiport) {
 		rpp->clkdivw = spi0_clkdiv_calc(spiclk_base, args->clkw);
 		rpp->clkdivr = spi0_clkdiv_calc(spiclk_base, args->clkr);
-		ccw = spiclk_base / rpp->clkdivw;
-		ccr = spiclk_base / rpp->clkdivr;
+		ccw = spiclk_base / (rpp->clkdivw ? rpp->clkdivw : 65536);
+		ccr = spiclk_base / (rpp->clkdivr ? rpp->clkdivr : 65536);
 	} else {
 		rpp->clkdivw = spi1_clkdiv_calc(spiclk_base, args->clkw);
 		rpp->clkdivr = spi1_clkdiv_calc(spiclk_base, args->clkr);

--- a/src/hal/drivers/mesa-hostmot2/sserial.c
+++ b/src/hal/drivers/mesa-hostmot2/sserial.c
@@ -28,10 +28,7 @@
 
 #include "hostmot2.h"
 
-// Local definition of labs() because RTAI compile barfs on using labs(). It
-// could be optimized using compiler built-ins, but the single use in here is
-// not critical.
-static inline rtapi_s64 xlabs(rtapi_s64 x) { return x < 0 ? -x : x; }
+
 
 int getbits(hm2_sserial_remote_t *chan, rtapi_u64 *val, int start, int len){
     //load the bits from the registers in to bit 0+ of *val
@@ -308,6 +305,9 @@ int hm2_sserial_get_bytes(hostmot2_t *hm2,
 
         *(ptr++) = (unsigned char)data;
     }
+    if (string < 0) {
+        *ptr = '\0';
+    }
     return addr;
 }
 
@@ -426,8 +426,6 @@ int hm2_sserial_create_params(hostmot2_t *hm2, hm2_sserial_remote_t *chan){
     for (i = 0 ; i < chan->num_globals ; i++){
         global = chan->globals[i];
 
-        r = 0;
-
         hal_dir = (global.DataDir == LBP_IN) ? HAL_RO : HAL_RW;
 
         chan->params[i].type = global.DataType;
@@ -519,22 +517,24 @@ int hm2_sserial_get_globals_list(hostmot2_t *hm2, hm2_sserial_remote_t *chan){
                 return -EINVAL;
             }
             // process is a subset of global. The only way to tell is to compare
-            for (i = 0; i <= chan->num_confs ; i ++) {
-                if (chan->confs[i].ParmAddr == data.ParmAddr){i = 1000;}
+            for (i = 0; i < chan->num_confs ; i ++) {
+                if (chan->confs[i].ParmAddr == data.ParmAddr) break;
             }
-            if (data.RecordType == LBP_DATA && i < 1000) {
+            if (data.RecordType == LBP_DATA && i == chan->num_confs) {
+                hm2_sserial_data_t *globals;
+
                 addr = hm2_sserial_get_bytes(hm2, chan, &(data.UnitString), addr, -1);
                 if (addr < 0){ return -EINVAL;}
                 addr = hm2_sserial_get_bytes(hm2, chan, &(data.NameString), addr, -1);
                 if (addr < 0){ return -EINVAL;}
                 HM2_DBG("Global: %s  RecordType: %02X Datatype: %02X Dir: %02X Addr: %04X Length: %i\n",
                            data.NameString, data.RecordType, data.DataType, data.DataDir, data.ParmAddr, data.DataLength);
-                chan->num_globals++;
-                chan->globals = (hm2_sserial_data_t *)
-                         rtapi_krealloc(chan->globals,
-                         chan->num_globals * sizeof(hm2_sserial_data_t),
+                globals = rtapi_krealloc(chan->globals,
+                         (chan->num_globals + 1) * sizeof(*globals),
                          RTAPI_GFP_KERNEL);
-                chan->globals[chan->num_globals - 1] = data;
+                if (globals == NULL) return -ENOMEM;
+                chan->globals = globals;
+                chan->globals[chan->num_globals++] = data;
             }
             else if (data.RecordType== LBP_MODE){
                 char * type;
@@ -637,6 +637,8 @@ int hm2_sserial_parse_md(hostmot2_t *hm2, int md_index){
         r = -ENOMEM;
         goto fail0;
     }
+    memset(hm2->sserial.instance, 0,
+           hm2->sserial.num_instances * sizeof(*hm2->sserial.instance));
     // We can't create the pins until we know what is on each channel, and
     // can't communicate until the pin directions are set up.
 
@@ -673,6 +675,10 @@ int hm2_sserial_parse_md(hostmot2_t *hm2, int md_index){
 
     // Now iterate through the sserial instances, seeing what is on the enabled pins.
     for (i = 0 ; i < md->instances ; i++) {
+        // Keep probing physical ports until the configured number of populated
+        // ports has been found.  Empty lower-numbered ports do not consume an
+        // entry in the compact instance array.
+        if (count >= hm2->sserial.num_instances) break;
         hm2_sserial_instance_t *inst = &hm2->sserial.instance[count];
         inst->index = i;
         inst->num_channels = chan_counts[i];
@@ -810,9 +816,8 @@ int hm2_sserial_parse_md(hostmot2_t *hm2, int md_index){
                 HM2_ERR("Failed to restart device %i on instance\n",
                         inst->device_id);
                 goto fail0;}
-            if ((r = hm2_sserial_check_local_errors(hm2, inst)) < 0) {
-                //goto fail0; // Ignore it for the moment.
-            }
+            // Ignore startup errors here; the realtime path tracks them.
+            (void)hm2_sserial_check_local_errors(hm2, inst);
             //only increment the instance index if this one is populated
             //otherwise the "slot" is re-used to keep active ports
             //contiguous in the array
@@ -1038,7 +1043,6 @@ int hm2_sserial_read_configs(hostmot2_t *hm2,  hm2_sserial_remote_t *chan){
     ptoc=(buff & 0xffff);
     if (ptoc == 0) {return chan->num_confs;} // Old 8i20 or 7i64
 
-    c = m = 0;
     chan->num_confs = 0;
     do {
         addr = 0;
@@ -1049,11 +1053,12 @@ int hm2_sserial_read_configs(hostmot2_t *hm2,  hm2_sserial_remote_t *chan){
         }
 
         if (rectype == LBP_DATA) {
+            hm2_sserial_data_t *confs = rtapi_krealloc(chan->confs,
+                    (chan->num_confs + 1) * sizeof(*confs),
+                    RTAPI_GFP_KERNEL);
+            if (confs == NULL) return -ENOMEM;
+            chan->confs = confs;
             c = chan->num_confs++;
-            chan->confs = (hm2_sserial_data_t *)
-                            rtapi_krealloc(chan->confs,
-                                    chan->num_confs * sizeof(hm2_sserial_data_t),
-                                    RTAPI_GFP_KERNEL);
             addr = hm2_sserial_get_bytes(hm2, chan, &chan->confs[c], addr, 14);
             if (addr < 0){ return -EINVAL;}
             addr = hm2_sserial_get_bytes(hm2, chan,
@@ -1076,12 +1081,12 @@ int hm2_sserial_read_configs(hostmot2_t *hm2,  hm2_sserial_remote_t *chan){
             HM2_DBG("Process: %s  RecordType: %02X Datatype: %02X Dir: %02X Addr: %04X Length: %i\n",
                            chan->confs[c].NameString, chan->confs[c].RecordType,chan->confs[c].DataType, chan->confs[c].DataDir, chan->confs[c].ParmAddr, chan->confs[c].DataLength);
         } else if (rectype == LBP_MODE ) {
-            chan->num_modes++;
-            m = chan->num_modes - 1;
-            chan->modes = (hm2_sserial_mode_t *)
-                            rtapi_krealloc(chan->modes,
-                                     chan->num_modes * sizeof(hm2_sserial_mode_t),
-                                     RTAPI_GFP_KERNEL);
+            hm2_sserial_mode_t *modes = rtapi_krealloc(chan->modes,
+                    (chan->num_modes + 1) * sizeof(*modes),
+                    RTAPI_GFP_KERNEL);
+            if (modes == NULL) return -ENOMEM;
+            chan->modes = modes;
+            m = chan->num_modes++;
             addr = hm2_sserial_get_bytes(hm2, chan, &chan->modes[m], addr, 4);
             if (addr < 0){ return -EINVAL;}
             addr = hm2_sserial_get_bytes(hm2, chan,
@@ -1367,11 +1372,9 @@ fail1:
 
  int hm2_sserial_update_params(hostmot2_t *hm2, hm2_sserial_instance_t *inst, long period){
     // init this here to silence a compiler warning
-    hm2_sserial_remote_t *r = &(inst->remotes[0]);
+    hm2_sserial_remote_t *r;
     hm2_sserial_params_t *p;
     hm2_sserial_data_t   *g;
-    int shift; // used for floating point comparisons
-
     switch (hal_get_ui32(inst->state2)){
         case 0: // init loop counters
             inst->r_index = 0;
@@ -1408,26 +1411,25 @@ fail1:
                             return hal_set_ui32(inst->state2, 2); // increment indices
                         case LBP_FLOAT:
                         case LBP_NONVOL_FLOAT:
-                            // comparing floats that might have different sizes is not trivial
-                            // this does a bitwise comparison of as many mantissa bits as might
-                            // be expected to have been sent by the sserial remote
+                            // Parameter read/write supports IEEE binary32 and
+                            // binary64 only; 8/16-bit float formats are not
+                            // decoded by hm2_sserial_get_param_value().
                             switch (g->DataLength){
-                                // ( double significand - variable type significand)
-                                default:
-                                HM2_ERR("Non IEEE float type parameter of length %i\n", g->DataLength);
-                                /* Fallthrough */
-                                case 8:
-                                    shift = (52 -  4); break; // 1.3.4 minifloat, if we ever add them
-                                case 16:
-                                    shift = (52 - 10); break;
                                 case 32:
-                                    shift = (52 - 23); break;
+                                    if ((float)hal_get_real(p->param.r)
+                                            != (float)p->float_written) break;
+                                    return hal_set_ui32(inst->state2, 2);
                                 case 64:
-                                    shift = 0;
-                                }
-                            // FIXME: This overlayed s64 read is very wrong!
-                            if (xlabs((hal_get_sint(p->param.s) - p->s64_written) >> shift) > 2) break;
-                            return hal_set_ui32(inst->state2, 2); // increment indices
+                                    if (hal_get_real(p->param.r)
+                                            != p->float_written) break;
+                                    return hal_set_ui32(inst->state2, 2);
+                                default:
+                                    HM2_ERR("Non IEEE float type parameter of length %i\n",
+                                            g->DataLength);
+                                    p->type = LBP_PAD; // warn once, then ignore
+                                    return hal_set_ui32(inst->state2, 2);
+                            }
+                            break;
                         default:
                             return hal_set_ui32(inst->state2, 2); // increment indices
                         }
@@ -1436,7 +1438,7 @@ fail1:
                     inst->timer = 20000000;
                     *inst->command_reg_write = 0x800; // stop all
                     break;
-                 case 1:
+                case 1:
                     ret = hm2_sserial_wait(hm2, inst, period);
                     if (ret > 0) break;
                     // FIXME: Assigns 100 to state3 and then unconditionally assigns 2
@@ -1644,7 +1646,8 @@ void hm2_sserial_write_pins(hostmot2_t *hm2, hm2_sserial_instance_t *inst){
                     "if this is happening frequently.\n",
                     inst->index, hm2->llio->name, inst->index);
         }
-        fault_count = hal_set_ui32(inst->fault_count, fault_count + hal_get_ui32(inst->fault_inc));
+        hal_set_ui32(inst->fault_count,
+                     fault_count + hal_get_ui32(inst->fault_inc));
         *inst->command_reg_write = 0x80000000; // set bit31 for ignored cmd
         return; // give the register chance to clear
     }
@@ -1653,11 +1656,12 @@ void hm2_sserial_write_pins(hostmot2_t *hm2, hm2_sserial_instance_t *inst){
     }
 
     if (fault_count > hal_get_ui32(inst->fault_dec)) {
-        fault_count = hal_set_ui32(inst->fault_count, fault_count - hal_get_ui32(inst->fault_dec));
+        hal_set_ui32(inst->fault_count,
+                     fault_count - hal_get_ui32(inst->fault_dec));
     }
     else
     {
-        fault_count = hal_set_ui32(inst->fault_count, 0);
+        hal_set_ui32(inst->fault_count, 0);
     }
 
     // All seems well, handle the pins.
@@ -1675,6 +1679,7 @@ void hm2_sserial_write_pins(hostmot2_t *hm2, hm2_sserial_instance_t *inst){
             hm2_sserial_data_t *conf = &chan->confs[p];
             hm2_sserial_pins_t *pin = &chan->pins[p];
             if (conf->DataDir & 0xC0){
+                buff = 0;
                 switch (conf->DataType){
                     case LBP_PAD:
                         // do nothing
@@ -2145,24 +2150,37 @@ void hm2_sserial_force_write(hostmot2_t *hm2){
 void hm2_sserial_cleanup(hostmot2_t *hm2){
     int i,r;
     rtapi_u32 buff;
-    for (i = 1 ; i < hm2->sserial.num_instances; i++){
+    if (hm2->sserial.instance == NULL) return;
+
+    for (i = 0 ; i < hm2->sserial.num_instances; i++){
         //Shut down the sserial devices rather than leave that to the watchdog.
-        buff = 0x800;
-        hm2->llio->write(hm2->llio,
-                         hm2->sserial.instance[i].command_reg_addr,
-                         &buff,
-                         sizeof(rtapi_u32));
+        if (hm2->sserial.instance[i].command_reg_addr != 0) {
+            buff = 0x800;
+            hm2->llio->write(hm2->llio,
+                             hm2->sserial.instance[i].command_reg_addr,
+                             &buff,
+                             sizeof(rtapi_u32));
+        }
         if (hm2->sserial.instance[i].remotes != NULL){
             for (r = 0 ; r < hm2->sserial.instance[i].num_remotes; r++){
-                if (hm2->sserial.instance[i].remotes[r].num_confs > 0){
-                    rtapi_kfree(hm2->sserial.instance[i].remotes[r].confs);
-                };
-                if (hm2->sserial.instance[i].remotes[r].num_modes > 0){
-                    rtapi_kfree(hm2->sserial.instance[i].remotes[r].modes);
-                }
+                hm2_sserial_remote_t *remote =
+                    &hm2->sserial.instance[i].remotes[r];
+
+                rtapi_kfree(remote->confs);
+                remote->confs = NULL;
+                remote->num_confs = 0;
+                rtapi_kfree(remote->modes);
+                remote->modes = NULL;
+                remote->num_modes = 0;
+                rtapi_kfree(remote->globals);
+                remote->globals = NULL;
+                remote->num_globals = 0;
             }
             rtapi_kfree(hm2->sserial.instance[i].remotes);
+            hm2->sserial.instance[i].remotes = NULL;
         }
+        hm2->sserial.instance[i].num_remotes = 0;
 
     }
+    hm2->sserial.num_instances = 0;
 }

--- a/src/hal/drivers/mesa-hostmot2/tp_pwmgen.c
+++ b/src/hal/drivers/mesa-hostmot2/tp_pwmgen.c
@@ -443,9 +443,9 @@ void hm2_tp_pwmgen_prepare_tram_write(hostmot2_t *hm2) {
         if (scaled_Avalue > 1.0) scaled_Avalue = 1.0;
         else if (scaled_Avalue < -1.0) scaled_Avalue = -1.0;
         if (scaled_Bvalue > 1.0) scaled_Bvalue = 1.0;
-        else if (scaled_Avalue < -1.0) scaled_Avalue = -1.0;
+        else if (scaled_Bvalue < -1.0) scaled_Bvalue = -1.0;
         if (scaled_Cvalue > 1.0) scaled_Cvalue = 1.0;
-        else if (scaled_Avalue < -1.0) scaled_Avalue = -1.0;
+        else if (scaled_Cvalue < -1.0) scaled_Cvalue = -1.0;
 
         // duty_cycle goes from 0.0 to 1.0, and needs to be puffed out to 10 bits
 

--- a/src/hal/drivers/mesa-hostmot2/uart.c
+++ b/src/hal/drivers/mesa-hostmot2/uart.c
@@ -189,25 +189,28 @@ int hm2_uart_send(char *name,  unsigned char data[], int count)
     static int err_flag = 0;
     
     inst = hm2_get_uart(&hm2, name);
-    if (inst < 0 && !err_flag){
-        HM2_ERR_NO_LL("Can not find UART instance %s.\n", name);
+    if (inst < 0){
+        if (!err_flag)
+            HM2_ERR_NO_LL("Can not find UART instance %s.\n", name);
         err_flag = 1;
-        return -1;
+        return -ENODEV;
     }
-    if (hm2->uart.instance[inst].bitrate == 0 && !err_flag){
-        HM2_ERR("The selected UART instance %s.\n" 
-                "Has not been configured.\n", name);
+    if (hm2->uart.instance[inst].bitrate == 0){
+        if (!err_flag)
+            HM2_ERR("The selected UART instance %s.\n"
+                    "Has not been configured.\n", name);
         err_flag = 1; // don't fill dmesg with junk. 
-        return -1;
+        return -EINVAL;
     }
+    if (count < 0) return -EINVAL;
     
     c = 0;
     err_flag = 0;
     while (c < count - 3){
-        buff = (data[c] + 
-                (data[c+1] << 8) +
-                (data[c+2] << 16) +
-                (data[c+3] << 24));
+        buff = ((rtapi_u32)data[c]
+                | ((rtapi_u32)data[c+1] << 8)
+                | ((rtapi_u32)data[c+2] << 16)
+                | ((rtapi_u32)data[c+3] << 24));
         r = hm2->llio->write(hm2->llio, hm2->uart.instance[inst].tx4_addr,
                              &buff, sizeof(rtapi_u32));
         if (r < 0) {
@@ -230,8 +233,8 @@ int hm2_uart_send(char *name,  unsigned char data[], int count)
                 return c + 1;
             }
         case 2:
-            buff = (data[c] + 
-                    (data[c+1] << 8));
+            buff = ((rtapi_u32)data[c]
+                    | ((rtapi_u32)data[c+1] << 8));
             r = hm2->llio->write(hm2->llio, hm2->uart.instance[inst].tx2_addr,
                                  &buff, sizeof(rtapi_u32));
             if (r < 0){
@@ -241,9 +244,9 @@ int hm2_uart_send(char *name,  unsigned char data[], int count)
                 return c + 2;
             }
         case 3:
-            buff = (data[c] + 
-                    (data[c+1] << 8) +
-                    (data[c+2] << 16));
+            buff = ((rtapi_u32)data[c]
+                    | ((rtapi_u32)data[c+1] << 8)
+                    | ((rtapi_u32)data[c+2] << 16));
             r = hm2->llio->write(hm2->llio, hm2->uart.instance[inst].tx3_addr,
                                  &buff, sizeof(rtapi_u32));
             if (r < 0){
@@ -286,7 +289,6 @@ int hm2_uart_read(char *name, unsigned char data[])
     
     r = hm2->llio->read(hm2->llio, hm2->uart.instance[inst].rx_fifo_count_addr,
                         &buff, sizeof(rtapi_u32));
-    
     count = buff & 0x1F; 
     c = 0;
     while (c < count - 3 && c < 16){
@@ -370,4 +372,3 @@ void hm2_uart_write(hostmot2_t *hm2)
 {
     (void)hm2;
 }
-


### PR DESCRIPTION
Hello! This PR fixes some subtle safety and correctness bugs in the hostmot2 HAL drivers.

A few things this cleans up:
- Hardened socket send/receive checks in `hm2_eth` to ensure packet sizes match exactly, and added some bounds checking to prevent overflows.
- Plugged a firmware memory leak on failure in `setsserial.c` and made `krealloc` pointer handling safer across the board.
- Fixed some integer overflows when bit-shifting in `pktuart.c`.
- Fixed a copy-paste bug in the Three-Phase PWM config (`tp_pwmgen.c`) and an off-by-one bug in `hm2_sserial_cleanup`.

Please let me know if you have any feedback or see any issues with these fixes!