### PR TITLE
gmoccapy: arm a minimal SIGTERM handler before the slow startup phase

### DIFF
--- a/src/emc/usr_intf/gmoccapy/gmoccapy.py
+++ b/src/emc/usr_intf/gmoccapy/gmoccapy.py
@@ -26,6 +26,19 @@
 
 """
 
+import os                  # needed to get the paths and directories
+import signal              # clean shutdown on SIGTERM/SIGINT
+import sys                 # handle system calls
+
+# Arm a minimal SIGTERM handler before the slow imports and app
+# construction: a shutdown SIGTERM landing there would otherwise kill
+# the process mid-startup with no cleanup. Exit through SystemExit so
+# atexit handlers run. The full handler below replaces this one.
+def _early_sigterm(signum, frame):
+    sys.exit(0)
+
+signal.signal(signal.SIGTERM, _early_sigterm)
+
 import gi
 gi.require_version('Gtk', '3.0')
 gi.require_version('Gdk', '3.0')
@@ -38,9 +51,6 @@ from gi.repository import Pango
 import traceback            # needed to launch traceback errors
 import hal                  # base hal class to react to hal signals
 from common import hal_glib # needed to make our own hal pins
-import sys                 # handle system calls
-import os                  # needed to get the paths and directories
-import signal              # clean shutdown on SIGTERM/SIGINT
 import atexit              # needed to register child's to be closed on closing the GUI
 import subprocess          # to launch onboard and other processes
 import tempfile            # needed only if the user click new in edit mode to open a new empty file


### PR DESCRIPTION
Follow-up to 699af8e5ae (merged via #4501).

That fix arms the SIGTERM/SIGINT handler only right before `Gtk.main()`. A shutdown SIGTERM landing earlier, during the gi/GTK imports or app construction (glade load, HAL component and pin creation, postgui halcmd spawns), hits the default disposition and kills the process mid-startup: no SystemExit unwind, so the atexit child cleanup and the `_hal` `Py_AtExit` hook never run. On a loaded machine this window stretches past task startup, so real shutdowns and the ui-smoke gmoccapy-quit driver can land SIGTERM in it.

This arms a minimal handler that exits through SystemExit as the first action of the script, before `import gi`. The full handler replaces it when installed.

Tested locally with an exit-code-recording wrapper around `bin/gmoccapy`: SIGTERM in the import window now exits 0 with a clean linuxcnc shutdown, where master dies with 143; SIGTERM during app construction also exits 0. `tests/ui-smoke/gmoccapy-quit` still passes.
