### PR TITLE
rs274ngc: drop dead rtapi_math.h includes

### DIFF
--- a/src/emc/rs274ngc/interp_arc.cc
+++ b/src/emc/rs274ngc/interp_arc.cc
@@ -23,7 +23,6 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <libintl.h>
-#include <rtapi_math.h>
 #include "rs274ngc.hh"
 #include "rs274ngc_return.hh"
 #include "rs274ngc_interp.hh"

--- a/src/emc/rs274ngc/interp_execute.cc
+++ b/src/emc/rs274ngc/interp_execute.cc
@@ -22,7 +22,6 @@
 #include <ctype.h>
 #include <sys/types.h>
 #include <sys/stat.h>
-#include <rtapi_math.h>
 #include "rs274ngc.hh"
 #include "rs274ngc_return.hh"
 #include "interp_internal.hh"

--- a/src/emc/rs274ngc/interp_find.cc
+++ b/src/emc/rs274ngc/interp_find.cc
@@ -22,7 +22,6 @@
 #include <ctype.h>
 #include <sys/types.h>
 #include <sys/stat.h>
-#include <rtapi_math.h>
 #include "rs274ngc.hh"
 #include "nml_intf/interp_return.hh"
 #include "interp_internal.hh"


### PR DESCRIPTION
Follow-up to #4493: three interpreter files still included <rtapi_math.h> despite using no rtapi_ symbols at all.

interp_arc.cc, interp_execute.cc and interp_find.cc get their math functions and M_PIl from <math.h>, which they already include (_GNU_SOURCE is defined first, so glibc exposes M_PIl). The rs274ngc interpreter is built only as the userspace librs274.so, so the kernel branch of rtapi_math.h never applied to these files either.

Completes the rtapi-include cleanup #4493 started (it covered interp_convert.cc and interp_read.cc).
