### PR TITLE
hostmot2: Fix the (superseded) SPI driver's low-level IO return values

### DIFF
--- a/src/hal/drivers/mesa-hostmot2/hm2_rpspi.c
+++ b/src/hal/drivers/mesa-hostmot2/hm2_rpspi.c
@@ -333,7 +333,7 @@ static int hm2_rpspi_write_spi1(hm2_lowlevel_io_t *llio, uint32_t addr, const vo
 	if(size == 0)
 		return 0;
 	if((size % 4) || size / 4 >= RPSPI_MAX_MSG)
-		return -EINVAL;
+		return 0; // -EINVAL
 
 	gpio_debug_pin(false);
 
@@ -398,7 +398,7 @@ static int hm2_rpspi_read_spi1(hm2_lowlevel_io_t *llio, uint32_t addr, void *buf
 	if(size == 0)
 		return 0;
 	if((size % 4) || size / 4 >= RPSPI_MAX_MSG)
-		return -EINVAL;
+		return 0; // -EINVAL
 
 	gpio_debug_pin(false);
 
@@ -519,7 +519,7 @@ static int hm2_rpspi_write_spi0(hm2_lowlevel_io_t *llio, uint32_t addr, const vo
 	if(size == 0)
 		return 0;
 	if((size % 4) || size / 4 >= RPSPI_MAX_MSG)
-		return -EINVAL;
+		return 0; // -EINVAL
 
 	gpio_debug_pin(false);
 
@@ -586,7 +586,7 @@ static int hm2_rpspi_read_spi0(hm2_lowlevel_io_t *llio, uint32_t addr, void *buf
 	if(size == 0)
 		return 0;
 	if((size % 4) || size / 4 >= RPSPI_MAX_MSG)
-		return -EINVAL;
+		return 0; // -EINVAL
 
 	gpio_debug_pin(false);
 
@@ -825,7 +825,7 @@ static int probe_board(hm2_rpspi_t *board) {
 
 	// Read the IDROM from the board. The IDROM address offset was returned in
 	// the cookie check.
-	if(board->llio.read(&board->llio, (uint32_t)ret, &idrom, sizeof(hm2_idrom_t)) <= 0) {
+	if(!board->llio.read(&board->llio, (uint32_t)ret, &idrom, sizeof(hm2_idrom_t))) {
 		rtapi_print_msg(RPSPI_ERR, "hm2_rpspi: SPI%d/CE%d Board ident read failed\n", board->spidevid, board->spiceid);
 		return -EIO;	// Cookie could be read, so this is a comms error
 	}

--- a/src/hal/drivers/mesa-hostmot2/hm2_spi.c
+++ b/src/hal/drivers/mesa-hostmot2/hm2_spi.c
@@ -144,12 +144,12 @@ static int send_queued_writes(hm2_lowlevel_io_t *llio) {
 static int queue_write(hm2_lowlevel_io_t *llio, rtapi_u32 addr, const void *buffer, int size) {
     hm2_spi_t *this = (hm2_spi_t*) llio;
     if(size == 0) return 0;
-    if(size % 4) return -EINVAL;
+    if(size % 4) return 0; // -EINVAL
 
     int wsize = size / 4;
     if(wsize + this->nbuf + 1 > MAX_TRX) {
         int r = do_pending(this);
-        if(r < 0) return r;
+        if(r < 0) return 0;
     }
 
     PUT(write_command(addr, wsize), NULL);
@@ -170,12 +170,12 @@ static int send_queued_reads(hm2_lowlevel_io_t *llio) {
 static int queue_read(hm2_lowlevel_io_t *llio, rtapi_u32 addr, void *buffer, int size) {
     hm2_spi_t *this = (hm2_spi_t*) llio;
     if(size == 0) return 0;
-    if(size % 4) return -EINVAL;
+    if(size % 4) return 0; // -EINVAL
 
     int wsize = size / 4;
     if(wsize + this->nbuf + 1 > MAX_TRX) {
         int r = do_pending(this);
-        if(r < 0) return r;
+        if(r < 0) return 0;
     }
 
     uint32_t *wbuffer = buffer;
@@ -190,15 +190,15 @@ static int queue_read(hm2_lowlevel_io_t *llio, rtapi_u32 addr, void *buffer, int
 static int do_write(hm2_lowlevel_io_t *llio, rtapi_u32 addr, const void *buffer, int size) {
     hm2_spi_t *this = (hm2_spi_t*) llio;
     int r = queue_write(llio, addr, buffer, size);
-    if(r < 0) return r;
+    if(!r) return 0;
     return do_pending(this) >= 0;
 }
 
 static int do_read(hm2_lowlevel_io_t *llio, rtapi_u32 addr, void *buffer, int size) {
     hm2_spi_t *this = (hm2_spi_t*) llio;
     int r = queue_read(llio, addr, buffer, size);
-    if(r < 0) return r;
-    return do_pending(this);
+    if(!r) return 0;
+    return do_pending(this) >= 0;
 }
 
 static int spidev_set_lsb_first(int fd, uint8_t lsb_first) {
@@ -260,7 +260,7 @@ static int check_cookie(hm2_spi_t *board) {
     uint32_t cookie[4];
     uint32_t xcookie[4] = {0x55aacafe, 0x54534f48, 0x32544f4d, 0x00000400};
     int r = do_read(&board->llio, 0x100, cookie, 16);
-    if(r < 0) return -errno;
+    if(!r) return -EIO;
 
     if(memcmp(cookie, xcookie, sizeof(cookie))) {
         rtapi_print_msg(RTAPI_MSG_ERR, "Invalid cookie\n");
@@ -290,7 +290,7 @@ static int probe(char *dev, int rate) {
 
     // Read the IDROM from the board.
     hm2_idrom_t idrom;
-    if(do_read(&board->llio, 0x400, &idrom, sizeof(hm2_idrom_t)) <= 0) {
+    if(!do_read(&board->llio, 0x400, &idrom, sizeof(hm2_idrom_t))) {
         rtapi_print_msg(RTAPI_MSG_ERR, "Board ident read failed (dev=%s)\n", dev);
         r = -EIO; // Cookie could be read, so this is a comms error
         goto fail;


### PR DESCRIPTION
The old and superseded SPI drivers for `hm2_rpspi` and `hm2_spi` did not return the correct low-level IO read/write return value. Even for these superseded drivers, as long as they are there, they should do the correct thing.

Note: for anyone using these old superseded drivers: you should be using `hm2_spix` instead.