### PR TITLE
tests: Update all components in tests to getter/setter

### DIFF
--- a/tests/halcompile/extralib/extralib_test.comp
+++ b/tests/halcompile/extralib/extralib_test.comp
@@ -1,6 +1,6 @@
 component extralib_test;
-pin in float theta;
-pin out float sin_;
+pin in real theta;
+pin out real sin_;
 license "GPL";
 option userspace;
 option extra_link_args "-lm";
@@ -8,6 +8,6 @@ option extra_link_args "-lm";
 #include <math.h>
 void user_mainloop(void) {
     while(1) {
-        FOR_ALL_INSTS() sin_ = sin(theta);
+        FOR_ALL_INSTS() sin__set(sin(theta));
     }
 }

--- a/tests/halcompile/names/names_dont_match.comp
+++ b/tests/halcompile/names/names_dont_match.comp
@@ -1,6 +1,7 @@
 component wrong_name;
 license "GPL";
-pin out bit out;
+pin out bool out;
+option period no;
 function _;
 ;;
-FUNCTION(_) {}
+FUNCTION(_) { out_set(0); }

--- a/tests/halcompile/names/names_match.comp
+++ b/tests/halcompile/names/names_match.comp
@@ -1,6 +1,7 @@
 component names_match;
 license "GPL";
-pin out bit out;
+pin out bool out;
+option period no;
 function _;
 ;;
-FUNCTION(_) {}
+FUNCTION(_) { out_set(0); }

--- a/tests/halcompile/relative-header-user/relative_header.comp
+++ b/tests/halcompile/relative-header-user/relative_header.comp
@@ -1,10 +1,10 @@
 component relative_header;
-pin out bit out;
+pin out bool out;
 include "local.h";
 license "GPL";
 option userspace yes;
 ;;
 void user_mainloop(void) {
-    FOR_ALL_INSTS() { out = ! out; }
+    FOR_ALL_INSTS() { out_set(! out); }
     rtapi_delay(100 * 1000 * 1000);
 }

--- a/tests/halcompile/relative-header/relative_header.comp
+++ b/tests/halcompile/relative-header/relative_header.comp
@@ -1,7 +1,8 @@
 component relative_header;
-pin out bit out;
+pin out bool out;
+option period no;
 include "local.h";
 function _;
 license "GPL";
 ;;
-out = X;
+out_set(X);

--- a/tests/halcompile/userspace-count-names/userspace_count_names.comp
+++ b/tests/halcompile/userspace-count-names/userspace_count_names.comp
@@ -2,7 +2,7 @@ component userspace_count_names;
 option userspace;
 option userinit;
 
-pin out signed out = 42;
+pin out si32 out = 42;
 license "GPL";
 ;;
 #include <unistd.h>

--- a/tests/halcompile/userspace/rand.comp
+++ b/tests/halcompile/userspace/rand.comp
@@ -1,7 +1,7 @@
 component rand;
 option userspace;
 
-pin out float out;
+pin out real out;
 license "GPL";
 ;;
 #include <unistd.h>
@@ -9,7 +9,7 @@ license "GPL";
 void user_mainloop(void) {
     while(1) {
         usleep(1000);
-        FOR_ALL_INSTS() out = drand48();
+        FOR_ALL_INSTS() out_set(drand48());
     }
 }
 

--- a/tests/module-loading/rtapi-app-main-fails/rtapi_app_main_fails.comp
+++ b/tests/module-loading/rtapi-app-main-fails/rtapi_app_main_fails.comp
@@ -1,12 +1,16 @@
 component rtapi_app_main_fails "rtapi_app_main error test";
-pin out bit boo;
+pin out bool boo;
 option rtapi_app no;
+option period no;
 function _;
 license "GPL";
 
 ;;
 
+void *x; // Must be global or the compiler may remove it
+
 int rtapi_app_main(void) {
+    x = export; // Prevent "warning: 'export' defined but not used"
     return -ERANGE;
 }
 
@@ -14,4 +18,4 @@ void rtapi_app_exit(void) {
     return;
 }
 
-FUNCTION(_) { boo ^= 0x1; }
+FUNCTION(_) { boo_set(boo ^ 0x1); }

--- a/tests/realtime-math/rtmath.comp
+++ b/tests/realtime-math/rtmath.comp
@@ -1,60 +1,61 @@
 component rtmath "Test realtime math functions";
 
-pin in float sin-in;
-pin out float sin-out;
+pin in  real sin-in;
+pin out real sin-out;
 
-pin in float cos-in;
-pin out float cos-out;
+pin in  real cos-in;
+pin out real cos-out;
 
-pin in float tan-in;
-pin out float tan-out;
+pin in  real tan-in;
+pin out real tan-out;
 
-pin in float sqrt-in;
-pin out float sqrt-out;
+pin in  real sqrt-in;
+pin out real sqrt-out;
 
-pin in float fabs-in;
-pin out float fabs-out;
+pin in  real fabs-in;
+pin out real fabs-out;
 
-pin in float atan-in;
-pin out float atan-out;
+pin in  real atan-in;
+pin out real atan-out;
 
-pin in float atan2-in1;
-pin in float atan2-in2;
-pin out float atan2-out;
+pin in  real atan2-in1;
+pin in  real atan2-in2;
+pin out real atan2-out;
 
-pin in float asin-in;
-pin out float asin-out;
+pin in  real asin-in;
+pin out real asin-out;
 
-pin in float acos-in;
-pin out float acos-out;
+pin in  real acos-in;
+pin out real acos-out;
 
-pin in float pow-base;
-pin in float pow-exponent;
-pin out float pow-out;
+pin in  real pow-base;
+pin in  real pow-exponent;
+pin out real pow-out;
 
-pin in float round-in;
-pin out float round-out;
+pin in  real round-in;
+pin out real round-out;
 
-pin in float ceil-in;
-pin out float ceil-out;
+pin in  real ceil-in;
+pin out real ceil-out;
 
-pin in float floor-in;
-pin out float floor-out;
+pin in  real floor-in;
+pin out real floor-out;
 
-pin in float isnan-in;
-pin out bit isnan-out;
+pin in  real isnan-in;
+pin out bool isnan-out;
 
-pin in float isinf-in;
-pin out bit isinf-out;
+pin in  real isinf-in;
+pin out bool isinf-out;
 
-pin in float exp-in;
-pin out float exp-out;
+pin in  real exp-in;
+pin out real exp-out;
 
-pin in float fmod-in;
-pin out float fmod-out;
+pin in  real fmod-in;
+pin out real fmod-out;
 
-pin out float nan-out;
+pin out real nan-out;
 
+option period no;
 function _;
 
 license "GPL";
@@ -64,23 +65,23 @@ license "GPL";
 #include <rtapi_math.h>
 
 FUNCTION(_) {
-    sin_out = sin(sin_in);
-    cos_out = cos(cos_in);
-    tan_out = tan(tan_in);
-    sqrt_out = sqrt(sqrt_in);
-    fabs_out = fabs(fabs_in);
-    atan_out = atan(atan_in);
-    atan2_out = atan2(atan2_in1, atan2_in2);
-    asin_out = asin(asin_in);
-    acos_out = acos(acos_in);
-    pow_out = pow(pow_base, pow_exponent);
-    round_out = round(round_in);
-    ceil_out = ceil(ceil_in);
-    floor_out = floor(floor_in);
-    isnan_out = isnan(isnan_in);
-    isinf_out = isinf(isinf_in);
-    exp_out = exp(exp_in);
-    fmod_out = fmod(fmod_in,fmod_in);
-    nan_out = nan("");
+    sin_out_set(sin(sin_in));
+    cos_out_set(cos(cos_in));
+    tan_out_set(tan(tan_in));
+    sqrt_out_set(sqrt(sqrt_in));
+    fabs_out_set(fabs(fabs_in));
+    atan_out_set(atan(atan_in));
+    atan2_out_set(atan2(atan2_in1, atan2_in2));
+    asin_out_set(asin(asin_in));
+    acos_out_set(acos(acos_in));
+    pow_out_set(pow(pow_base, pow_exponent));
+    round_out_set(round(round_in));
+    ceil_out_set(ceil(ceil_in));
+    floor_out_set(floor(floor_in));
+    isnan_out_set(isnan(isnan_in));
+    isinf_out_set(isinf(isinf_in));
+    exp_out_set(exp(exp_in));
+    fmod_out_set(fmod(fmod_in,fmod_in));
+    nan_out_set(nan(""));
 }
 

--- a/tests/rtapi-shmem/test_shmem_rtcomp.comp
+++ b/tests/rtapi-shmem/test_shmem_rtcomp.comp
@@ -18,8 +18,9 @@ component test_shmem_rtcomp "Validate rtapi's shmem initialization behavior";
 option extra_setup;
 option extra_cleanup;
 option singleton;
+option period no;
 
-pin out bit ready = 0 "Goes true when shmem is initialized";
+pin out bool ready = 0 "Goes true when shmem is initialized";
 
 function _;
 license "GPL";
@@ -80,6 +81,9 @@ void shmem_free(void) {
 
 
 EXTRA_SETUP() {
+    (void)__comp_inst;
+    (void)prefix;
+    (void)extra_arg;
     int i;
     int r;
     uint8_t *p;
@@ -114,6 +118,6 @@ EXTRA_CLEANUP() {
 
 
 FUNCTION(_) {
-    ready = 1;
+    ready_set(1);
 }
 

--- a/tests/symbols.0/test_define.comp
+++ b/tests/symbols.0/test_define.comp
@@ -1,9 +1,10 @@
 component test_define;
 
-pin out bit out;
+pin out bool out;
+option period no;
 function _;
 license "GPL";
 ;;
 void testdefine(void) {}
 
-FUNCTION(_) {}
+FUNCTION(_) { out_set(0); }

--- a/tests/symbols.0/test_use.comp
+++ b/tests/symbols.0/test_use.comp
@@ -1,9 +1,10 @@
 component test_use;
 
-pin out bit out;
+pin out bool out;
+option period no;
 function _;
 license "GPL";
 ;;
 void testuse(void);
 
-FUNCTION(_) { testuse(); }
+FUNCTION(_) { testuse(); out_set(0); }

--- a/tests/symbols.1/test_define1.comp
+++ b/tests/symbols.1/test_define1.comp
@@ -1,9 +1,10 @@
 component test_define1;
 
-pin out s32 out;
+pin out si32 out;
+option period no;
 function _;
 license "GPL";
 ;;
 int testdefine;
 
-FUNCTION(_) { out = testdefine++; }
+FUNCTION(_) { out_set(testdefine++); }

--- a/tests/symbols.1/test_use1.comp
+++ b/tests/symbols.1/test_use1.comp
@@ -1,9 +1,10 @@
 component test_use1;
 
-pin out s32 out;
+pin out si32 out;
+option period no;
 function _;
 license "GPL";
 ;;
 int testdefine;
 
-FUNCTION(_) { out = testdefine; }
+FUNCTION(_) { out_set(testdefine); }


### PR DESCRIPTION
There are components used in the tests. These also need to be converted to getter/setter or the tests will (soon) fail.

This PR addresses that issue. Additionally, several components generated compiler warnings. All of the unused arg/variable/function warnings. These have been quelled by mostly obvious means.