### PR TITLE
optimisation: rtapi: copy strings without going through vsnprintf

### DIFF
--- a/src/rtapi/rtapi_string.h
+++ b/src/rtapi/rtapi_string.h
@@ -48,7 +48,13 @@ RTAPI_END_DECLS
 #endif
 RTAPI_BEGIN_DECLS
 static inline size_t rtapi_strlcpy(char *dst, const char *src, size_t size) {
-    return rtapi_snprintf(dst, size, "%s", src);
+    size_t len = strlen(src);
+    if (size) {
+        size_t n = (len < size - 1) ? len : size - 1;
+        memcpy(dst, src, n);
+        dst[n] = '\0';
+    }
+    return len;
 }
 #define rtapi_strxcpy(dst, src) ({ \
     rtapi_static_assert(rtapi_is_array(dst), "dst must be non-const array"); \
@@ -56,8 +62,10 @@ static inline size_t rtapi_strlcpy(char *dst, const char *src, size_t size) {
 })
 
 static inline size_t rtapi_strlcat(char *dst, const char *src, size_t size) {
-    size_t l = strlen(dst);
-    return rtapi_snprintf(dst+l, size-l, "%s", src);
+    size_t l = strnlen(dst, size);
+    if (l == size)
+        return l + strlen(src);
+    return l + rtapi_strlcpy(dst+l, src, size-l);
 }
 
 #define rtapi_strxcat(dst, src) ({ \


### PR DESCRIPTION
_Another bottleneck found, and probably it is time to stop here with optimisation._ 

`rtapi_strlcpy` ran a full `vsnprintf` per call, and `rtapi_strxcpy` is on the interpreter hot path (`write_state_tag`, once per motion block): 

Benchmarked this fix: _parse-only over a 13.7M-line file drops 11.19s to 9.21s (1.21x)._  

`rtapi_strlcat` is not on hotpath but also fixed to avoid `vnsprintf`. Behaviour changed to return BSD return value, and avoid overrun when size-l underflows. No callers in linuxcnc code used return value of `rtapi_strlcat` so the fix is safe.