### PR TITLE
gmoccapy: fix SIGTERM/SIGINT hang while a modal dialog is up

### DIFF
--- a/lib/python/gladevcp/hal_sourceview.py
+++ b/lib/python/gladevcp/hal_sourceview.py
@@ -55,7 +55,9 @@ class EMC_SourceView(GtkSource.View, _EMC_ActionBase):
         self.program_length = 0
         self.idle_line_reset = True
         self.buf = self.get_buffer()
-        self.buf.set_max_undo_levels(20)
+        # set_max_undo_levels is gone from newer GtkSourceView 4 releases
+        if hasattr(self.buf, 'set_max_undo_levels'):
+            self.buf.set_max_undo_levels(20)
         self.buf.connect('changed', self.update_iter)
         self.buf.connect('modified-changed', self.modified_changed)
         self.lm = GtkSource.LanguageManager()

--- a/src/emc/usr_intf/gmoccapy/gmoccapy.py
+++ b/src/emc/usr_intf/gmoccapy/gmoccapy.py
@@ -68,7 +68,8 @@ def excepthook(exc_type, exc_obj, exc_tb):
         return
     try:
         w = app.widgets.window1
-    except NameError:
+    except Exception:
+        # app not built (or partially built): parentless dialog
         w = None
     lines = traceback.format_exception(exc_type, exc_obj, exc_tb)
     message ="Found an error!\nThe following information may be useful in troubleshooting:\n\n" + "".join(lines)
@@ -81,8 +82,10 @@ def excepthook(exc_type, exc_obj, exc_tb):
                           buttons = Gtk.ButtonsType.OK,)
 
     m.show()
-    m.run()
-    m.destroy()
+    try:
+        m.run()
+    finally:
+        m.destroy()
 
 
 sys.excepthook = excepthook
@@ -6605,12 +6608,21 @@ if __name__ == "__main__":
 
 
     # Exit on SIGTERM/SIGINT whether or not a main loop is running.
-    # Gtk.main_quit() does nothing outside a running loop, so quit the
-    # loop if one is active, otherwise exit the process.
+    # A modal dialog's gtk_dialog_run() loop is invisible to
+    # Gtk.main_quit(): destroy all other toplevels so run() returns and
+    # the unwind reaches Gtk.main(); force exit as a last resort.
+    def _force_exit():
+        LOG.warning("clean shutdown did not finish, forcing exit")
+        os._exit(0)
+
     def _terminate(signum, frame):
         LOG.info("gmoccapy received signal {}, shutting down".format(signum))
         if Gtk.main_level() > 0:
             Gtk.main_quit()
+            for w in Gtk.Window.list_toplevels():
+                if w is not app.widgets.window1:
+                    w.destroy()
+            GLib.timeout_add(2000, _force_exit)
         else:
             sys.exit(0)
     signal.signal(signal.SIGTERM, _terminate)


### PR DESCRIPTION
Fixes #4500.

## Problem

The ui-smoke gmoccapy-quit test intermittently fails with `UI_SMOKE_QUIT_FAIL: GUI still alive 15s after SIGTERM`, and c-morley confirmed the same lockup interactively: gmoccapy sometimes refuses to close and has to be killed.

Root cause: GTK3's `gtk_dialog_run()` spins a private `GMainLoop` that `Gtk.main_quit()` cannot reach. When SIGTERM/SIGINT arrives while any modal dialog is up, the handler flags the outer `Gtk.main()` for exit, but that loop cannot unwind until the dialog returns, and the dialog waits for an OK click that never comes on an unattended machine or a headless CI runner. The process then survives until SIGKILL.

The trigger on the CI runner was an `AttributeError` during widget construction: newer GtkSourceView 4 releases dropped `set_max_undo_levels()`, and the exception popped gmoccapy's modal "Found an error!" dialog from the excepthook.

## Fix

In the SIGTERM/SIGINT handler: after `Gtk.main_quit()`, destroy every toplevel except the main window. Destroying a dialog makes its `gtk_dialog_run()` return, so the unwind proceeds to the outer loop and the process exits through the normal path (atexit handlers, HAL cleanup). A forced `os._exit()` after 2s remains as a last resort. This covers not just the excepthook dialog but every modal dialog gmoccapy opens (entry, yes/no, system dialogs).

Also:

- `hal_sourceview.py`: guard the `set_max_undo_levels()` call with `hasattr()` so newer GtkSourceView 4 no longer raises during construction.
- excepthook: catch any exception (not just `NameError`) when fetching the parent window, so an error raised before or during app construction is reported instead of being lost to a second exception inside the hook; destroy the dialog via `try/finally`.

## Testing

Reproduced the exact CI failure locally (`GUI still alive 15s after SIGTERM`) by injecting an exception into the running main loop under full CPU load. With the fix, the same scenario exits 1-3s after SIGTERM across repeated loaded runs, and the normal no-dialog quit path is unchanged (1s).
