### PR TITLE
docs: drop dangling qtvcp_center_finder image ref

### DIFF
--- a/docs/src/gui/qtvcp-vcp-panels.adoc
+++ b/docs/src/gui/qtvcp-vcp-panels.adoc
@@ -32,8 +32,6 @@ image::images/qtvcp_copy_dialog.png["QtVCP copy Dialog - Screen, Panel or Vismac
 
 === `center`
 
-image::images/qtvcp_center_finder.png["QtVCP Center Finder Panel VCP",align="center"]
-
 Used for *finding center of three points*.
 
 In a terminal run:


### PR DESCRIPTION
24eb9899c9 added a `center` section to `docs/src/gui/qtvcp-vcp-panels.adoc` referencing `image::images/qtvcp_center_finder.png`, but the screenshot was never committed.

That breaks `make -O docs` (run by `htmldocs` and all three `package-indep` jobs) with `cp: cannot stat .../qtvcp_center_finder.png`. CI builds each PR against the current master tip, so these jobs are red on master and on every open PR.

Drops the dangling macro so the build passes.

@cmorley please push the screenshot to `docs/src/gui/images/qtvcp_center_finder.png`; the image line can be restored after.
