### PR TITLE
hal: add tap component, UI override for bit outputs

### DIFF
--- a/docs/src/hal/components.adoc
+++ b/docs/src/hal/components.adoc
@@ -209,6 +209,7 @@ To search in the man pages, use the UNIX tool `apropos`.
 | link:../man/man9/output_buffer.9.html[output_buffer] |Feed through multiple bits when enable pin is set ||
 | link:../man/man9/reset.9.html[reset]             |Resets an IO signal ||
 | link:../man/man9/select8.9.html[select8]         |8-bit binary match detector. ||
+| link:../man/man9/tap.9.html[tap]                 |Tap into a HAL boolean signal to override it from a UI ||
 | link:../man/man9/tof.9.html[tof]                 |IEC TOF timer - delay falling edge on a signal ||
 | link:../man/man9/toggle.9.html[toggle]           |Push-on, push-off from momentary pushbuttons ||
 | link:../man/man9/toggle2nist.9.html[toggle2nist] |Toggle button to nist logic ||

--- a/src/hal/components/tap.comp
+++ b/src/hal/components/tap.comp
@@ -1,0 +1,79 @@
+//   This is a component for LinuxCNC HAL
+//   Copyright 2026 Luca Toniolo
+//
+//   This program is free software; you can redistribute it and/or modify
+//   it under the terms of the GNU General Public License as published by
+//   the Free Software Foundation; either version 2 of the License, or
+//   (at your option) any later version.
+//
+//   This program is distributed in the hope that it will be useful,
+//   but WITHOUT ANY WARRANTY; without even the implied warranty of
+//   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//   GNU General Public License for more details.
+//
+//   You should have received a copy of the GNU General Public License
+//   along with this program; if not, write to the Free Software
+//   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+component tap "Tap into a HAL boolean signal to override it from a UI";
+
+pin in bool in "signal from HAL logic, e.g. driven by M64/M65";
+pin io bool io "override pin, typically connected to a UI control";
+pin out bool out "output to the hardware pin";
+
+function _ "Update the output on edges of in or io";
+option period no;
+license "GPL";
+author "Luca Toniolo";
+
+description """
+The *tap* component sits between a HAL boolean signal (typically driven
+by HAL logic or by G-code digital outputs such as *M64*/*M65*) and the
+output it controls, giving the operator a way to see and force the state
+from a UI without issuing MDI commands.
+
+The *in* pin is driven by the HAL logic as usual. On any edge of *in*,
+the *out* pin follows *in* and *io* is updated to match, so the UI
+always shows the current state.
+
+The *io* pin is an I/O pin intended to be read and written by a UI
+(for example a PyVCP or GladeVCP button/LED). On any edge of *io*,
+the *out* pin follows *io*, letting the operator force the output on or
+off even while the HAL logic holds *in* at a different state. The next
+edge of *in* makes the HAL logic take control again.
+
+The *tap* component reacts to changes only. It does not enforce a state
+continuously, so the *io* pin must not be linked to a signal that is
+written every cycle (such as a streamer output); it is meant for
+event-driven writers like UI buttons, *halcmd setp*, or *halcmd sets*
+on an unlinked pin.
+""";
+
+examples """
+loadrt tap
+addf tap.0 servo-thread
+net coolant-flood iocontrol.0.coolant-flood => tap.0.in
+net coolant-flood-out tap.0.out => parport.0.pin-14-out
+# UI button/LED connected to tap.0.io shows and can force the state
+""";
+
+variable rtapi_bool prev_in = false;
+variable rtapi_bool prev_io = false;
+;;
+
+FUNCTION(_) {
+    rtapi_bool inpin = in;
+    rtapi_bool iopin = io;
+
+    if (iopin != prev_io) {
+        // UI override; consumes a simultaneous in edge, io wins the tie
+        out_set(iopin);
+        prev_io = iopin;
+        prev_in = inpin;
+    } else if (inpin != prev_in) {
+        // HAL logic change; mirror it to the UI via io
+        out_set(inpin);
+        io_set(inpin);
+        prev_in = inpin;
+        prev_io = inpin;
+    }
+}

--- a/tests/tap.0/checkresult
+++ b/tests/tap.0/checkresult
@@ -1,0 +1,2 @@
+#!/bin/sh
+exit 0 # test failure is indicated by test.sh exit value

--- a/tests/tap.0/taptest.py
+++ b/tests/tap.0/taptest.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+
+import hal
+import time
+
+BEATTIMEOUT = 10.0
+
+
+# RT to non-RT synchronized wait to prevent race conditions.
+# The minimum wait should normally be >= 2 because you can catch the
+# threadbeat variable's increment event, which in itself does not run
+# the cycle. When you see an increment by 2, then you can be sure that
+# the cycle ran at least once.
+def waitThreadBeat(n):
+    assert n > 0, "Number of threadbeat wait cycles must be >= 1"
+    beat = hal.get_p('fast.threadbeat')
+    starttime = time.time()
+    while hal.get_p('fast.threadbeat') - beat < n:
+        time.sleep(0.001)
+        if time.time() - starttime > BEATTIMEOUT:
+            raise RuntimeError("waitThreadBeat: Timeout after {} seconds".format(BEATTIMEOUT))
+
+
+def check(pin, want, msg):
+    got = hal.get_p(pin)
+    assert got == want, "%s: %s is %r, want %r" % (msg, pin, got, want)
+    print("ok: %s: %s=%r" % (msg, pin, got))
+
+
+# initial state: everything low
+check("tap.0.out", 0, "initial out")
+check("tap.0.io", 0, "initial io")
+
+# HAL logic drives in high; out and io follow
+hal.set_p("tap.0.in", True)
+waitThreadBeat(2)
+check("tap.0.out", 1, "in rise drives out")
+check("tap.0.io", 1, "in rise drives io")
+
+# UI forces output off via io while in stays high
+hal.set_p("tap.0.io", False)
+waitThreadBeat(2)
+check("tap.0.out", 0, "io forced off drives out")
+check("tap.0.in", 1, "in still high")
+
+# UI forces output back on
+hal.set_p("tap.0.io", True)
+waitThreadBeat(2)
+check("tap.0.out", 1, "io forced on drives out")
+
+# UI forces off again; HAL logic takes control back on the next in edge
+hal.set_p("tap.0.io", False)
+waitThreadBeat(2)
+check("tap.0.out", 0, "forced off again")
+hal.set_p("tap.0.in", False)
+waitThreadBeat(2)
+check("tap.0.out", 0, "in fall keeps out low")
+check("tap.0.io", 0, "in fall drives io")
+hal.set_p("tap.0.in", True)
+waitThreadBeat(2)
+check("tap.0.out", 1, "in rise retakes control")
+
+print("PASS")

--- a/tests/tap.0/test.hal
+++ b/tests/tap.0/test.hal
@@ -1,0 +1,7 @@
+loadrt threads name1=fast period1=1000000
+loadrt tap
+
+addf tap.0 fast
+start
+
+loadusr -w ./taptest.py


### PR DESCRIPTION
Adds a small HAL component `tap` that sits between a HAL bit signal (typically driven by HAL logic or G-code digital outputs like M64/M65) and the output it controls.

- Edges on `in` pass the HAL logic state through to `out` and mirror it to `io`, so a UI always shows the current state.
- A UI (PyVCP/GladeVCP button, halcmd) can force the output on or off via the `io` pin without sending MDI or remembering which pin does what.
- The next edge of `in` hands control back to the HAL logic.

Use case: turning off something that is still on from an M64 without MDI gymnastics.

Includes extracted manpage documentation, a components.adoc entry, and a regression test (tests/tap.0).
