### PR TITLE
rs274ngc: Don't use RTAPI. This is non-RT userspace code

### DIFF
--- a/src/emc/rs274ngc/interp_convert.cc
+++ b/src/emc/rs274ngc/interp_convert.cc
@@ -28,14 +28,12 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <string>
-#include <rtapi_math.h>
 #include "rs274ngc.hh"
 #include "rs274ngc_return.hh"
 #include "rs274ngc_interp.hh"
 #include "interp_internal.hh"
 #include "interp_queue.hh"
 #include "interp_parameter_def.hh"
-#include <rtapi_string.h>
 
 #include "units.h"
 #define TOOL_INSIDE_ARC(side, turn) (((side)==CUTTER_COMP::LEFT&&(turn)>0)||((side)==CUTTER_COMP::RIGHT&&(turn)<0))
@@ -2018,12 +2016,12 @@ int Interp::convert_param_comment(char *comment, char *expanded, int /*len*/)
                 int n = snprintf(valbuf, VAL_LEN, format, pvalue);
                 bool fail = (n >= VAL_LEN || n < 0);
                 if(fail)
-                    rtapi_strxcpy(valbuf, "######");
+                    rs274ngc_strxcpy(valbuf, "######");
 
             }
             else
             {
-                rtapi_strxcpy(valbuf, "######");
+                rs274ngc_strxcpy(valbuf, "######");
             }
             logDebug("found:%d value:|%s|", found, valbuf);
 
@@ -3757,7 +3755,7 @@ int Interp::restore_settings(setup_pointer settings,
 	    int status = execute(s);
 	    if (status != INTERP_OK) {
 		char currentError[LINELEN+1];
-		rtapi_strxcpy(currentError,getSavedError());
+		rs274ngc_strxcpy(currentError,getSavedError());
 		CHKS(status, _("M7x: restore_settings failed executing: '%s': %s"), s, currentError);
 	    }
 	    s = strtok_r(NULL, "\n", &stateptr);

--- a/src/emc/rs274ngc/interp_internal.hh
+++ b/src/emc/rs274ngc/interp_internal.hh
@@ -26,7 +26,6 @@
 #include "libintl.h"
 #include <boost/python/object_fwd.hpp>
 #include <cmath>
-#include <rtapi_string.h>	// rtapi_strlcpy()
 #include "interp_parameter_def.hh"
 #include "interp_fwd.hh"
 #include "interp_base.hh"
@@ -883,13 +882,26 @@ macros totally crash-proof. If the function call stack is deeper than
 
 */
 
+#include <assert.h>
+#include <type_traits>
+
+static inline void rs274ngc_strlcpy(char *dst, const char *src, size_t dstsize) {
+    strncpy(dst, src, dstsize);
+    dst[dstsize-1] = 0;
+}
+
+#define rs274ngc_strxcpy(dst, src) do { \
+        static_assert(std::is_array<decltype(dst)>::value, "dst must be non-const array"); \
+        strncpy(dst, src, sizeof(dst)); \
+        dst[sizeof(dst)-1] = 0; \
+    } while(0)
 
 // Just set an error string using printf-style formats, do NOT return
 #define ERM(fmt, ...)                                      \
     do {                                                   \
         setError (fmt, ## __VA_ARGS__);                    \
         _setup.stack_index = 0;                            \
-        (rtapi_strlcpy(_setup.stack[_setup.stack_index], __PRETTY_FUNCTION__, STACK_ENTRY_LEN)); \
+        (rs274ngc_strlcpy(_setup.stack[_setup.stack_index], __PRETTY_FUNCTION__, STACK_ENTRY_LEN)); \
         _setup.stack[_setup.stack_index][STACK_ENTRY_LEN-1] = 0; \
         _setup.stack_index++; \
         _setup.stack[_setup.stack_index][0] = 0;           \
@@ -900,7 +912,7 @@ macros totally crash-proof. If the function call stack is deeper than
     do {                                                   \
         setError (fmt, ## __VA_ARGS__);                    \
         _setup.stack_index = 0;                            \
-        (rtapi_strlcpy(_setup.stack[_setup.stack_index], __PRETTY_FUNCTION__, STACK_ENTRY_LEN)); \
+        (rs274ngc_strlcpy(_setup.stack[_setup.stack_index], __PRETTY_FUNCTION__, STACK_ENTRY_LEN)); \
         _setup.stack[_setup.stack_index][STACK_ENTRY_LEN-1] = 0; \
         _setup.stack_index++; \
         _setup.stack[_setup.stack_index][0] = 0;           \
@@ -911,7 +923,7 @@ macros totally crash-proof. If the function call stack is deeper than
 #define ERN(error_code)                                    \
     do {                                                   \
         _setup.stack_index = 0;                            \
-        (rtapi_strlcpy(_setup.stack[_setup.stack_index], __PRETTY_FUNCTION__, STACK_ENTRY_LEN)); \
+        (rs274ngc_strlcpy(_setup.stack[_setup.stack_index], __PRETTY_FUNCTION__, STACK_ENTRY_LEN)); \
         _setup.stack[_setup.stack_index][STACK_ENTRY_LEN-1] = 0; \
         _setup.stack_index++; \
         _setup.stack[_setup.stack_index][0] = 0;           \
@@ -923,7 +935,7 @@ macros totally crash-proof. If the function call stack is deeper than
 #define ERP(error_code)                                        \
     do {                                                       \
         if (_setup.stack_index < STACK_LEN - 1) {                         \
-            (rtapi_strlcpy(_setup.stack[_setup.stack_index], __PRETTY_FUNCTION__, STACK_ENTRY_LEN)); \
+            (rs274ngc_strlcpy(_setup.stack[_setup.stack_index], __PRETTY_FUNCTION__, STACK_ENTRY_LEN)); \
             _setup.stack[_setup.stack_index][STACK_ENTRY_LEN-1] = 0;    \
             _setup.stack_index++;                                       \
             _setup.stack[_setup.stack_index][0] = 0;           \

--- a/src/emc/rs274ngc/interp_o_word.cc
+++ b/src/emc/rs274ngc/interp_o_word.cc
@@ -34,7 +34,6 @@
 #include "rs274ngc_interp.hh"
 #include "pythonplugin/python_plugin.hh"
 #include "interp_python.hh"
-#include <rtapi_string.h>	// rtapi_strlcpy()
 
 namespace bp = boost::python;
 
@@ -60,7 +59,7 @@ int Interp::findFile( // ARGUMENTS
     snprintf(targetPath, PATH_MAX, "%s/%s", direct, target);
     file = fopen(targetPath, "r");
     if (file) {
-        rtapi_strlcpy(foundFileDirect, direct, PATH_MAX);
+        rs274ngc_strlcpy(foundFileDirect, direct, PATH_MAX);
         fclose(file);
         return INTERP_OK;
     }
@@ -456,7 +455,7 @@ int Interp::execute_return(setup_pointer settings, context_pointer current_frame
 	    if (previous_frame->position == -1) {
 		if (settings->file_pointer) fclose(settings->file_pointer);
 		settings->file_pointer = NULL;
-		rtapi_strxcpy(settings->filename, "");
+		rs274ngc_strxcpy(settings->filename, "");
 	    } else {
 		if(settings->file_pointer == NULL) {
 		    ERS(NCE_FILE_NOT_OPEN);
@@ -470,7 +469,7 @@ int Interp::execute_return(setup_pointer settings, context_pointer current_frame
 			    previous_frame->filename,
 			    strerror(errno));
 		    }
-		    rtapi_strxcpy(settings->filename, previous_frame->filename);
+		    rs274ngc_strxcpy(settings->filename, previous_frame->filename);
 		}
 		fseek(settings->file_pointer, previous_frame->position, SEEK_SET);
 		settings->sequence_number = previous_frame->sequence_number;

--- a/src/emc/rs274ngc/interp_read.cc
+++ b/src/emc/rs274ngc/interp_read.cc
@@ -27,9 +27,7 @@
 #include "rs274ngc_return.hh"
 #include "interp_internal.hh"
 #include "rs274ngc_interp.hh"
-#include <rtapi_math.h>
 #include <cmath>
-#include <rtapi_string.h>	// rtapi_strlcpy()
 
 using namespace interp_param_global;
 
@@ -1597,7 +1595,7 @@ int Interp::read_o(    /* ARGUMENTS                                     */
 	  // context
           if (strlen(_setup.sub_context[_setup.call_level].subName) >= sizeof(oNameBuf))
               ERS(NCE_UNABLE_TO_OPEN_FILE, _setup.sub_context[_setup.call_level].subName);
-	  rtapi_strlcpy(oNameBuf, _setup.sub_context[_setup.call_level].subName,
+	  rs274ngc_strlcpy(oNameBuf, _setup.sub_context[_setup.call_level].subName,
                   sizeof(oNameBuf));
       } else
 	  // any other m-code should have been handled by read_m()
@@ -3166,7 +3164,7 @@ int Interp::read_text(
          index--) { // remove space at end of raw_line, especially CR & LF
       raw_line[index] = 0;
     }
-    rtapi_strlcpy(line, raw_line, LINELEN);
+    rs274ngc_strlcpy(line, raw_line, LINELEN);
     CHP(close_and_downcase(line));
     if ((line[0] == '%') && (line[1] == 0) && (_setup.percent_flag)) {
         FINISH();
@@ -3174,8 +3172,8 @@ int Interp::read_text(
     }
   } else {
     CHKS((strlen(command) >= LINELEN), NCE_COMMAND_TOO_LONG);
-    rtapi_strlcpy(raw_line, command, LINELEN);
-    rtapi_strlcpy(line, command, LINELEN);
+    rs274ngc_strlcpy(raw_line, command, LINELEN);
+    rs274ngc_strlcpy(line, command, LINELEN);
     CHP(close_and_downcase(line));
   }
 

--- a/src/emc/rs274ngc/interp_remap.cc
+++ b/src/emc/rs274ngc/interp_remap.cc
@@ -29,7 +29,6 @@ namespace bp = boost::python;
 #include "rs274ngc.hh"
 #include "rs274ngc_interp.hh"
 #include "interp_internal.hh"
-#include <rtapi_string.h>
 
 #include <string>
 #include <string_view>
@@ -415,7 +414,7 @@ int Interp::parse_remap(const char *inistring, int lineno)
     memset((void *)&r, 0, sizeof(remap));
     r.modal_group = -1; // mark as unset, required param for m/g
     r.motion_code = INT_MIN;
-    rtapi_strxcpy(iniline, inistring);
+    rs274ngc_strxcpy(iniline, inistring);
     // strip trailing comments
     if ((s = strchr(iniline, '#')) != NULL) {
 	*s = '\0';

--- a/src/emc/rs274ngc/interp_write.cc
+++ b/src/emc/rs274ngc/interp_write.cc
@@ -226,8 +226,7 @@ int Interp::write_state_tag(block_pointer block,
     bool in_sub = (settings->call_level > 0 && settings->remap_level == 0);
     bool external_sub = strcmp(settings->filename,
 			       settings->sub_context[0].filename);
-    rtapi_strxcpy(state.filename, settings->filename);
-    state.filename[sizeof(state.filename)-1] = 0;
+    rs274ngc_strxcpy(state.filename, settings->filename);
 
     state.flags[GM_FLAG_IN_REMAP] = in_remap;
     state.flags[GM_FLAG_IN_SUB] = in_sub;

--- a/src/emc/rs274ngc/rs274ngc_pre.cc
+++ b/src/emc/rs274ngc/rs274ngc_pre.cc
@@ -89,9 +89,7 @@ include an option for suppressing superfluous commands.
 #include <set>
 #include <stdexcept>
 #include <new>
-#include <rtapi_string.h>	// rtapi_strlcpy()
 
-#include <rtapi.h>
 #include <inifile.hh>
 #include "rs274ngc.hh"
 #include "rs274ngc_return.hh"
@@ -986,7 +984,7 @@ int Interp::init()
             for (dct=0; dct < MAX_SUB_DIRS; dct++) {
                  _setup.subroutines[dct] = NULL;
             }
-            rtapi_strxcpy(tmpdirs,inistring->c_str());
+            rs274ngc_strxcpy(tmpdirs,inistring->c_str());
             char *saveptr;
             nextdir = strtok_r(tmpdirs,":",&saveptr);  // first token
             dct = 0;
@@ -1085,7 +1083,7 @@ int Interp::init()
   USE_LENGTH_UNITS(_setup.length_units);
   GET_EXTERNAL_PARAMETER_FILE_NAME(filename, LINELEN);
   if (filename[0] == 0)
-    rtapi_strxcpy(filename, RS274NGC_PARAMETER_FILE_NAME_DEFAULT);
+    rs274ngc_strxcpy(filename, RS274NGC_PARAMETER_FILE_NAME_DEFAULT);
   CHP(restore_parameters(filename));
   pars = _setup.parameters;
   _setup.origin_index = (int) (pars[5220] + 0.0001);
@@ -1438,7 +1436,7 @@ int Interp::open(const char *filename) //!< string: the name of the input NC-pro
     _setup.percent_flag = false;
     _setup.sequence_number = 0; // Going back to line 0
   }
-  rtapi_strxcpy(_setup.filename, filename);
+  rs274ngc_strxcpy(_setup.filename, filename);
   reset();
   return INTERP_OK;
 }
@@ -1724,7 +1722,7 @@ int Interp::unwind_call(int status, const char *file, int line, const char *func
 		_setup.file_pointer = fopen(sub->filename, "r");
 		logDebug("unwind_call: reopening '%s' at %ld",
 			 sub->filename, sub->position);
-		rtapi_strxcpy(_setup.filename, sub->filename);
+		rs274ngc_strxcpy(_setup.filename, sub->filename);
 	    }
 	    fseek(_setup.file_pointer, sub->position, SEEK_SET);
 	}


### PR DESCRIPTION
Remove the RTAPI string calls in the g-code interpreter. There is no RT in the interpreter and it is an unnecessary complication and rather slow in some of the paths where it is being used.

Unlike #4492, this does not change RTAPI code, which is a chore for another time.
