### PR TITLE
Added tests that cover aborting a pending tool prepare or tool change

### DIFF
--- a/tests/toolchanger/abort-during-change/abort-test.ini
+++ b/tests/toolchanger/abort-during-change/abort-test.ini
@@ -1,0 +1,105 @@
+[EMC]
+DEBUG = 0x0
+VERSION = 1.1
+
+[DISPLAY]
+DISPLAY = ./test-ui.py
+
+[TASK]
+TASK = milltask
+CYCLE_TIME = 0.001
+MDI_QUEUED_COMMANDS=10000
+
+[RS274NGC]
+PARAMETER_FILE = sim.var
+
+[EMCMOT]
+EMCMOT = motmod
+COMM_TIMEOUT = 4.0
+BASE_PERIOD = 0
+SERVO_PERIOD = 1000000
+
+[HAL]
+HALUI = halui
+HALFILE = mod_core_sim.hal
+POSTGUI_HALFILE = postgui.hal
+
+[TRAJ]
+NO_FORCE_HOMING=1
+AXES =                  3
+COORDINATES =           X Y Z
+HOME =                  0 0 0
+LINEAR_UNITS =          inch
+ANGULAR_UNITS =         degree
+DEFAULT_LINEAR_VELOCITY = 1.2
+MAX_LINEAR_VELOCITY =   4
+
+[KINS]
+KINEMATICS = trivkins
+JOINTS = 3
+
+[JOINT_0]
+TYPE =             LINEAR
+HOME =             0.000
+MAX_VELOCITY =     4
+MAX_ACCELERATION = 1000.0
+BACKLASH =         0.000
+INPUT_SCALE =      4000
+OUTPUT_SCALE =     1.000
+MIN_LIMIT =        -40.0
+MAX_LIMIT =        40.0
+FERROR =           0.050
+MIN_FERROR =       0.010
+
+[JOINT_1]
+TYPE =             LINEAR
+HOME =             0.000
+MAX_VELOCITY =     4
+MAX_ACCELERATION = 1000.0
+BACKLASH =         0.000
+INPUT_SCALE =      4000
+OUTPUT_SCALE =     1.000
+MIN_LIMIT =        -40.0
+MAX_LIMIT =        40.0
+FERROR =           0.050
+MIN_FERROR =       0.010
+
+[JOINT_2]
+TYPE =             LINEAR
+HOME =             0.0
+MAX_VELOCITY =     4
+MAX_ACCELERATION = 1000.0
+BACKLASH =         0.000
+INPUT_SCALE =      4000
+OUTPUT_SCALE =     1.000
+MIN_LIMIT =        -4.0
+MAX_LIMIT =        4.0
+FERROR =           0.050
+MIN_FERROR =       0.010
+
+[AXIS_X]
+HOME =             0.000
+MAX_VELOCITY =     4
+MAX_ACCELERATION = 1000.0
+MIN_LIMIT =        -40.0
+MAX_LIMIT =        40.0
+
+[AXIS_Y]
+HOME =             0.000
+MAX_VELOCITY =     4
+MAX_ACCELERATION = 1000.0
+MIN_LIMIT =        -40.0
+MAX_LIMIT =        40.0
+
+[AXIS_Z]
+HOME =             0.0
+MAX_VELOCITY =     4
+MAX_ACCELERATION = 1000.0
+MIN_LIMIT =        -4.0
+MAX_LIMIT =        4.0
+
+[EMCIO]
+TOOL_TABLE = simpockets.tbl
+TOOL_CHANGE_QUILL_UP = 1
+RANDOM_TOOLCHANGER = 0
+

--- a/tests/toolchanger/abort-during-change/checkresult
+++ b/tests/toolchanger/abort-during-change/checkresult
@@ -1,0 +1,2 @@
+#!/bin/sh
+exit 0 # test failure is indicated by test.sh exit value

--- a/tests/toolchanger/abort-during-change/mod_core_sim.hal
+++ b/tests/toolchanger/abort-during-change/mod_core_sim.hal
@@ -1,0 +1,61 @@
+# core HAL config file for simulation
+
+# first load all the RT modules that will be needed
+# kinematics
+loadrt trivkins
+# motion controller, get name and thread periods from INI file
+loadrt [EMCMOT]EMCMOT base_period_nsec=[EMCMOT]BASE_PERIOD servo_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=[TRAJ]AXES
+# load 6 differentiators (for velocity and accel signals
+loadrt ddt count=6
+# load additional blocks
+loadrt hypot count=2
+loadrt comp count=3
+loadrt or2 count=1
+
+# add motion controller functions to servo thread
+addf motion-command-handler servo-thread
+addf motion-controller servo-thread
+# link the differentiator functions into the code
+addf ddt.0 servo-thread
+addf ddt.1 servo-thread
+addf ddt.2 servo-thread
+addf ddt.3 servo-thread
+addf ddt.4 servo-thread
+addf ddt.5 servo-thread
+addf hypot.0 servo-thread
+addf hypot.1 servo-thread
+
+# create HAL signals for position commands from motion module
+# loop position commands back to motion module feedback
+net Xpos joint.0.motor-pos-cmd => joint.0.motor-pos-fb ddt.0.in
+net Ypos joint.1.motor-pos-cmd => joint.1.motor-pos-fb ddt.2.in
+net Zpos joint.2.motor-pos-cmd => joint.2.motor-pos-fb ddt.4.in
+
+# send the position commands thru differentiators to
+# generate velocity and accel signals
+net Xvel ddt.0.out => ddt.1.in hypot.0.in0
+net Xacc <= ddt.1.out 
+net Yvel ddt.2.out => ddt.3.in hypot.0.in1
+net Yacc <= ddt.3.out 
+net Zvel ddt.4.out => ddt.5.in hypot.1.in0
+net Zacc <= ddt.5.out 
+
+# Cartesian 2- and 3-axis velocities
+net XYvel hypot.0.out => hypot.1.in1
+net XYZvel <= hypot.1.out
+
+# estop loopback
+net estop-loop iocontrol.0.user-enable-out iocontrol.0.emc-enable-in
+
+# create signals for tool loading loopback
+net tool-prepare <= iocontrol.0.tool-prepare
+net tool-prepared => iocontrol.0.tool-prepared
+
+net tool-change <= iocontrol.0.tool-change
+net tool-changed => iocontrol.0.tool-changed
+
+net tool-number <= iocontrol.0.tool-number
+net tool-prep-number <= iocontrol.0.tool-prep-number
+net tool-prep-pocket <= iocontrol.0.tool-prep-pocket
+net tool-from-pocket <= iocontrol.0.tool-from-pocket
+

--- a/tests/toolchanger/abort-during-change/postgui.hal
+++ b/tests/toolchanger/abort-during-change/postgui.hal
@@ -1,0 +1,12 @@
+
+net tool-prepare => python-ui.tool-prepare
+net tool-prepared <= python-ui.tool-prepared
+
+net tool-change => python-ui.tool-change
+net tool-changed <= python-ui.tool-changed
+
+net tool-number => python-ui.tool-number
+net tool-prep-number => python-ui.tool-prep-number
+net tool-prep-pocket => python-ui.tool-prep-pocket
+net tool-from-pocket => python-ui.tool-from-pocket
+

--- a/tests/toolchanger/abort-during-change/test-ui.py
+++ b/tests/toolchanger/abort-during-change/test-ui.py
@@ -1,0 +1,224 @@
+#!/usr/bin/env python3
+
+# Aborting a program while a tool prepare or tool change is pending used to
+# leave emcStatus->io.status at RCS_EXEC forever: emcIoAbort() drops the
+# tool-prepare/tool-change output pins, so read_tool_inputs() can never see the
+# handshake complete and can never set the status back to RCS_DONE.  Task then
+# blocks every subsequent command in WAITING_FOR_IO.
+#
+# This test aborts in both phases and checks that the machine comes back to
+# RCS_DONE without pretending the tool change happened.
+
+import linuxcnc
+import hal
+
+import time
+import sys
+import os
+
+
+timeout = 1.0
+
+
+def introspect():
+    os.system("halcmd show pin python-ui")
+    os.system("halcmd show pin iocontrol")
+
+
+def wait_for_pin_value(pin_name, value, timeout=1):
+    print("waiting for %s to go to %f (timeout=%f)" % (pin_name, value, timeout))
+
+    start = time.time()
+    while (h[pin_name] != value) and ((time.time() - start) < timeout):
+        time.sleep(0.010)
+
+    if h[pin_name] != value:
+        print("timeout!  pin %s is %f, didn't get to %f" % (pin_name, h[pin_name], value))
+        introspect()
+        sys.exit(1)
+
+    print("pin %s went to %f!" % (pin_name, value))
+
+
+def verify_pin_value(pin_name, value):
+    if (h[pin_name] != value):
+        print("pin %s is %f, not %f" % (pin_name, h[pin_name], value))
+        introspect()
+        sys.exit(1)
+
+    print("pin %s is %f" % (pin_name, value))
+
+
+def wait_for_rcs_done(what, timeout=2):
+    # this is the actual regression check: without the fix in
+    # Task::emcIoAbort() the state stays RCS_EXEC forever
+    print("waiting for RCS_DONE after %s" % what)
+
+    start = time.time()
+    while (time.time() - start) < timeout:
+        s.poll()
+        if s.state == linuxcnc.RCS_DONE:
+            print("state is RCS_DONE after %s" % what)
+            return
+        time.sleep(0.010)
+
+    s.poll()
+    print("ERROR: stuck after %s: stat.state=%d (RCS_DONE=%d), exec_state=%d, "
+          "interp_state=%d"
+          % (what, s.state, linuxcnc.RCS_DONE, s.exec_state, s.interp_state))
+    introspect()
+    sys.exit(1)
+
+
+def verify_tool_in_spindle(tool_number):
+    s.poll()
+    if s.tool_in_spindle != tool_number:
+        print("ERROR: stat buffer .tool_in_spindle is %d, should be %d"
+              % (s.tool_in_spindle, tool_number))
+        introspect()
+        sys.exit(1)
+    verify_pin_value('tool-number', tool_number)
+    print("tool %d is in the spindle" % tool_number)
+
+
+def verify_mdi_works(gcode, axis_index, expected):
+    # proves task is not stuck in WAITING_FOR_IO / WAITING_FOR_MOTION_AND_IO
+    print("*** verifying the machine still accepts MDI: %s" % gcode)
+    c.mode(linuxcnc.MODE_MDI)
+    c.mdi(gcode)
+    c.wait_complete(5)
+
+    s.poll()
+    actual = s.position[axis_index]
+    if abs(actual - expected) > 0.001:
+        print("ERROR: '%s' did not run (axis %d is at %f, expected %f)"
+              % (gcode, axis_index, actual, expected))
+        introspect()
+        sys.exit(1)
+    print("'%s' ran, axis %d is at %f" % (gcode, axis_index, actual))
+
+
+def do_tool_prepare_handshake(tool_number, pocket_number):
+    wait_for_pin_value('tool-prepare', 1)
+    verify_pin_value('tool-prep-number', tool_number)
+    verify_pin_value('tool-prep-pocket', pocket_number)
+
+    h['tool-prepared'] = 1
+    wait_for_pin_value('tool-prepare', 0)
+    h['tool-prepared'] = 0
+
+
+def do_tool_change_handshake():
+    wait_for_pin_value('tool-change', 1)
+    h['tool-changed'] = 1
+    wait_for_pin_value('tool-change', 0)
+    h['tool-changed'] = 0
+
+
+#
+# set up pins
+#
+
+h = hal.component("python-ui")
+
+h.newpin("tool-number", hal.HAL_S32, hal.HAL_IN)
+h.newpin("tool-prep-number", hal.HAL_S32, hal.HAL_IN)
+h.newpin("tool-prep-pocket", hal.HAL_S32, hal.HAL_IN)
+h.newpin("tool-from-pocket", hal.HAL_S32, hal.HAL_IN)
+
+h.newpin("tool-prepare", hal.HAL_BIT, hal.HAL_IN)
+h.newpin("tool-prepared", hal.HAL_BIT, hal.HAL_OUT)
+
+h.newpin("tool-change", hal.HAL_BIT, hal.HAL_IN)
+h.newpin("tool-changed", hal.HAL_BIT, hal.HAL_OUT)
+
+h.ready()
+
+os.system("halcmd source ./postgui.hal")
+
+
+#
+# connect to LinuxCNC
+#
+
+c = linuxcnc.command()
+s = linuxcnc.stat()
+e = linuxcnc.error_channel()
+
+c.state(linuxcnc.STATE_ESTOP_RESET)
+c.state(linuxcnc.STATE_ON)
+c.mode(linuxcnc.MODE_MDI)
+c.wait_complete()
+
+verify_tool_in_spindle(0)
+
+
+#
+# baseline: a complete tool change still works
+#
+
+print("*** baseline 'T1 M6'")
+
+c.mdi('t1 m6')
+do_tool_prepare_handshake(tool_number=1, pocket_number=1)
+do_tool_change_handshake()
+c.wait_complete(5)
+
+verify_tool_in_spindle(1)
+
+
+#
+# abort while the tool PREPARE handshake is pending
+#
+
+print("*** aborting during tool prepare")
+
+c.mdi('t10 m6')
+wait_for_pin_value('tool-prepare', 1)
+
+c.abort()
+
+wait_for_pin_value('tool-prepare', 0)
+wait_for_rcs_done("abort during tool prepare")
+verify_tool_in_spindle(1)
+verify_mdi_works('g0 x1', 0, 1.0)
+
+
+#
+# abort while the tool CHANGE handshake is pending
+#
+
+print("*** aborting during tool change")
+
+c.mode(linuxcnc.MODE_MDI)
+c.mdi('t10 m6')
+do_tool_prepare_handshake(tool_number=10, pocket_number=3)
+wait_for_pin_value('tool-change', 1)
+
+c.abort()
+
+wait_for_pin_value('tool-change', 0)
+wait_for_rcs_done("abort during tool change")
+
+# the change did NOT happen, so the spindle must still hold the old tool --
+# faking the handshake instead of fixing emcIoAbort() would break this
+verify_tool_in_spindle(1)
+verify_mdi_works('g0 x2', 0, 2.0)
+
+
+#
+# and a complete tool change still works afterwards
+#
+
+print("*** 'T10 M6' after the aborts")
+
+c.mode(linuxcnc.MODE_MDI)
+c.mdi('t10 m6')
+do_tool_prepare_handshake(tool_number=10, pocket_number=3)
+do_tool_change_handshake()
+c.wait_complete(5)
+
+verify_tool_in_spindle(10)
+
+print("*** all good")
+sys.exit(0)

--- a/tests/toolchanger/abort-during-change/test.sh
+++ b/tests/toolchanger/abort-during-change/test.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+cp -f ../simpockets.tbl.original simpockets.tbl
+
+exec linuxcnc -r abort-test.ini


### PR DESCRIPTION
The problem
-----------
Commit 764655eb4d moved IO handling out of the separate iocontrol process and into Task. The old NML dispatcher set RCS_DONE by default for every command it handled; the in-process emcIoAbort() did not, so EMC_TOOL_ABORT dropped the tool-change and tool-prepare output pins but left emcioStatus.status at the RCS_EXEC that emcToolPrepare()/emcToolLoad() had set.

Nothing could clear it afterwards. read_tool_inputs() only reports completion while the corresponding output pin is still high, and the abort had just lowered it, so the handshake it waits for could never be observed. Because the MDI, auto and state-restore paths in emctaskmain gate on io.status == RCS_DONE, aborting while a tool change was pending wedged task: no further MDI command or program run would start, and the machine had to be restarted.

The fix
-------
Fixed in commit 990cb293bd, "task: set io.status=DONE on emcIoAbort to unblock tool-change abort" (PR #4031, closes issue #3675), which sets emcioStatus.status back to RCS_DONE in Task::emcIoAbort().

That fix landed without a regression test. This commit adds one; it contains no functional change.

What the test covers
--------------------
tests/toolchanger/abort-during-change drives a sim machine whose tool-prepare and tool-change handshake pins are brought out to the test itself rather than looped back, so the test can leave a change pending for as long as it likes and abort in the middle of it. It checks four things:

  - a complete T1 M6 works, so the rest of the run starts from a known state;

  - aborting while tool PREPARE is pending returns the machine to RCS_DONE, the tool in the spindle is unchanged, and MDI still runs -- proving task is not stuck in WAITING_FOR_IO;

  - aborting while tool CHANGE is pending does the same. The tool in the spindle is asserted to be the *old* one: satisfying the status check by pretending the change completed would pass the RCS_DONE assertion but fail here;

  - a full tool change still succeeds after both aborts, so the abort path does not leave the tool-change state machine unusable.

The test fails against a tree with the emcIoAbort() line from 990cb293bd removed and passes with it, and the surrounding tests/toolchanger tests are unaffected.

The layout follows the existing tests/toolchanger/m61 test; mod_core_sim.hal and postgui.hal are that test's files unchanged.